### PR TITLE
Добавлена документация через Swagger и пара мелких фиксов

### DIFF
--- a/cmd/awg-manager/docs.go
+++ b/cmd/awg-manager/docs.go
@@ -1,0 +1,20 @@
+// Package main — OpenAPI metadata for swag. Regenerate YAML before commit when API comments change:
+//
+//	go generate ./cmd/awg-manager
+//
+// In dev, Swagger UI: open the Svelte app at /dev/api-docs (Vite proxies /api to the daemon).
+//
+// Requires Go ≥ module version (see go.mod). Output: internal/openapi/swagger.yaml
+//
+//	@title						AWG Manager API
+//	@version					1.0
+//	@description				HTTP API for the AWG Manager daemon (tunnels, routing, system).
+//	@BasePath					/api
+//
+//	@securityDefinitions.apikey	CookieAuth
+//	@in							cookie
+//	@name						awg_session
+//	@description				Session cookie set by POST /auth/login. Omit for public routes.
+package main
+
+//go:generate go run github.com/swaggo/swag/cmd/swag@v1.16.4 init -g docs.go -d .,../../internal/api -o ../../internal/openapi --parseInternal --ot yaml

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,3 @@
+VITE_API_TARGET=http://192.168.1.1:2222
+# Set to 1 when using Prism mock (paths in spec are without /api prefix).
+VITE_API_STRIP_PREFIX=0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "svelte": "^5.49.2",
         "svelte-check": "^4.3.6",
         "sveltekit-superforms": "^2.29.1",
+        "swagger-ui-dist": "^5.32.5",
         "tailwindcss": "^4.0.0",
         "tslib": "2.8.1",
         "typescript": "5.7.3",
@@ -1012,6 +1013,14 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -1123,7 +1132,6 @@
       "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -1166,7 +1174,6 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -1206,6 +1213,7 @@
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2313,7 +2321,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2464,7 +2471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2960,14 +2966,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.12.41",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
-      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/lightningcss": {
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
@@ -3424,7 +3422,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3461,7 +3458,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3729,7 +3725,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.54.1.tgz",
       "integrity": "sha512-ow8tncN097Ty8U1H+C3bM1xNlsCbnO2UZeN0lWBnv8f3jKho7QTTQ2LWbMXrPQDodLjH91n4kpNnLolyRhVE6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3873,13 +3868,22 @@
         }
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.5.tgz",
+      "integrity": "sha512-7/FQfWe9A4qoyYFdAwy0chD0uDYidDp/ZT9VQ9LZlgD4AnnHJk8/+ytAA1HkJYOPySmK6helPDdJQMlcumt7HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0.tgz",
       "integrity": "sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -4018,7 +4022,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4071,7 +4074,6 @@
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=5"
       },
@@ -4098,7 +4100,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4391,7 +4392,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "svelte": "^5.49.2",
     "svelte-check": "^4.3.6",
     "sveltekit-superforms": "^2.29.1",
+    "swagger-ui-dist": "^5.32.5",
     "tailwindcss": "^4.0.0",
     "tslib": "2.8.1",
     "typescript": "5.7.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "sync:openapi": "cp ../internal/openapi/swagger.yaml ./static/openapi.yaml",
     "dev:mock": "npm run sync:openapi && VITE_API_STRIP_PREFIX=1 VITE_API_TARGET=http://127.0.0.1:8080 vite dev",
     "mock": "npx -y @stoplight/prism-cli mock ../internal/openapi/swagger.yaml -p 8080 --host 0.0.0.0",
+    "mock:dynamic": "npx -y @stoplight/prism-cli mock ../internal/openapi/swagger.yaml -p 8080 --host 0.0.0.0 --dynamic",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
+    "sync:openapi": "cp ../internal/openapi/swagger.yaml ./static/openapi.yaml",
+    "dev:mock": "npm run sync:openapi && VITE_API_STRIP_PREFIX=1 VITE_API_TARGET=http://127.0.0.1:8080 vite dev",
+    "mock": "npx -y @stoplight/prism-cli mock ../internal/openapi/swagger.yaml -p 8080 --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -250,6 +250,10 @@ input::placeholder {
 	color: var(--text-muted);
 }
 
+.setting-row input, .setting-row textarea, .setting-row select {
+	max-width: 276px;
+}
+
 label {
 	display: block;
 	margin-bottom: 0.25rem;

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,0 +1,10 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+
+// swagger-ui-dist ships a plain UMD bundle with no TypeScript types.
+declare module 'swagger-ui-dist/swagger-ui-bundle.js' {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const SwaggerUIBundle: any;
+	export = SwaggerUIBundle;
+}
+
+declare namespace App {}

--- a/frontend/src/lib/components/hrneo/HrNeoTab.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoTab.svelte
@@ -78,7 +78,7 @@
 
 	async function loadGeoFiles() {
 		try {
-			geoFiles = await api.getGeoFiles();
+			geoFiles = (await api.getGeoFiles()) ?? [];
 		} catch {
 			geoFiles = [];
 		}

--- a/frontend/src/lib/components/tunnels/ExternalTunnelCard.svelte
+++ b/frontend/src/lib/components/tunnels/ExternalTunnelCard.svelte
@@ -16,68 +16,56 @@
 	}
 </script>
 
-<div class="card flex flex-col gap-4 border-2 border-dashed border-warning-500/30">
+<div class="card ext-card flex flex-col gap-4">
 	<div class="flex justify-between items-start gap-3">
-		<div class="flex flex-col gap-1">
-			<div class="flex items-center gap-2">
-				<h3 class="text-lg font-semibold">{tunnel.interfaceName}</h3>
-				<span
-					class="inline-flex items-center gap-1.5 px-2.5 py-0.5 text-xs font-medium rounded-full bg-warning-500/15 text-warning-500"
-				>
-					Внешний
-				</span>
+		<div class="flex flex-col gap-1 min-w-0">
+			<h3 class="tunnel-name">{tunnel.interfaceName}</h3>
+			<div class="flex items-center gap-2 flex-wrap">
+				<span class="iface-name">WG туннель</span>
+				<span class="version-badge badge-external">Внешний</span>
 			</div>
-			<span class="text-xs text-surface-400 font-mono">AWG туннель</span>
 		</div>
-		<div>
+		<div class="shrink-0">
 			{#if tunnel.lastHandshake}
-				<span
-					class="inline-flex items-center gap-1.5 px-2.5 py-0.5 text-xs font-medium rounded-full bg-success-500/15 text-success-500"
-				>
-					<span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+				<span class="status-badge status-active">
+					<span class="led-dot"></span>
 					Подключён
 				</span>
 			{:else}
-				<span
-					class="inline-flex items-center gap-1.5 px-2.5 py-0.5 text-xs font-medium rounded-full bg-surface-400/15 text-surface-400"
-				>
-					<span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+				<span class="status-badge status-inactive">
+					<span class="led-dot"></span>
 					Неактивен
 				</span>
 			{/if}
 		</div>
 	</div>
 
-	<div class="flex flex-col gap-2 pt-3 border-t border-surface-300-700">
+	<div class="details">
 		{#if tunnel.endpoint}
-			<div class="flex gap-4">
-				<div class="flex flex-col gap-0.5 min-w-0">
-					<span class="text-xs text-surface-400 uppercase">Endpoint</span>
-					<span class="text-sm font-mono">{tunnel.endpoint}</span>
-				</div>
+			<div class="flex flex-col gap-0.5 min-w-0">
+				<span class="detail-label">Endpoint</span>
+				<span class="detail-value">{tunnel.endpoint}</span>
 			</div>
 		{/if}
 		{#if tunnel.lastHandshake}
-			<div class="flex gap-4">
-				<div class="flex flex-col gap-0.5 min-w-0">
-					<span class="text-xs text-surface-400 uppercase">Handshake</span>
-					<span class="text-sm font-mono">{tunnel.lastHandshake}</span>
-				</div>
+			<div class="flex flex-col gap-0.5 min-w-0">
+				<span class="detail-label">Handshake</span>
+				<span class="detail-value">{tunnel.lastHandshake}</span>
 			</div>
 		{/if}
-		<div class="flex gap-4">
+		<div class="flex gap-6">
 			<div class="flex flex-col gap-0.5 min-w-0">
-				<span class="text-xs text-surface-400 uppercase">RX</span>
-				<span class="text-sm font-mono">{formatBytes(tunnel.rxBytes)}</span>
+				<span class="detail-label">RX</span>
+				<span class="detail-value">{formatBytes(tunnel.rxBytes)}</span>
 			</div>
 			<div class="flex flex-col gap-0.5 min-w-0">
-				<span class="text-xs text-surface-400 uppercase">TX</span>
-				<span class="text-sm font-mono">{formatBytes(tunnel.txBytes)}</span>
+				<span class="detail-label">TX</span>
+				<span class="detail-value">{formatBytes(tunnel.txBytes)}</span>
 			</div>
 		</div>
 	</div>
 
-	<div class="pt-3 border-t border-surface-300-700">
+	<div class="actions-wrapper">
 		<Button variant="primary" onclick={handleAdopt}>
 			{#snippet iconBefore()}
 				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -89,3 +77,91 @@
 		</Button>
 	</div>
 </div>
+
+<style>
+	.ext-card {
+		border: 1px dashed color-mix(in srgb, var(--warning, #f59e0b) 40%, transparent);
+	}
+
+	.tunnel-name {
+		font-size: 1rem;
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.iface-name {
+		font-size: 12px;
+		font-family: var(--font-mono, monospace);
+		color: var(--text-muted);
+	}
+
+	.version-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 8px;
+		font-size: 11px;
+		font-weight: 500;
+		border-radius: 10px;
+	}
+
+	.badge-external {
+		background: rgba(245, 158, 11, 0.15);
+		color: var(--warning, #f59e0b);
+	}
+
+	.status-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 2px 10px;
+		font-size: 12px;
+		font-weight: 500;
+		border-radius: 10px;
+	}
+
+	.status-active {
+		background: rgba(16, 185, 129, 0.15);
+		color: var(--success, #10b981);
+	}
+
+	.status-inactive {
+		background: rgba(148, 163, 184, 0.15);
+		color: var(--text-muted);
+	}
+
+	.led-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: currentColor;
+		flex-shrink: 0;
+	}
+
+	.details {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding-top: 12px;
+		border-top: 1px solid var(--border);
+	}
+
+	.detail-label {
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.detail-value {
+		font-size: 13px;
+		font-family: var(--font-mono, monospace);
+		color: var(--text-secondary);
+	}
+
+	.actions-wrapper {
+		padding-top: 12px;
+		border-top: 1px solid var(--border);
+	}
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -491,7 +491,8 @@
 			</div>
 
 			{#if externalList.length > 0}
-				<h2 class="text-lg font-semibold mt-6 mb-4">Внешние туннели</h2>
+			<div class="external-section">
+				<h2 class="section-title">Внешние туннели</h2>
 				<div class="tunnel-grid">
 					{#each externalList as extTunnel (extTunnel.interfaceName)}
 						<ExternalTunnelCard
@@ -500,7 +501,8 @@
 						/>
 					{/each}
 				</div>
-			{/if}
+			</div>
+		{/if}
 		{/if}
 		{:else}
 			<SingboxInstallBanner />
@@ -939,5 +941,18 @@
 		background: var(--color-accent);
 		color: #fff;
 		border-color: var(--color-accent);
+	}
+
+	.external-section {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border);
+	}
+
+	.section-title {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin-bottom: 1rem;
 	}
 </style>

--- a/frontend/src/routes/dev/api-docs/+page.svelte
+++ b/frontend/src/routes/dev/api-docs/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let root: HTMLDivElement | undefined;
+
+	onMount(() => {
+		let destroyed = false;
+		(async () => {
+			await import('swagger-ui-dist/swagger-ui.css');
+			const mod = await import('swagger-ui-dist/swagger-ui-bundle.js');
+			const SwaggerUIBundle = (mod as { default?: unknown }).default ?? mod;
+			if (destroyed || !root) return;
+			(SwaggerUIBundle as (opts: Record<string, unknown>) => { preauthorizeBasic?: unknown })(
+				{
+					domNode: root,
+					url: '/api/openapi.yaml'
+				}
+			);
+		})();
+		return () => {
+			destroyed = true;
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>API docs (dev)</title>
+</svelte:head>
+
+<div class="wrap">
+	<p class="hint">
+		OpenAPI spec: <a href="/api/openapi.yaml">/api/openapi.yaml</a> (file:
+		<code>internal/openapi/swagger.yaml</code>) — regenerate from repo root with
+		<code>go generate ./cmd/awg-manager</code>
+	</p>
+	<div bind:this={root} class="swagger-root"></div>
+</div>
+
+<style>
+	.wrap {
+		padding: 0.75rem 1rem;
+		min-height: 100vh;
+	}
+	.hint {
+		margin: 0 0 0.75rem;
+		font-size: 0.875rem;
+		color: var(--tw-prose-body, #444);
+	}
+	.hint code {
+		font-size: 0.8125rem;
+	}
+	.swagger-root {
+		min-height: 70vh;
+	}
+</style>

--- a/frontend/src/routes/dev/api-docs/+page.svelte
+++ b/frontend/src/routes/dev/api-docs/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 
 	let root: HTMLDivElement | undefined;
+	const specCandidates = ['/api/openapi.yaml', '/openapi.yaml'];
 
 	onMount(() => {
 		let destroyed = false;
@@ -10,10 +11,24 @@
 			const mod = await import('swagger-ui-dist/swagger-ui-bundle.js');
 			const SwaggerUIBundle = (mod as { default?: unknown }).default ?? mod;
 			if (destroyed || !root) return;
+
+			let chosenURL = specCandidates[0];
+			for (const candidate of specCandidates) {
+				try {
+					const res = await fetch(candidate, { method: 'GET' });
+					if (res.ok) {
+						chosenURL = candidate;
+						break;
+					}
+				} catch {
+					// try next candidate
+				}
+			}
+
 			(SwaggerUIBundle as (opts: Record<string, unknown>) => { preauthorizeBasic?: unknown })(
 				{
 					domNode: root,
-					url: '/api/openapi.yaml'
+					url: chosenURL
 				}
 			);
 		})();
@@ -29,8 +44,9 @@
 
 <div class="wrap">
 	<p class="hint">
-		OpenAPI spec: <a href="/api/openapi.yaml">/api/openapi.yaml</a> (file:
-		<code>internal/openapi/swagger.yaml</code>) — regenerate from repo root with
+		OpenAPI spec: first <code>/api/openapi.yaml</code>, fallback <code>/openapi.yaml</code> (file:
+		<code>internal/openapi/swagger.yaml</code>, for fallback sync to <code>frontend/static/openapi.yaml</code>) —
+		regenerate from repo root with
 		<code>go generate ./cmd/awg-manager</code>
 	</p>
 	<div bind:this={root} class="swagger-root"></div>

--- a/frontend/src/routes/dev/api-docs/+page.svelte
+++ b/frontend/src/routes/dev/api-docs/+page.svelte
@@ -40,6 +40,199 @@
 
 <svelte:head>
 	<title>API docs (dev)</title>
+	<!-- Global Swagger UI theme overrides — scoped to this page via .swagger-root -->
+	<style>
+		/* ── Transparent scheme container in both themes ── */
+		.swagger-ui .scheme-container {
+			background: transparent !important;
+			box-shadow: none !important;
+			padding: 12px 0 !important;
+		}
+
+		/* ── Dark theme overrides ── */
+		[data-theme="dark"] .swagger-ui,
+		[data-theme="dark"] .swagger-ui .wrapper,
+		[data-theme="dark"] .swagger-ui .opblock-tag-section {
+			background: transparent;
+			color: #c0caf5;
+		}
+
+		[data-theme="dark"] .swagger-ui .info .title,
+		[data-theme="dark"] .swagger-ui .info h1,
+		[data-theme="dark"] .swagger-ui .info h2,
+		[data-theme="dark"] .swagger-ui .info p,
+		[data-theme="dark"] .swagger-ui .info li,
+		[data-theme="dark"] .swagger-ui .info a {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .info .base-url {
+			color: #a9b1d6 !important;
+		}
+
+		/* Tags / operation headers */
+		[data-theme="dark"] .swagger-ui .opblock-tag {
+			border-bottom: 1px solid #3b4261 !important;
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .opblock-tag:hover,
+		[data-theme="dark"] .swagger-ui .opblock-tag small {
+			color: #a9b1d6 !important;
+		}
+
+		/* Operation blocks */
+		[data-theme="dark"] .swagger-ui .opblock {
+			background: #1e2030 !important;
+			border: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .opblock .opblock-summary {
+			border-bottom: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .opblock .opblock-summary-description,
+		[data-theme="dark"] .swagger-ui .opblock .opblock-summary-path,
+		[data-theme="dark"] .swagger-ui .opblock .opblock-summary-path__deprecated {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .opblock-body {
+			background: #1a1b26 !important;
+		}
+
+		/* Parameters / responses section */
+		[data-theme="dark"] .swagger-ui .opblock-section-header {
+			background: #24283b !important;
+			border-bottom: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .opblock-section-header h4,
+		[data-theme="dark"] .swagger-ui .opblock-section-header label {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui table thead tr th,
+		[data-theme="dark"] .swagger-ui .parameters-col_description,
+		[data-theme="dark"] .swagger-ui .parameters-col_name,
+		[data-theme="dark"] .swagger-ui .col_header {
+			color: #a9b1d6 !important;
+			border-bottom: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .parameter__name,
+		[data-theme="dark"] .swagger-ui .parameter__type,
+		[data-theme="dark"] .swagger-ui .parameter__in {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .renderedMarkdown p,
+		[data-theme="dark"] .swagger-ui .renderedMarkdown li,
+		[data-theme="dark"] .swagger-ui .markdown p,
+		[data-theme="dark"] .swagger-ui .markdown li {
+			color: #a9b1d6 !important;
+		}
+
+		/* Response codes & text */
+		[data-theme="dark"] .swagger-ui .response-col_status {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .response-col_description {
+			color: #a9b1d6 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .response-col_links {
+			color: #a9b1d6 !important;
+		}
+
+		/* Code / models */
+		[data-theme="dark"] .swagger-ui .highlight-code,
+		[data-theme="dark"] .swagger-ui pre.microlight {
+			background: #24283b !important;
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .model-box,
+		[data-theme="dark"] .swagger-ui section.models .model-container {
+			background: #1e2030 !important;
+			border: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui section.models {
+			border: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui section.models h4,
+		[data-theme="dark"] .swagger-ui .model-title,
+		[data-theme="dark"] .swagger-ui .model .property,
+		[data-theme="dark"] .swagger-ui .model .property.primitive,
+		[data-theme="dark"] .swagger-ui .model span {
+			color: #c0caf5 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .model-toggle::after {
+			filter: invert(0.8) !important;
+		}
+
+		/* Form inputs / selects */
+		[data-theme="dark"] .swagger-ui input[type="text"],
+		[data-theme="dark"] .swagger-ui textarea,
+		[data-theme="dark"] .swagger-ui select {
+			background: #24283b !important;
+			color: #c0caf5 !important;
+			border: 1px solid #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui label {
+			color: #a9b1d6 !important;
+		}
+
+		/* Try-it-out / execute */
+		[data-theme="dark"] .swagger-ui .btn {
+			color: #c0caf5 !important;
+			border-color: #3b4261 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .btn.execute {
+			background: #7aa2f7 !important;
+			color: #1a1b26 !important;
+			border-color: #7aa2f7 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .btn.cancel {
+			color: #f7768e !important;
+			border-color: #f7768e !important;
+		}
+
+		/* Topbar — hide it, nav is in the app shell */
+		[data-theme="dark"] .swagger-ui .topbar,
+		.swagger-ui .topbar {
+			display: none !important;
+		}
+
+		/* Servers dropdown */
+		[data-theme="dark"] .swagger-ui .servers-title,
+		[data-theme="dark"] .swagger-ui .servers > label {
+			color: #a9b1d6 !important;
+		}
+
+		[data-theme="dark"] .swagger-ui .servers select {
+			background: #24283b !important;
+			color: #c0caf5 !important;
+			border: 1px solid #3b4261 !important;
+		}
+
+		/* Auth button */
+		[data-theme="dark"] .swagger-ui .authorization__btn {
+			color: #7aa2f7 !important;
+		}
+
+		/* Required asterisk */
+		[data-theme="dark"] .swagger-ui .required {
+			color: #f7768e !important;
+		}
+	</style>
 </svelte:head>
 
 <div class="wrap">
@@ -60,12 +253,12 @@
 	.hint {
 		margin: 0 0 0.75rem;
 		font-size: 0.875rem;
-		color: var(--tw-prose-body, #444);
+		color: var(--color-text-secondary, #a9b1d6);
 	}
 	.hint code {
 		font-size: 0.8125rem;
 	}
-	.swagger-root {
+	:global(.swagger-root) {
 		min-height: 70vh;
 	}
 </style>

--- a/frontend/static/openapi.yaml
+++ b/frontend/static/openapi.yaml
@@ -1,5 +1,186 @@
 basePath: /api
 definitions:
+  api.APIEnvelope:
+    properties:
+      data:
+        type: object
+      message:
+        example: ok
+        type: string
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.APIErrorEnvelope:
+    properties:
+      code:
+        example: BAD_REQUEST
+        type: string
+      error:
+        example: true
+        type: boolean
+      message:
+        example: invalid request
+        type: string
+    type: object
+  api.AWGInterfaceDTO:
+    properties:
+      address:
+        example: 10.0.0.2/32
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      h1:
+        example: "1"
+        type: string
+      h2:
+        example: "2"
+        type: string
+      h3:
+        example: "3"
+        type: string
+      h4:
+        example: "4"
+        type: string
+      jc:
+        example: 4
+        type: integer
+      jmax:
+        example: 70
+        type: integer
+      jmin:
+        example: 40
+        type: integer
+      mtu:
+        example: 1420
+        type: integer
+      privateKey:
+        example: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        type: string
+      s1:
+        example: 0
+        type: integer
+      s2:
+        example: 0
+        type: integer
+      s3:
+        example: 0
+        type: integer
+      s4:
+        example: 0
+        type: integer
+    type: object
+  api.AWGPeerDTO:
+    properties:
+      allowedIPs:
+        example:
+        - 0.0.0.0/0
+        items:
+          type: string
+        type: array
+      endpoint:
+        example: vpn.example.com:51820
+        type: string
+      persistentKeepalive:
+        example: 25
+        type: integer
+      publicKey:
+        example: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+        type: string
+    type: object
+  api.AWGTunnelDTO:
+    properties:
+      backend:
+        example: nativewg
+        type: string
+      defaultRoute:
+        example: false
+        type: boolean
+      enabled:
+        example: true
+        type: boolean
+      id:
+        example: tun_abc123
+        type: string
+      interface:
+        $ref: '#/definitions/api.AWGInterfaceDTO'
+      interfaceName:
+        example: nwg0
+        type: string
+      name:
+        example: My VPN
+        type: string
+      peer:
+        $ref: '#/definitions/api.AWGPeerDTO'
+      state:
+        example: connected
+        type: string
+      stateInfo:
+        $ref: '#/definitions/api.TunnelStateInfoDTO'
+      type:
+        enum:
+        - awg
+        - wg
+        example: awg
+        type: string
+    type: object
+  api.AccessPoliciesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.AccessPolicyDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.AccessPolicyDTO:
+    properties:
+      description:
+        example: Default policy
+        type: string
+      deviceCount:
+        example: 5
+        type: integer
+      interfaces:
+        items:
+          $ref: '#/definitions/api.AccessPolicyInterfaceDTO'
+        type: array
+      name:
+        example: default
+        type: string
+      standalone:
+        example: false
+        type: boolean
+    type: object
+  api.AccessPolicyInterfaceDTO:
+    properties:
+      denied:
+        example: false
+        type: boolean
+      label:
+        example: My VPN
+        type: string
+      name:
+        example: nwg0
+        type: string
+      order:
+        example: 1
+        type: integer
+    type: object
+  api.AddPeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      tunnelIP:
+        example: 10.10.0.2/32
+        type: string
+    type: object
   api.AdoptRequest:
     properties:
       content:
@@ -7,12 +188,1001 @@ definitions:
       name:
         type: string
     type: object
+  api.AllInterfacesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.RouterInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.AuthStatusResponse:
+    properties:
+      authDisabled:
+        example: false
+        type: boolean
+      authenticated:
+        example: true
+        type: boolean
+      expiresIn:
+        example: 3600
+        type: integer
+      login:
+        example: admin
+        type: string
+    type: object
+  api.BootStatusResponse:
+    properties:
+      initializing:
+        example: false
+        type: boolean
+      instanceId:
+        example: a1b2c3d4e5f6
+        type: string
+      phase:
+        example: ready
+        type: string
+      remainingSeconds:
+        example: 0
+        type: integer
+    type: object
+  api.ChangelogData:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/api.ChangelogEntryDTO'
+        type: array
+    type: object
+  api.ChangelogEntryDTO:
+    properties:
+      date:
+        example: "2024-01-15"
+        type: string
+      groups:
+        items:
+          $ref: '#/definitions/api.ChangelogGroupDTO'
+        type: array
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.ChangelogGroupDTO:
+    properties:
+      heading:
+        example: Bug Fixes
+        type: string
+      items:
+        example:
+        - Fixed tunnel restart loop
+        items:
+          type: string
+        type: array
+    type: object
+  api.ChangelogResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ChangelogData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ClientRouteDTO:
+    properties:
+      clientHostname:
+        example: My-Phone
+        type: string
+      clientIp:
+        example: 192.168.1.100
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      fallback:
+        example: drop
+        type: string
+      id:
+        example: cr_001
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.ClientRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.ClientRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConnectionProtocolsDTO:
+    properties:
+      icmp:
+        example: 2
+        type: integer
+      tcp:
+        example: 28
+        type: integer
+      udp:
+        example: 12
+        type: integer
+    type: object
+  api.ConnectionStatsDTO:
+    properties:
+      direct:
+        example: 30
+        type: integer
+      protocols:
+        $ref: '#/definitions/api.ConnectionProtocolsDTO'
+      total:
+        example: 42
+        type: integer
+      tunneled:
+        example: 12
+        type: integer
+    type: object
+  api.ConnectionsData:
+    properties:
+      connections:
+        items:
+          $ref: '#/definitions/api.ConntrackConnectionDTO'
+        type: array
+      fetchedAt:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      pagination:
+        $ref: '#/definitions/api.ConnectionsPaginationDTO'
+      stats:
+        $ref: '#/definitions/api.ConnectionStatsDTO'
+      tunnels:
+        type: object
+    type: object
+  api.ConnectionsPaginationDTO:
+    properties:
+      limit:
+        example: 50
+        type: integer
+      offset:
+        example: 0
+        type: integer
+      returned:
+        example: 42
+        type: integer
+      total:
+        example: 42
+        type: integer
+    type: object
+  api.ConnectionsResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.ConnectionsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConnectivityResultData:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      latency:
+        example: 42
+        type: integer
+      reason:
+        example: ""
+        type: string
+    type: object
+  api.ConnectivityResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ConnectivityResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConntrackConnectionDTO:
+    properties:
+      bytes:
+        example: 4096
+        type: integer
+      clientMac:
+        example: aa:bb:cc:dd:ee:ff
+        type: string
+      clientName:
+        example: My Phone
+        type: string
+      dst:
+        example: 8.8.8.8
+        type: string
+      dstPort:
+        example: 443
+        type: integer
+      interface:
+        example: nwg0
+        type: string
+      packets:
+        example: 15
+        type: integer
+      protocol:
+        example: tcp
+        type: string
+      src:
+        example: 192.168.1.100
+        type: string
+      srcPort:
+        example: 54321
+        type: integer
+      state:
+        example: ESTABLISHED
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.CreateServerRequestDTO:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      description:
+        example: My WG Server
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      endpoint:
+        example: 203.0.113.42:51821
+        type: string
+      listenPort:
+        example: 51821
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+    type: object
+  api.DNSRouteSettingsDTO:
+    properties:
+      autoRefreshEnabled:
+        example: true
+        type: boolean
+      refreshDailyTime:
+        example: "03:00"
+        type: string
+      refreshIntervalHours:
+        example: 24
+        type: integer
+      refreshMode:
+        example: interval
+        type: string
+    type: object
+  api.DeviceProxyAuthDTO:
+    properties:
+      enabled:
+        example: false
+        type: boolean
+      password:
+        example: ""
+        type: string
+      username:
+        example: ""
+        type: string
+    type: object
+  api.DeviceProxyConfigData:
+    properties:
+      auth:
+        $ref: '#/definitions/api.DeviceProxyAuthDTO'
+      enabled:
+        example: false
+        type: boolean
+      listenAll:
+        example: true
+        type: boolean
+      listenInterface:
+        example: br0
+        type: string
+      port:
+        example: 1080
+        type: integer
+      selectedOutbound:
+        example: proxy-01
+        type: string
+    type: object
+  api.DeviceProxyOutboundDTO:
+    properties:
+      detail:
+        example: proxy.example.com:443
+        type: string
+      kind:
+        example: singbox
+        type: string
+      label:
+        example: proxy-01 (VLESS)
+        type: string
+      tag:
+        example: proxy-01
+        type: string
+    type: object
+  api.DeviceProxyRuntimeData:
+    properties:
+      activeTag:
+        example: proxy-01
+        type: string
+      alive:
+        example: true
+        type: boolean
+      defaultTag:
+        example: proxy-01
+        type: string
+    type: object
+  api.DiagnosticsStatusData:
+    properties:
+      progress:
+        example: ""
+        type: string
+      status:
+        example: idle
+        type: string
+    type: object
+  api.DiagnosticsStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DiagnosticsStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsCheckResultDTO:
+    properties:
+      detail:
+        example: ""
+        type: string
+      id:
+        example: dns_leak
+        type: string
+      message:
+        example: No DNS leak detected
+        type: string
+      status:
+        example: ok
+        type: string
+      title:
+        example: DNS Leak Test
+        type: string
+    type: object
+  api.DnsCheckStartData:
+    properties:
+      checks:
+        items:
+          $ref: '#/definitions/api.DnsCheckResultDTO'
+        type: array
+      clientIP:
+        example: 192.168.1.100
+        type: string
+      hostname:
+        example: my-phone.local
+        type: string
+    type: object
+  api.DnsCheckStartResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.DnsCheckStartData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsRouteDTO:
+    properties:
+      backend:
+        example: ndms
+        type: string
+      createdAt:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      domains:
+        example:
+        - example.com
+        items:
+          type: string
+        type: array
+      enabled:
+        example: true
+        type: boolean
+      id:
+        example: dns_xyz789
+        type: string
+      manualDomains:
+        example:
+        - corp.internal
+        items:
+          type: string
+        type: array
+      name:
+        example: Work VPN
+        type: string
+      routes:
+        items:
+          $ref: '#/definitions/api.DnsRouteTargetDTO'
+        type: array
+      subscriptions:
+        items:
+          $ref: '#/definitions/api.DnsRouteSubscriptionDTO'
+        type: array
+      updatedAt:
+        example: "2024-01-15T12:00:00Z"
+        type: string
+    type: object
+  api.DnsRouteResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DnsRouteDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsRouteSubscriptionDTO:
+    properties:
+      lastCount:
+        example: 1500
+        type: integer
+      lastFetched:
+        example: "2024-01-15T02:00:00Z"
+        type: string
+      name:
+        example: Block list
+        type: string
+      url:
+        example: https://example.com/list.txt
+        type: string
+    type: object
+  api.DnsRouteTargetDTO:
+    properties:
+      fallback:
+        example: auto
+        type: string
+      interface:
+        example: nwg0
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.DnsRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.DnsRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ExternalTunnelDTO:
+    properties:
+      endpoint:
+        example: ext.example.com:51820
+        type: string
+      interfaceName:
+        example: Wireguard2
+        type: string
+      isAWG:
+        example: true
+        type: boolean
+      publicKey:
+        example: KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK=
+        type: string
+      rxBytes:
+        example: 1048576
+        type: integer
+      tunnelNumber:
+        example: 2
+        type: integer
+      txBytes:
+        example: 524288
+        type: integer
+    type: object
+  api.ExternalTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.ExternalTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.HealthData:
+    properties:
+      ok:
+        example: true
+        type: boolean
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.HealthResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.HealthData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.HydraRouteStatusData:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      running:
+        example: true
+        type: boolean
+      version:
+        example: 0.3.1
+        type: string
+    type: object
+  api.HydraRouteStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.HydraRouteStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.IPCheckServiceDTO:
+    properties:
+      label:
+        example: ipinfo.io
+        type: string
+      url:
+        example: https://ipinfo.io/ip
+        type: string
+    type: object
+  api.IPResultData:
+    properties:
+      directIp:
+        example: 203.0.113.1
+        type: string
+      endpointIp:
+        example: 203.0.113.42
+        type: string
+      ipChanged:
+        example: true
+        type: boolean
+      vpnIp:
+        example: 185.220.101.1
+        type: string
+    type: object
+  api.IPResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.IPResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.IPServicesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.IPCheckServiceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.LogEntryDTO:
+    properties:
+      action:
+        example: connect
+        type: string
+      group:
+        example: tunnel
+        type: string
+      level:
+        example: info
+        type: string
+      message:
+        example: Tunnel connected
+        type: string
+      subgroup:
+        example: tun_abc123
+        type: string
+      target:
+        example: vpn.example.com:51820
+        type: string
+      timestamp:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.LoggingSettingsDTO:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      logLevel:
+        example: info
+        type: string
+      maxAge:
+        example: 7
+        type: integer
+    type: object
   api.LoginRequest:
     properties:
       login:
         type: string
       password:
         type: string
+    type: object
+  api.LoginResponseRaw:
+    properties:
+      login:
+        example: admin
+        type: string
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.LogsData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      logs:
+        items:
+          $ref: '#/definitions/api.LogEntryDTO'
+        type: array
+      total:
+        example: 42
+        type: integer
+    type: object
+  api.LogsResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.LogsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ManagedPeerStatsDTO:
+    properties:
+      endpoint:
+        example: 5.6.7.8:54321
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF=
+        type: string
+      rxBytes:
+        example: 2097152
+        type: integer
+      txBytes:
+        example: 1048576
+        type: integer
+    type: object
+  api.ManagedServerStatsDTO:
+    properties:
+      peers:
+        items:
+          $ref: '#/definitions/api.ManagedPeerStatsDTO'
+        type: array
+      status:
+        example: up
+        type: string
+    type: object
+  api.MonitoringCellDTO:
+    properties:
+      activeForRestart:
+        example: false
+        type: boolean
+      isSelf:
+        example: false
+        type: boolean
+      latencyMs:
+        example: 42
+        type: integer
+      ok:
+        example: true
+        type: boolean
+      targetId:
+        example: target_google
+        type: string
+      ts:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.MonitoringHistoryResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.MonitoringSampleDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.MonitoringSampleDTO:
+    properties:
+      latencyMs:
+        example: 42
+        type: integer
+      ok:
+        example: true
+        type: boolean
+      ts:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.MonitoringSnapshotData:
+    properties:
+      cells:
+        items:
+          $ref: '#/definitions/api.MonitoringCellDTO'
+        type: array
+      targets:
+        items:
+          $ref: '#/definitions/api.MonitoringTargetDTO'
+        type: array
+      tunnels:
+        items:
+          $ref: '#/definitions/api.MonitoringTunnelDTO'
+        type: array
+      updatedAt:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.MonitoringSnapshotResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.MonitoringSnapshotData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.MonitoringTargetDTO:
+    properties:
+      host:
+        example: https://www.google.com
+        type: string
+      id:
+        example: target_google
+        type: string
+      name:
+        example: Google
+        type: string
+    type: object
+  api.MonitoringTunnelDTO:
+    properties:
+      id:
+        example: tun_abc123
+        type: string
+      ifaceName:
+        example: nwg0
+        type: string
+      name:
+        example: My VPN
+        type: string
+      pingcheckTarget:
+        example: target_google
+        type: string
+      selfMethod:
+        example: http
+        type: string
+      selfTarget:
+        example: target_self_tun_abc123
+        type: string
+    type: object
+  api.NativePingCheckStatusDTO:
+    properties:
+      bound:
+        example: true
+        type: boolean
+      exists:
+        example: true
+        type: boolean
+      failCount:
+        example: 0
+        type: integer
+      host:
+        example: https://www.google.com
+        type: string
+      interval:
+        example: 30
+        type: integer
+      maxFails:
+        example: 3
+        type: integer
+      minSuccess:
+        example: 1
+        type: integer
+      mode:
+        example: connect
+        type: string
+      restart:
+        example: true
+        type: boolean
+      status:
+        example: alive
+        type: string
+      successCount:
+        example: 120
+        type: integer
+      timeout:
+        example: 5
+        type: integer
+    type: object
+  api.NativePingCheckStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.NativePingCheckStatusDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PingCheckDefaultsDTO:
+    properties:
+      deadInterval:
+        example: 120
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      interval:
+        example: 30
+        type: integer
+      method:
+        example: http
+        type: string
+      target:
+        example: https://www.google.com
+        type: string
+    type: object
+  api.PingCheckSettingsDTO:
+    properties:
+      defaults:
+        $ref: '#/definitions/api.PingCheckDefaultsDTO'
+      enabled:
+        example: true
+        type: boolean
+    type: object
+  api.PingCheckStatusData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      tunnels:
+        items:
+          $ref: '#/definitions/api.TunnelPingStatusDTO'
+        type: array
+    type: object
+  api.PingCheckStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.PingCheckStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PingLogEntryDTO:
+    properties:
+      error:
+        example: ""
+        type: string
+      failCount:
+        example: 0
+        type: integer
+      latency:
+        example: 35
+        type: integer
+      stateChange:
+        example: ""
+        type: string
+      success:
+        example: true
+        type: boolean
+      threshold:
+        example: 3
+        type: integer
+      timestamp:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.PingLogsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.PingLogEntryDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PolicyGlobalInterfaceDTO:
+    properties:
+      label:
+        example: My VPN
+        type: string
+      name:
+        example: nwg0
+        type: string
+      up:
+        example: true
+        type: boolean
+    type: object
+  api.PolicyInterfacesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.PolicyGlobalInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyConfigResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DeviceProxyConfigData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyListenChoicesData:
+    properties:
+      lanIP:
+        example: 192.168.1.1
+        type: string
+      singboxRunning:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyListenChoicesResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ProxyListenChoicesData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyOutboundsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.DeviceProxyOutboundDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyRuntimeResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DeviceProxyRuntimeData'
+      success:
+        example: true
+        type: boolean
     type: object
   api.ResolveResponse:
     properties:
@@ -25,6 +1195,35 @@ definitions:
           type: string
         type: array
     type: object
+  api.RouterInterfaceDTO:
+    properties:
+      label:
+        example: Home Network
+        type: string
+      name:
+        example: br0
+        type: string
+      up:
+        example: true
+        type: boolean
+    type: object
+  api.RoutingRefreshData:
+    properties:
+      missing:
+        example:
+        - ""
+        items:
+          type: string
+        type: array
+    type: object
+  api.RoutingRefreshResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.RoutingRefreshData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.SaveStatusDTO:
     properties:
       lastError:
@@ -35,6 +1234,965 @@ definitions:
         type: integer
       state:
         type: string
+    type: object
+  api.ServerSettingsDTO:
+    properties:
+      interface:
+        example: ""
+        type: string
+      port:
+        example: 8080
+        type: integer
+    type: object
+  api.ServersAllData:
+    properties:
+      managedStats:
+        $ref: '#/definitions/api.ManagedServerStatsDTO'
+      servers:
+        items:
+          $ref: '#/definitions/api.WireguardServerDTO'
+        type: array
+      wanIP:
+        example: 203.0.113.42
+        type: string
+    type: object
+  api.ServersAllResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ServersAllData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SettingsData:
+    properties:
+      authEnabled:
+        example: false
+        type: boolean
+      disableMemorySaving:
+        example: false
+        type: boolean
+      dnsRoute:
+        $ref: '#/definitions/api.DNSRouteSettingsDTO'
+      logging:
+        $ref: '#/definitions/api.LoggingSettingsDTO'
+      pingCheck:
+        $ref: '#/definitions/api.PingCheckSettingsDTO'
+      schemaVersion:
+        example: 3
+        type: integer
+      server:
+        $ref: '#/definitions/api.ServerSettingsDTO'
+      updates:
+        $ref: '#/definitions/api.UpdateSettingsDTO'
+    type: object
+  api.SettingsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SettingsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SignatureCaptureData:
+    properties:
+      ok:
+        example: true
+        type: boolean
+      packets:
+        $ref: '#/definitions/api.SignaturePacketsDTO'
+      source:
+        example: Wireguard0
+        type: string
+      warning:
+        example: ""
+        type: string
+    type: object
+  api.SignatureCaptureResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SignatureCaptureData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SignaturePacketsDTO:
+    properties:
+      i1:
+        example: 0a1b2c3d
+        type: string
+      i2:
+        example: 4e5f6a7b
+        type: string
+      i3:
+        example: 8c9d0e1f
+        type: string
+      i4:
+        example: 2a3b4c5d
+        type: string
+      i5:
+        example: 6e7f8a9b
+        type: string
+    type: object
+  api.SingboxStatusData:
+    properties:
+      features:
+        example:
+        - with_quic
+        items:
+          type: string
+        type: array
+      installed:
+        example: true
+        type: boolean
+      pid:
+        example: 12345
+        type: integer
+      proxyComponent:
+        example: true
+        type: boolean
+      running:
+        example: true
+        type: boolean
+      tunnelCount:
+        example: 2
+        type: integer
+      version:
+        example: 1.9.3
+        type: string
+    type: object
+  api.SingboxStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxTunnelConnectivity:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      latency:
+        example: 42
+        type: integer
+    type: object
+  api.SingboxTunnelDTO:
+    properties:
+      connectivity:
+        $ref: '#/definitions/api.SingboxTunnelConnectivity'
+      fingerprint:
+        example: chrome
+        type: string
+      listenPort:
+        example: 7891
+        type: integer
+      port:
+        example: 443
+        type: integer
+      protocol:
+        example: vless
+        type: string
+      proxyInterface:
+        example: br0
+        type: string
+      running:
+        example: true
+        type: boolean
+      security:
+        example: reality
+        type: string
+      server:
+        example: proxy.example.com
+        type: string
+      sni:
+        example: cdn.example.com
+        type: string
+      tag:
+        example: proxy-01
+        type: string
+      transport:
+        example: tcp
+        type: string
+    type: object
+  api.SingboxTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestInfoData:
+    properties:
+      available:
+        example: true
+        type: boolean
+      servers:
+        items:
+          $ref: '#/definitions/api.SpeedTestServerDTO'
+        type: array
+    type: object
+  api.SpeedTestInfoResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SpeedTestInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestResultData:
+    properties:
+      bandwidth:
+        example: 52428800
+        type: number
+      bytes:
+        example: 157286400
+        type: integer
+      direction:
+        example: download
+        type: string
+      duration:
+        example: 3
+        type: number
+      retransmits:
+        example: 0
+        type: integer
+      server:
+        example: speedtest.msk.ru
+        type: string
+    type: object
+  api.SpeedTestResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SpeedTestResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestServerDTO:
+    properties:
+      host:
+        example: speedtest.msk.ru
+        type: string
+      label:
+        example: Moscow, RU
+        type: string
+      port:
+        example: 5201
+        type: integer
+    type: object
+  api.StaticRouteDTO:
+    properties:
+      createdAt:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      fallback:
+        example: ""
+        type: string
+      id:
+        example: sr_001
+        type: string
+      name:
+        example: Office subnets
+        type: string
+      subnets:
+        example:
+        - 192.168.10.0/24
+        items:
+          type: string
+        type: array
+      tunnelID:
+        example: tun_abc123
+        type: string
+      updatedAt:
+        example: "2024-01-15T12:00:00Z"
+        type: string
+    type: object
+  api.StaticRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.StaticRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoBackendAvailability:
+    properties:
+      kernel:
+        example: false
+        type: boolean
+      nativewg:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoData:
+    properties:
+      activeBackend:
+        example: nativewg
+        type: string
+      backendAvailability:
+        $ref: '#/definitions/api.SystemInfoBackendAvailability'
+      bootInProgress:
+        example: false
+        type: boolean
+      disableMemorySaving:
+        example: false
+        type: boolean
+      firmwareVersion:
+        example: 4.2.1
+        type: string
+      gcMemLimit:
+        example: 128MiB
+        type: string
+      goArch:
+        example: arm64
+        type: string
+      goOS:
+        example: linux
+        type: string
+      goVersion:
+        example: go1.23.0
+        type: string
+      gogc:
+        example: "25"
+        type: string
+      isAarch64:
+        example: true
+        type: boolean
+      isLowMemory:
+        example: false
+        type: boolean
+      isOS5:
+        example: true
+        type: boolean
+      keeneticOS:
+        example: ndms
+        type: string
+      kernelModuleExists:
+        example: true
+        type: boolean
+      kernelModuleLoaded:
+        example: false
+        type: boolean
+      kernelModuleModel:
+        example: MT7981
+        type: string
+      kernelModuleVersion:
+        example: ""
+        type: string
+      routerIP:
+        example: 192.168.1.1
+        type: string
+      singbox:
+        $ref: '#/definitions/api.SystemInfoSingbox'
+      supportsExtendedASC:
+        example: true
+        type: boolean
+      supportsHRanges:
+        example: true
+        type: boolean
+      supportsPingCheck:
+        example: true
+        type: boolean
+      totalMemoryMB:
+        example: 512
+        type: integer
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.SystemInfoResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SystemInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoSingbox:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      version:
+        example: 1.9.3
+        type: string
+    type: object
+  api.SystemTunnelDTO:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      description:
+        example: Home Server
+        type: string
+      id:
+        example: Wireguard0
+        type: string
+      interfaceName:
+        example: Wireguard0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      peer:
+        $ref: '#/definitions/api.SystemTunnelPeerDTO'
+      status:
+        example: up
+        type: string
+    type: object
+  api.SystemTunnelPeerDTO:
+    properties:
+      endpoint:
+        example: vpn2.example.com:51820
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=
+        type: string
+      rxBytes:
+        example: 2097152
+        type: integer
+      txBytes:
+        example: 1048576
+        type: integer
+    type: object
+  api.SystemTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SystemTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TerminalStartData:
+    properties:
+      port:
+        example: 7681
+        type: integer
+    type: object
+  api.TerminalStartResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TerminalStartData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TerminalStatusResponse:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      running:
+        example: false
+        type: boolean
+      sessionActive:
+        example: false
+        type: boolean
+    type: object
+  api.TunnelControlData:
+    properties:
+      id:
+        example: tun_abc123
+        type: string
+      status:
+        example: connected
+        type: string
+    type: object
+  api.TunnelControlResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelControlData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDeleteResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelDeleteResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDeleteResultData:
+    properties:
+      success:
+        example: true
+        type: boolean
+      tunnelId:
+        example: tun_abc123
+        type: string
+      verified:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDetailResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.AWGTunnelDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelListItemDTO:
+    properties:
+      address:
+        example: 10.0.0.2/32
+        type: string
+      awgVersion:
+        enum:
+        - wg
+        - awg1.0
+        - awg1.5
+        - awg2.0
+        example: awg2.0
+        type: string
+      backend:
+        enum:
+        - nativewg
+        - kernel
+        example: nativewg
+        type: string
+      defaultRoute:
+        example: false
+        type: boolean
+      enabled:
+        example: true
+        type: boolean
+      endpoint:
+        example: vpn.example.com:51820
+        type: string
+      hasAddressConflict:
+        example: false
+        type: boolean
+      id:
+        example: tun_abc123
+        type: string
+      interfaceName:
+        example: nwg0
+        type: string
+      ispInterface:
+        example: PPPoE0
+        type: string
+      ispInterfaceLabel:
+        example: WAN
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      name:
+        example: My AWG Tunnel
+        type: string
+      ndmsName:
+        example: Wireguard0
+        type: string
+      pingCheck:
+        $ref: '#/definitions/api.TunnelPingCheckStatus'
+      resolvedIspInterface:
+        example: PPPoE0
+        type: string
+      resolvedIspInterfaceLabel:
+        example: WAN
+        type: string
+      rxBytes:
+        example: 10485760
+        type: integer
+      startedAt:
+        example: "2024-01-15T10:00:00Z"
+        type: string
+      status:
+        enum:
+        - connected
+        - disconnected
+        - error
+        - disabled
+        example: connected
+        type: string
+      txBytes:
+        example: 5242880
+        type: integer
+      type:
+        enum:
+        - awg
+        - wg
+        example: awg
+        type: string
+    type: object
+  api.TunnelListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.TunnelListItemDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelPingCheckStatus:
+    properties:
+      failCount:
+        example: 0
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      restartCount:
+        example: 0
+        type: integer
+      status:
+        example: alive
+        type: string
+    type: object
+  api.TunnelPingStatusDTO:
+    properties:
+      backend:
+        example: nativewg
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      failCount:
+        example: 0
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      lastLatency:
+        example: 35
+        type: integer
+      method:
+        example: http
+        type: string
+      restartCount:
+        example: 0
+        type: integer
+      status:
+        example: alive
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.TunnelStateInfoDTO:
+    properties:
+      hasHandshake:
+        example: true
+        type: boolean
+      interfaceUp:
+        example: true
+        type: boolean
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      processRunning:
+        example: true
+        type: boolean
+      rxBytes:
+        example: 10485760
+        type: integer
+      state:
+        example: 3
+        type: integer
+      txBytes:
+        example: 5242880
+        type: integer
+    type: object
+  api.TunnelTrafficData:
+    properties:
+      points:
+        items:
+          $ref: '#/definitions/api.TunnelTrafficPoint'
+        type: array
+      stats:
+        $ref: '#/definitions/api.TunnelTrafficStats'
+    type: object
+  api.TunnelTrafficPoint:
+    properties:
+      rx:
+        example: 1024000
+        type: integer
+      t:
+        example: 1705312200
+        type: integer
+      tx:
+        example: 512000
+        type: integer
+    type: object
+  api.TunnelTrafficResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelTrafficData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelTrafficStats:
+    properties:
+      avgRx:
+        example: 524288
+        type: number
+      avgTx:
+        example: 262144
+        type: number
+      currentRx:
+        example: 102400
+        type: number
+      currentTx:
+        example: 51200
+        type: number
+      peakRate:
+        example: 1048576
+        type: number
+      points:
+        example: 60
+        type: integer
+    type: object
+  api.TunnelsAllResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelsAllSnapshotData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelsAllSnapshotData:
+    properties:
+      external:
+        items:
+          $ref: '#/definitions/api.ExternalTunnelDTO'
+        type: array
+      system:
+        items:
+          $ref: '#/definitions/api.SystemTunnelDTO'
+        type: array
+      tunnels:
+        items:
+          $ref: '#/definitions/api.TunnelListItemDTO'
+        type: array
+    type: object
+  api.UpdateApplyData:
+    properties:
+      status:
+        example: updating
+        type: string
+    type: object
+  api.UpdateApplyResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.UpdateApplyData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.UpdateCheckResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.UpdateInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.UpdateInfoData:
+    properties:
+      available:
+        example: false
+        type: boolean
+      checkedAt:
+        example: "2024-01-15T10:00:00Z"
+        type: string
+      checking:
+        example: false
+        type: boolean
+      currentVersion:
+        example: 2.5.0
+        type: string
+      latestVersion:
+        example: 2.5.0
+        type: string
+    type: object
+  api.UpdatePeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      tunnelIP:
+        example: 10.10.0.2/32
+        type: string
+    type: object
+  api.UpdateServerRequestDTO:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      description:
+        example: My WG Server
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      endpoint:
+        example: 203.0.113.42:51821
+        type: string
+      listenPort:
+        example: 51821
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+    type: object
+  api.UpdateSettingsDTO:
+    properties:
+      checkEnabled:
+        example: true
+        type: boolean
+    type: object
+  api.WANIPData:
+    properties:
+      ip:
+        example: 203.0.113.42
+        type: string
+    type: object
+  api.WANIPResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.WANIPData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WANInterfaceDTO:
+    properties:
+      label:
+        example: Home Internet
+        type: string
+      name:
+        example: ISP1
+        type: string
+      state:
+        example: up
+        type: string
+    type: object
+  api.WANInterfacesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.WANInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WANStatusEnvelope:
+    properties:
+      data:
+        properties:
+          anyWANUp:
+            example: true
+            type: boolean
+        type: object
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WireguardServerDTO:
+    properties:
+      address:
+        example: 10.0.1.1
+        type: string
+      connected:
+        example: true
+        type: boolean
+      description:
+        example: Wireguard VPN Server
+        type: string
+      id:
+        example: Wireguard0
+        type: string
+      interfaceName:
+        example: Wireguard0
+        type: string
+      listenPort:
+        example: 51820
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      peers:
+        items:
+          $ref: '#/definitions/api.WireguardServerPeerDTO'
+        type: array
+      publicKey:
+        example: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE=
+        type: string
+      status:
+        example: up
+        type: string
+    type: object
+  api.WireguardServerPeerDTO:
+    properties:
+      allowedIPs:
+        example:
+        - 10.0.1.2/32
+        items:
+          type: string
+        type: array
+      description:
+        example: Phone
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      endpoint:
+        example: 1.2.3.4:12345
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD=
+        type: string
+      rxBytes:
+        example: 1048576
+        type: integer
+      txBytes:
+        example: 524288
+        type: integer
     type: object
 info:
   contact: {}
@@ -62,8 +2220,10 @@ paths:
       - access-policy
   /access-policies/assign:
     delete:
+      description: Removes the policy binding for the LAN device identified by MAC.
+        The device falls back to the default policy.
       parameters:
-      - description: Device MAC
+      - description: Device MAC address
         in: query
         name: mac
         required: true
@@ -76,14 +2236,34 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Unassign device from policy
       tags:
-      - access-policy
+      - access-policies
     post:
       consumes:
       - application/json
+      description: Binds the LAN device identified by MAC to the named policy. Replaces
+        any existing assignment.
+      parameters:
+      - description: '{mac, policy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -92,11 +2272,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Assign device to policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/create:
     post:
       consumes:
@@ -116,8 +2306,10 @@ paths:
       - access-policy
   /access-policies/delete:
     delete:
+      description: Removes the named access policy. Bound LAN devices revert to the
+        default policy.
       parameters:
-      - description: Policy name
+      - description: Policy name (e.g. Policy0)
         in: query
         name: name
         required: true
@@ -130,11 +2322,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Delete access policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/description:
     post:
       consumes:
@@ -205,6 +2407,7 @@ paths:
       - access-policy
   /access-policies/permit:
     delete:
+      description: Removes the named interface from the policy.
       parameters:
       - description: Policy name
         in: query
@@ -224,14 +2427,34 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Remove permitted interface
+      summary: Deny interface for policy
       tags:
-      - access-policy
+      - access-policies
     post:
       consumes:
       - application/json
+      description: Adds the named interface to the policy at the given order (lower
+        = higher priority).
+      parameters:
+      - description: '{name, interface, order}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -240,11 +2463,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Permit interface on policy
+      summary: Permit interface for policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/standalone:
     post:
       consumes:
@@ -279,25 +2512,21 @@ paths:
       - application/json
       responses:
         "200":
-          description: success, login
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.LoginResponseRaw'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "401":
           description: Unauthorized
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "503":
           description: Service Unavailable
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Login
       tags:
       - auth
@@ -309,8 +2538,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Logout
       tags:
       - auth
@@ -320,10 +2556,17 @@ paths:
       - application/json
       responses:
         "200":
-          description: authenticated, login, expiresIn, authDisabled
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.AuthStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Auth status
       tags:
       - auth
@@ -336,8 +2579,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.BootStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Boot status
       tags:
       - system
@@ -349,10 +2599,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List client routes
@@ -368,8 +2623,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create client route
@@ -389,8 +2651,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete client route
@@ -412,8 +2681,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle client route
@@ -435,8 +2711,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update client route
@@ -450,8 +2733,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ConnectionsResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Connections list
@@ -471,8 +2761,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart tunnel
@@ -486,10 +2783,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart all enabled tunnels
@@ -509,8 +2811,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start tunnel
@@ -530,8 +2839,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Stop tunnel
@@ -551,8 +2867,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle default route
@@ -572,8 +2895,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle tunnel autostart
@@ -588,6 +2918,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Download diagnostics report
@@ -601,8 +2939,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Run diagnostics
@@ -616,8 +2961,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DiagnosticsStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Diagnostics status
@@ -632,6 +2984,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Diagnostics SSE stream
@@ -645,8 +3005,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: DNS check probe (CORS)
       tags:
       - dns-check
@@ -658,8 +3025,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsCheckStartResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start DNS check
@@ -675,10 +3049,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Bulk set DNS route backend
@@ -694,8 +3073,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create DNS route list
@@ -711,8 +3097,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create DNS route lists (batch)
@@ -732,10 +3125,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete DNS route list
@@ -751,10 +3149,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete DNS route lists (batch)
@@ -774,8 +3177,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get DNS route list
@@ -789,10 +3199,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.DnsRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List DNS route lists
@@ -811,8 +3226,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Refresh DNS route subscriptions
@@ -834,10 +3256,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set DNS route list enabled
@@ -859,8 +3286,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update DNS route list
@@ -875,6 +3309,14 @@ paths:
           description: Server-Sent Events
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: SSE event stream
@@ -888,9 +3330,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              type: object
-            type: array
+            $ref: '#/definitions/api.ExternalTunnelsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List external tunnels
@@ -918,8 +3366,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Adopt external tunnel
@@ -932,10 +3387,17 @@ paths:
       - application/json
       responses:
         "200":
-          description: ok, version
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HealthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Health / liveness
       tags:
       - system
@@ -957,8 +3419,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: NDMS shell hook
       tags:
       - hook
@@ -982,11 +3451,31 @@ paths:
     put:
       consumes:
       - application/json
+      description: Persists the HydraRoute (HrNeo) config and schedules a neo restart.
+        The cached status becomes stale and is invalidated via SSE.
+      parameters:
+      - description: hydraroute.Config
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1031,8 +3520,10 @@ paths:
       - hydraroute
   /hydraroute/geo-files/delete:
     delete:
+      description: Removes the tracked geo data file at the given path and re-syncs
+        the geo file list to config.
       parameters:
-      - description: File path
+      - description: Filesystem path of the geo file
         in: query
         name: path
         required: true
@@ -1042,6 +3533,16 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1146,8 +3647,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Import tunnel config
@@ -1161,8 +3669,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.LogsResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get logs
@@ -1176,15 +3691,24 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Clear logs
       tags:
       - logs
-  /managed-server:
+  /managed-servers:
     get:
+      description: Returns every managed server (id, address, listen port, peers,
+        ASC, NAT, enabled flag, ...). Always a JSON array, never null.
       produces:
       - application/json
       responses:
@@ -1193,29 +3717,28 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Get managed WireGuard server
-      tags:
-      - managed-server
-  /managed-server/asc:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "405":
+          description: Method Not Allowed
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
-      summary: Get managed server ASC
+      summary: List managed servers
       tags:
-      - managed-server
+      - managed-servers
     post:
       consumes:
       - application/json
+      description: Creates a new managed WireGuard server. The id is allocated server-side
+        (next free Wireguard{N} slot).
+      parameters:
+      - description: Address, mask, port, ASC, name
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateServerRequestDTO'
       produces:
       - application/json
       responses:
@@ -1224,20 +3747,13 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server ASC
-      tags:
-      - managed-server
-  /managed-server/create:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1245,14 +3761,32 @@ paths:
       - CookieAuth: []
       summary: Create managed server
       tags:
-      - managed-server
-  /managed-server/delete:
+      - managed-servers
+  /managed-servers/{id}:
     delete:
+      description: Removes the named managed server along with all its peers. Returns
+        the fresh ServersSnapshot.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1260,64 +3794,13 @@ paths:
       - CookieAuth: []
       summary: Delete managed server
       tags:
-      - managed-server
-  /managed-server/enabled:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Enable/disable managed server
-      tags:
-      - managed-server
-  /managed-server/nat:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server NAT
-      tags:
-      - managed-server
-  /managed-server/peers:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Add managed server peer
-      tags:
-      - managed-server
-  /managed-server/peers/conf:
+      - managed-servers
     get:
+      description: Returns a single managed server by id (Wireguard{N}).
       parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
+      - description: Server id (e.g. Wireguard0)
+        in: path
+        name: id
         required: true
         type: string
       produces:
@@ -1328,59 +3811,38 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Peer WireGuard conf
-      tags:
-      - managed-server
-  /managed-server/peers/delete:
-    delete:
-      parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
-      summary: Delete managed server peer
+      summary: Get managed server
       tags:
-      - managed-server
-  /managed-server/peers/toggle:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Toggle managed server peer
-      tags:
-      - managed-server
-  /managed-server/peers/update:
+      - managed-servers
     put:
       consumes:
       - application/json
+      description: Updates a managed server's address, listen port, name, and/or other
+        top-level fields. Returns the fresh ServersSnapshot.
       parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
+      - description: Server id
+        in: path
+        name: id
         required: true
         type: string
+      - description: Update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateServerRequestDTO'
       produces:
       - application/json
       responses:
@@ -1389,84 +3851,18 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Update managed server peer
-      tags:
-      - managed-server
-  /managed-server/policies:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List IP policy profiles
-      tags:
-      - managed-server
-  /managed-server/policy:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "400":
+          description: Bad Request
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server hotspot policy
-      tags:
-      - managed-server
-  /managed-server/stats:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "404":
+          description: Not Found
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Managed server stats
-      tags:
-      - managed-server
-  /managed-server/suggest-address:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Suggest managed server address
-      tags:
-      - managed-server
-  /managed-server/update:
-    put:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1474,7 +3870,581 @@ paths:
       - CookieAuth: []
       summary: Update managed server
       tags:
-      - managed-server
+      - managed-servers
+  /managed-servers/{id}/asc:
+    get:
+      consumes:
+      - application/json
+      description: GET reads, PUT writes the AWG signature/obfuscation params for
+        the named managed server. PUT body is the raw ASC JSON object.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: ASC params (PUT only)
+        in: body
+        name: body
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get/set managed-server ASC params
+      tags:
+      - managed-servers
+    put:
+      consumes:
+      - application/json
+      description: GET reads, PUT writes the AWG signature/obfuscation params for
+        the named managed server. PUT body is the raw ASC JSON object.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: ASC params (PUT only)
+        in: body
+        name: body
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get/set managed-server ASC params
+      tags:
+      - managed-servers
+  /managed-servers/{id}/enabled:
+    post:
+      consumes:
+      - application/json
+      description: Brings the named managed server interface up or down (and persists
+        the desired state).
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server enabled
+      tags:
+      - managed-servers
+  /managed-servers/{id}/nat:
+    post:
+      consumes:
+      - application/json
+      description: Enables or disables NAT (masquerade) on the named managed server
+        interface.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server NAT
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers:
+    post:
+      consumes:
+      - application/json
+      description: Adds a new peer to the named managed server. The pubkey is generated
+        server-side if absent.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.AddPeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add managed-server peer
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}:
+    delete:
+      description: Removes the peer identified by pubkey from the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed-server peer
+      tags:
+      - managed-servers
+    put:
+      consumes:
+      - application/json
+      description: Updates fields (name, allowed-ips, ...) of the peer identified
+        by pubkey on the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: Peer update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdatePeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed-server peer
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}/conf:
+    get:
+      description: Returns the WireGuard client .conf for the peer identified by pubkey
+        on the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Generate peer .conf
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}/toggle:
+    post:
+      consumes:
+      - application/json
+      description: Enables or disables the peer identified by pubkey on the named
+        managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server peer enabled
+      tags:
+      - managed-servers
+  /managed-servers/{id}/policy:
+    post:
+      consumes:
+      - application/json
+      description: Updates the IP hotspot policy bound to the managed server interface.
+        The policy must exist (see /managed-servers/policies).
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{policy: string}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed-server IP policy
+      tags:
+      - managed-servers
+  /managed-servers/{id}/stats:
+    get:
+      description: Returns per-peer runtime stats (handshake, rx/tx) for the named
+        managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed-server peer stats
+      tags:
+      - managed-servers
+  /managed-servers/policies:
+    get:
+      description: Returns the global router catalog of IP Policy profiles for use
+        by the per-server policy dropdown. Always a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List IP Policy profiles
+      tags:
+      - managed-servers
+  /managed-servers/suggest-address:
+    get:
+      description: Returns a free private /24 (address, mask) for the create-server
+        UI. Avoids collisions with already-used managed-server subnets.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Suggest managed-server address
+      tags:
+      - managed-servers
+  /monitoring/history:
+    get:
+      description: Returns up to `limit` (default 60) most-recent samples for a single
+        (target, tunnelId) pair, oldest-first.
+      parameters:
+      - description: Target identifier
+        in: query
+        name: target
+        required: true
+        type: string
+      - description: Tunnel identifier
+        in: query
+        name: tunnelId
+        required: true
+        type: string
+      - description: Max samples to return (default 60)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MonitoringHistoryResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get monitoring history
+      tags:
+      - monitoring
+  /monitoring/matrix:
+    get:
+      description: Returns the latest cross-tunnel × cross-target latency/loss matrix
+        snapshot. Responds 503 until the monitoring service has finished bootstrap.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MonitoringSnapshotResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get monitoring matrix snapshot
+      tags:
+      - monitoring
   /ndms/save-status:
     get:
       produces:
@@ -1484,6 +4454,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.SaveStatusDTO'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: NDMS save coordinator status
@@ -1497,8 +4475,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Trigger ping check now
@@ -1517,10 +4502,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.PingLogsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Ping check logs
@@ -1534,8 +4524,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Clear ping check logs
@@ -1549,8 +4546,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PingCheckStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Ping check status
@@ -1564,8 +4568,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Force apply device proxy
@@ -1579,8 +4590,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get device proxy config
@@ -1595,8 +4613,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Save device proxy config
@@ -1610,8 +4635,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyListenChoicesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Device proxy listen choices
@@ -1625,10 +4657,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ProxyOutboundsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List device proxy outbounds
@@ -1642,8 +4679,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyRuntimeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Device proxy runtime state
@@ -1659,8 +4703,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyRuntimeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Select device proxy outbound
@@ -1675,8 +4726,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.AccessPoliciesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: OS4 access policies stub
@@ -1690,10 +4748,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List client routes
@@ -1707,10 +4770,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.DnsRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List DNS route lists
@@ -1742,8 +4810,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PolicyInterfacesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: OS4 policy interfaces stub
@@ -1757,8 +4832,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.RoutingRefreshResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Invalidate routing caches
@@ -1779,6 +4861,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.ResolveResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Resolve domain
@@ -1792,10 +4882,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List static routes
@@ -1812,89 +4907,46 @@ paths:
             items:
               type: object
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Routing tunnel catalog
       tags:
       - routing
-  /servers:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List VPN server interfaces
-      tags:
-      - servers
   /servers/all:
     get:
+      description: 'Returns the composite servers snapshot: WireGuard servers list,
+        managed server, stats and WAN IP.'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Servers composite snapshot
-      tags:
-      - servers
-  /servers/config:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+            $ref: '#/definitions/api.ServersAllResponse'
+        "500":
+          description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: Server RC config for export
-      tags:
-      - servers
-  /servers/get:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Get VPN server by name
+      summary: Get all servers snapshot
       tags:
       - servers
   /servers/mark:
     delete:
+      description: POST marks the named WG interface as a server (visible under Servers,
+        hidden from Tunnels). DELETE unmarks (returns it to the Tunnels list). Both
+        return the fresh ServersSnapshot.
       parameters:
-      - description: NDMS interface name
+      - description: Interface name (e.g. Wireguard0)
         in: query
         name: name
         required: true
@@ -1907,14 +4959,27 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Unmark server interface
+      summary: Mark/unmark interface as server
       tags:
       - servers
     post:
+      description: POST marks the named WG interface as a server (visible under Servers,
+        hidden from Tunnels). DELETE unmarks (returns it to the Tunnels list). Both
+        return the fresh ServersSnapshot.
       parameters:
-      - description: NDMS interface name
+      - description: Interface name (e.g. Wireguard0)
         in: query
         name: name
         required: true
@@ -1927,69 +4992,139 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Mark server interface
+      summary: Mark/unmark interface as server
       tags:
       - servers
   /servers/marked:
     get:
+      description: Returns the list of interface IDs that have been marked as servers.
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              type: string
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: List marked server interface ids
+      summary: Get marked server interfaces
       tags:
       - servers
   /servers/wan-ip:
     get:
+      description: Returns the router's external WAN IP address.
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.WANIPResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: WAN IP for server conf
+      summary: Get WAN IP
       tags:
       - servers
   /settings/get:
     get:
+      description: Returns the full Settings object (server, pingCheck, logging, dnsRoute,
+        managed, apiKey, ...).
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SettingsResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get settings
+      tags:
+      - settings
+  /settings/regenerate-api-key:
+    post:
+      description: 'Generates a fresh UUID v4 via crypto/rand, stores it into Settings.ApiKey,
+        and returns the updated Settings. The new key takes effect immediately as
+        a `Authorization: Bearer <key>` substitute for the session cookie.'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SettingsResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Regenerate API key
       tags:
       - settings
   /settings/update:
     post:
       consumes:
       - application/json
+      description: Persists Settings. Sub-structs (server, pingCheck, logging, dnsRoute,
+        managedServers, ...) preserved when zero/nil. ApiKey preserved when empty
+        (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled,
+        disableMemorySaving, onboardingCompleted) MUST be sent on every save.
+      parameters:
+      - description: Settings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SettingsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update settings
@@ -2009,15 +5144,62 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SignatureCaptureResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Signature capture
       tags:
       - signature
-  /singbox/install:
+  /singbox/awg-outbounds/tags:
+    get:
+      description: Returns the catalog of AWG-direct outbound tags currently exposed
+        to sing-box (one per managed/system AWG tunnel). Used by the singbox-router
+        rule editor outbound dropdown.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+        "405":
+          description: Method Not Allowed
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: List AWG outbound tags
+      tags:
+      - singbox
+  /singbox/control:
     post:
+      consumes:
+      - application/json
+      description: Starts, stops, or restarts the sing-box engine. Returns the fresh
+        status snapshot. Mirrors /system/hydraroute-control.
+      parameters:
+      - description: '{action: start|stop|restart}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -2026,11 +5208,1344 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Control sing-box process
+      tags:
+      - singbox
+  /singbox/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Install sing-box
       tags:
       - singbox
+  /singbox/router/disable:
+    post:
+      description: Stops the singbox-router engine and uninstalls iptables/policy
+        rules. Idempotent.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Disable singbox-router
+      tags:
+      - singbox-router
+  /singbox/router/dns/globals:
+    get:
+      description: 'Returns the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get singbox-router DNS globals
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: 'Persists the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      parameters:
+      - description: '{final, strategy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS globals
+      tags:
+      - singbox-router
+    put:
+      consumes:
+      - application/json
+      description: 'Persists the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      parameters:
+      - description: '{final, strategy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS globals
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/add:
+    post:
+      consumes:
+      - application/json
+      description: Appends a new DNS routing rule. The rule's server tag must already
+        exist.
+      parameters:
+      - description: router.DNSRule
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the DNS rule at the given index (0-based priority slot).
+      parameters:
+      - description: '{index}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/list:
+    get:
+      description: Returns all DNS routing rules in priority (top-first) order. Always
+        a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router DNS rules
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/move:
+    post:
+      consumes:
+      - application/json
+      description: Moves the DNS rule from index `from` to index `to` (both 0-based).
+      parameters:
+      - description: '{from, to}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Move singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the DNS rule at the given index (0-based priority slot)
+        with the provided one.
+      parameters:
+      - description: '{index, rule}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/add:
+    post:
+      consumes:
+      - application/json
+      description: Registers a new DNS upstream (tag must be unique).
+      parameters:
+      - description: router.DNSServer
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the DNS upstream identified by tag. Refuses if any DNS
+        rule references it; pass force=true to override.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/list:
+    get:
+      description: Returns all configured DNS upstreams (tag, address, type, ...).
+        Always a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router DNS servers
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the DNS upstream identified by tag with the provided one.
+      parameters:
+      - description: '{tag, server}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/enable:
+    post:
+      description: Starts the singbox-router engine and installs iptables/policy rules.
+        Returns 400 with code POLICY_NOT_CONFIGURED or POLICY_MISSING when the router
+        policy mode is incomplete.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Enable singbox-router
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/add:
+    post:
+      consumes:
+      - application/json
+      description: Creates a new composite outbound. The base outbounds it references
+        must already exist.
+      parameters:
+      - description: router.Outbound
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the composite outbound identified by tag. Refuses if any
+        rule references it; pass force=true to override.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/list:
+    get:
+      description: Returns all composite outbounds (sing-box selectors/urltests over
+        multiple base outbounds).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router outbounds
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the composite outbound identified by tag with the provided
+        one.
+      parameters:
+      - description: '{tag, outbound}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/policies:
+    get:
+      description: Returns all NDMS policies known to the singbox-router engine. Always
+        a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router policies
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: Creates a new NDMS policy with the given description. Returns the
+        created policy.
+      parameters:
+      - description: '{description}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices:
+    get:
+      description: Returns the LAN devices currently bound to the named policy. Always
+        a JSON array, never null.
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router policy devices
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices/bind:
+    post:
+      consumes:
+      - application/json
+      description: Binds the LAN device (MAC) to the named policy. Replaces any existing
+        binding.
+      parameters:
+      - description: '{mac, policyName}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Bind device to singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices/unbind:
+    post:
+      consumes:
+      - application/json
+      description: Removes any policy binding for the LAN device identified by MAC.
+      parameters:
+      - description: '{mac}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unbind device from singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/presets/apply:
+    post:
+      consumes:
+      - application/json
+      description: Materialises the preset (id) into rules + rulesets, routing matched
+        traffic via the selected outbound. Existing rules with the same tag are overwritten.
+      parameters:
+      - description: '{id, outbound}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Apply singbox-router preset
+      tags:
+      - singbox-router
+  /singbox/router/presets/list:
+    get:
+      description: Returns the catalog of built-in presets the user can apply (each
+        preset = a curated bundle of rules + rulesets).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router presets
+      tags:
+      - singbox-router
+  /singbox/router/rules/add:
+    post:
+      consumes:
+      - application/json
+      description: Appends a new routing rule. Rule conditions reference rulesets/outbounds
+        that must already exist.
+      parameters:
+      - description: router.Rule
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the rule at the given index (0-based priority slot).
+      parameters:
+      - description: '{index}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/list:
+    get:
+      description: Returns all routing rules in priority (top-first) order.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router rules
+      tags:
+      - singbox-router
+  /singbox/router/rules/move:
+    post:
+      consumes:
+      - application/json
+      description: Moves the rule from index `from` to index `to` (both 0-based).
+        Adjusts other rules' indices accordingly.
+      parameters:
+      - description: '{from, to}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Move singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the rule at index with the provided one. Index is the
+        priority slot (0-based).
+      parameters:
+      - description: '{index, rule}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/add:
+    post:
+      consumes:
+      - application/json
+      description: Registers a new ruleset. For remote rulesets the file is downloaded
+        synchronously.
+      parameters:
+      - description: router.RuleSet
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the ruleset identified by tag. Refuses if any rule references
+        it; pass force=true to ignore references.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/list:
+    get:
+      description: Returns all configured rulesets (downloaded geo files / inline
+        lists), with their tag, type, and freshness metadata.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router rulesets
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/refresh:
+    post:
+      consumes:
+      - application/json
+      description: Re-downloads the remote ruleset identified by tag and updates its
+        content/timestamp.
+      parameters:
+      - description: '{tag}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/settings:
+    get:
+      description: Reads the current singbox-router settings (policy mode, defaults,
+        ...).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get singbox-router settings
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: Persists singbox-router settings. The router is restarted only
+        when fields that affect the running config change.
+      parameters:
+      - description: storage.SingboxRouterSettings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router settings
+      tags:
+      - singbox-router
+    put:
+      consumes:
+      - application/json
+      description: Persists singbox-router settings. The router is restarted only
+        when fields that affect the running config change.
+      parameters:
+      - description: storage.SingboxRouterSettings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router settings
+      tags:
+      - singbox-router
+  /singbox/router/status:
+    get:
+      description: Returns the singbox-router status snapshot (running, mode, policy/iptables
+        state, rule/ruleset/outbound counts).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get sing-box router status
+      tags:
+      - singbox-router
   /singbox/status:
     get:
       description: Available when sing-box integration is enabled in the build.
@@ -2040,8 +6555,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box status
@@ -2055,8 +6577,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete sing-box tunnel
@@ -2074,8 +6603,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxTunnelsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List or get sing-box tunnel(s)
@@ -2090,8 +6626,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add sing-box tunnel(s)
@@ -2106,8 +6649,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update sing-box tunnel
@@ -2127,8 +6677,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box delay check
@@ -2143,6 +6700,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box tunnel speed test stream
@@ -2158,8 +6723,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create static route
@@ -2179,8 +6751,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete static route
@@ -2196,8 +6775,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Import static routes
@@ -2211,10 +6797,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List static routes
@@ -2236,8 +6827,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set static route enabled
@@ -2253,8 +6851,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update static route
@@ -2268,10 +6873,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: All tunnel statuses
@@ -2291,8 +6901,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Tunnel status
@@ -2300,25 +6917,29 @@ paths:
       - status
   /system-tunnels:
     get:
+      description: Returns all WireGuard tunnels managed by the router OS itself (non-hidden).
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.SystemTunnelsResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: List system WireGuard tunnels
+      summary: List system tunnels
       tags:
       - system-tunnels
   /system-tunnels/asc:
     get:
+      description: Reads AWG signature/obfuscation parameters for the named system
+        (NativeWG / kernel-WG) tunnel.
       parameters:
-      - description: NDMS interface name
+      - description: Tunnel name
         in: query
         name: name
         required: true
@@ -2328,6 +6949,16 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -2337,157 +6968,44 @@ paths:
       tags:
       - system-tunnels
     post:
+      consumes:
+      - application/json
+      description: Persists AWG signature/obfuscation parameters for the named system
+        tunnel. Body is the raw ASC JSON object.
       parameters:
-      - description: NDMS interface name
+      - description: Tunnel name
         in: query
         name: name
         required: true
         type: string
+      - description: ASC params
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
       summary: Set system tunnel ASC params
-      tags:
-      - system-tunnels
-  /system-tunnels/get:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Get system tunnel
-      tags:
-      - system-tunnels
-  /system-tunnels/hidden:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              type: string
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List hidden system tunnels
-      tags:
-      - system-tunnels
-  /system-tunnels/hide:
-    delete:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Unhide system tunnel
-      tags:
-      - system-tunnels
-    post:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Hide system tunnel
-      tags:
-      - system-tunnels
-  /system-tunnels/test-connectivity:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: System tunnel connectivity test
-      tags:
-      - system-tunnels
-  /system-tunnels/test-ip:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: System tunnel IP check
-      tags:
-      - system-tunnels
-  /system-tunnels/test-speed:
-    get:
-      produces:
-      - text/event-stream
-      responses:
-        "200":
-          description: SSE stream
-          schema:
-            type: string
-      security:
-      - CookieAuth: []
-      summary: System tunnel speed test (SSE)
       tags:
       - system-tunnels
   /system/all-interfaces:
@@ -2498,10 +7016,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.AllInterfacesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: All interfaces
@@ -2517,8 +7040,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute control (system)
@@ -2532,8 +7062,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HydraRouteStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute status (system)
@@ -2547,8 +7084,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SystemInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: System info
@@ -2562,8 +7106,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart daemon
@@ -2577,8 +7128,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.UpdateApplyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Apply system update
@@ -2602,8 +7160,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ChangelogResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update changelog
@@ -2622,8 +7187,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.UpdateCheckResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update check
@@ -2637,10 +7209,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.WANInterfacesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: WAN interfaces
@@ -2654,8 +7231,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TerminalStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Install terminal (ttyd)
@@ -2669,8 +7253,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TerminalStartResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start terminal
@@ -2684,8 +7275,20 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.TerminalStatusResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Terminal status
@@ -2699,8 +7302,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Stop terminal
@@ -2715,6 +7325,14 @@ paths:
           description: WebSocket upgrade
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Terminal WebSocket
@@ -2734,8 +7352,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ConnectivityResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Connectivity check
@@ -2758,8 +7383,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.IPResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: IP leak check
@@ -2773,10 +7405,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.IPServicesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: IP check services
@@ -2790,8 +7427,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SpeedTestResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test (sync)
@@ -2805,8 +7449,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SpeedTestInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test servers
@@ -2821,6 +7472,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test stream
@@ -2834,8 +7493,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelsAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Composite tunnels snapshot
@@ -2851,8 +7517,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create tunnel
@@ -2872,8 +7545,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelDeleteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete tunnel
@@ -2894,6 +7574,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Export tunnel config
@@ -2908,6 +7596,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Export all tunnels (zip)
@@ -2927,8 +7623,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get tunnel
@@ -2942,10 +7645,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.TunnelListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List tunnels
@@ -2965,8 +7673,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.NativePingCheckStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get per-tunnel NDMS ping-check
@@ -2987,8 +7702,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Configure per-tunnel NDMS ping-check
@@ -3008,8 +7730,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Remove per-tunnel NDMS ping-check
@@ -3031,8 +7760,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Replace tunnel from conf
@@ -3057,8 +7793,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelTrafficResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Tunnel traffic history
@@ -3080,8 +7823,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update tunnel
@@ -3095,8 +7845,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.WANStatusEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: WAN status

--- a/frontend/static/openapi.yaml
+++ b/frontend/static/openapi.yaml
@@ -1,0 +1,3111 @@
+basePath: /api
+definitions:
+  api.AdoptRequest:
+    properties:
+      content:
+        type: string
+      name:
+        type: string
+    type: object
+  api.LoginRequest:
+    properties:
+      login:
+        type: string
+      password:
+        type: string
+    type: object
+  api.ResolveResponse:
+    properties:
+      domain:
+        type: string
+      error:
+        type: string
+      ips:
+        items:
+          type: string
+        type: array
+    type: object
+  api.SaveStatusDTO:
+    properties:
+      lastError:
+        type: string
+      lastSaveAt:
+        type: string
+      pendingCount:
+        type: integer
+      state:
+        type: string
+    type: object
+info:
+  contact: {}
+  description: HTTP API for the AWG Manager daemon (tunnels, routing, system).
+  title: AWG Manager API
+  version: "1.0"
+paths:
+  /access-policies:
+    get:
+      description: KeeneticOS 5 only when route is registered.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List access policies
+      tags:
+      - access-policy
+  /access-policies/assign:
+    delete:
+      parameters:
+      - description: Device MAC
+        in: query
+        name: mac
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unassign device from policy
+      tags:
+      - access-policy
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Assign device to policy
+      tags:
+      - access-policy
+  /access-policies/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create access policy
+      tags:
+      - access-policy
+  /access-policies/delete:
+    delete:
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete access policy
+      tags:
+      - access-policy
+  /access-policies/description:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set access policy description
+      tags:
+      - access-policy
+  /access-policies/devices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List policy devices
+      tags:
+      - access-policy
+  /access-policies/interface-up:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set interface admin up
+      tags:
+      - access-policy
+  /access-policies/interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List global policy interfaces
+      tags:
+      - access-policy
+  /access-policies/permit:
+    delete:
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: Interface name
+        in: query
+        name: interface
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Remove permitted interface
+      tags:
+      - access-policy
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Permit interface on policy
+      tags:
+      - access-policy
+  /access-policies/standalone:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set access policy standalone mode
+      tags:
+      - access-policy
+  /auth/login:
+    post:
+      consumes:
+      - application/json
+      description: Authenticates with Keenetic credentials; sets HttpOnly session
+        cookie awg_session.
+      parameters:
+      - description: Router login and password
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.LoginRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success, login
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties: true
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Login
+      tags:
+      - auth
+  /auth/logout:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Logout
+      tags:
+      - auth
+  /auth/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: authenticated, login, expiresIn, authDisabled
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Auth status
+      tags:
+      - auth
+  /boot-status:
+    get:
+      description: 'Public snapshot: initializing flag, phase, instance id.'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Boot status
+      tags:
+      - system
+  /client-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List client routes
+      tags:
+      - client-routes
+  /client-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create client route
+      tags:
+      - client-routes
+  /client-routes/delete:
+    post:
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete client route
+      tags:
+      - client-routes
+  /client-routes/toggle:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle client route
+      tags:
+      - client-routes
+  /client-routes/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update client route
+      tags:
+      - client-routes
+  /connections:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Connections list
+      tags:
+      - connections
+  /control/restart:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Restart tunnel
+      tags:
+      - control
+  /control/restart-all:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Restart all enabled tunnels
+      tags:
+      - control
+  /control/start:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start tunnel
+      tags:
+      - control
+  /control/stop:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Stop tunnel
+      tags:
+      - control
+  /control/toggle-default-route:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle default route
+      tags:
+      - control
+  /control/toggle-enabled:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle tunnel autostart
+      tags:
+      - control
+  /diagnostics/result:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Download diagnostics report
+      tags:
+      - diagnostics
+  /diagnostics/run:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Run diagnostics
+      tags:
+      - diagnostics
+  /diagnostics/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Diagnostics status
+      tags:
+      - diagnostics
+  /diagnostics/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Diagnostics SSE stream
+      tags:
+      - diagnostics
+  /dns-check/probe:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: DNS check probe (CORS)
+      tags:
+      - dns-check
+  /dns-check/start:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start DNS check
+      tags:
+      - dns-check
+  /dns-routes/bulk-backend:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Bulk set DNS route backend
+      tags:
+      - dns-routes
+  /dns-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/create-batch:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create DNS route lists (batch)
+      tags:
+      - dns-routes
+  /dns-routes/delete:
+    post:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Delete DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/delete-batch:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Delete DNS route lists (batch)
+      tags:
+      - dns-routes
+  /dns-routes/get:
+    get:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List DNS route lists
+      tags:
+      - dns-routes
+  /dns-routes/refresh:
+    post:
+      parameters:
+      - description: List id (omit for all)
+        in: query
+        name: id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh DNS route subscriptions
+      tags:
+      - dns-routes
+  /dns-routes/set-enabled:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Set DNS route list enabled
+      tags:
+      - dns-routes
+  /dns-routes/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update DNS route list
+      tags:
+      - dns-routes
+  /events:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: Server-Sent Events
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: SSE event stream
+      tags:
+      - events
+  /external-tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List external tunnels
+      tags:
+      - tunnels
+  /external-tunnels/adopt:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: interface
+        required: true
+        type: string
+      - description: Tunnel config body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.AdoptRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Adopt external tunnel
+      tags:
+      - tunnels
+  /health:
+    get:
+      description: Cheap check for frontend pollers; no NDMS or I/O.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok, version
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Health / liveness
+      tags:
+      - system
+  /hook/ndms:
+    post:
+      consumes:
+      - application/x-www-form-urlencoded
+      description: 'Called from router scripts (public). Form fields: type, id, system_name,
+        layer, etc.'
+      parameters:
+      - description: Event type (iflayerchanged, ifcreated, ...)
+        in: formData
+        name: type
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: NDMS shell hook
+      tags:
+      - hook
+  /hydraroute/config:
+    get:
+      description: Available when HydraRoute service is wired on the device.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get HydraRoute config
+      tags:
+      - hydraroute
+  /hydraroute/config/update:
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update HydraRoute config
+      tags:
+      - hydraroute
+  /hydraroute/geo-files:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List HydraRoute geo files
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/add:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add HydraRoute geo file
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/delete:
+    delete:
+      parameters:
+      - description: File path
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete HydraRoute geo file
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh HydraRoute geo file(s)
+      tags:
+      - hydraroute
+  /hydraroute/geo-tags:
+    get:
+      parameters:
+      - description: Geo file path
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: HydraRoute geo tags
+      tags:
+      - hydraroute
+  /hydraroute/ipset-usage:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute ipset usage
+      tags:
+      - hydraroute
+  /hydraroute/oversized-tags:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute oversized geo tags
+      tags:
+      - hydraroute
+  /hydraroute/policy-order:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set HydraRoute policy order
+      tags:
+      - hydraroute
+  /import/conf:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Import tunnel config
+      tags:
+      - import
+  /logs:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get logs
+      tags:
+      - logs
+  /logs/clear:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Clear logs
+      tags:
+      - logs
+  /managed-server:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed WireGuard server
+      tags:
+      - managed-server
+  /managed-server/asc:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed server ASC
+      tags:
+      - managed-server
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server ASC
+      tags:
+      - managed-server
+  /managed-server/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create managed server
+      tags:
+      - managed-server
+  /managed-server/delete:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed server
+      tags:
+      - managed-server
+  /managed-server/enabled:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Enable/disable managed server
+      tags:
+      - managed-server
+  /managed-server/nat:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server NAT
+      tags:
+      - managed-server
+  /managed-server/peers:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/conf:
+    get:
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Peer WireGuard conf
+      tags:
+      - managed-server
+  /managed-server/peers/delete:
+    delete:
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/toggle:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/update:
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed server peer
+      tags:
+      - managed-server
+  /managed-server/policies:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List IP policy profiles
+      tags:
+      - managed-server
+  /managed-server/policy:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server hotspot policy
+      tags:
+      - managed-server
+  /managed-server/stats:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Managed server stats
+      tags:
+      - managed-server
+  /managed-server/suggest-address:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Suggest managed server address
+      tags:
+      - managed-server
+  /managed-server/update:
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed server
+      tags:
+      - managed-server
+  /ndms/save-status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SaveStatusDTO'
+      security:
+      - CookieAuth: []
+      summary: NDMS save coordinator status
+      tags:
+      - ndms
+  /pingcheck/check-now:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Trigger ping check now
+      tags:
+      - pingcheck
+  /pingcheck/logs:
+    get:
+      parameters:
+      - description: Filter by tunnel id
+        in: query
+        name: tunnelId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Ping check logs
+      tags:
+      - pingcheck
+  /pingcheck/logs/clear:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Clear ping check logs
+      tags:
+      - pingcheck
+  /pingcheck/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Ping check status
+      tags:
+      - pingcheck
+  /proxy/apply:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Force apply device proxy
+      tags:
+      - device-proxy
+  /proxy/config:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get device proxy config
+      tags:
+      - device-proxy
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Save device proxy config
+      tags:
+      - device-proxy
+  /proxy/listen-choices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Device proxy listen choices
+      tags:
+      - device-proxy
+  /proxy/outbounds:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List device proxy outbounds
+      tags:
+      - device-proxy
+  /proxy/runtime:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Device proxy runtime state
+      tags:
+      - device-proxy
+  /proxy/runtime/select:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Select device proxy outbound
+      tags:
+      - device-proxy
+  /routing/access-policies:
+    get:
+      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: OS4 access policies stub
+      tags:
+      - routing
+  /routing/client-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List client routes
+      tags:
+      - client-routes
+  /routing/dns-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List DNS route lists
+      tags:
+      - dns-routes
+  /routing/policy-devices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List policy devices
+      tags:
+      - access-policy
+  /routing/policy-interfaces:
+    get:
+      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: OS4 policy interfaces stub
+      tags:
+      - routing
+  /routing/refresh:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Invalidate routing caches
+      tags:
+      - routing
+  /routing/resolve:
+    get:
+      parameters:
+      - description: Hostname to resolve
+        in: query
+        name: domain
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ResolveResponse'
+      security:
+      - CookieAuth: []
+      summary: Resolve domain
+      tags:
+      - routing
+  /routing/static-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List static routes
+      tags:
+      - static-routes
+  /routing/tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Routing tunnel catalog
+      tags:
+      - routing
+  /servers:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List VPN server interfaces
+      tags:
+      - servers
+  /servers/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Servers composite snapshot
+      tags:
+      - servers
+  /servers/config:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Server RC config for export
+      tags:
+      - servers
+  /servers/get:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get VPN server by name
+      tags:
+      - servers
+  /servers/mark:
+    delete:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unmark server interface
+      tags:
+      - servers
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Mark server interface
+      tags:
+      - servers
+  /servers/marked:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List marked server interface ids
+      tags:
+      - servers
+  /servers/wan-ip:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: WAN IP for server conf
+      tags:
+      - servers
+  /settings/get:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get settings
+      tags:
+      - settings
+  /settings/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update settings
+      tags:
+      - settings
+  /signature/capture:
+    get:
+      parameters:
+      - description: Domain name
+        in: query
+        name: domain
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Signature capture
+      tags:
+      - signature
+  /singbox/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Install sing-box
+      tags:
+      - singbox
+  /singbox/status:
+    get:
+      description: Available when sing-box integration is enabled in the build.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Sing-box status
+      tags:
+      - singbox
+  /singbox/tunnels:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete sing-box tunnel
+      tags:
+      - singbox
+    get:
+      parameters:
+      - description: When set, returns single tunnel
+        in: query
+        name: tag
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List or get sing-box tunnel(s)
+      tags:
+      - singbox
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add sing-box tunnel(s)
+      tags:
+      - singbox
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update sing-box tunnel
+      tags:
+      - singbox
+  /singbox/tunnels/delay-check:
+    post:
+      parameters:
+      - description: Tunnel tag
+        in: query
+        name: tag
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Sing-box delay check
+      tags:
+      - singbox
+  /singbox/tunnels/test/speed/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Sing-box tunnel speed test stream
+      tags:
+      - singbox
+  /static-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create static route
+      tags:
+      - static-routes
+  /static-routes/delete:
+    post:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete static route
+      tags:
+      - static-routes
+  /static-routes/import:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Import static routes
+      tags:
+      - static-routes
+  /static-routes/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List static routes
+      tags:
+      - static-routes
+  /static-routes/set-enabled:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set static route enabled
+      tags:
+      - static-routes
+  /static-routes/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update static route
+      tags:
+      - static-routes
+  /status/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: All tunnel statuses
+      tags:
+      - status
+  /status/get:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Tunnel status
+      tags:
+      - status
+  /system-tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List system WireGuard tunnels
+      tags:
+      - system-tunnels
+  /system-tunnels/asc:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get system tunnel ASC params
+      tags:
+      - system-tunnels
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set system tunnel ASC params
+      tags:
+      - system-tunnels
+  /system-tunnels/get:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get system tunnel
+      tags:
+      - system-tunnels
+  /system-tunnels/hidden:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List hidden system tunnels
+      tags:
+      - system-tunnels
+  /system-tunnels/hide:
+    delete:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unhide system tunnel
+      tags:
+      - system-tunnels
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Hide system tunnel
+      tags:
+      - system-tunnels
+  /system-tunnels/test-connectivity:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System tunnel connectivity test
+      tags:
+      - system-tunnels
+  /system-tunnels/test-ip:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System tunnel IP check
+      tags:
+      - system-tunnels
+  /system-tunnels/test-speed:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: System tunnel speed test (SSE)
+      tags:
+      - system-tunnels
+  /system/all-interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: All interfaces
+      tags:
+      - system
+  /system/hydraroute-control:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute control (system)
+      tags:
+      - system
+  /system/hydraroute-status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute status (system)
+      tags:
+      - system
+  /system/info:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System info
+      tags:
+      - system
+  /system/restart:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Restart daemon
+      tags:
+      - system
+  /system/update/apply:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Apply system update
+      tags:
+      - update
+  /system/update/changelog:
+    get:
+      parameters:
+      - description: From version
+        in: query
+        name: from
+        type: string
+      - description: To version
+        in: query
+        name: to
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update changelog
+      tags:
+      - update
+  /system/update/check:
+    get:
+      parameters:
+      - description: Force refresh from upstream
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update check
+      tags:
+      - update
+  /system/wan-interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: WAN interfaces
+      tags:
+      - system
+  /terminal/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Install terminal (ttyd)
+      tags:
+      - terminal
+  /terminal/start:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start terminal
+      tags:
+      - terminal
+  /terminal/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Terminal status
+      tags:
+      - terminal
+  /terminal/stop:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Stop terminal
+      tags:
+      - terminal
+  /terminal/ws:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: WebSocket upgrade
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Terminal WebSocket
+      tags:
+      - terminal
+  /test/connectivity:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Connectivity check
+      tags:
+      - test
+  /test/ip:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        type: string
+      - description: Check service id
+        in: query
+        name: service
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: IP leak check
+      tags:
+      - test
+  /test/ip/services:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: IP check services
+      tags:
+      - test
+  /test/speed:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Speed test (sync)
+      tags:
+      - test
+  /test/speed/servers:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Speed test servers
+      tags:
+      - test
+  /test/speed/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Speed test stream
+      tags:
+      - test
+  /tunnels/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Composite tunnels snapshot
+      tags:
+      - tunnels
+  /tunnels/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create tunnel
+      tags:
+      - tunnels
+  /tunnels/delete:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete tunnel
+      tags:
+      - tunnels
+  /tunnels/export:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Export tunnel config
+      tags:
+      - tunnels
+  /tunnels/export-all:
+    get:
+      produces:
+      - application/zip
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Export all tunnels (zip)
+      tags:
+      - tunnels
+  /tunnels/get:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get tunnel
+      tags:
+      - tunnels
+  /tunnels/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List tunnels
+      tags:
+      - tunnels
+  /tunnels/pingcheck:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Configure per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+  /tunnels/pingcheck/remove:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Remove per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+  /tunnels/replace:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Replace tunnel from conf
+      tags:
+      - tunnels
+  /tunnels/traffic:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: 1h or 24h
+        in: query
+        name: period
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Tunnel traffic history
+      tags:
+      - tunnels
+  /tunnels/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update tunnel
+      tags:
+      - tunnels
+  /wan/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: WAN status
+      tags:
+      - wan
+securityDefinitions:
+  CookieAuth:
+    description: Session cookie set by POST /auth/login. Omit for public routes.
+    in: cookie
+    name: awg_session
+    type: apiKey
+swagger: "2.0"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
 
 /**
  * Strip /routes/dev/* contents during production build so dev-only
@@ -36,14 +36,21 @@ const stubDevRoutes = (): Plugin => ({
 	}
 });
 
-export default defineConfig({
-	plugins: [stubDevRoutes(), tailwindcss(), sveltekit()],
-	server: {
-		proxy: {
-			'/api': {
-				target: 'http://127.0.0.1:8080',
-				changeOrigin: true
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd(), '');
+	const apiTarget = env.VITE_API_TARGET || 'http://127.0.0.1:8080';
+	const useMockRewrite = env.VITE_API_STRIP_PREFIX === '1';
+
+	return {
+		plugins: [stubDevRoutes(), tailwindcss(), sveltekit()],
+		server: {
+			proxy: {
+				'/api': {
+					target: apiTarget,
+					changeOrigin: true,
+					rewrite: useMockRewrite ? (p) => p.replace(/^\/api/, '') : undefined
+				}
 			}
 		}
-	}
+	};
 });

--- a/internal/api/accesspolicy.go
+++ b/internal/api/accesspolicy.go
@@ -35,6 +35,14 @@ func NewAccessPolicyHandler(svc accesspolicy.Service) *AccessPolicyHandler {
 
 // List returns all access policies.
 // GET /api/access-policies
+//
+//	@Summary		List access policies
+//	@Description	KeeneticOS 5 only when route is registered.
+//	@Tags			access-policy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/access-policies [get]
 func (h *AccessPolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -55,6 +63,14 @@ func (h *AccessPolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 // Create creates a new access policy.
 // POST /api/access-policies/create
 // Body: {"description":"..."}
+//
+//	@Summary		Create access policy
+//	@Tags			access-policy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/access-policies/create [post]
 func (h *AccessPolicyHandler) Create(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		Description string `json:"description"`
@@ -105,6 +121,14 @@ func (h *AccessPolicyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // SetDescription updates the description of an access policy.
 // POST /api/access-policies/description
 // Body: {"name":"Policy0","description":"..."}
+//
+//	@Summary		Set access policy description
+//	@Tags			access-policy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/access-policies/description [post]
 func (h *AccessPolicyHandler) SetDescription(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		Name        string `json:"name"`
@@ -128,6 +152,14 @@ func (h *AccessPolicyHandler) SetDescription(w http.ResponseWriter, r *http.Requ
 // SetStandalone enables or disables standalone mode on an access policy.
 // POST /api/access-policies/standalone
 // Body: {"name":"Policy0","enabled":true}
+//
+//	@Summary		Set access policy standalone mode
+//	@Tags			access-policy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/access-policies/standalone [post]
 func (h *AccessPolicyHandler) SetStandalone(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		Name    string `json:"name"`
@@ -148,18 +180,19 @@ func (h *AccessPolicyHandler) SetStandalone(w http.ResponseWriter, r *http.Reque
 	h.publishPoliciesUpdated("set-standalone")
 }
 
-// PermitInterface handles permit/deny operations for policy interfaces.
-// POST /api/access-policies/permit — add interface
-// Body: {"name":"Policy0","interface":"Wireguard0","order":0}
-// DELETE /api/access-policies/permit?name=Policy0&interface=Wireguard0 — remove interface
-func (h *AccessPolicyHandler) PermitInterface(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodPost:
-		h.permitInterfaceAdd(w, r)
-	case http.MethodDelete:
-		h.permitInterfaceRemove(w, r)
-	default:
+// PermitInterfaceAdd adds an interface to a policy (POST /api/access-policies/permit).
+//
+//	@Summary		Permit interface on policy
+//	@Tags			access-policy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/access-policies/permit [post]
+func (h *AccessPolicyHandler) PermitInterfaceAdd(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
+		return
 	}
 }
 
@@ -315,6 +348,14 @@ func (h *AccessPolicyHandler) unassignDeviceDelete(w http.ResponseWriter, r *htt
 
 // ListDevices returns all LAN devices with their policy assignments.
 // GET /api/access-policies/devices
+//
+//	@Summary		List policy devices
+//	@Tags			access-policy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/access-policies/devices [get]
+//	@Router			/routing/policy-devices [get]
 func (h *AccessPolicyHandler) ListDevices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -334,6 +375,13 @@ func (h *AccessPolicyHandler) ListDevices(w http.ResponseWriter, r *http.Request
 
 // ListGlobalInterfaces returns all router interfaces available for policy routing.
 // GET /api/access-policies/interfaces
+//
+//	@Summary		List global policy interfaces
+//	@Tags			access-policy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/access-policies/interfaces [get]
 func (h *AccessPolicyHandler) ListGlobalInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -350,6 +398,14 @@ func (h *AccessPolicyHandler) ListGlobalInterfaces(w http.ResponseWriter, r *htt
 // SetInterfaceUp brings an interface up or down.
 // POST /api/access-policies/interface-up
 // Body: {"name":"Wireguard0","up":true}
+//
+//	@Summary		Set interface admin up
+//	@Tags			access-policy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/access-policies/interface-up [post]
 func (h *AccessPolicyHandler) SetInterfaceUp(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		Name string `json:"name"`

--- a/internal/api/accesspolicy.go
+++ b/internal/api/accesspolicy.go
@@ -8,6 +8,61 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// AccessPolicyInterfaceDTO mirrors frontend AccessPolicyInterface.
+type AccessPolicyInterfaceDTO struct {
+	Name   string `json:"name" example:"nwg0"`
+	Label  string `json:"label,omitempty" example:"My VPN"`
+	Order  int    `json:"order" example:"1"`
+	Denied bool   `json:"denied,omitempty" example:"false"`
+}
+
+// AccessPolicyDTO mirrors frontend AccessPolicy.
+type AccessPolicyDTO struct {
+	Name        string                     `json:"name" example:"default"`
+	Description string                     `json:"description" example:"Default policy"`
+	Standalone  bool                       `json:"standalone" example:"false"`
+	Interfaces  []AccessPolicyInterfaceDTO `json:"interfaces"`
+	DeviceCount int                        `json:"deviceCount" example:"5"`
+}
+
+// AccessPoliciesListResponse is the envelope for GET /access-policies.
+type AccessPoliciesListResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []AccessPolicyDTO `json:"data"`
+}
+
+// PolicyDeviceDTO mirrors frontend PolicyDevice.
+type PolicyDeviceDTO struct {
+	MAC      string `json:"mac" example:"aa:bb:cc:dd:ee:ff"`
+	IP       string `json:"ip" example:"192.168.1.100"`
+	Name     string `json:"name" example:"My Phone"`
+	Hostname string `json:"hostname" example:"my-phone"`
+	Active   bool   `json:"active" example:"true"`
+	Link     string `json:"link" example:"WiFi"`
+	Policy   string `json:"policy" example:"default"`
+}
+
+// PolicyDevicesListResponse is the envelope for GET /access-policies/devices.
+type PolicyDevicesListResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []PolicyDeviceDTO `json:"data"`
+}
+
+// PolicyGlobalInterfaceDTO mirrors frontend PolicyGlobalInterface.
+type PolicyGlobalInterfaceDTO struct {
+	Name  string `json:"name" example:"nwg0"`
+	Label string `json:"label" example:"My VPN"`
+	Up    bool   `json:"up" example:"true"`
+}
+
+// PolicyInterfacesListResponse is the envelope for GET /access-policies/interfaces.
+type PolicyInterfacesListResponse struct {
+	Success bool                       `json:"success" example:"true"`
+	Data    []PolicyGlobalInterfaceDTO `json:"data"`
+}
+
 // AccessPolicyHandler handles access policy CRUD and device assignment operations.
 type AccessPolicyHandler struct {
 	svc accesspolicy.Service

--- a/internal/api/api_common.go
+++ b/internal/api/api_common.go
@@ -1,0 +1,17 @@
+package api
+
+// APIEnvelope describes the common successful API response shape.
+// Most handlers return: { success: true, data: ... }.
+type APIEnvelope struct {
+	Success bool   `json:"success" example:"true"`
+	Data    any    `json:"data,omitempty" swaggertype:"object"`
+	Message string `json:"message,omitempty" example:"ok"`
+}
+
+// APIErrorEnvelope describes the common error response shape.
+// Most handlers return: { error: true, message: "...", code: "..." }.
+type APIErrorEnvelope struct {
+	Error   bool   `json:"error" example:"true"`
+	Message string `json:"message" example:"invalid request"`
+	Code    string `json:"code" example:"BAD_REQUEST"`
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -36,7 +36,19 @@ type LoginRequest struct {
 	Password string `json:"password"`
 }
 
-// Login handles POST /api/auth/login
+// Login authenticates against the router and sets the session cookie.
+//
+//	@Summary		Login
+//	@Description	Authenticates with Keenetic credentials; sets HttpOnly session cookie awg_session.
+//	@Tags			auth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		LoginRequest	true	"Router login and password"
+//	@Success		200		{object}	map[string]interface{}	"success, login"
+//	@Failure		400		{object}	map[string]interface{}
+//	@Failure		401		{object}	map[string]interface{}
+//	@Failure		503		{object}	map[string]interface{}
+//	@Router			/auth/login [post]
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -91,7 +103,13 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Logout handles POST /api/auth/logout
+// Logout clears the session cookie and invalidates the server-side session.
+//
+//	@Summary		Logout
+//	@Tags			auth
+//	@Produce		json
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/auth/logout [post]
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -119,7 +137,13 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Status handles GET /api/auth/status
+// Status returns whether the client is authenticated and optional session metadata.
+//
+//	@Summary		Auth status
+//	@Tags			auth
+//	@Produce		json
+//	@Success		200	{object}	map[string]interface{}	"authenticated, login, expiresIn, authDisabled"
+//	@Router			/auth/status [get]
 func (h *AuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -12,6 +12,22 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// LoginResponseRaw is the raw response for POST /auth/login.
+type LoginResponseRaw struct {
+	Success bool   `json:"success" example:"true"`
+	Login   string `json:"login" example:"admin"`
+}
+
+// AuthStatusResponse is the raw (non-enveloped) payload for GET /auth/status.
+type AuthStatusResponse struct {
+	Authenticated bool   `json:"authenticated" example:"true"`
+	AuthDisabled  bool   `json:"authDisabled" example:"false"`
+	Login         string `json:"login,omitempty" example:"admin"`
+	ExpiresIn     int    `json:"expiresIn,omitempty" example:"3600"`
+}
+
 // AuthHandler handles authentication endpoints.
 type AuthHandler struct {
 	keenetic *auth.KeeneticClient
@@ -44,10 +60,10 @@ type LoginRequest struct {
 //	@Accept			json
 //	@Produce		json
 //	@Param			body	body		LoginRequest	true	"Router login and password"
-//	@Success		200		{object}	map[string]interface{}	"success, login"
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		401		{object}	map[string]interface{}
-//	@Failure		503		{object}	map[string]interface{}
+//	@Success		200		{object}	LoginResponseRaw
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		401		{object}	APIErrorEnvelope
+//	@Failure		503		{object}	APIErrorEnvelope
 //	@Router			/auth/login [post]
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -108,7 +124,9 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 //	@Summary		Logout
 //	@Tags			auth
 //	@Produce		json
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/auth/logout [post]
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -142,7 +160,9 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 //	@Summary		Auth status
 //	@Tags			auth
 //	@Produce		json
-//	@Success		200	{object}	map[string]interface{}	"authenticated, login, expiresIn, authDisabled"
+//	@Success		200	{object}	AuthStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/auth/status [get]
 func (h *AuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/bootstatus.go
+++ b/internal/api/bootstatus.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// BootStatusHandler serves GET /api/boot-status (public).
+type BootStatusHandler struct {
+	InstanceID string
+}
+
+// NewBootStatusHandler returns a handler that reports boot phase and instance id.
+func NewBootStatusHandler(instanceID string) *BootStatusHandler {
+	return &BootStatusHandler{InstanceID: instanceID}
+}
+
+// Get responds with boot readiness and instance id for frontend restart detection.
+//
+//	@Summary		Boot status
+//	@Description	Public snapshot: initializing flag, phase, instance id.
+//	@Tags			system
+//	@Produce		json
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/boot-status [get]
+func (h *BootStatusHandler) Get(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"initializing":     false,
+		"remainingSeconds": 0,
+		"phase":            "ready",
+		"instanceId":       h.InstanceID,
+	})
+}

--- a/internal/api/bootstatus.go
+++ b/internal/api/bootstatus.go
@@ -5,6 +5,16 @@ import (
 	"net/http"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// BootStatusResponse is the raw (non-enveloped) payload for GET /boot-status.
+type BootStatusResponse struct {
+	Initializing     bool   `json:"initializing" example:"false"`
+	RemainingSeconds int    `json:"remainingSeconds" example:"0"`
+	Phase            string `json:"phase" example:"ready"`
+	InstanceId       string `json:"instanceId" example:"a1b2c3d4e5f6"`
+}
+
 // BootStatusHandler serves GET /api/boot-status (public).
 type BootStatusHandler struct {
 	InstanceID string
@@ -21,7 +31,9 @@ func NewBootStatusHandler(instanceID string) *BootStatusHandler {
 //	@Description	Public snapshot: initializing flag, phase, instance id.
 //	@Tags			system
 //	@Produce		json
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	BootStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/boot-status [get]
 func (h *BootStatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/clientroutes.go
+++ b/internal/api/clientroutes.go
@@ -8,6 +8,24 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// ClientRouteDTO mirrors frontend ClientRoute.
+type ClientRouteDTO struct {
+	ID             string `json:"id" example:"cr_001"`
+	ClientIp       string `json:"clientIp" example:"192.168.1.100"`
+	ClientHostname string `json:"clientHostname" example:"My-Phone"`
+	TunnelId       string `json:"tunnelId" example:"tun_abc123"`
+	Fallback       string `json:"fallback" example:"drop"`
+	Enabled        bool   `json:"enabled" example:"true"`
+}
+
+// ClientRoutesListResponse is the envelope for GET /client-routes.
+type ClientRoutesListResponse struct {
+	Success bool             `json:"success" example:"true"`
+	Data    []ClientRouteDTO `json:"data"`
+}
+
 // ClientRouteHandler handles client route CRUD operations.
 type ClientRouteHandler struct {
 	svc clientroute.Service
@@ -35,7 +53,9 @@ func NewClientRouteHandler(svc clientroute.Service) *ClientRouteHandler {
 //	@Tags			client-routes
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	ClientRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes [get]
 //	@Router			/routing/client-routes [get]
 func (h *ClientRouteHandler) HandleList(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +80,9 @@ func (h *ClientRouteHandler) HandleList(w http.ResponseWriter, r *http.Request) 
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ClientRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/create [post]
 func (h *ClientRouteHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	route, ok := parseJSON[clientroute.ClientRoute](w, r, http.MethodPost)
@@ -86,7 +108,9 @@ func (h *ClientRouteHandler) HandleCreate(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ClientRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/update [post]
 func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	route, ok := parseJSON[clientroute.ClientRoute](w, r, http.MethodPost)
@@ -116,7 +140,9 @@ func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ClientRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/delete [post]
 func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -146,7 +172,9 @@ func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ClientRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/toggle [post]
 func (h *ClientRouteHandler) HandleToggle(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[enabledToggle](w, r, http.MethodPost)

--- a/internal/api/clientroutes.go
+++ b/internal/api/clientroutes.go
@@ -30,6 +30,14 @@ func NewClientRouteHandler(svc clientroute.Service) *ClientRouteHandler {
 
 // HandleList returns all client routes.
 // GET /api/client-routes
+//
+//	@Summary		List client routes
+//	@Tags			client-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/client-routes [get]
+//	@Router			/routing/client-routes [get]
 func (h *ClientRouteHandler) HandleList(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -46,6 +54,14 @@ func (h *ClientRouteHandler) HandleList(w http.ResponseWriter, r *http.Request) 
 // HandleCreate creates a new client route.
 // POST /api/client-routes/create
 // Body: ClientRoute JSON
+//
+//	@Summary		Create client route
+//	@Tags			client-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/client-routes/create [post]
 func (h *ClientRouteHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	route, ok := parseJSON[clientroute.ClientRoute](w, r, http.MethodPost)
 	if !ok {
@@ -63,6 +79,15 @@ func (h *ClientRouteHandler) HandleCreate(w http.ResponseWriter, r *http.Request
 // HandleUpdate updates an existing client route.
 // POST /api/client-routes/update?id=xxx
 // Body: ClientRoute JSON
+//
+//	@Summary		Update client route
+//	@Tags			client-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Route id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/client-routes/update [post]
 func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	route, ok := parseJSON[clientroute.ClientRoute](w, r, http.MethodPost)
 	if !ok {
@@ -85,6 +110,14 @@ func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request
 
 // HandleDelete deletes a client route.
 // POST /api/client-routes/delete?id=xxx
+//
+//	@Summary		Delete client route
+//	@Tags			client-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Route id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/client-routes/delete [post]
 func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -106,6 +139,15 @@ func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 // HandleToggle enables or disables a client route.
 // POST /api/client-routes/toggle?id=xxx
 // Body: {"enabled": bool}
+//
+//	@Summary		Toggle client route
+//	@Tags			client-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Route id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/client-routes/toggle [post]
 func (h *ClientRouteHandler) HandleToggle(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
 	if !ok {

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -8,6 +8,70 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// ConnectionProtocolsDTO holds per-protocol connection counts.
+type ConnectionProtocolsDTO struct {
+	TCP  int `json:"tcp" example:"28"`
+	UDP  int `json:"udp" example:"12"`
+	ICMP int `json:"icmp" example:"2"`
+}
+
+// ConnectionStatsDTO mirrors frontend ConnectionStats.
+type ConnectionStatsDTO struct {
+	Total     int                    `json:"total" example:"42"`
+	Direct    int                    `json:"direct" example:"30"`
+	Tunneled  int                    `json:"tunneled" example:"12"`
+	Protocols ConnectionProtocolsDTO `json:"protocols"`
+}
+
+// ConntrackConnectionDTO mirrors frontend ConntrackConnection.
+type ConntrackConnectionDTO struct {
+	Protocol   string `json:"protocol" example:"tcp"`
+	Src        string `json:"src" example:"192.168.1.100"`
+	Dst        string `json:"dst" example:"8.8.8.8"`
+	SrcPort    int    `json:"srcPort" example:"54321"`
+	DstPort    int    `json:"dstPort" example:"443"`
+	State      string `json:"state" example:"ESTABLISHED"`
+	Packets    int    `json:"packets" example:"15"`
+	Bytes      int    `json:"bytes" example:"4096"`
+	Interface  string `json:"interface" example:"nwg0"`
+	TunnelId   string `json:"tunnelId" example:"tun_abc123"`
+	TunnelName string `json:"tunnelName" example:"My VPN"`
+	ClientMac  string `json:"clientMac" example:"aa:bb:cc:dd:ee:ff"`
+	ClientName string `json:"clientName" example:"My Phone"`
+}
+
+// ConnectionsPaginationDTO mirrors frontend ConnectionsPagination.
+type ConnectionsPaginationDTO struct {
+	Total    int `json:"total" example:"42"`
+	Offset   int `json:"offset" example:"0"`
+	Limit    int `json:"limit" example:"50"`
+	Returned int `json:"returned" example:"42"`
+}
+
+// TunnelConnectionInfoDTO mirrors frontend TunnelConnectionInfo.
+type TunnelConnectionInfoDTO struct {
+	Name      string `json:"name" example:"My VPN"`
+	Interface string `json:"interface" example:"nwg0"`
+	Count     int    `json:"count" example:"12"`
+}
+
+// ConnectionsData mirrors frontend ConnectionsResponse.
+type ConnectionsData struct {
+	Stats      ConnectionStatsDTO               `json:"stats"`
+	Tunnels    map[string]TunnelConnectionInfoDTO `json:"tunnels" swaggertype:"object"`
+	Connections []ConntrackConnectionDTO         `json:"connections"`
+	Pagination ConnectionsPaginationDTO          `json:"pagination"`
+	FetchedAt  string                           `json:"fetchedAt" example:"2024-01-15T10:30:00Z"`
+}
+
+// ConnectionsResponseEnvelope is the envelope for GET /connections.
+type ConnectionsResponseEnvelope struct {
+	Success bool            `json:"success" example:"true"`
+	Data    ConnectionsData `json:"data"`
+}
+
 // ConnectionsHandler handles GET /api/connections.
 type ConnectionsHandler struct {
 	svc *connections.Service
@@ -24,7 +88,9 @@ func NewConnectionsHandler(svc *connections.Service) *ConnectionsHandler {
 //	@Tags			connections
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ConnectionsResponseEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/connections [get]
 func (h *ConnectionsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -19,6 +19,13 @@ func NewConnectionsHandler(svc *connections.Service) *ConnectionsHandler {
 }
 
 // List returns filtered and paginated conntrack connections.
+//
+//	@Summary		Connections list
+//	@Tags			connections
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/connections [get]
 func (h *ConnectionsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/control.go
+++ b/internal/api/control.go
@@ -68,6 +68,14 @@ func (h *ControlHandler) getStatus(r *http.Request, id string) string {
 }
 
 // Start starts a tunnel.
+//
+//	@Summary		Start tunnel
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/control/start [post]
 func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -111,6 +119,14 @@ func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 }
 
 // Stop stops a tunnel.
+//
+//	@Summary		Stop tunnel
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/control/stop [post]
 func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -154,6 +170,14 @@ func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 }
 
 // Restart restarts a tunnel.
+//
+//	@Summary		Restart tunnel
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/control/restart [post]
 func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -193,6 +217,13 @@ func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 }
 
 // RestartAll restarts all enabled tunnels.
+//
+//	@Summary		Restart all enabled tunnels
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/control/restart-all [post]
 func (h *ControlHandler) RestartAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -242,6 +273,14 @@ func (h *ControlHandler) RestartAll(w http.ResponseWriter, r *http.Request) {
 }
 
 // ToggleEnabled toggles the auto-start setting for a tunnel.
+//
+//	@Summary		Toggle tunnel autostart
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/control/toggle-enabled [post]
 func (h *ControlHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -290,6 +329,14 @@ func (h *ControlHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 }
 
 // ToggleDefaultRoute toggles the default route setting for a tunnel.
+//
+//	@Summary		Toggle default route
+//	@Tags			control
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/control/toggle-default-route [post]
 func (h *ControlHandler) ToggleDefaultRoute(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/control.go
+++ b/internal/api/control.go
@@ -14,6 +14,20 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// TunnelControlData is the response data for control operations (start/stop/restart).
+type TunnelControlData struct {
+	ID     string `json:"id" example:"tun_abc123"`
+	Status string `json:"status" example:"connected"`
+}
+
+// TunnelControlResponse is the envelope for control operations.
+type TunnelControlResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    TunnelControlData `json:"data"`
+}
+
 // ControlHandler handles tunnel start/stop/restart operations.
 type ControlHandler struct {
 	svc            TunnelService
@@ -74,7 +88,9 @@ func (h *ControlHandler) getStatus(r *http.Request, id string) string {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelControlResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/start [post]
 func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -125,7 +141,9 @@ func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelControlResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/stop [post]
 func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -176,7 +194,9 @@ func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelControlResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/restart [post]
 func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -222,7 +242,9 @@ func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 //	@Tags			control
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/restart-all [post]
 func (h *ControlHandler) RestartAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -279,7 +301,9 @@ func (h *ControlHandler) RestartAll(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/toggle-enabled [post]
 func (h *ControlHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -335,7 +359,9 @@ func (h *ControlHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/control/toggle-default-route [post]
 func (h *ControlHandler) ToggleDefaultRoute(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/deviceproxy.go
+++ b/internal/api/deviceproxy.go
@@ -26,6 +26,13 @@ func NewDeviceProxyHandler(svc *deviceproxy.Service, appLogger logging.AppLogger
 }
 
 // GetConfig handles GET /api/proxy/config.
+//
+//	@Summary		Get device proxy config
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/config [get]
 func (h *DeviceProxyHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -35,6 +42,14 @@ func (h *DeviceProxyHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // SaveConfig handles PUT /api/proxy/config.
+//
+//	@Summary		Save device proxy config
+//	@Tags			device-proxy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/config [put]
 func (h *DeviceProxyHandler) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
 		response.MethodNotAllowed(w)
@@ -69,6 +84,13 @@ func (h *DeviceProxyHandler) SaveConfig(w http.ResponseWriter, r *http.Request) 
 // "Применить сейчас" affordance when the user saved a new default via
 // the no-reload surgical path and now wants the live selector to
 // snap to that default.
+//
+//	@Summary		Force apply device proxy
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/apply [post]
 func (h *DeviceProxyHandler) ForceApply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -82,6 +104,13 @@ func (h *DeviceProxyHandler) ForceApply(w http.ResponseWriter, r *http.Request) 
 }
 
 // GetRuntime — GET /api/proxy/runtime
+//
+//	@Summary		Device proxy runtime state
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/runtime [get]
 func (h *DeviceProxyHandler) GetRuntime(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -91,6 +120,14 @@ func (h *DeviceProxyHandler) GetRuntime(w http.ResponseWriter, r *http.Request) 
 }
 
 // SelectRuntime — POST /api/proxy/runtime/select  body {"tag":"..."}
+//
+//	@Summary		Select device proxy outbound
+//	@Tags			device-proxy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/runtime/select [post]
 func (h *DeviceProxyHandler) SelectRuntime(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -120,6 +157,13 @@ func (h *DeviceProxyHandler) SelectRuntime(w http.ResponseWriter, r *http.Reques
 }
 
 // ListOutbounds handles GET /api/proxy/outbounds.
+//
+//	@Summary		List device proxy outbounds
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/proxy/outbounds [get]
 func (h *DeviceProxyHandler) ListOutbounds(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -131,6 +175,13 @@ func (h *DeviceProxyHandler) ListOutbounds(w http.ResponseWriter, r *http.Reques
 // ListenChoices handles GET /api/proxy/listen-choices.
 // Returns the bridge interface list, LAN IP, and singbox-running status
 // needed by the frontend inbound settings form.
+//
+//	@Summary		Device proxy listen choices
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/proxy/listen-choices [get]
 func (h *DeviceProxyHandler) ListenChoices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/deviceproxy.go
+++ b/internal/api/deviceproxy.go
@@ -11,6 +11,70 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/singbox"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// DeviceProxyAuthDTO mirrors frontend DeviceProxyAuth.
+type DeviceProxyAuthDTO struct {
+	Enabled  bool   `json:"enabled" example:"false"`
+	Username string `json:"username" example:""`
+	Password string `json:"password" example:""`
+}
+
+// DeviceProxyConfigData mirrors frontend DeviceProxyConfig.
+type DeviceProxyConfigData struct {
+	Enabled          bool               `json:"enabled" example:"false"`
+	ListenAll        bool               `json:"listenAll" example:"true"`
+	ListenInterface  string             `json:"listenInterface" example:"br0"`
+	Port             int                `json:"port" example:"1080"`
+	Auth             DeviceProxyAuthDTO `json:"auth"`
+	SelectedOutbound string             `json:"selectedOutbound" example:"proxy-01"`
+}
+
+// ProxyConfigResponse is the envelope for GET /proxy/config.
+type ProxyConfigResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    DeviceProxyConfigData `json:"data"`
+}
+
+// DeviceProxyRuntimeData mirrors frontend DeviceProxyRuntime.
+type DeviceProxyRuntimeData struct {
+	Alive      bool   `json:"alive" example:"true"`
+	ActiveTag  string `json:"activeTag" example:"proxy-01"`
+	DefaultTag string `json:"defaultTag" example:"proxy-01"`
+}
+
+// ProxyRuntimeResponse is the envelope for GET /proxy/runtime.
+type ProxyRuntimeResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    DeviceProxyRuntimeData `json:"data"`
+}
+
+// DeviceProxyOutboundDTO mirrors frontend DeviceProxyOutbound.
+type DeviceProxyOutboundDTO struct {
+	Tag    string `json:"tag" example:"proxy-01"`
+	Kind   string `json:"kind" example:"singbox"`
+	Label  string `json:"label" example:"proxy-01 (VLESS)"`
+	Detail string `json:"detail" example:"proxy.example.com:443"`
+}
+
+// ProxyOutboundsResponse is the envelope for GET /proxy/outbounds.
+type ProxyOutboundsResponse struct {
+	Success bool                     `json:"success" example:"true"`
+	Data    []DeviceProxyOutboundDTO `json:"data"`
+}
+
+// ProxyListenChoicesData mirrors the listen-choices payload.
+type ProxyListenChoicesData struct {
+	LanIP         string `json:"lanIP" example:"192.168.1.1"`
+	SingboxRunning bool  `json:"singboxRunning" example:"true"`
+}
+
+// ProxyListenChoicesResponse is the envelope for GET /proxy/listen-choices.
+type ProxyListenChoicesResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    ProxyListenChoicesData `json:"data"`
+}
+
 // DeviceProxyHandler handles /api/proxy/* endpoints.
 type DeviceProxyHandler struct {
 	svc *deviceproxy.Service
@@ -31,7 +95,9 @@ func NewDeviceProxyHandler(svc *deviceproxy.Service, appLogger logging.AppLogger
 //	@Tags			device-proxy
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ProxyConfigResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/config [get]
 func (h *DeviceProxyHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -48,7 +114,9 @@ func (h *DeviceProxyHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ProxyConfigResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/config [put]
 func (h *DeviceProxyHandler) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
@@ -89,7 +157,9 @@ func (h *DeviceProxyHandler) SaveConfig(w http.ResponseWriter, r *http.Request) 
 //	@Tags			device-proxy
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/apply [post]
 func (h *DeviceProxyHandler) ForceApply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -109,7 +179,9 @@ func (h *DeviceProxyHandler) ForceApply(w http.ResponseWriter, r *http.Request) 
 //	@Tags			device-proxy
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ProxyRuntimeResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/runtime [get]
 func (h *DeviceProxyHandler) GetRuntime(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -126,7 +198,9 @@ func (h *DeviceProxyHandler) GetRuntime(w http.ResponseWriter, r *http.Request) 
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ProxyRuntimeResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/runtime/select [post]
 func (h *DeviceProxyHandler) SelectRuntime(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -162,7 +236,9 @@ func (h *DeviceProxyHandler) SelectRuntime(w http.ResponseWriter, r *http.Reques
 //	@Tags			device-proxy
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	ProxyOutboundsResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/outbounds [get]
 func (h *DeviceProxyHandler) ListOutbounds(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -180,7 +256,9 @@ func (h *DeviceProxyHandler) ListOutbounds(w http.ResponseWriter, r *http.Reques
 //	@Tags			device-proxy
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ProxyListenChoicesResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/proxy/listen-choices [get]
 func (h *DeviceProxyHandler) ListenChoices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/diagnostics.go
+++ b/internal/api/diagnostics.go
@@ -33,6 +33,13 @@ func NewDiagnosticsHandler(runner DiagnosticsRunner) *DiagnosticsHandler {
 
 // Run starts a background diagnostic run.
 // POST /api/diagnostics/run
+//
+//	@Summary		Run diagnostics
+//	@Tags			diagnostics
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/diagnostics/run [post]
 func (h *DiagnosticsHandler) Run(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -51,6 +58,13 @@ func (h *DiagnosticsHandler) Run(w http.ResponseWriter, r *http.Request) {
 
 // Status returns the current diagnostic run status.
 // GET /api/diagnostics/status
+//
+//	@Summary		Diagnostics status
+//	@Tags			diagnostics
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/diagnostics/status [get]
 func (h *DiagnosticsHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -62,6 +76,13 @@ func (h *DiagnosticsHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 // Result returns the last completed diagnostics report as a JSON file download.
 // GET /api/diagnostics/result
+//
+//	@Summary		Download diagnostics report
+//	@Tags			diagnostics
+//	@Produce		application/json
+//	@Security		CookieAuth
+//	@Success		200	{file}	binary
+//	@Router			/diagnostics/result [get]
 func (h *DiagnosticsHandler) Result(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -118,6 +139,13 @@ func sanitizeFilenamePart(s string) string {
 
 // Stream starts a diagnostic run and streams results via SSE.
 // GET /api/diagnostics/stream?mode=quick&restart=false&route=direct|tunnel&tunnelId=<id>
+//
+//	@Summary		Diagnostics SSE stream
+//	@Tags			diagnostics
+//	@Produce		text/event-stream
+//	@Security		CookieAuth
+//	@Success		200	{string}	string	"SSE stream"
+//	@Router			/diagnostics/stream [get]
 func (h *DiagnosticsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/diagnostics.go
+++ b/internal/api/diagnostics.go
@@ -13,6 +13,20 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// DiagnosticsStatusData mirrors frontend DiagnosticsStatus.
+type DiagnosticsStatusData struct {
+	Status   string `json:"status" example:"idle"`
+	Progress string `json:"progress" example:""`
+}
+
+// DiagnosticsStatusResponse is the envelope for GET /diagnostics/status.
+type DiagnosticsStatusResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    DiagnosticsStatusData `json:"data"`
+}
+
 // DiagnosticsRunner is the interface for running diagnostics.
 type DiagnosticsRunner interface {
 	Run(ctx context.Context) error
@@ -38,7 +52,9 @@ func NewDiagnosticsHandler(runner DiagnosticsRunner) *DiagnosticsHandler {
 //	@Tags			diagnostics
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/diagnostics/run [post]
 func (h *DiagnosticsHandler) Run(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -63,7 +79,9 @@ func (h *DiagnosticsHandler) Run(w http.ResponseWriter, r *http.Request) {
 //	@Tags			diagnostics
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	DiagnosticsStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/diagnostics/status [get]
 func (h *DiagnosticsHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -82,6 +100,8 @@ func (h *DiagnosticsHandler) Status(w http.ResponseWriter, r *http.Request) {
 //	@Produce		application/json
 //	@Security		CookieAuth
 //	@Success		200	{file}	binary
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/diagnostics/result [get]
 func (h *DiagnosticsHandler) Result(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -145,6 +165,8 @@ func sanitizeFilenamePart(s string) string {
 //	@Produce		text/event-stream
 //	@Security		CookieAuth
 //	@Success		200	{string}	string	"SSE stream"
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/diagnostics/stream [get]
 func (h *DiagnosticsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/dnscheck.go
+++ b/internal/api/dnscheck.go
@@ -9,6 +9,30 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// DnsCheckResultDTO mirrors frontend DnsCheckResult.
+type DnsCheckResultDTO struct {
+	ID      string `json:"id" example:"dns_leak"`
+	Status  string `json:"status" example:"ok"`
+	Title   string `json:"title" example:"DNS Leak Test"`
+	Message string `json:"message" example:"No DNS leak detected"`
+	Detail  string `json:"detail,omitempty" example:""`
+}
+
+// DnsCheckStartData mirrors frontend DnsCheckStartResponse.
+type DnsCheckStartData struct {
+	ClientIP string              `json:"clientIP" example:"192.168.1.100"`
+	Hostname string              `json:"hostname" example:"my-phone.local"`
+	Checks   []DnsCheckResultDTO `json:"checks"`
+}
+
+// DnsCheckStartResponseEnvelope is the envelope for POST /dns-check/start.
+type DnsCheckStartResponseEnvelope struct {
+	Success bool              `json:"success" example:"true"`
+	Data    DnsCheckStartData `json:"data"`
+}
+
 type DnsCheckHandler struct {
 	svc *dnscheck.Service
 }
@@ -23,7 +47,9 @@ func NewDnsCheckHandler(svc *dnscheck.Service) *DnsCheckHandler {
 //	@Tags			dns-check
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	DnsCheckStartResponseEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-check/start [post]
 func (h *DnsCheckHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -46,7 +72,9 @@ func (h *DnsCheckHandler) Start(w http.ResponseWriter, r *http.Request) {
 //	@Summary		DNS check probe (CORS)
 //	@Tags			dns-check
 //	@Produce		json
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-check/probe [get]
 func (h *DnsCheckHandler) Probe(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/internal/api/dnscheck.go
+++ b/internal/api/dnscheck.go
@@ -18,6 +18,13 @@ func NewDnsCheckHandler(svc *dnscheck.Service) *DnsCheckHandler {
 }
 
 // Start initiates DNS diagnostic check (server-side checks only).
+//
+//	@Summary		Start DNS check
+//	@Tags			dns-check
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-check/start [post]
 func (h *DnsCheckHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -35,6 +42,12 @@ func (h *DnsCheckHandler) Start(w http.ResponseWriter, r *http.Request) {
 // Probe — cross-origin endpoint hit by the client's DNS probe fetch.
 // If the client's DNS resolves awgm-dnscheck.test to the router, this
 // endpoint is reachable and responds with 200. NO auth required.
+//
+//	@Summary		DNS check probe (CORS)
+//	@Tags			dns-check
+//	@Produce		json
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-check/probe [get]
 func (h *DnsCheckHandler) Probe(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -10,6 +10,49 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// DnsRouteSubscriptionDTO mirrors frontend DnsRouteSubscription.
+type DnsRouteSubscriptionDTO struct {
+	URL         string `json:"url" example:"https://example.com/list.txt"`
+	Name        string `json:"name" example:"Block list"`
+	LastFetched string `json:"lastFetched,omitempty" example:"2024-01-15T02:00:00Z"`
+	LastCount   int    `json:"lastCount,omitempty" example:"1500"`
+}
+
+// DnsRouteTargetDTO mirrors frontend DnsRouteTarget.
+type DnsRouteTargetDTO struct {
+	Interface string `json:"interface" example:"nwg0"`
+	TunnelId  string `json:"tunnelId" example:"tun_abc123"`
+	Fallback  string `json:"fallback,omitempty" example:"auto"`
+}
+
+// DnsRouteDTO mirrors frontend DnsRoute.
+type DnsRouteDTO struct {
+	ID            string                    `json:"id" example:"dns_xyz789"`
+	Name          string                    `json:"name" example:"Work VPN"`
+	Domains       []string                  `json:"domains" example:"example.com"`
+	ManualDomains []string                  `json:"manualDomains" example:"corp.internal"`
+	Subscriptions []DnsRouteSubscriptionDTO `json:"subscriptions,omitempty"`
+	Routes        []DnsRouteTargetDTO       `json:"routes"`
+	Enabled       bool                      `json:"enabled" example:"true"`
+	CreatedAt     string                    `json:"createdAt" example:"2024-01-01T00:00:00Z"`
+	UpdatedAt     string                    `json:"updatedAt" example:"2024-01-15T12:00:00Z"`
+	Backend       string                    `json:"backend,omitempty" example:"ndms"`
+}
+
+// DnsRoutesListResponse is the envelope for GET /dns-routes/list.
+type DnsRoutesListResponse struct {
+	Success bool          `json:"success" example:"true"`
+	Data    []DnsRouteDTO `json:"data"`
+}
+
+// DnsRouteResponse is the envelope for GET /dns-routes/get and mutations.
+type DnsRouteResponse struct {
+	Success bool        `json:"success" example:"true"`
+	Data    DnsRouteDTO `json:"data"`
+}
+
 // DNSRouteService defines what the DNS route handler needs from the service.
 type DNSRouteService interface {
 	Create(ctx context.Context, list dnsroute.DomainList) (*dnsroute.DomainList, error)
@@ -59,7 +102,9 @@ func NewDNSRouteHandler(svc DNSRouteService, appLogger logging.AppLogger) *DNSRo
 //	@Tags			dns-routes
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	DnsRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/list [get]
 //	@Router			/routing/dns-routes [get]
 func (h *DNSRouteHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -84,7 +129,9 @@ func (h *DNSRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	DnsRouteResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/get [get]
 func (h *DNSRouteHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -114,7 +161,9 @@ func (h *DNSRouteHandler) Get(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	DnsRouteResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/create [post]
 func (h *DNSRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 	list, ok := parseJSON[dnsroute.DomainList](w, r, http.MethodPost)
@@ -141,7 +190,9 @@ func (h *DNSRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	DnsRouteResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/update [post]
 func (h *DNSRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 	list, ok := parseJSON[dnsroute.DomainList](w, r, http.MethodPost)
@@ -175,7 +226,9 @@ func (h *DNSRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/delete [post]
 func (h *DNSRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -213,7 +266,9 @@ func (h *DNSRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/delete-batch [post]
 func (h *DNSRouteHandler) DeleteBatch(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
@@ -255,7 +310,9 @@ func (h *DNSRouteHandler) DeleteBatch(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/create-batch [post]
 func (h *DNSRouteHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 	lists, ok := parseJSON[[]dnsroute.DomainList](w, r, http.MethodPost)
@@ -288,7 +345,9 @@ func (h *DNSRouteHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/set-enabled [post]
 func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
@@ -330,7 +389,9 @@ func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/bulk-backend [post]
 func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
@@ -380,7 +441,9 @@ func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	false	"List id (omit for all)"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/refresh [post]
 func (h *DNSRouteHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -54,6 +54,14 @@ func NewDNSRouteHandler(svc DNSRouteService, appLogger logging.AppLogger) *DNSRo
 }
 
 // List returns all domain lists.
+//
+//	@Summary		List DNS route lists
+//	@Tags			dns-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/dns-routes/list [get]
+//	@Router			/routing/dns-routes [get]
 func (h *DNSRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -70,6 +78,14 @@ func (h *DNSRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // Get returns a single domain list by ID.
+//
+//	@Summary		Get DNS route list
+//	@Tags			dns-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-routes/get [get]
 func (h *DNSRouteHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -92,6 +108,14 @@ func (h *DNSRouteHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create creates a new domain list.
+//
+//	@Summary		Create DNS route list
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-routes/create [post]
 func (h *DNSRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 	list, ok := parseJSON[dnsroute.DomainList](w, r, http.MethodPost)
 	if !ok {
@@ -110,6 +134,15 @@ func (h *DNSRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 // Update updates an existing domain list.
+//
+//	@Summary		Update DNS route list
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-routes/update [post]
 func (h *DNSRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 	list, ok := parseJSON[dnsroute.DomainList](w, r, http.MethodPost)
 	if !ok {
@@ -136,6 +169,14 @@ func (h *DNSRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 // Delete deletes a domain list by ID and returns the fresh list so the
 // client can call applyMutationResponse without a separate refetch.
+//
+//	@Summary		Delete DNS route list
+//	@Tags			dns-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/dns-routes/delete [post]
 func (h *DNSRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -166,6 +207,14 @@ func (h *DNSRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteBatch deletes multiple domain lists by IDs.
+//
+//	@Summary		Delete DNS route lists (batch)
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/dns-routes/delete-batch [post]
 func (h *DNSRouteHandler) DeleteBatch(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
 		IDs []string `json:"ids"`
@@ -200,6 +249,14 @@ func (h *DNSRouteHandler) DeleteBatch(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateBatch creates multiple domain lists at once.
+//
+//	@Summary		Create DNS route lists (batch)
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-routes/create-batch [post]
 func (h *DNSRouteHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 	lists, ok := parseJSON[[]dnsroute.DomainList](w, r, http.MethodPost)
 	if !ok {
@@ -224,6 +281,15 @@ func (h *DNSRouteHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 }
 
 // SetEnabled toggles the enabled state of a domain list.
+//
+//	@Summary		Set DNS route list enabled
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/dns-routes/set-enabled [post]
 func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
 	if !ok {
@@ -258,6 +324,14 @@ func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 }
 
 // BulkBackend switches the routing backend for multiple lists.
+//
+//	@Summary		Bulk set DNS route backend
+//	@Tags			dns-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/dns-routes/bulk-backend [post]
 func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		ListIDs []string `json:"listIDs"`
@@ -300,6 +374,14 @@ func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 }
 
 // Refresh refreshes subscriptions for a single list or all lists.
+//
+//	@Summary		Refresh DNS route subscriptions
+//	@Tags			dns-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	false	"List id (omit for all)"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/dns-routes/refresh [post]
 func (h *DNSRouteHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -21,6 +21,13 @@ func NewEventsHandler(bus *events.Bus) *EventsHandler {
 // Stream serves the SSE event stream.
 // GET /api/events
 //
+//	@Summary		SSE event stream
+//	@Tags			events
+//	@Produce		text/event-stream
+//	@Security		CookieAuth
+//	@Success		200	{string}	string	"Server-Sent Events"
+//	@Router			/events [get]
+//
 // The stream carries only incremental/push-only events (traffic,
 // connectivity, logs, ping-check logs, sing-box delay/traffic, geo
 // download progress, DNS-route failover notifications, and the generic

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -26,6 +26,8 @@ func NewEventsHandler(bus *events.Bus) *EventsHandler {
 //	@Produce		text/event-stream
 //	@Security		CookieAuth
 //	@Success		200	{string}	string	"Server-Sent Events"
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/events [get]
 //
 // The stream carries only incremental/push-only events (traffic,

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -11,6 +11,25 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/service"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// ExternalTunnelDTO mirrors frontend ExternalTunnel.
+type ExternalTunnelDTO struct {
+	InterfaceName string `json:"interfaceName" example:"Wireguard2"`
+	TunnelNumber  int    `json:"tunnelNumber" example:"2"`
+	IsAWG         bool   `json:"isAWG" example:"true"`
+	PublicKey     string `json:"publicKey,omitempty" example:"KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK="`
+	Endpoint      string `json:"endpoint,omitempty" example:"ext.example.com:51820"`
+	RxBytes       int64  `json:"rxBytes" example:"1048576"`
+	TxBytes       int64  `json:"txBytes" example:"524288"`
+}
+
+// ExternalTunnelsResponse is the envelope for GET /external-tunnels.
+type ExternalTunnelsResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    []ExternalTunnelDTO `json:"data"`
+}
+
 // ExternalTunnelService defines the interface for external tunnel operations.
 type ExternalTunnelService interface {
 	List(ctx context.Context) ([]external.TunnelInfo, error)
@@ -60,7 +79,9 @@ func (h *ExternalTunnelsHandler) listExternal(ctx context.Context) ([]external.T
 //	@Tags			tunnels
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	object
+//	@Success		200	{object}	ExternalTunnelsResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/external-tunnels [get]
 func (h *ExternalTunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -93,7 +114,9 @@ type AdoptRequest struct {
 //	@Security		CookieAuth
 //	@Param			interface	query		string			true	"NDMS interface name"
 //	@Param			body		body		AdoptRequest	true	"Tunnel config body"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/external-tunnels/adopt [post]
 func (h *ExternalTunnelsHandler) Adopt(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -55,6 +55,13 @@ func (h *ExternalTunnelsHandler) listExternal(ctx context.Context) ([]external.T
 
 // List returns all external (unmanaged) tunnels.
 // Endpoint: GET /api/external-tunnels
+//
+//	@Summary		List external tunnels
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	object
+//	@Router			/external-tunnels [get]
 func (h *ExternalTunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -70,14 +77,24 @@ func (h *ExternalTunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	response.Success(w, tunnels)
 }
 
-// adoptRequest represents the request body for adopting an external tunnel.
-type adoptRequest struct {
+// AdoptRequest is the request body for adopting an external tunnel.
+type AdoptRequest struct {
 	Content string `json:"content"`
 	Name    string `json:"name"`
 }
 
 // Adopt takes control of an external tunnel.
 // Endpoint: POST /api/external-tunnels/adopt?interface=opkgtunX
+//
+//	@Summary		Adopt external tunnel
+//	@Tags			tunnels
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			interface	query		string			true	"NDMS interface name"
+//	@Param			body		body		AdoptRequest	true	"Tunnel config body"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/external-tunnels/adopt [post]
 func (h *ExternalTunnelsHandler) Adopt(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -88,7 +105,7 @@ func (h *ExternalTunnelsHandler) Adopt(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, "missing interface parameter", "MISSING_INTERFACE")
 		return
 	}
-	req, ok := parseJSON[adoptRequest](w, r, http.MethodPost)
+	req, ok := parseJSON[AdoptRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -23,6 +23,13 @@ func NewHealthHandler(version string) *HealthHandler {
 
 // ServeHTTP responds to GET with { ok: true, version: "..." }. Any
 // other method returns 405 Method Not Allowed.
+//
+//	@Summary		Health / liveness
+//	@Description	Cheap check for frontend pollers; no NDMS or I/O.
+//	@Tags			system
+//	@Produce		json
+//	@Success		200	{object}	map[string]interface{}	"ok, version"
+//	@Router			/health [get]
 func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -6,6 +6,20 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// HealthData is the response data for GET /health.
+type HealthData struct {
+	OK      bool   `json:"ok" example:"true"`
+	Version string `json:"version" example:"2.5.0"`
+}
+
+// HealthResponse is the envelope for GET /health.
+type HealthResponse struct {
+	Success bool       `json:"success" example:"true"`
+	Data    HealthData `json:"data"`
+}
+
 // HealthHandler serves GET /api/health. A cheap liveness check that
 // does no I/O, no NDMS calls — used by the frontend 5-second poller
 // to decide when to show the full-screen "backend offline" overlay
@@ -28,7 +42,9 @@ func NewHealthHandler(version string) *HealthHandler {
 //	@Description	Cheap check for frontend pollers; no NDMS or I/O.
 //	@Tags			system
 //	@Produce		json
-//	@Success		200	{object}	map[string]interface{}	"ok, version"
+//	@Success		200	{object}	HealthResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/health [get]
 func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/hook.go
+++ b/internal/api/hook.go
@@ -115,7 +115,9 @@ func (h *HookHandler) SetTunnelRefresher(fn TunnelHookInvalidator) {
 //	@Accept			x-www-form-urlencoded
 //	@Produce		json
 //	@Param			type	formData	string	true	"Event type (iflayerchanged, ifcreated, ...)"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/hook/ndms [post]
 func (h *HookHandler) HandleNDMS(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/hook.go
+++ b/internal/api/hook.go
@@ -108,6 +108,15 @@ func (h *HookHandler) SetTunnelRefresher(fn TunnelHookInvalidator) {
 //   address=<ipv4>                        (ipchanged only)
 //   up=<0|1>
 //   connected=<0|1>
+//
+//	@Summary		NDMS shell hook
+//	@Description	Called from router scripts (public). Form fields: type, id, system_name, layer, etc.
+//	@Tags			hook
+//	@Accept			x-www-form-urlencoded
+//	@Produce		json
+//	@Param			type	formData	string	true	"Event type (iflayerchanged, ifcreated, ...)"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hook/ndms [post]
 func (h *HookHandler) HandleNDMS(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -9,6 +9,60 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// HydraRouteConfigData mirrors frontend HydraRouteConfig.
+type HydraRouteConfigData struct {
+	AutoStart          bool     `json:"autoStart" example:"true"`
+	ClearIPSet         bool     `json:"clearIPSet" example:"false"`
+	CIDR               bool     `json:"cidr" example:"true"`
+	IpsetEnableTimeout bool     `json:"ipsetEnableTimeout" example:"false"`
+	IpsetTimeout       int      `json:"ipsetTimeout" example:"0"`
+	IpsetMaxElem       int      `json:"ipsetMaxElem" example:"65536"`
+	DirectRouteEnabled bool     `json:"directRouteEnabled" example:"false"`
+	GlobalRouting      bool     `json:"globalRouting" example:"false"`
+	ConntrackFlush     bool     `json:"conntrackFlush" example:"true"`
+	Log                string   `json:"log" example:"warn"`
+	LogFile            string   `json:"logFile" example:"/var/log/hrneo.log"`
+	GeoIPFiles         []string `json:"geoIPFiles" example:"/opt/etc/hrneo/geoip.db"`
+	GeoSiteFiles       []string `json:"geoSiteFiles" example:"/opt/etc/hrneo/geosite.db"`
+	PolicyOrder        []string `json:"policyOrder" example:"default"`
+}
+
+// HydraRouteConfigResponse is the envelope for GET /hydraroute/config.
+type HydraRouteConfigResponse struct {
+	Success bool                 `json:"success" example:"true"`
+	Data    HydraRouteConfigData `json:"data"`
+}
+
+// GeoFileEntryDTO mirrors frontend GeoFileEntry.
+type GeoFileEntryDTO struct {
+	Type     string `json:"type" example:"geosite"`
+	Path     string `json:"path" example:"/opt/etc/hrneo/geosite.db"`
+	URL      string `json:"url" example:"https://cdn.example.com/geosite.db"`
+	Size     int64  `json:"size" example:"3145728"`
+	TagCount int    `json:"tagCount" example:"420"`
+	Updated  string `json:"updated" example:"2024-01-15T02:00:00Z"`
+}
+
+// GeoFilesResponse is the envelope for GET /hydraroute/geo-files.
+type GeoFilesResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []GeoFileEntryDTO `json:"data"`
+}
+
+// GeoTagDTO mirrors frontend GeoTag.
+type GeoTagDTO struct {
+	Name  string `json:"name" example:"google"`
+	Count int    `json:"count" example:"1250"`
+}
+
+// GeoTagsResponse is the envelope for GET /hydraroute/geo-tags.
+type GeoTagsResponse struct {
+	Success bool        `json:"success" example:"true"`
+	Data    []GeoTagDTO `json:"data"`
+}
+
 // HydraRouteHandler handles HydraRoute Neo settings API endpoints.
 type HydraRouteHandler struct {
 	svc *hydraroute.Service
@@ -33,7 +87,7 @@ func (h *HydraRouteHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 //	@Tags			hydraroute
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	HydraRouteConfigResponse
 //	@Router			/hydraroute/config [get]
 func (h *HydraRouteHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -58,10 +112,10 @@ func (h *HydraRouteHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"hydraroute.Config"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		HydraRouteConfigData	true	"hydraroute.Config"
+//	@Success		200		{object}	HydraRouteConfigResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/hydraroute/config/update [put]
 func (h *HydraRouteHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -27,6 +27,14 @@ func NewHydraRouteHandler(svc *hydraroute.Service) *HydraRouteHandler {
 func (h *HydraRouteHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 
 // GetConfig returns the current HydraRoute config.
+//
+//	@Summary		Get HydraRoute config
+//	@Description	Available when HydraRoute service is wired on the device.
+//	@Tags			hydraroute
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/config [get]
 func (h *HydraRouteHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -79,6 +87,13 @@ func (h *HydraRouteHandler) UpdateConfig(w http.ResponseWriter, r *http.Request)
 }
 
 // ListGeoFiles returns all tracked geo data files.
+//
+//	@Summary		List HydraRoute geo files
+//	@Tags			hydraroute
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/hydraroute/geo-files [get]
 func (h *HydraRouteHandler) ListGeoFiles(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -95,6 +110,14 @@ func (h *HydraRouteHandler) ListGeoFiles(w http.ResponseWriter, r *http.Request)
 }
 
 // AddGeoFile downloads and registers a new geo data file.
+//
+//	@Summary		Add HydraRoute geo file
+//	@Tags			hydraroute
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/geo-files/add [post]
 func (h *HydraRouteHandler) AddGeoFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -174,6 +197,14 @@ func (h *HydraRouteHandler) DeleteGeoFile(w http.ResponseWriter, r *http.Request
 }
 
 // UpdateGeoFile re-downloads a geo data file (or all files if path is empty).
+//
+//	@Summary		Refresh HydraRoute geo file(s)
+//	@Tags			hydraroute
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/geo-files/update [post]
 func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -225,6 +256,14 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 }
 
 // GetGeoTags returns the tag list for a specific geo data file.
+//
+//	@Summary		HydraRoute geo tags
+//	@Tags			hydraroute
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			path	query	string	true	"Geo file path"
+//	@Success		200	{array}	string
+//	@Router			/hydraroute/geo-tags [get]
 func (h *HydraRouteHandler) GetGeoTags(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -253,6 +292,13 @@ func (h *HydraRouteHandler) GetGeoTags(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetIpsetUsage returns the current ipset usage per kernel interface.
+//
+//	@Summary		HydraRoute ipset usage
+//	@Tags			hydraroute
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/ipset-usage [get]
 func (h *HydraRouteHandler) GetIpsetUsage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -269,6 +315,14 @@ func (h *HydraRouteHandler) GetIpsetUsage(w http.ResponseWriter, r *http.Request
 }
 
 // SetPolicyOrder updates the PolicyOrder in hrneo.conf.
+//
+//	@Summary		Set HydraRoute policy order
+//	@Tags			hydraroute
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/policy-order [post]
 func (h *HydraRouteHandler) SetPolicyOrder(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -297,6 +351,13 @@ func (h *HydraRouteHandler) SetPolicyOrder(w http.ResponseWriter, r *http.Reques
 // GetOversizedTags returns the list of geoip tags HR Neo excluded plus
 // the current IpsetMaxElem so the frontend can render the 'Отключённые
 // теги' pane and enforce picker limits.
+//
+//	@Summary		HydraRoute oversized geo tags
+//	@Tags			hydraroute
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/hydraroute/oversized-tags [get]
 func (h *HydraRouteHandler) GetOversizedTags(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -43,6 +43,14 @@ func (h *ImportHandler) SetTunnelsHandler(th *TunnelsHandler) {
 }
 
 // ImportConf imports a WireGuard/AmneziaWG config file.
+//
+//	@Summary		Import tunnel config
+//	@Tags			import
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/import/conf [post]
 func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
 		Content string `json:"content"`

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -49,7 +49,9 @@ func (h *ImportHandler) SetTunnelsHandler(th *TunnelsHandler) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/import/conf [post]
 func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -10,6 +10,32 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// LogEntryDTO mirrors frontend LogEntry.
+type LogEntryDTO struct {
+	Timestamp string `json:"timestamp" example:"2024-01-15T10:30:00Z"`
+	Level     string `json:"level" example:"info"`
+	Group     string `json:"group" example:"tunnel"`
+	Subgroup  string `json:"subgroup" example:"tun_abc123"`
+	Action    string `json:"action" example:"connect"`
+	Target    string `json:"target" example:"vpn.example.com:51820"`
+	Message   string `json:"message" example:"Tunnel connected"`
+}
+
+// LogsData mirrors frontend LogsResponse.
+type LogsData struct {
+	Enabled bool          `json:"enabled" example:"true"`
+	Logs    []LogEntryDTO `json:"logs"`
+	Total   int           `json:"total" example:"42"`
+}
+
+// LogsResponse is the envelope for GET /logs.
+type LogsResponseEnvelope struct {
+	Success bool     `json:"success" example:"true"`
+	Data    LogsData `json:"data"`
+}
+
 // LoggingHandler handles logging API endpoints.
 type LoggingHandler struct {
 	svc *logging.Service
@@ -48,7 +74,9 @@ type LogsResponse struct {
 //	@Tags			logs
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	LogsResponseEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/logs [get]
 func (h *LoggingHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -115,7 +143,9 @@ func (h *LoggingHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 //	@Tags			logs
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/logs/clear [post]
 func (h *LoggingHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -43,6 +43,13 @@ type LogsResponse struct {
 
 // GetLogs returns log entries with optional filtering.
 // GET /api/logs?group=&subgroup=&level= (new) or ?category=&level= (backward compat)
+//
+//	@Summary		Get logs
+//	@Tags			logs
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/logs [get]
 func (h *LoggingHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -103,6 +110,13 @@ func (h *LoggingHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 
 // ClearLogs removes all log entries.
 // POST /api/logs/clear
+//
+//	@Summary		Clear logs
+//	@Tags			logs
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/logs/clear [post]
 func (h *LoggingHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")

--- a/internal/api/managed.go
+++ b/internal/api/managed.go
@@ -13,6 +13,61 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// ManagedPeerDTO mirrors frontend ManagedPeer.
+type ManagedPeerDTO struct {
+	PublicKey    string `json:"publicKey" example:"HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH="`
+	PrivateKey   string `json:"privateKey" example:"IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII="`
+	PresharedKey string `json:"presharedKey" example:"JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ="`
+	Description  string `json:"description" example:"My Phone"`
+	TunnelIP     string `json:"tunnelIP" example:"10.10.0.2"`
+	DNS          string `json:"dns,omitempty" example:"8.8.8.8"`
+	Enabled      bool   `json:"enabled" example:"true"`
+}
+
+// ManagedServerDTO mirrors frontend ManagedServer.
+type ManagedServerDTO struct {
+	InterfaceName string           `json:"interfaceName" example:"Wireguard1"`
+	Address       string           `json:"address" example:"10.10.0.1"`
+	Mask          string           `json:"mask" example:"255.255.255.0"`
+	ListenPort    int              `json:"listenPort" example:"51821"`
+	Endpoint      string           `json:"endpoint,omitempty" example:"203.0.113.42:51821"`
+	DNS           string           `json:"dns,omitempty" example:"8.8.8.8"`
+	MTU           int              `json:"mtu,omitempty" example:"1420"`
+	NatEnabled    bool             `json:"natEnabled,omitempty" example:"true"`
+	Policy        string           `json:"policy" example:"default"`
+	Peers         []ManagedPeerDTO `json:"peers"`
+}
+
+// ManagedServerResponse is the envelope for GET /managed-server.
+type ManagedServerResponse struct {
+	Success bool             `json:"success" example:"true"`
+	Data    ManagedServerDTO `json:"data"`
+}
+
+// CreateServerRequestDTO is the swagger-visible body for POST /managed-servers.
+type CreateServerRequestDTO struct {
+	Address     string `json:"address" example:"10.10.0.1"`
+	Mask        string `json:"mask" example:"255.255.255.0"`
+	ListenPort  int    `json:"listenPort" example:"51821"`
+	Description string `json:"description,omitempty" example:"My WG Server"`
+	Endpoint    string `json:"endpoint,omitempty" example:"203.0.113.42:51821"`
+	DNS         string `json:"dns,omitempty" example:"8.8.8.8"`
+	MTU         int    `json:"mtu,omitempty" example:"1420"`
+}
+
+// UpdateServerRequestDTO is the swagger-visible body for PUT /managed-servers/{id}.
+type UpdateServerRequestDTO struct {
+	Address     string  `json:"address" example:"10.10.0.1"`
+	Mask        string  `json:"mask" example:"255.255.255.0"`
+	ListenPort  int     `json:"listenPort" example:"51821"`
+	Description *string `json:"description,omitempty" example:"My WG Server"`
+	Endpoint    *string `json:"endpoint,omitempty" example:"203.0.113.42:51821"`
+	DNS         *string `json:"dns,omitempty" example:"8.8.8.8"`
+	MTU         *int    `json:"mtu,omitempty" example:"1420"`
+}
+
 // isValidWGKey checks that a string is a valid WireGuard key (44-char base64, 32 bytes decoded).
 func isValidWGKey(key string) bool {
 	if len(key) != 44 || key[43] != '=' {
@@ -438,7 +493,7 @@ func (h *ManagedServerHandler) Stats(w http.ResponseWriter, r *http.Request, id 
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		managed.CreateServerRequest	true	"Address, mask, port, ASC, name"
+//	@Param			body	body		CreateServerRequestDTO	true	"Address, mask, port, ASC, name"
 //	@Success		200		{object}	map[string]interface{}
 //	@Failure		400		{object}	map[string]interface{}
 //	@Failure		500		{object}	map[string]interface{}
@@ -467,7 +522,7 @@ func (h *ManagedServerHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id		path		string						true	"Server id"
-//	@Param			body	body		managed.UpdateServerRequest	true	"Update payload"
+//	@Param			body	body		UpdateServerRequestDTO	true	"Update payload"
 //	@Success		200		{object}	map[string]interface{}
 //	@Failure		400		{object}	map[string]interface{}
 //	@Failure		404		{object}	map[string]interface{}

--- a/internal/api/managed_peers.go
+++ b/internal/api/managed_peers.go
@@ -7,6 +7,20 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// AddPeerRequestDTO is the swagger-visible body for POST /managed-servers/{id}/peers.
+type AddPeerRequestDTO struct {
+	Description string `json:"description" example:"My Phone"`
+	TunnelIP    string `json:"tunnelIP" example:"10.10.0.2/32"`
+	DNS         string `json:"dns,omitempty" example:"8.8.8.8"`
+}
+
+// UpdatePeerRequestDTO is the swagger-visible body for PUT /managed-servers/{id}/peers/{pubkey}.
+type UpdatePeerRequestDTO struct {
+	Description string `json:"description" example:"My Phone"`
+	TunnelIP    string `json:"tunnelIP" example:"10.10.0.2/32"`
+	DNS         string `json:"dns,omitempty" example:"8.8.8.8"`
+}
+
 // AddPeer adds a new peer to a managed server.
 // POST /api/managed-servers/{id}/peers
 //
@@ -17,7 +31,7 @@ import (
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
-//	@Param			body	body		managed.AddPeerRequest	true	"Peer payload"
+//	@Param			body	body		AddPeerRequestDTO	true	"Peer payload"
 //	@Success		200		{object}	map[string]interface{}
 //	@Failure		400		{object}	map[string]interface{}
 //	@Failure		500		{object}	map[string]interface{}
@@ -47,7 +61,7 @@ func (h *ManagedServerHandler) AddPeer(w http.ResponseWriter, r *http.Request, i
 //	@Security		CookieAuth
 //	@Param			id		path		string						true	"Server id"
 //	@Param			pubkey	path		string						true	"Peer public key (URL-encoded)"
-//	@Param			body	body		managed.UpdatePeerRequest	true	"Peer update payload"
+//	@Param			body	body		UpdatePeerRequestDTO	true	"Peer update payload"
 //	@Success		200		{object}	map[string]interface{}
 //	@Failure		400		{object}	map[string]interface{}
 //	@Failure		404		{object}	map[string]interface{}

--- a/internal/api/monitoring.go
+++ b/internal/api/monitoring.go
@@ -8,6 +8,63 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// MonitoringTargetDTO mirrors frontend MonitoringTarget.
+type MonitoringTargetDTO struct {
+	ID   string `json:"id" example:"target_google"`
+	Host string `json:"host" example:"https://www.google.com"`
+	Name string `json:"name" example:"Google"`
+}
+
+// MonitoringTunnelDTO mirrors frontend MonitoringTunnel.
+type MonitoringTunnelDTO struct {
+	ID              string `json:"id" example:"tun_abc123"`
+	Name            string `json:"name" example:"My VPN"`
+	IfaceName       string `json:"ifaceName" example:"nwg0"`
+	PingcheckTarget string `json:"pingcheckTarget" example:"target_google"`
+	SelfTarget      string `json:"selfTarget" example:"target_self_tun_abc123"`
+	SelfMethod      string `json:"selfMethod" example:"http"`
+}
+
+// MonitoringCellDTO mirrors frontend MonitoringCell.
+type MonitoringCellDTO struct {
+	TargetID        string  `json:"targetId" example:"target_google"`
+	TunnelID        string  `json:"tunnelId" example:"tun_abc123"`
+	LatencyMs       *int    `json:"latencyMs" swaggertype:"integer" example:"42"`
+	OK              bool    `json:"ok" example:"true"`
+	ActiveForRestart bool   `json:"activeForRestart" example:"false"`
+	IsSelf          bool    `json:"isSelf" example:"false"`
+	Ts              string  `json:"ts" example:"2024-01-15T10:30:00Z"`
+}
+
+// MonitoringSnapshotResponse is the envelope for GET /monitoring/matrix.
+type MonitoringSnapshotResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    MonitoringSnapshotData `json:"data"`
+}
+
+// MonitoringSnapshotData mirrors frontend MonitoringSnapshot.
+type MonitoringSnapshotData struct {
+	Targets   []MonitoringTargetDTO `json:"targets"`
+	Tunnels   []MonitoringTunnelDTO `json:"tunnels"`
+	Cells     []MonitoringCellDTO   `json:"cells"`
+	UpdatedAt string                `json:"updatedAt" example:"2024-01-15T10:30:00Z"`
+}
+
+// MonitoringSampleDTO mirrors frontend MonitoringSample.
+type MonitoringSampleDTO struct {
+	Ts        string `json:"ts" example:"2024-01-15T10:30:00Z"`
+	LatencyMs *int   `json:"latencyMs" swaggertype:"integer" example:"42"`
+	OK        bool   `json:"ok" example:"true"`
+}
+
+// MonitoringHistoryResponse is the envelope for GET /monitoring/history.
+type MonitoringHistoryResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    []MonitoringSampleDTO `json:"data"`
+}
+
 // MonitoringHandler exposes the monitoring matrix endpoints.
 type MonitoringHandler struct {
 	svc *monitoring.Service
@@ -27,9 +84,9 @@ func NewMonitoringHandler(svc *monitoring.Service) *MonitoringHandler {
 //	@Tags			monitoring
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		503	{object}	map[string]interface{}
+//	@Success		200	{object}	MonitoringSnapshotResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		503	{object}	APIErrorEnvelope
 //	@Router			/monitoring/matrix [get]
 func (h *MonitoringHandler) GetMatrix(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -56,10 +113,10 @@ func (h *MonitoringHandler) GetMatrix(w http.ResponseWriter, r *http.Request) {
 //	@Param			target		query		string	true	"Target identifier"
 //	@Param			tunnelId	query		string	true	"Tunnel identifier"
 //	@Param			limit		query		int		false	"Max samples to return (default 60)"
-//	@Success		200			{object}	map[string]interface{}
-//	@Failure		400			{object}	map[string]interface{}
-//	@Failure		405			{object}	map[string]interface{}
-//	@Failure		503			{object}	map[string]interface{}
+//	@Success		200			{object}	MonitoringHistoryResponse
+//	@Failure		400			{object}	APIErrorEnvelope
+//	@Failure		405			{object}	APIErrorEnvelope
+//	@Failure		503			{object}	APIErrorEnvelope
 //	@Router			/monitoring/history [get]
 func (h *MonitoringHandler) GetHistory(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/ndms.go
+++ b/internal/api/ndms.go
@@ -46,6 +46,8 @@ type SaveStatusDTO struct {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Success		200	{object}	SaveStatusDTO
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/ndms/save-status [get]
 func (h *NDMSHandler) GetSaveStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/ndms.go
+++ b/internal/api/ndms.go
@@ -27,11 +27,11 @@ func NewNDMSHandler(save *ndmscommand.SaveCoordinator) *NDMSHandler {
 	return &NDMSHandler{save: save}
 }
 
-// saveStatusDTO is the wire shape returned by GET /api/ndms/save-status.
+// SaveStatusDTO is the wire shape returned by GET /api/ndms/save-status.
 // State is one of: "idle" | "pending" | "saving" | "error" | "failed".
 // Mirrors the shape UI consumers previously read from the SSE event bus
 // so the polling store keeps the same keys.
-type saveStatusDTO struct {
+type SaveStatusDTO struct {
 	State        string    `json:"state"`
 	LastError    string    `json:"lastError,omitempty"`
 	LastSaveAt   time.Time `json:"lastSaveAt,omitempty"`
@@ -40,6 +40,13 @@ type saveStatusDTO struct {
 
 // GetSaveStatus returns the current NDMS save-coordinator status as JSON.
 // GET /api/ndms/save-status
+//
+//	@Summary		NDMS save coordinator status
+//	@Tags			ndms
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SaveStatusDTO
+//	@Router			/ndms/save-status [get]
 func (h *NDMSHandler) GetSaveStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -47,11 +54,11 @@ func (h *NDMSHandler) GetSaveStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.save == nil {
 		// Defensive: handler built without a coordinator. Return idle.
-		response.Success(w, saveStatusDTO{State: "idle"})
+		response.Success(w, SaveStatusDTO{State: "idle"})
 		return
 	}
 	s := h.save.Status()
-	response.Success(w, saveStatusDTO{
+	response.Success(w, SaveStatusDTO{
 		State:        s.State.String(),
 		LastError:    s.LastError,
 		LastSaveAt:   s.LastSaveAt,

--- a/internal/api/pingcheck.go
+++ b/internal/api/pingcheck.go
@@ -14,6 +14,75 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/nwg"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// TunnelPingStatusDTO mirrors frontend TunnelPingStatus.
+type TunnelPingStatusDTO struct {
+	TunnelId      string `json:"tunnelId" example:"tun_abc123"`
+	TunnelName    string `json:"tunnelName" example:"My VPN"`
+	Enabled       bool   `json:"enabled" example:"true"`
+	Backend       string `json:"backend" example:"nativewg"`
+	Status        string `json:"status" example:"alive"`
+	Method        string `json:"method" example:"http"`
+	LastLatency   int    `json:"lastLatency" example:"35"`
+	FailCount     int    `json:"failCount" example:"0"`
+	FailThreshold int    `json:"failThreshold" example:"3"`
+	RestartCount  int    `json:"restartCount" example:"0"`
+}
+
+// PingCheckStatusData mirrors frontend PingCheckStatus.
+type PingCheckStatusData struct {
+	Enabled bool                  `json:"enabled" example:"true"`
+	Tunnels []TunnelPingStatusDTO `json:"tunnels"`
+}
+
+// PingCheckStatusResponse is the envelope for GET /pingcheck/status.
+type PingCheckStatusResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    PingCheckStatusData `json:"data"`
+}
+
+// PingLogEntryDTO mirrors frontend PingLogEntry.
+type PingLogEntryDTO struct {
+	Timestamp   string `json:"timestamp" example:"2024-01-15T10:30:00Z"`
+	TunnelId    string `json:"tunnelId" example:"tun_abc123"`
+	TunnelName  string `json:"tunnelName" example:"My VPN"`
+	Success     bool   `json:"success" example:"true"`
+	Latency     int    `json:"latency" example:"35"`
+	Error       string `json:"error" example:""`
+	FailCount   int    `json:"failCount" example:"0"`
+	Threshold   int    `json:"threshold" example:"3"`
+	StateChange string `json:"stateChange" example:""`
+}
+
+// PingLogsResponse is the envelope for GET /pingcheck/logs.
+type PingLogsResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []PingLogEntryDTO `json:"data"`
+}
+
+// NativePingCheckStatusDTO mirrors frontend NativePingCheckStatus.
+type NativePingCheckStatusDTO struct {
+	Exists       bool   `json:"exists" example:"true"`
+	Host         string `json:"host" example:"https://www.google.com"`
+	Mode         string `json:"mode" example:"connect"`
+	Interval     int    `json:"interval" example:"30"`
+	MaxFails     int    `json:"maxFails" example:"3"`
+	MinSuccess   int    `json:"minSuccess" example:"1"`
+	Timeout      int    `json:"timeout" example:"5"`
+	Restart      bool   `json:"restart" example:"true"`
+	Bound        bool   `json:"bound" example:"true"`
+	Status       string `json:"status" example:"alive"`
+	FailCount    int    `json:"failCount" example:"0"`
+	SuccessCount int    `json:"successCount" example:"120"`
+}
+
+// NativePingCheckStatusResponse is the envelope for GET /tunnels/pingcheck.
+type NativePingCheckStatusResponse struct {
+	Success bool                     `json:"success" example:"true"`
+	Data    NativePingCheckStatusDTO `json:"data"`
+}
+
 // PingCheckService defines the interface for ping check operations.
 // Uses pingcheck types directly — no adapter needed.
 type PingCheckService interface {
@@ -75,7 +144,9 @@ func (h *PingCheckHandler) PublishSnapshot() {
 //	@Tags			pingcheck
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	PingCheckStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/pingcheck/status [get]
 func (h *PingCheckHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -105,7 +176,9 @@ func (h *PingCheckHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			tunnelId	query	string	false	"Filter by tunnel id"
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	PingLogsResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/pingcheck/logs [get]
 func (h *PingCheckHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -143,7 +216,9 @@ func (h *PingCheckHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 //	@Tags			pingcheck
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/pingcheck/logs/clear [post]
 func (h *PingCheckHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -169,7 +244,9 @@ func (h *PingCheckHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 //	@Tags			pingcheck
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/pingcheck/check-now [post]
 func (h *PingCheckHandler) CheckNow(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -196,7 +273,9 @@ func (h *PingCheckHandler) CheckNow(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	NativePingCheckStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/pingcheck [get]
 func (h *PingCheckHandler) GetTunnelPingCheckStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -250,7 +329,9 @@ func (h *PingCheckHandler) GetTunnelPingCheckStatus(w http.ResponseWriter, r *ht
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/pingcheck [post]
 func (h *PingCheckHandler) ConfigureTunnelPingCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -334,7 +415,9 @@ func (h *PingCheckHandler) ConfigureTunnelPingCheck(w http.ResponseWriter, r *ht
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/pingcheck/remove [post]
 func (h *PingCheckHandler) RemoveTunnelPingCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/pingcheck.go
+++ b/internal/api/pingcheck.go
@@ -70,6 +70,13 @@ func (h *PingCheckHandler) PublishSnapshot() {
 }
 
 // GetStatus returns the current status of all monitored tunnels.
+//
+//	@Summary		Ping check status
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/pingcheck/status [get]
 func (h *PingCheckHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -92,6 +99,14 @@ func (h *PingCheckHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetLogs returns ping check logs.
+//
+//	@Summary		Ping check logs
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			tunnelId	query	string	false	"Filter by tunnel id"
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/pingcheck/logs [get]
 func (h *PingCheckHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -123,6 +138,13 @@ func (h *PingCheckHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 // ClearLogs removes all ping check log entries.
+//
+//	@Summary		Clear ping check logs
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/pingcheck/logs/clear [post]
 func (h *PingCheckHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -142,6 +164,13 @@ func (h *PingCheckHandler) ClearLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 // CheckNow triggers an immediate check on all tunnels.
+//
+//	@Summary		Trigger ping check now
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/pingcheck/check-now [post]
 func (h *PingCheckHandler) CheckNow(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -161,6 +190,14 @@ func (h *PingCheckHandler) CheckNow(w http.ResponseWriter, r *http.Request) {
 
 // GetTunnelPingCheckStatus returns NDMS ping-check status for a single nativewg tunnel.
 // GET /api/tunnels/pingcheck?id=xxx
+//
+//	@Summary		Get per-tunnel NDMS ping-check
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/pingcheck [get]
 func (h *PingCheckHandler) GetTunnelPingCheckStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -206,6 +243,15 @@ func (h *PingCheckHandler) GetTunnelPingCheckStatus(w http.ResponseWriter, r *ht
 
 // ConfigureTunnelPingCheck creates/updates NDMS ping-check for a nativewg tunnel.
 // POST /api/tunnels/pingcheck?id=xxx
+//
+//	@Summary		Configure per-tunnel NDMS ping-check
+//	@Tags			pingcheck
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/pingcheck [post]
 func (h *PingCheckHandler) ConfigureTunnelPingCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -282,6 +328,14 @@ func (h *PingCheckHandler) ConfigureTunnelPingCheck(w http.ResponseWriter, r *ht
 
 // RemoveTunnelPingCheck removes NDMS ping-check for a nativewg tunnel.
 // POST /api/tunnels/pingcheck/remove?id=xxx
+//
+//	@Summary		Remove per-tunnel NDMS ping-check
+//	@Tags			pingcheck
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/pingcheck/remove [post]
 func (h *PingCheckHandler) RemoveTunnelPingCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -15,12 +15,22 @@ func NewResolveHandler() *ResolveHandler {
 	return &ResolveHandler{}
 }
 
-type resolveResponse struct {
+// ResolveResponse is the JSON body for GET /api/routing/resolve.
+type ResolveResponse struct {
 	Domain string   `json:"domain"`
 	IPs    []string `json:"ips"`
 	Error  string   `json:"error,omitempty"`
 }
 
+// Resolve performs a DNS lookup (IPv4 only) for routing search.
+//
+//	@Summary		Resolve domain
+//	@Tags			routing
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			domain	query	string	true	"Hostname to resolve"
+//	@Success		200	{object}	ResolveResponse
+//	@Router			/routing/resolve [get]
 func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -39,7 +49,7 @@ func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	resolver := &net.Resolver{}
 	addrs, err := resolver.LookupHost(ctx, domain)
 	if err != nil {
-		response.Success(w, resolveResponse{
+		response.Success(w, ResolveResponse{
 			Domain: domain,
 			IPs:    []string{},
 			Error:  "Не удалось резолвить домен: " + err.Error(),
@@ -58,7 +68,7 @@ func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		ipv4 = []string{}
 	}
 
-	response.Success(w, resolveResponse{
+	response.Success(w, ResolveResponse{
 		Domain: domain,
 		IPs:    ipv4,
 	})

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -30,6 +30,8 @@ type ResolveResponse struct {
 //	@Security		CookieAuth
 //	@Param			domain	query	string	true	"Hostname to resolve"
 //	@Success		200	{object}	ResolveResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/resolve [get]
 func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/routing.go
+++ b/internal/api/routing.go
@@ -27,6 +27,13 @@ func (h *RoutingHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 
 // Tunnels returns available tunnels for routing dropdowns.
 // GET /api/routing/tunnels
+//
+//	@Summary		Routing tunnel catalog
+//	@Tags			routing
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	object
+//	@Router			/routing/tunnels [get]
 func (h *RoutingHandler) Tunnels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -42,6 +49,13 @@ func (h *RoutingHandler) Tunnels(w http.ResponseWriter, r *http.Request) {
 // Missing list from a freshly-built snapshot so the caller can tell
 // whether the retry succeeded.
 // POST /api/routing/refresh
+//
+//	@Summary		Invalidate routing caches
+//	@Tags			routing
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/routing/refresh [post]
 func (h *RoutingHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -73,4 +87,40 @@ func (h *RoutingHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	publishInvalidated(h.bus, ResourceRoutingClientRoutes, "refresh")
 	publishInvalidated(h.bus, ResourceRoutingTunnels, "refresh")
 	response.Success(w, map[string]any{"missing": snap.Missing})
+}
+
+// ServeOS4EmptyAccessPolicies returns an empty access-policies list on OS4 (no NDMS policies API).
+//
+//	@Summary		OS4 access policies stub
+//	@Description	Always {"data":[]}. Real data on KeeneticOS 5 only.
+//	@Tags			routing
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/routing/access-policies [get]
+func ServeOS4EmptyAccessPolicies(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"data":[]}`))
+}
+
+// ServeOS4EmptyPolicyInterfaces returns an empty policy-interfaces list on OS4.
+//
+//	@Summary		OS4 policy interfaces stub
+//	@Description	Always {"data":[]}. Real data on KeeneticOS 5 only.
+//	@Tags			routing
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/routing/policy-interfaces [get]
+func ServeOS4EmptyPolicyInterfaces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"data":[]}`))
 }

--- a/internal/api/routing.go
+++ b/internal/api/routing.go
@@ -9,6 +9,35 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/routing"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// RoutingTunnelDTO mirrors frontend RoutingTunnel.
+type RoutingTunnelDTO struct {
+	ID        string `json:"id" example:"tun_abc123"`
+	Name      string `json:"name" example:"My VPN"`
+	Iface     string `json:"iface,omitempty" example:"nwg0"`
+	Type      string `json:"type" example:"managed"`
+	Status    string `json:"status" example:"connected"`
+	Available bool   `json:"available" example:"true"`
+}
+
+// RoutingTunnelsResponse is the envelope for GET /routing/tunnels.
+type RoutingTunnelsResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    []RoutingTunnelDTO `json:"data"`
+}
+
+// RoutingRefreshData is the payload for POST /routing/refresh.
+type RoutingRefreshData struct {
+	Missing []string `json:"missing" example:""`
+}
+
+// RoutingRefreshResponse is the envelope for POST /routing/refresh.
+type RoutingRefreshResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    RoutingRefreshData `json:"data"`
+}
+
 // RoutingHandler handles routing API endpoints.
 type RoutingHandler struct {
 	catalog routing.Catalog
@@ -33,6 +62,8 @@ func (h *RoutingHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Success		200	{array}	object
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/tunnels [get]
 func (h *RoutingHandler) Tunnels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -54,7 +85,9 @@ func (h *RoutingHandler) Tunnels(w http.ResponseWriter, r *http.Request) {
 //	@Tags			routing
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	RoutingRefreshResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/refresh [post]
 func (h *RoutingHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -96,7 +129,9 @@ func (h *RoutingHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 //	@Tags			routing
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	AccessPoliciesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/access-policies [get]
 func ServeOS4EmptyAccessPolicies(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -114,7 +149,9 @@ func ServeOS4EmptyAccessPolicies(w http.ResponseWriter, r *http.Request) {
 //	@Tags			routing
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	PolicyInterfacesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/policy-interfaces [get]
 func ServeOS4EmptyPolicyInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -19,6 +19,100 @@ import (
 // file no longer depends on the legacy tunnel/ndms package.
 var wireguardNamePattern = regexp.MustCompile(`^Wireguard\d+$`)
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// WireguardServerPeerDTO mirrors frontend WireguardServerPeer.
+type WireguardServerPeerDTO struct {
+	PublicKey     string   `json:"publicKey" example:"DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="`
+	Description   string   `json:"description" example:"Phone"`
+	Endpoint      string   `json:"endpoint" example:"1.2.3.4:12345"`
+	AllowedIPs    []string `json:"allowedIPs" example:"10.0.1.2/32"`
+	RxBytes       int64    `json:"rxBytes" example:"1048576"`
+	TxBytes       int64    `json:"txBytes" example:"524288"`
+	LastHandshake string   `json:"lastHandshake" example:"2024-01-15T10:30:00Z"`
+	Online        bool     `json:"online" example:"true"`
+	Enabled       bool     `json:"enabled" example:"true"`
+}
+
+// WireguardServerDTO mirrors frontend WireguardServer.
+type WireguardServerDTO struct {
+	ID            string                   `json:"id" example:"Wireguard0"`
+	InterfaceName string                   `json:"interfaceName" example:"Wireguard0"`
+	Description   string                   `json:"description" example:"Wireguard VPN Server"`
+	Status        string                   `json:"status" example:"up"`
+	Connected     bool                     `json:"connected" example:"true"`
+	MTU           int                      `json:"mtu" example:"1420"`
+	Address       string                   `json:"address" example:"10.0.1.1"`
+	Mask          string                   `json:"mask" example:"255.255.255.0"`
+	PublicKey     string                   `json:"publicKey" example:"EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE="`
+	ListenPort    int                      `json:"listenPort" example:"51820"`
+	Peers         []WireguardServerPeerDTO `json:"peers"`
+}
+
+// ManagedPeerStatsDTO mirrors frontend ManagedPeerStats.
+type ManagedPeerStatsDTO struct {
+	PublicKey     string `json:"publicKey" example:"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF="`
+	Endpoint      string `json:"endpoint" example:"5.6.7.8:54321"`
+	RxBytes       int64  `json:"rxBytes" example:"2097152"`
+	TxBytes       int64  `json:"txBytes" example:"1048576"`
+	LastHandshake string `json:"lastHandshake" example:"2024-01-15T10:30:00Z"`
+	Online        bool   `json:"online" example:"true"`
+}
+
+// ManagedServerStatsDTO mirrors frontend ManagedServerStats.
+type ManagedServerStatsDTO struct {
+	Status string                `json:"status" example:"up"`
+	Peers  []ManagedPeerStatsDTO `json:"peers"`
+}
+
+// ServersAllData is the composite payload for GET /servers/all.
+type ServersAllData struct {
+	Servers      []WireguardServerDTO   `json:"servers"`
+	ManagedStats *ManagedServerStatsDTO `json:"managedStats"`
+	WANIP        string                 `json:"wanIP" example:"203.0.113.42"`
+}
+
+// ServersAllResponse is the envelope for GET /servers/all.
+type ServersAllResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    ServersAllData `json:"data"`
+}
+
+// WANIPData is the data for GET /servers/wan-ip.
+type WANIPData struct {
+	IP string `json:"ip" example:"203.0.113.42"`
+}
+
+// WANIPResponse is the envelope for GET /servers/wan-ip.
+type WANIPResponse struct {
+	Success bool      `json:"success" example:"true"`
+	Data    WANIPData `json:"data"`
+}
+
+// WireguardServerConfigPeerDTO mirrors frontend WireguardServerPeerConfig.
+type WireguardServerConfigPeerDTO struct {
+	PublicKey    string   `json:"publicKey" example:"DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD="`
+	Description  string   `json:"description" example:"Phone"`
+	PresharedKey string   `json:"presharedKey" example:"GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG="`
+	AllowedIPs   []string `json:"allowedIPs" example:"10.0.1.2/32"`
+	Address      string   `json:"address" example:"10.0.1.2"`
+}
+
+// WireguardServerConfigDTO mirrors frontend WireguardServerConfig.
+type WireguardServerConfigDTO struct {
+	PublicKey  string                         `json:"publicKey" example:"EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE="`
+	ListenPort int                            `json:"listenPort" example:"51820"`
+	MTU        int                            `json:"mtu" example:"1420"`
+	Address    string                         `json:"address" example:"10.0.1.1"`
+	Peers      []WireguardServerConfigPeerDTO `json:"peers"`
+}
+
+// ServerConfigResponse is the envelope for GET /servers/config.
+type ServerConfigResponse struct {
+	Success bool                     `json:"success" example:"true"`
+	Data    WireguardServerConfigDTO `json:"data"`
+}
+
 // isValidWireguardName checks that the name matches "WireguardN" pattern.
 // Used to prevent command injection in ndmc/RCI calls.
 func isValidWireguardName(name string) bool {
@@ -175,6 +269,15 @@ func (h *ServersHandler) writeAll(w http.ResponseWriter, r *http.Request) {
 // GetAll returns the composite servers snapshot (list + managed + stats + wanIP).
 // Replaces the snapshot:servers SSE event — the frontend polls this.
 // GET /api/servers/all
+//
+//	@Summary		Get all servers snapshot
+//	@Description	Returns the composite servers snapshot: WireGuard servers list, managed server, stats and WAN IP.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ServersAllResponse
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/servers/all [get]
 func (h *ServersHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -265,6 +368,15 @@ func (h *ServersHandler) Mark(w http.ResponseWriter, r *http.Request) {
 
 // WANIP returns the external WAN IP for .conf generation.
 // GET /api/servers/wan-ip
+//
+//	@Summary		Get WAN IP
+//	@Description	Returns the router's external WAN IP address.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	WANIPResponse
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/servers/wan-ip [get]
 func (h *ServersHandler) WANIP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -280,6 +392,15 @@ func (h *ServersHandler) WANIP(w http.ResponseWriter, r *http.Request) {
 
 // Marked returns the list of server interface IDs.
 // GET /api/servers/marked
+//
+//	@Summary		Get marked server interfaces
+//	@Description	Returns the list of interface IDs that have been marked as servers.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/servers/marked [get]
 func (h *ServersHandler) Marked(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -10,6 +10,67 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// ServerSettingsDTO mirrors frontend ServerSettings.
+type ServerSettingsDTO struct {
+	Port      int    `json:"port" example:"8080"`
+	Interface string `json:"interface" example:""`
+}
+
+// PingCheckDefaultsDTO mirrors frontend PingCheckDefaults.
+type PingCheckDefaultsDTO struct {
+	Method        string `json:"method" example:"http"`
+	Target        string `json:"target" example:"https://www.google.com"`
+	Interval      int    `json:"interval" example:"30"`
+	DeadInterval  int    `json:"deadInterval" example:"120"`
+	FailThreshold int    `json:"failThreshold" example:"3"`
+}
+
+// PingCheckSettingsDTO mirrors frontend PingCheckSettings.
+type PingCheckSettingsDTO struct {
+	Enabled  bool                 `json:"enabled" example:"true"`
+	Defaults PingCheckDefaultsDTO `json:"defaults"`
+}
+
+// LoggingSettingsDTO mirrors frontend LoggingSettings.
+type LoggingSettingsDTO struct {
+	Enabled  bool   `json:"enabled" example:"true"`
+	MaxAge   int    `json:"maxAge" example:"7"`
+	LogLevel string `json:"logLevel" example:"info"`
+}
+
+// UpdateSettingsDTO mirrors frontend UpdateSettings.
+type UpdateSettingsDTO struct {
+	CheckEnabled bool `json:"checkEnabled" example:"true"`
+}
+
+// DNSRouteSettingsDTO mirrors frontend DNSRouteSettings.
+type DNSRouteSettingsDTO struct {
+	AutoRefreshEnabled   bool   `json:"autoRefreshEnabled" example:"true"`
+	RefreshIntervalHours int    `json:"refreshIntervalHours" example:"24"`
+	RefreshMode          string `json:"refreshMode" example:"interval"`
+	RefreshDailyTime     string `json:"refreshDailyTime" example:"03:00"`
+}
+
+// SettingsData is the payload for GET /settings/get.
+type SettingsData struct {
+	SchemaVersion       int                  `json:"schemaVersion" example:"3"`
+	AuthEnabled         bool                 `json:"authEnabled" example:"false"`
+	Server              ServerSettingsDTO    `json:"server"`
+	PingCheck           PingCheckSettingsDTO `json:"pingCheck"`
+	Logging             LoggingSettingsDTO   `json:"logging"`
+	DisableMemorySaving bool                 `json:"disableMemorySaving" example:"false"`
+	Updates             UpdateSettingsDTO    `json:"updates"`
+	DnsRoute            DNSRouteSettingsDTO  `json:"dnsRoute"`
+}
+
+// SettingsResponse is the envelope for GET /settings/get.
+type SettingsResponse struct {
+	Success bool         `json:"success" example:"true"`
+	Data    SettingsData `json:"data"`
+}
+
 // PingCheckToggleService defines the interface for ping check toggle operations.
 type PingCheckToggleService interface {
 	StartMonitoringAllRunning()
@@ -57,10 +118,10 @@ func (h *SettingsHandler) SetLogsSnapshot(fn func()) { h.logsSnapshot = fn }
 //	@Tags			settings
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
-//	@Router			/settings [get]
+//	@Success		200	{object}	SettingsResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/settings/get [get]
 func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
@@ -85,10 +146,10 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			body	body		map[string]interface{}	true	"Settings"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
-//	@Router			/settings [post]
+//	@Success		200		{object}	SettingsResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/settings/update [post]
 func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	settings, ok := parseJSON[storage.Settings](w, r, http.MethodPost)
 	if !ok {
@@ -243,9 +304,9 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 //	@Tags			settings
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SettingsResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/settings/regenerate-api-key [post]
 func (h *SettingsHandler) RegenerateApiKey(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/signature.go
+++ b/internal/api/signature.go
@@ -8,6 +8,31 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/signature"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// SignaturePacketsDTO is the packets field in SignatureCaptureResult.
+type SignaturePacketsDTO struct {
+	I1 string `json:"i1" example:"0a1b2c3d"`
+	I2 string `json:"i2" example:"4e5f6a7b"`
+	I3 string `json:"i3" example:"8c9d0e1f"`
+	I4 string `json:"i4" example:"2a3b4c5d"`
+	I5 string `json:"i5" example:"6e7f8a9b"`
+}
+
+// SignatureCaptureData mirrors frontend SignatureCaptureResult.
+type SignatureCaptureData struct {
+	OK      bool                `json:"ok" example:"true"`
+	Source  string              `json:"source" example:"Wireguard0"`
+	Packets SignaturePacketsDTO `json:"packets"`
+	Warning string              `json:"warning,omitempty" example:""`
+}
+
+// SignatureCaptureResponse is the envelope for GET /signature/capture.
+type SignatureCaptureResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    SignatureCaptureData `json:"data"`
+}
+
 var validDomain = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$`)
 
 type SignatureHandler struct{}
@@ -23,7 +48,9 @@ func NewSignatureHandler() *SignatureHandler {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			domain	query	string	true	"Domain name"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SignatureCaptureResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/signature/capture [get]
 func (h *SignatureHandler) Capture(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/signature.go
+++ b/internal/api/signature.go
@@ -16,6 +16,15 @@ func NewSignatureHandler() *SignatureHandler {
 	return &SignatureHandler{}
 }
 
+// Capture runs TLS certificate capture for a domain.
+//
+//	@Summary		Signature capture
+//	@Tags			signature
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			domain	query	string	true	"Domain name"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/signature/capture [get]
 func (h *SignatureHandler) Capture(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/singbox.go
+++ b/internal/api/singbox.go
@@ -28,6 +28,14 @@ func NewSingboxHandler(op *singbox.Operator, bus *events.Bus, dc *singbox.DelayC
 }
 
 // DelayCheck handles POST /api/singbox/tunnels/delay-check?tag=X.
+//
+//	@Summary		Sing-box delay check
+//	@Tags			singbox
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			tag	query	string	true	"Tunnel tag"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/tunnels/delay-check [post]
 func (h *SingboxHandler) DelayCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -51,6 +59,14 @@ func (h *SingboxHandler) DelayCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // Status handles GET /api/singbox/status.
+//
+//	@Summary		Sing-box status
+//	@Tags			singbox
+//	@Description	Available when sing-box integration is enabled in the build.
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/status [get]
 func (h *SingboxHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -63,6 +79,13 @@ func (h *SingboxHandler) Status(w http.ResponseWriter, r *http.Request) {
 // Install handles POST /api/singbox/install.
 // Returns the fresh status so the client can update cache without refetch.
 // Also publishes a resource:invalidated hint so other tabs/subscribers refresh.
+//
+//	@Summary		Install sing-box
+//	@Tags			singbox
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/install [post]
 func (h *SingboxHandler) Install(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -134,6 +157,27 @@ func (h *SingboxHandler) ListTunnels(w http.ResponseWriter, r *http.Request) {
 	response.Success(w, out)
 }
 
+// ServeGETTunnels handles GET /api/singbox/tunnels: list all tunnels, or single tunnel when query tag is set.
+//
+//	@Summary		List or get sing-box tunnel(s)
+//	@Tags			singbox
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			tag	query	string	false	"When set, returns single tunnel"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/tunnels [get]
+func (h *SingboxHandler) ServeGETTunnels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if r.URL.Query().Has("tag") {
+		h.GetTunnel(w, r)
+		return
+	}
+	h.ListTunnels(w, r)
+}
+
 type singboxConnectivity struct {
 	Connected bool `json:"connected"`
 	Latency   *int `json:"latency"`
@@ -171,6 +215,14 @@ func (h *SingboxHandler) enrichedTunnels(ctx context.Context) ([]singboxEnriched
 
 // AddTunnels handles POST /api/singbox/tunnels.
 // Body: {"links": "vless://...\nhy2://..."}. Returns imported tunnels and per-line errors.
+//
+//	@Summary		Add sing-box tunnel(s)
+//	@Tags			singbox
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/tunnels [post]
 func (h *SingboxHandler) AddTunnels(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
 		Links string `json:"links"`
@@ -235,6 +287,14 @@ func (h *SingboxHandler) GetTunnel(w http.ResponseWriter, r *http.Request) {
 
 // UpdateTunnel handles PUT /api/singbox/tunnels?tag={tag}.
 // Body: {"outbound": {...}}.
+//
+//	@Summary		Update sing-box tunnel
+//	@Tags			singbox
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/tunnels [put]
 func (h *SingboxHandler) UpdateTunnel(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
 		Outbound json.RawMessage `json:"outbound"`
@@ -263,6 +323,13 @@ func (h *SingboxHandler) UpdateTunnel(w http.ResponseWriter, r *http.Request) {
 // SpeedTestStream handles GET /api/singbox/tunnels/test/speed/stream?tag=X&server=Y&port=Z.
 // Runs download then upload sequentially, keyed by sing-box tunnel tag.
 // Streams events via SSE: phase, interval, result, done, error.
+//
+//	@Summary		Sing-box tunnel speed test stream
+//	@Tags			singbox
+//	@Produce		text/event-stream
+//	@Security		CookieAuth
+//	@Success		200	{string}	string	"SSE stream"
+//	@Router			/singbox/tunnels/test/speed/stream [get]
 func (h *SingboxHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -378,6 +445,13 @@ func (h *SingboxHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request)
 }
 
 // DeleteTunnel handles DELETE /api/singbox/tunnels?tag={tag}.
+//
+//	@Summary		Delete sing-box tunnel
+//	@Tags			singbox
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/singbox/tunnels [delete]
 func (h *SingboxHandler) DeleteTunnel(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		response.MethodNotAllowed(w)

--- a/internal/api/singbox.go
+++ b/internal/api/singbox.go
@@ -14,6 +14,53 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/testing"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// SingboxStatusData mirrors frontend SingboxStatus.
+type SingboxStatusData struct {
+	Installed      bool     `json:"installed" example:"true"`
+	Version        string   `json:"version,omitempty" example:"1.9.3"`
+	Running        bool     `json:"running" example:"true"`
+	PID            int      `json:"pid,omitempty" example:"12345"`
+	TunnelCount    int      `json:"tunnelCount" example:"2"`
+	ProxyComponent bool     `json:"proxyComponent" example:"true"`
+	Features       []string `json:"features,omitempty" example:"with_quic"`
+}
+
+// SingboxStatusResponse is the envelope for GET /singbox/status.
+type SingboxStatusResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    SingboxStatusData `json:"data"`
+}
+
+// SingboxTunnelConnectivity is the connectivity field in SingboxTunnel.
+type SingboxTunnelConnectivity struct {
+	Connected bool `json:"connected" example:"true"`
+	Latency   *int `json:"latency" swaggertype:"integer" example:"42"`
+}
+
+// SingboxTunnelDTO mirrors frontend SingboxTunnel.
+type SingboxTunnelDTO struct {
+	Tag            string                    `json:"tag" example:"proxy-01"`
+	Protocol       string                    `json:"protocol" example:"vless"`
+	Server         string                    `json:"server" example:"proxy.example.com"`
+	Port           int                       `json:"port" example:"443"`
+	Security       string                    `json:"security" example:"reality"`
+	Transport      string                    `json:"transport" example:"tcp"`
+	ListenPort     int                       `json:"listenPort" example:"7891"`
+	ProxyInterface string                    `json:"proxyInterface" example:"br0"`
+	SNI            string                    `json:"sni,omitempty" example:"cdn.example.com"`
+	Fingerprint    string                    `json:"fingerprint,omitempty" example:"chrome"`
+	Connectivity   SingboxTunnelConnectivity `json:"connectivity"`
+	Running        bool                      `json:"running" example:"true"`
+}
+
+// SingboxTunnelsResponse is the envelope for GET /singbox/tunnels.
+type SingboxTunnelsResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    []SingboxTunnelDTO `json:"data"`
+}
+
 // SingboxHandler serves /api/singbox/* routes.
 type SingboxHandler struct {
 	op           *singbox.Operator
@@ -34,7 +81,9 @@ func NewSingboxHandler(op *singbox.Operator, bus *events.Bus, dc *singbox.DelayC
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			tag	query	string	true	"Tunnel tag"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels/delay-check [post]
 func (h *SingboxHandler) DelayCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -65,7 +114,9 @@ func (h *SingboxHandler) DelayCheck(w http.ResponseWriter, r *http.Request) {
 //	@Description	Available when sing-box integration is enabled in the build.
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/status [get]
 func (h *SingboxHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -84,7 +135,9 @@ func (h *SingboxHandler) Status(w http.ResponseWriter, r *http.Request) {
 //	@Tags			singbox
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/install [post]
 func (h *SingboxHandler) Install(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -164,7 +217,9 @@ func (h *SingboxHandler) ListTunnels(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			tag	query	string	false	"When set, returns single tunnel"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxTunnelsResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels [get]
 func (h *SingboxHandler) ServeGETTunnels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -221,7 +276,9 @@ func (h *SingboxHandler) enrichedTunnels(ctx context.Context) ([]singboxEnriched
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels [post]
 func (h *SingboxHandler) AddTunnels(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
@@ -293,7 +350,9 @@ func (h *SingboxHandler) GetTunnel(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels [put]
 func (h *SingboxHandler) UpdateTunnel(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[struct {
@@ -329,6 +388,8 @@ func (h *SingboxHandler) UpdateTunnel(w http.ResponseWriter, r *http.Request) {
 //	@Produce		text/event-stream
 //	@Security		CookieAuth
 //	@Success		200	{string}	string	"SSE stream"
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels/test/speed/stream [get]
 func (h *SingboxHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -450,7 +511,9 @@ func (h *SingboxHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request)
 //	@Tags			singbox
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/tunnels [delete]
 func (h *SingboxHandler) DeleteTunnel(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {

--- a/internal/api/staticroute.go
+++ b/internal/api/staticroute.go
@@ -48,7 +48,15 @@ func NewStaticRouteHandler(svc StaticRouteService, appLogger logging.AppLogger) 
 	}
 }
 
-// List returns all static route lists.
+// List returns static IP routes.
+//
+//	@Summary		List static routes
+//	@Tags			static-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/static-routes/list [get]
+//	@Router			/routing/static-routes [get]
 func (h *StaticRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -65,6 +73,14 @@ func (h *StaticRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create creates a new static route list.
+//
+//	@Summary		Create static route
+//	@Tags			static-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/static-routes/create [post]
 func (h *StaticRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 	rl, ok := parseJSON[storage.StaticRouteList](w, r, http.MethodPost)
 	if !ok {
@@ -84,6 +100,14 @@ func (h *StaticRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 // Update updates an existing static route list.
+//
+//	@Summary		Update static route
+//	@Tags			static-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/static-routes/update [post]
 func (h *StaticRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 	rl, ok := parseJSON[storage.StaticRouteList](w, r, http.MethodPost)
 	if !ok {
@@ -103,6 +127,14 @@ func (h *StaticRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 }
 
 // Delete deletes a static route list by ID.
+//
+//	@Summary		Delete static route
+//	@Tags			static-routes
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/static-routes/delete [post]
 func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -127,6 +159,15 @@ func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // SetEnabled toggles the enabled state of a static route list.
+//
+//	@Summary		Set static route enabled
+//	@Tags			static-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"List id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/static-routes/set-enabled [post]
 func (h *StaticRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
 	if !ok {
@@ -162,6 +203,14 @@ type staticRouteImportReq struct {
 }
 
 // Import imports subnets from a .bat file content.
+//
+//	@Summary		Import static routes
+//	@Tags			static-routes
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/static-routes/import [post]
 func (h *StaticRouteHandler) Import(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[staticRouteImportReq](w, r, http.MethodPost)
 	if !ok {

--- a/internal/api/staticroute.go
+++ b/internal/api/staticroute.go
@@ -11,6 +11,26 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// StaticRouteDTO mirrors frontend StaticRouteList.
+type StaticRouteDTO struct {
+	ID        string   `json:"id" example:"sr_001"`
+	Name      string   `json:"name" example:"Office subnets"`
+	TunnelID  string   `json:"tunnelID" example:"tun_abc123"`
+	Subnets   []string `json:"subnets" example:"192.168.10.0/24"`
+	Fallback  string   `json:"fallback,omitempty" example:""`
+	Enabled   bool     `json:"enabled" example:"true"`
+	CreatedAt string   `json:"createdAt" example:"2024-01-01T00:00:00Z"`
+	UpdatedAt string   `json:"updatedAt" example:"2024-01-15T12:00:00Z"`
+}
+
+// StaticRoutesListResponse is the envelope for GET /static-routes/list.
+type StaticRoutesListResponse struct {
+	Success bool             `json:"success" example:"true"`
+	Data    []StaticRouteDTO `json:"data"`
+}
+
 // StaticRouteService defines what the static route handler needs from the service.
 type StaticRouteService interface {
 	List() ([]storage.StaticRouteList, error)
@@ -54,7 +74,9 @@ func NewStaticRouteHandler(svc StaticRouteService, appLogger logging.AppLogger) 
 //	@Tags			static-routes
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	StaticRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/list [get]
 //	@Router			/routing/static-routes [get]
 func (h *StaticRouteHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +101,9 @@ func (h *StaticRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	StaticRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/create [post]
 func (h *StaticRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 	rl, ok := parseJSON[storage.StaticRouteList](w, r, http.MethodPost)
@@ -106,7 +130,9 @@ func (h *StaticRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	StaticRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/update [post]
 func (h *StaticRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 	rl, ok := parseJSON[storage.StaticRouteList](w, r, http.MethodPost)
@@ -133,7 +159,9 @@ func (h *StaticRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/delete [post]
 func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -166,7 +194,9 @@ func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"List id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/set-enabled [post]
 func (h *StaticRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
@@ -209,7 +239,9 @@ type staticRouteImportReq struct {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	StaticRoutesListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/import [post]
 func (h *StaticRouteHandler) Import(w http.ResponseWriter, r *http.Request) {
 	body, ok := parseJSON[staticRouteImportReq](w, r, http.MethodPost)

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -23,7 +23,9 @@ func NewStatusHandler(svc TunnelService) *StatusHandler {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/status/get [get]
 func (h *StatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -60,7 +62,9 @@ func (h *StatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 //	@Tags			status
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/status/all [get]
 func (h *StatusHandler) All(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/status.go
+++ b/internal/api/status.go
@@ -17,6 +17,14 @@ func NewStatusHandler(svc TunnelService) *StatusHandler {
 }
 
 // Get returns the status of a single tunnel.
+//
+//	@Summary		Tunnel status
+//	@Tags			status
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/status/get [get]
 func (h *StatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -47,6 +55,13 @@ func (h *StatusHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 // All returns the status of all tunnels.
+//
+//	@Summary		All tunnel statuses
+//	@Tags			status
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/status/all [get]
 func (h *StatusHandler) All(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -116,6 +116,13 @@ func (h *SystemHandler) SetSingboxOperator(op *singbox.Operator) {
 }
 
 // RestartDaemon triggers a self-restart of the AWG Manager daemon.
+//
+//	@Summary		Restart daemon
+//	@Tags			system
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/restart [post]
 func (h *SystemHandler) RestartDaemon(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -130,6 +137,13 @@ func (h *SystemHandler) RestartDaemon(w http.ResponseWriter, r *http.Request) {
 }
 
 // HydraRouteStatus returns HydraRoute Neo detection status.
+//
+//	@Summary		HydraRoute status (system)
+//	@Tags			system
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/hydraroute-status [get]
 func (h *SystemHandler) HydraRouteStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -143,6 +157,14 @@ func (h *SystemHandler) HydraRouteStatus(w http.ResponseWriter, r *http.Request)
 }
 
 // HydraRouteControl starts/stops/restarts the HydraRoute daemon.
+//
+//	@Summary		HydraRoute control (system)
+//	@Tags			system
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/hydraroute-control [post]
 func (h *SystemHandler) HydraRouteControl(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -168,6 +190,13 @@ func (h *SystemHandler) HydraRouteControl(w http.ResponseWriter, r *http.Request
 }
 
 // Info returns system information.
+//
+//	@Summary		System info
+//	@Tags			system
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/info [get]
 func (h *SystemHandler) Info(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -362,6 +391,13 @@ type wanInterfaceJSON struct {
 
 // WANInterfaces returns available WAN interfaces for routing.
 // GET /api/system/wan-interfaces
+//
+//	@Summary		WAN interfaces
+//	@Tags			system
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/system/wan-interfaces [get]
 func (h *SystemHandler) WANInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -389,6 +425,13 @@ func (h *SystemHandler) WANInterfaces(w http.ResponseWriter, r *http.Request) {
 
 // AllInterfaces returns all router interfaces for routing configuration.
 // GET /api/system/all-interfaces
+//
+//	@Summary		All interfaces
+//	@Tags			system
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/system/all-interfaces [get]
 func (h *SystemHandler) AllInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -19,6 +19,106 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/backend"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// SystemInfoBackendAvailability shows which tunnel backends are available.
+type SystemInfoBackendAvailability struct {
+	Nativewg bool `json:"nativewg" example:"true"`
+	Kernel   bool `json:"kernel" example:"false"`
+}
+
+// SystemInfoSingbox shows sing-box component info embedded in system info.
+type SystemInfoSingbox struct {
+	Installed bool   `json:"installed" example:"true"`
+	Version   string `json:"version" example:"1.9.3"`
+}
+
+// SystemInfoData is the payload returned by GET /system/info.
+type SystemInfoData struct {
+	Version              string                        `json:"version" example:"2.5.0"`
+	GoVersion            string                        `json:"goVersion" example:"go1.23.0"`
+	GoArch               string                        `json:"goArch" example:"arm64"`
+	GoOS                 string                        `json:"goOS" example:"linux"`
+	KeeneticOS           string                        `json:"keeneticOS" example:"ndms"`
+	IsOS5                bool                          `json:"isOS5" example:"true"`
+	FirmwareVersion      string                        `json:"firmwareVersion" example:"4.2.1"`
+	SupportsExtendedASC  bool                          `json:"supportsExtendedASC" example:"true"`
+	SupportsHRanges      bool                          `json:"supportsHRanges" example:"true"`
+	SupportsPingCheck    bool                          `json:"supportsPingCheck" example:"true"`
+	TotalMemoryMB        int                           `json:"totalMemoryMB" example:"512"`
+	IsLowMemory          bool                          `json:"isLowMemory" example:"false"`
+	GcMemLimit           string                        `json:"gcMemLimit" example:"128MiB"`
+	Gogc                 string                        `json:"gogc" example:"25"`
+	DisableMemorySaving  bool                          `json:"disableMemorySaving" example:"false"`
+	KernelModuleExists   bool                          `json:"kernelModuleExists" example:"true"`
+	KernelModuleLoaded   bool                          `json:"kernelModuleLoaded" example:"false"`
+	KernelModuleModel    string                        `json:"kernelModuleModel" example:"MT7981"`
+	KernelModuleVersion  string                        `json:"kernelModuleVersion" example:""`
+	IsAarch64            bool                          `json:"isAarch64" example:"true"`
+	ActiveBackend        string                        `json:"activeBackend" example:"nativewg"`
+	RouterIP             string                        `json:"routerIP" example:"192.168.1.1"`
+	BootInProgress       bool                          `json:"bootInProgress" example:"false"`
+	BackendAvailability  SystemInfoBackendAvailability `json:"backendAvailability"`
+	Singbox              SystemInfoSingbox             `json:"singbox"`
+}
+
+// SystemInfoResponse is the envelope for GET /system/info.
+type SystemInfoResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    SystemInfoData `json:"data"`
+}
+
+// HydraRouteStatusData mirrors frontend HydraRouteStatus.
+type HydraRouteStatusData struct {
+	Installed bool   `json:"installed" example:"true"`
+	Running   bool   `json:"running" example:"true"`
+	Version   string `json:"version,omitempty" example:"0.3.1"`
+}
+
+// HydraRouteStatusResponse is the envelope for GET /system/hydraroute-status.
+type HydraRouteStatusResponse struct {
+	Success bool                 `json:"success" example:"true"`
+	Data    HydraRouteStatusData `json:"data"`
+}
+
+// WANInterfaceDTO mirrors frontend WANInterface.
+type WANInterfaceDTO struct {
+	Name  string `json:"name" example:"ISP1"`
+	Label string `json:"label" example:"Home Internet"`
+	State string `json:"state" example:"up"`
+}
+
+// WANInterfacesResponse is the envelope for GET /system/wan-interfaces.
+type WANInterfacesResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []WANInterfaceDTO `json:"data"`
+}
+
+// RouterInterfaceDTO mirrors frontend RouterInterface.
+type RouterInterfaceDTO struct {
+	Name  string `json:"name" example:"br0"`
+	Label string `json:"label" example:"Home Network"`
+	Up    bool   `json:"up" example:"true"`
+}
+
+// AllInterfacesResponse is the envelope for GET /system/all-interfaces.
+type AllInterfacesResponse struct {
+	Success bool                 `json:"success" example:"true"`
+	Data    []RouterInterfaceDTO `json:"data"`
+}
+
+// WANInterfaceStatusDTO is a single WAN interface status.
+type WANInterfaceStatusDTO struct {
+	Up    bool   `json:"up" example:"true"`
+	Label string `json:"label" example:"Home Internet"`
+}
+
+// WANInterfaceStatusDTO is a single WAN interface status entry.
+type WANInterfaceStatusItemDTO struct {
+	Up    bool   `json:"up" example:"true"`
+	Label string `json:"label" example:"Home Internet"`
+}
+
 // SettingsProvider provides access to settings.
 type SettingsProvider interface {
 	Get() (*storage.Settings, error)
@@ -121,7 +221,9 @@ func (h *SystemHandler) SetSingboxOperator(op *singbox.Operator) {
 //	@Tags			system
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/restart [post]
 func (h *SystemHandler) RestartDaemon(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -142,7 +244,9 @@ func (h *SystemHandler) RestartDaemon(w http.ResponseWriter, r *http.Request) {
 //	@Tags			system
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	HydraRouteStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/hydraroute-status [get]
 func (h *SystemHandler) HydraRouteStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -163,7 +267,9 @@ func (h *SystemHandler) HydraRouteStatus(w http.ResponseWriter, r *http.Request)
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/hydraroute-control [post]
 func (h *SystemHandler) HydraRouteControl(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -195,7 +301,9 @@ func (h *SystemHandler) HydraRouteControl(w http.ResponseWriter, r *http.Request
 //	@Tags			system
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SystemInfoResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/info [get]
 func (h *SystemHandler) Info(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -396,7 +504,9 @@ type wanInterfaceJSON struct {
 //	@Tags			system
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	WANInterfacesResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/wan-interfaces [get]
 func (h *SystemHandler) WANInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -430,7 +540,9 @@ func (h *SystemHandler) WANInterfaces(w http.ResponseWriter, r *http.Request) {
 //	@Tags			system
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	AllInterfacesResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/all-interfaces [get]
 func (h *SystemHandler) AllInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/systemtunnels.go
+++ b/internal/api/systemtunnels.go
@@ -17,6 +17,35 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/systemtunnel"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// SystemTunnelPeerDTO mirrors the peer field in SystemTunnel.
+type SystemTunnelPeerDTO struct {
+	PublicKey     string `json:"publicKey" example:"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC="`
+	Endpoint      string `json:"endpoint" example:"vpn2.example.com:51820"`
+	RxBytes       int64  `json:"rxBytes" example:"2097152"`
+	TxBytes       int64  `json:"txBytes" example:"1048576"`
+	LastHandshake string `json:"lastHandshake" example:"2024-01-15T10:30:00Z"`
+	Online        bool   `json:"online" example:"true"`
+}
+
+// SystemTunnelDTO mirrors frontend SystemTunnel.
+type SystemTunnelDTO struct {
+	ID            string               `json:"id" example:"Wireguard0"`
+	InterfaceName string               `json:"interfaceName" example:"Wireguard0"`
+	Description   string               `json:"description" example:"Home Server"`
+	Status        string               `json:"status" example:"up"`
+	Connected     bool                 `json:"connected" example:"true"`
+	MTU           int                  `json:"mtu" example:"1420"`
+	Peer          *SystemTunnelPeerDTO `json:"peer,omitempty"`
+}
+
+// SystemTunnelsResponse is the envelope for GET /system-tunnels.
+type SystemTunnelsResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []SystemTunnelDTO `json:"data"`
+}
+
 // SystemTunnelsHandler handles system WireGuard tunnel operations.
 type SystemTunnelsHandler struct {
 	svc      systemtunnel.Service
@@ -86,6 +115,15 @@ func (h *SystemTunnelsHandler) listSystemTunnels(ctx context.Context) ([]ndms.Sy
 
 // List returns all visible (non-hidden) system WireGuard tunnels.
 // GET /api/system-tunnels
+//
+//	@Summary		List system tunnels
+//	@Description	Returns all WireGuard tunnels managed by the router OS itself (non-hidden).
+//	@Tags			system-tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SystemTunnelsResponse
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/system-tunnels [get]
 func (h *SystemTunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -13,6 +13,19 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/terminal"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// TerminalStartData is the payload returned by POST /terminal/start.
+type TerminalStartData struct {
+	Port int `json:"port" example:"7681"`
+}
+
+// TerminalStartResponse is the envelope for POST /terminal/start.
+type TerminalStartResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    TerminalStartData `json:"data"`
+}
+
 // TerminalHandler handles terminal API endpoints.
 type TerminalHandler struct {
 	manager terminal.Manager
@@ -26,9 +39,9 @@ func NewTerminalHandler(manager terminal.Manager, log logging.AppLogger) *Termin
 
 // TerminalStatusResponse represents terminal status.
 type TerminalStatusResponse struct {
-	Installed     bool `json:"installed"`
-	Running       bool `json:"running"`
-	SessionActive bool `json:"sessionActive"`
+	Installed     bool `json:"installed" example:"true"`
+	Running       bool `json:"running" example:"false"`
+	SessionActive bool `json:"sessionActive" example:"false"`
 }
 
 // Status returns the current terminal state.
@@ -38,7 +51,9 @@ type TerminalStatusResponse struct {
 //	@Tags			terminal
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope{data=TerminalStatusResponse}
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/status [get]
 func (h *TerminalHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -59,7 +74,9 @@ func (h *TerminalHandler) Status(w http.ResponseWriter, r *http.Request) {
 //	@Tags			terminal
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TerminalStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/install [post]
 func (h *TerminalHandler) Install(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -87,7 +104,9 @@ func (h *TerminalHandler) Install(w http.ResponseWriter, r *http.Request) {
 //	@Tags			terminal
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TerminalStartResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/start [post]
 func (h *TerminalHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -116,7 +135,9 @@ func (h *TerminalHandler) Start(w http.ResponseWriter, r *http.Request) {
 //	@Tags			terminal
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/stop [post]
 func (h *TerminalHandler) Stop(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -141,6 +162,8 @@ func (h *TerminalHandler) Stop(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Success		200	{string}	string	"WebSocket upgrade"
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/ws [get]
 func (h *TerminalHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 	if h.manager.HasActiveSession() {

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -33,6 +33,13 @@ type TerminalStatusResponse struct {
 
 // Status returns the current terminal state.
 // GET /api/terminal/status
+//
+//	@Summary		Terminal status
+//	@Tags			terminal
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/terminal/status [get]
 func (h *TerminalHandler) Status(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -47,6 +54,13 @@ func (h *TerminalHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 // Install installs ttyd via opkg.
 // POST /api/terminal/install
+//
+//	@Summary		Install terminal (ttyd)
+//	@Tags			terminal
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/terminal/install [post]
 func (h *TerminalHandler) Install(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -68,6 +82,13 @@ func (h *TerminalHandler) Install(w http.ResponseWriter, r *http.Request) {
 
 // Start launches the ttyd process.
 // POST /api/terminal/start
+//
+//	@Summary		Start terminal
+//	@Tags			terminal
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/terminal/start [post]
 func (h *TerminalHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -90,6 +111,13 @@ func (h *TerminalHandler) Start(w http.ResponseWriter, r *http.Request) {
 
 // Stop kills the ttyd process.
 // POST /api/terminal/stop
+//
+//	@Summary		Stop terminal
+//	@Tags			terminal
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/terminal/stop [post]
 func (h *TerminalHandler) Stop(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -107,6 +135,13 @@ func (h *TerminalHandler) Stop(w http.ResponseWriter, r *http.Request) {
 
 // WebSocket proxies WebSocket connection to ttyd.
 // GET /api/terminal/ws
+//
+//	@Summary		Terminal WebSocket
+//	@Tags			terminal
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{string}	string	"WebSocket upgrade"
+//	@Router			/terminal/ws [get]
 func (h *TerminalHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 	if h.manager.HasActiveSession() {
 		response.ErrorWithStatus(w, http.StatusConflict, "Terminal already open in another tab", "SESSION_ACTIVE")

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -21,6 +21,15 @@ func NewTestingHandler(testingService *testing.Service) *TestingHandler {
 }
 
 // CheckIP tests if traffic goes through tunnel by comparing IPs.
+//
+//	@Summary		IP leak check
+//	@Tags			test
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id		query	string	false	"Tunnel id"
+//	@Param			service	query	string	false	"Check service id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/test/ip [get]
 func (h *TestingHandler) CheckIP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -49,6 +58,13 @@ func (h *TestingHandler) CheckIP(w http.ResponseWriter, r *http.Request) {
 }
 
 // IPCheckServices returns the list of available IP check services.
+//
+//	@Summary		IP check services
+//	@Tags			test
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/test/ip/services [get]
 func (h *TestingHandler) IPCheckServices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -59,6 +75,14 @@ func (h *TestingHandler) IPCheckServices(w http.ResponseWriter, r *http.Request)
 }
 
 // CheckConnectivity performs a quick connectivity test through tunnel.
+//
+//	@Summary		Connectivity check
+//	@Tags			test
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/test/connectivity [get]
 func (h *TestingHandler) CheckConnectivity(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -85,6 +109,13 @@ func (h *TestingHandler) CheckConnectivity(w http.ResponseWriter, r *http.Reques
 }
 
 // SpeedTestServers returns iperf3 availability and server list.
+//
+//	@Summary		Speed test servers
+//	@Tags			test
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/test/speed/servers [get]
 func (h *TestingHandler) SpeedTestServers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -95,6 +126,13 @@ func (h *TestingHandler) SpeedTestServers(w http.ResponseWriter, r *http.Request
 }
 
 // SpeedTest runs iperf3 speed test through a tunnel.
+//
+//	@Summary		Speed test (sync)
+//	@Tags			test
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/test/speed [get]
 func (h *TestingHandler) SpeedTest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -144,6 +182,13 @@ func (h *TestingHandler) SpeedTest(w http.ResponseWriter, r *http.Request) {
 }
 
 // SpeedTestStream runs iperf3 speed test with SSE streaming of per-second intervals.
+//
+//	@Summary		Speed test stream
+//	@Tags			test
+//	@Produce		text/event-stream
+//	@Security		CookieAuth
+//	@Success		200	{string}	string	"SSE stream"
+//	@Router			/test/speed/stream [get]
 func (h *TestingHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -10,6 +10,82 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/testing"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// IPResultData mirrors frontend IPResult.
+type IPResultData struct {
+	DirectIp   string `json:"directIp" example:"203.0.113.1"`
+	VpnIp      string `json:"vpnIp" example:"185.220.101.1"`
+	EndpointIp string `json:"endpointIp" example:"203.0.113.42"`
+	IpChanged  bool   `json:"ipChanged" example:"true"`
+}
+
+// IPResultResponse is the envelope for GET /test/ip.
+type IPResultResponse struct {
+	Success bool         `json:"success" example:"true"`
+	Data    IPResultData `json:"data"`
+}
+
+// ConnectivityResultData mirrors frontend ConnectivityResult.
+type ConnectivityResultData struct {
+	Connected bool   `json:"connected" example:"true"`
+	Latency   int    `json:"latency,omitempty" example:"42"`
+	Reason    string `json:"reason,omitempty" example:""`
+}
+
+// ConnectivityResultResponse is the envelope for GET /test/connectivity.
+type ConnectivityResultResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    ConnectivityResultData `json:"data"`
+}
+
+// IPCheckServiceDTO mirrors frontend IPCheckService.
+type IPCheckServiceDTO struct {
+	Label string `json:"label" example:"ipinfo.io"`
+	URL   string `json:"url" example:"https://ipinfo.io/ip"`
+}
+
+// IPServicesResponse is the envelope for GET /test/ip/services.
+type IPServicesResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    []IPCheckServiceDTO `json:"data"`
+}
+
+// SpeedTestServerDTO mirrors frontend SpeedTestServer.
+type SpeedTestServerDTO struct {
+	Label string `json:"label" example:"Moscow, RU"`
+	Host  string `json:"host" example:"speedtest.msk.ru"`
+	Port  int    `json:"port" example:"5201"`
+}
+
+// SpeedTestInfoData mirrors frontend SpeedTestInfo.
+type SpeedTestInfoData struct {
+	Available bool                 `json:"available" example:"true"`
+	Servers   []SpeedTestServerDTO `json:"servers"`
+}
+
+// SpeedTestInfoResponse is the envelope for GET /test/speed/servers.
+type SpeedTestInfoResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    SpeedTestInfoData `json:"data"`
+}
+
+// SpeedTestResultData mirrors frontend SpeedTestResult.
+type SpeedTestResultData struct {
+	Server      string  `json:"server" example:"speedtest.msk.ru"`
+	Direction   string  `json:"direction" example:"download"`
+	Bandwidth   float64 `json:"bandwidth" example:"52428800"`
+	Bytes       int64   `json:"bytes" example:"157286400"`
+	Duration    float64 `json:"duration" example:"3.0"`
+	Retransmits int     `json:"retransmits" example:"0"`
+}
+
+// SpeedTestResultResponse is the envelope for GET /test/speed.
+type SpeedTestResultResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    SpeedTestResultData `json:"data"`
+}
+
 // TestingHandler handles tunnel testing operations.
 type TestingHandler struct {
 	testingService *testing.Service
@@ -28,7 +104,9 @@ func NewTestingHandler(testingService *testing.Service) *TestingHandler {
 //	@Security		CookieAuth
 //	@Param			id		query	string	false	"Tunnel id"
 //	@Param			service	query	string	false	"Check service id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	IPResultResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/ip [get]
 func (h *TestingHandler) CheckIP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -63,7 +141,9 @@ func (h *TestingHandler) CheckIP(w http.ResponseWriter, r *http.Request) {
 //	@Tags			test
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	IPServicesResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/ip/services [get]
 func (h *TestingHandler) IPCheckServices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -81,7 +161,9 @@ func (h *TestingHandler) IPCheckServices(w http.ResponseWriter, r *http.Request)
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ConnectivityResultResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/connectivity [get]
 func (h *TestingHandler) CheckConnectivity(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -114,7 +196,9 @@ func (h *TestingHandler) CheckConnectivity(w http.ResponseWriter, r *http.Reques
 //	@Tags			test
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SpeedTestInfoResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/speed/servers [get]
 func (h *TestingHandler) SpeedTestServers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -131,7 +215,9 @@ func (h *TestingHandler) SpeedTestServers(w http.ResponseWriter, r *http.Request
 //	@Tags			test
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	SpeedTestResultResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/speed [get]
 func (h *TestingHandler) SpeedTest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -188,6 +274,8 @@ func (h *TestingHandler) SpeedTest(w http.ResponseWriter, r *http.Request) {
 //	@Produce		text/event-stream
 //	@Security		CookieAuth
 //	@Success		200	{string}	string	"SSE stream"
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/test/speed/stream [get]
 func (h *TestingHandler) SpeedTestStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/tunnels.go
+++ b/internal/api/tunnels.go
@@ -440,6 +440,13 @@ func (h *TunnelsHandler) listItems(ctx context.Context) ([]tunnelItem, error) {
 }
 
 // List returns all tunnels.
+//
+//	@Summary		List tunnels
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{array}	map[string]interface{}
+//	@Router			/tunnels/list [get]
 func (h *TunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -459,6 +466,13 @@ func (h *TunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 // system}) the frontend polls instead of listening to a legacy
 // snapshot SSE event.
 // GET /api/tunnels/all
+//
+//	@Summary		Composite tunnels snapshot
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/all [get]
 func (h *TunnelsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -498,6 +512,15 @@ func (h *TunnelsHandler) writeAll(w http.ResponseWriter, r *http.Request) {
 // Only 1h and 24h are accepted — anything else returns 400. 1h is
 // what the card chart fetches on mount to backfill before SSE takes
 // over; 24h is what the detail modal fetches when it opens.
+//
+//	@Summary		Tunnel traffic history
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id		query	string	true	"Tunnel id"
+//	@Param			period	query	string	true	"1h or 24h"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/traffic [get]
 func (h *TunnelsHandler) Traffic(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -543,6 +566,14 @@ func (h *TunnelsHandler) Traffic(w http.ResponseWriter, r *http.Request) {
 }
 
 // Get returns a single tunnel by ID.
+//
+//	@Summary		Get tunnel
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/get [get]
 func (h *TunnelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -568,6 +599,14 @@ func (h *TunnelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 // Create creates a new tunnel.
+//
+//	@Summary		Create tunnel
+//	@Tags			tunnels
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/create [post]
 func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[storage.AWGTunnel](w, r, http.MethodPost)
 	if !ok {
@@ -674,6 +713,15 @@ func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 // Update updates an existing tunnel.
+//
+//	@Summary		Update tunnel
+//	@Tags			tunnels
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/update [post]
 func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -854,6 +902,14 @@ func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 }
 
 // Delete deletes a tunnel.
+//
+//	@Summary		Delete tunnel
+//	@Tags			tunnels
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/delete [post]
 func (h *TunnelsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -916,6 +972,14 @@ func (h *TunnelsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // Export returns a single tunnel config as a downloadable .conf file.
+//
+//	@Summary		Export tunnel config
+//	@Tags			tunnels
+//	@Produce		plain
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{file}	binary
+//	@Router			/tunnels/export [get]
 func (h *TunnelsHandler) Export(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -947,6 +1011,13 @@ func (h *TunnelsHandler) Export(w http.ResponseWriter, r *http.Request) {
 }
 
 // ExportAll returns all tunnel configs as a downloadable ZIP archive.
+//
+//	@Summary		Export all tunnels (zip)
+//	@Tags			tunnels
+//	@Produce		application/zip
+//	@Security		CookieAuth
+//	@Success		200	{file}	binary
+//	@Router			/tunnels/export-all [get]
 func (h *TunnelsHandler) ExportAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -989,6 +1060,15 @@ func (h *TunnelsHandler) ExportAll(w http.ResponseWriter, r *http.Request) {
 
 // ReplaceConf replaces a tunnel's configuration from a new .conf file.
 // If the tunnel is running, it is stopped before replacement and restarted after.
+//
+//	@Summary		Replace tunnel from conf
+//	@Tags			tunnels
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	query	string	true	"Tunnel id"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/tunnels/replace [post]
 func (h *TunnelsHandler) ReplaceConf(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/tunnels.go
+++ b/internal/api/tunnels.go
@@ -29,6 +29,163 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/wan"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// TunnelPingCheckStatus is the ping-check status embedded in TunnelListItem.
+type TunnelPingCheckStatus struct {
+	Status        string `json:"status" example:"alive"`
+	RestartCount  int    `json:"restartCount" example:"0"`
+	FailCount     int    `json:"failCount" example:"0"`
+	FailThreshold int    `json:"failThreshold" example:"3"`
+}
+
+// TunnelListItemDTO mirrors frontend TunnelListItem.
+type TunnelListItemDTO struct {
+	ID                       string                `json:"id" example:"tun_abc123"`
+	Name                     string                `json:"name" example:"My AWG Tunnel"`
+	Type                     string                `json:"type" example:"awg" enums:"awg,wg"`
+	Status                   string                `json:"status" example:"connected" enums:"connected,disconnected,error,disabled"`
+	Enabled                  bool                  `json:"enabled" example:"true"`
+	DefaultRoute             bool                  `json:"defaultRoute" example:"false"`
+	Endpoint                 string                `json:"endpoint" example:"vpn.example.com:51820"`
+	Address                  string                `json:"address" example:"10.0.0.2/32"`
+	InterfaceName            string                `json:"interfaceName,omitempty" example:"nwg0"`
+	NdmsName                 string                `json:"ndmsName,omitempty" example:"Wireguard0"`
+	Backend                  string                `json:"backend,omitempty" example:"nativewg" enums:"nativewg,kernel"`
+	AWGVersion               string                `json:"awgVersion,omitempty" example:"awg2.0" enums:"wg,awg1.0,awg1.5,awg2.0"`
+	MTU                      int                   `json:"mtu,omitempty" example:"1420"`
+	IspInterface             string                `json:"ispInterface,omitempty" example:"PPPoE0"`
+	IspInterfaceLabel        string                `json:"ispInterfaceLabel,omitempty" example:"WAN"`
+	ResolvedIspInterface     string                `json:"resolvedIspInterface,omitempty" example:"PPPoE0"`
+	ResolvedIspInterfaceLabel string               `json:"resolvedIspInterfaceLabel,omitempty" example:"WAN"`
+	HasAddressConflict       bool                  `json:"hasAddressConflict,omitempty" example:"false"`
+	StartedAt                string                `json:"startedAt,omitempty" example:"2024-01-15T10:00:00Z"`
+	RxBytes                  int64                 `json:"rxBytes,omitempty" example:"10485760"`
+	TxBytes                  int64                 `json:"txBytes,omitempty" example:"5242880"`
+	LastHandshake            string                `json:"lastHandshake,omitempty" example:"2024-01-15T10:30:00Z"`
+	PingCheck                TunnelPingCheckStatus `json:"pingCheck"`
+}
+
+// TunnelListResponse is the envelope for GET /tunnels/list.
+type TunnelListResponse struct {
+	Success bool                `json:"success" example:"true"`
+	Data    []TunnelListItemDTO `json:"data"`
+}
+
+// TunnelsAllSnapshotData is the payload for GET /tunnels/all.
+type TunnelsAllSnapshotData struct {
+	Tunnels  []TunnelListItemDTO  `json:"tunnels"`
+	External []ExternalTunnelDTO  `json:"external"`
+	System   []SystemTunnelDTO    `json:"system"`
+}
+
+// TunnelsAllResponse is the envelope for GET /tunnels/all.
+type TunnelsAllResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    TunnelsAllSnapshotData `json:"data"`
+}
+
+// AWGInterfaceDTO mirrors frontend AWGInterface.
+type AWGInterfaceDTO struct {
+	PrivateKey string `json:"privateKey" example:"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="`
+	Address    string `json:"address" example:"10.0.0.2/32"`
+	MTU        int    `json:"mtu" example:"1420"`
+	DNS        string `json:"dns,omitempty" example:"8.8.8.8"`
+	Jc         int    `json:"jc" example:"4"`
+	Jmin       int    `json:"jmin" example:"40"`
+	Jmax       int    `json:"jmax" example:"70"`
+	S1         int    `json:"s1" example:"0"`
+	S2         int    `json:"s2" example:"0"`
+	S3         int    `json:"s3" example:"0"`
+	S4         int    `json:"s4" example:"0"`
+	H1         string `json:"h1" example:"1"`
+	H2         string `json:"h2" example:"2"`
+	H3         string `json:"h3" example:"3"`
+	H4         string `json:"h4" example:"4"`
+}
+
+// AWGPeerDTO mirrors frontend AWGPeer.
+type AWGPeerDTO struct {
+	PublicKey           string   `json:"publicKey" example:"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="`
+	Endpoint            string   `json:"endpoint" example:"vpn.example.com:51820"`
+	AllowedIPs          []string `json:"allowedIPs" example:"0.0.0.0/0"`
+	PersistentKeepalive int      `json:"persistentKeepalive,omitempty" example:"25"`
+}
+
+// TunnelStateInfoDTO mirrors frontend TunnelStateInfo.
+type TunnelStateInfoDTO struct {
+	State          int    `json:"state" example:"3"`
+	InterfaceUp    bool   `json:"interfaceUp" example:"true"`
+	ProcessRunning bool   `json:"processRunning" example:"true"`
+	HasHandshake   bool   `json:"hasHandshake" example:"true"`
+	LastHandshake  string `json:"lastHandshake" example:"2024-01-15T10:30:00Z"`
+	RxBytes        int64  `json:"rxBytes" example:"10485760"`
+	TxBytes        int64  `json:"txBytes" example:"5242880"`
+}
+
+// AWGTunnelDTO mirrors frontend AWGTunnel.
+type AWGTunnelDTO struct {
+	ID             string             `json:"id" example:"tun_abc123"`
+	Name           string             `json:"name" example:"My VPN"`
+	Type           string             `json:"type" example:"awg" enums:"awg,wg"`
+	Enabled        bool               `json:"enabled" example:"true"`
+	DefaultRoute   bool               `json:"defaultRoute" example:"false"`
+	InterfaceName  string             `json:"interfaceName,omitempty" example:"nwg0"`
+	State          string             `json:"state,omitempty" example:"connected"`
+	Backend        string             `json:"backend,omitempty" example:"nativewg"`
+	Interface      AWGInterfaceDTO    `json:"interface"`
+	Peer           AWGPeerDTO         `json:"peer"`
+	StateInfo      *TunnelStateInfoDTO `json:"stateInfo,omitempty"`
+}
+
+// TunnelDetailResponse is the envelope for GET /tunnels/get.
+type TunnelDetailResponse struct {
+	Success bool         `json:"success" example:"true"`
+	Data    AWGTunnelDTO `json:"data"`
+}
+
+// TunnelTrafficPoint is one point in a traffic chart.
+type TunnelTrafficPoint struct {
+	T  int64 `json:"t" example:"1705312200"`
+	Rx int64 `json:"rx" example:"1024000"`
+	Tx int64 `json:"tx" example:"512000"`
+}
+
+// TunnelTrafficStats are aggregate stats for a traffic period.
+type TunnelTrafficStats struct {
+	Points    int     `json:"points" example:"60"`
+	PeakRate  float64 `json:"peakRate" example:"1048576"`
+	AvgRx     float64 `json:"avgRx" example:"524288"`
+	AvgTx     float64 `json:"avgTx" example:"262144"`
+	CurrentRx float64 `json:"currentRx" example:"102400"`
+	CurrentTx float64 `json:"currentTx" example:"51200"`
+}
+
+// TunnelTrafficData is the payload for GET /tunnels/traffic.
+type TunnelTrafficData struct {
+	Points []TunnelTrafficPoint `json:"points"`
+	Stats  TunnelTrafficStats   `json:"stats"`
+}
+
+// TunnelTrafficResponse is the envelope for GET /tunnels/traffic.
+type TunnelTrafficResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    TunnelTrafficData `json:"data"`
+}
+
+// TunnelDeleteResultData mirrors frontend DeleteResult.
+type TunnelDeleteResultData struct {
+	Success  bool   `json:"success" example:"true"`
+	TunnelId string `json:"tunnelId" example:"tun_abc123"`
+	Verified bool   `json:"verified" example:"true"`
+}
+
+// TunnelDeleteResponse is the envelope for POST /tunnels/delete.
+type TunnelDeleteResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    TunnelDeleteResultData `json:"data"`
+}
+
 const maxBodySize = 1 << 20 // 1 MB
 
 // validTunnelID matches safe tunnel identifiers: starts with a letter,
@@ -445,7 +602,9 @@ func (h *TunnelsHandler) listItems(ctx context.Context) ([]tunnelItem, error) {
 //	@Tags			tunnels
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	TunnelListResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/list [get]
 func (h *TunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -471,7 +630,9 @@ func (h *TunnelsHandler) List(w http.ResponseWriter, r *http.Request) {
 //	@Tags			tunnels
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelsAllResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/all [get]
 func (h *TunnelsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -519,7 +680,9 @@ func (h *TunnelsHandler) writeAll(w http.ResponseWriter, r *http.Request) {
 //	@Security		CookieAuth
 //	@Param			id		query	string	true	"Tunnel id"
 //	@Param			period	query	string	true	"1h or 24h"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelTrafficResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/traffic [get]
 func (h *TunnelsHandler) Traffic(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -572,7 +735,9 @@ func (h *TunnelsHandler) Traffic(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelDetailResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/get [get]
 func (h *TunnelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -605,7 +770,9 @@ func (h *TunnelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/create [post]
 func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[storage.AWGTunnel](w, r, http.MethodPost)
@@ -720,7 +887,9 @@ func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/update [post]
 func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -908,7 +1077,9 @@ func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	TunnelDeleteResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/delete [post]
 func (h *TunnelsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -979,6 +1150,8 @@ func (h *TunnelsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
 //	@Success		200	{file}	binary
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/export [get]
 func (h *TunnelsHandler) Export(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -1017,6 +1190,8 @@ func (h *TunnelsHandler) Export(w http.ResponseWriter, r *http.Request) {
 //	@Produce		application/zip
 //	@Security		CookieAuth
 //	@Success		200	{file}	binary
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/export-all [get]
 func (h *TunnelsHandler) ExportAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -1067,7 +1242,9 @@ func (h *TunnelsHandler) ExportAll(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Tunnel id"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/tunnels/replace [post]
 func (h *TunnelsHandler) ReplaceConf(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/internal/api/update.go
+++ b/internal/api/update.go
@@ -24,6 +24,14 @@ func NewUpdateHandler(updater *updater.Service, appLogger logging.AppLogger) *Up
 
 // Check returns cached update info or triggers a fresh check.
 // GET /api/system/update/check?force=true
+//
+//	@Summary		Update check
+//	@Tags			update
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			force	query	boolean	false	"Force refresh from upstream"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/update/check [get]
 func (h *UpdateHandler) Check(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -44,6 +52,13 @@ func (h *UpdateHandler) Check(w http.ResponseWriter, r *http.Request) {
 
 // Apply starts the opkg upgrade process.
 // POST /api/system/update/apply
+//
+//	@Summary		Apply system update
+//	@Tags			update
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/update/apply [post]
 func (h *UpdateHandler) Apply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -76,6 +91,15 @@ func (h *UpdateHandler) Apply(w http.ResponseWriter, r *http.Request) {
 //
 // GET /api/system/update/changelog?from=2.7.5&to=2.8.0
 // GET /api/system/update/changelog?to=2.8.1
+//
+//	@Summary		Update changelog
+//	@Tags			update
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			from	query	string	false	"From version"
+//	@Param			to		query	string	true	"To version"
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/system/update/changelog [get]
 func (h *UpdateHandler) Changelog(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/update.go
+++ b/internal/api/update.go
@@ -8,6 +8,58 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/updater"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// UpdateInfoData mirrors frontend UpdateInfo.
+type UpdateInfoData struct {
+	Available      bool   `json:"available" example:"false"`
+	CurrentVersion string `json:"currentVersion" example:"2.5.0"`
+	LatestVersion  string `json:"latestVersion,omitempty" example:"2.5.0"`
+	CheckedAt      string `json:"checkedAt" example:"2024-01-15T10:00:00Z"`
+	Checking       bool   `json:"checking" example:"false"`
+}
+
+// UpdateCheckResponse is the envelope for GET /system/update/check.
+type UpdateCheckResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    UpdateInfoData `json:"data"`
+}
+
+// ChangelogGroupDTO mirrors frontend ChangelogGroup.
+type ChangelogGroupDTO struct {
+	Heading string   `json:"heading" example:"Bug Fixes"`
+	Items   []string `json:"items" example:"Fixed tunnel restart loop"`
+}
+
+// ChangelogEntryDTO mirrors frontend ChangelogEntry.
+type ChangelogEntryDTO struct {
+	Version string              `json:"version" example:"2.5.0"`
+	Date    string              `json:"date" example:"2024-01-15"`
+	Groups  []ChangelogGroupDTO `json:"groups"`
+}
+
+// ChangelogData is the payload for GET /system/update/changelog.
+type ChangelogData struct {
+	Entries []ChangelogEntryDTO `json:"entries"`
+}
+
+// ChangelogResponse is the envelope for GET /system/update/changelog.
+type ChangelogResponse struct {
+	Success bool          `json:"success" example:"true"`
+	Data    ChangelogData `json:"data"`
+}
+
+// UpdateApplyData is the payload for POST /system/update/apply.
+type UpdateApplyData struct {
+	Status string `json:"status" example:"updating"`
+}
+
+// UpdateApplyResponse is the envelope for POST /system/update/apply.
+type UpdateApplyResponse struct {
+	Success bool            `json:"success" example:"true"`
+	Data    UpdateApplyData `json:"data"`
+}
+
 // UpdateHandler handles update check and apply endpoints.
 type UpdateHandler struct {
 	updater *updater.Service
@@ -30,7 +82,9 @@ func NewUpdateHandler(updater *updater.Service, appLogger logging.AppLogger) *Up
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			force	query	boolean	false	"Force refresh from upstream"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	UpdateCheckResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/update/check [get]
 func (h *UpdateHandler) Check(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -57,7 +111,9 @@ func (h *UpdateHandler) Check(w http.ResponseWriter, r *http.Request) {
 //	@Tags			update
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	UpdateApplyResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/update/apply [post]
 func (h *UpdateHandler) Apply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -98,7 +154,9 @@ func (h *UpdateHandler) Apply(w http.ResponseWriter, r *http.Request) {
 //	@Security		CookieAuth
 //	@Param			from	query	string	false	"From version"
 //	@Param			to		query	string	true	"To version"
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	ChangelogResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/system/update/changelog [get]
 func (h *UpdateHandler) Changelog(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/wan.go
+++ b/internal/api/wan.go
@@ -9,6 +9,17 @@ import (
 	wanpkg "github.com/hoaxisr/awg-manager/internal/tunnel/wan"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// WANStatusEnvelope is the swagger-friendly envelope for GET /wan/status.
+// (The actual handler uses the local WANStatusResponse which embeds wanpkg types.)
+type WANStatusEnvelope struct {
+	Success bool   `json:"success" example:"true"`
+	Data    struct {
+		AnyWANUp bool `json:"anyWANUp" example:"true"`
+	} `json:"data"`
+}
+
 // WANHandler serves WAN status queries. WAN up/down events are handled
 // by HookHandler (/api/hook/ndms layer=ipv4).
 type WANHandler struct {
@@ -39,7 +50,9 @@ type WANStatusResponse struct {
 //	@Tags			wan
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	WANStatusEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/wan/status [get]
 func (h *WANHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/wan.go
+++ b/internal/api/wan.go
@@ -34,6 +34,13 @@ type WANStatusResponse struct {
 
 // GetStatus returns current WAN interface state.
 // GET /api/wan/status
+//
+//	@Summary		WAN status
+//	@Tags			wan
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Router			/wan/status [get]
 func (h *WANHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/openapi/embed.go
+++ b/internal/openapi/embed.go
@@ -1,0 +1,10 @@
+package openapi
+
+import _ "embed"
+
+// RawSpec is the committed OpenAPI (Swagger 2) document; regenerate with:
+//
+//	go generate ./cmd/awg-manager
+//
+//go:embed swagger.yaml
+var RawSpec []byte

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1,0 +1,3111 @@
+basePath: /api
+definitions:
+  api.AdoptRequest:
+    properties:
+      content:
+        type: string
+      name:
+        type: string
+    type: object
+  api.LoginRequest:
+    properties:
+      login:
+        type: string
+      password:
+        type: string
+    type: object
+  api.ResolveResponse:
+    properties:
+      domain:
+        type: string
+      error:
+        type: string
+      ips:
+        items:
+          type: string
+        type: array
+    type: object
+  api.SaveStatusDTO:
+    properties:
+      lastError:
+        type: string
+      lastSaveAt:
+        type: string
+      pendingCount:
+        type: integer
+      state:
+        type: string
+    type: object
+info:
+  contact: {}
+  description: HTTP API for the AWG Manager daemon (tunnels, routing, system).
+  title: AWG Manager API
+  version: "1.0"
+paths:
+  /access-policies:
+    get:
+      description: KeeneticOS 5 only when route is registered.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List access policies
+      tags:
+      - access-policy
+  /access-policies/assign:
+    delete:
+      parameters:
+      - description: Device MAC
+        in: query
+        name: mac
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unassign device from policy
+      tags:
+      - access-policy
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Assign device to policy
+      tags:
+      - access-policy
+  /access-policies/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create access policy
+      tags:
+      - access-policy
+  /access-policies/delete:
+    delete:
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete access policy
+      tags:
+      - access-policy
+  /access-policies/description:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set access policy description
+      tags:
+      - access-policy
+  /access-policies/devices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List policy devices
+      tags:
+      - access-policy
+  /access-policies/interface-up:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set interface admin up
+      tags:
+      - access-policy
+  /access-policies/interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List global policy interfaces
+      tags:
+      - access-policy
+  /access-policies/permit:
+    delete:
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: Interface name
+        in: query
+        name: interface
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Remove permitted interface
+      tags:
+      - access-policy
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Permit interface on policy
+      tags:
+      - access-policy
+  /access-policies/standalone:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set access policy standalone mode
+      tags:
+      - access-policy
+  /auth/login:
+    post:
+      consumes:
+      - application/json
+      description: Authenticates with Keenetic credentials; sets HttpOnly session
+        cookie awg_session.
+      parameters:
+      - description: Router login and password
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.LoginRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success, login
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties: true
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Login
+      tags:
+      - auth
+  /auth/logout:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Logout
+      tags:
+      - auth
+  /auth/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: authenticated, login, expiresIn, authDisabled
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Auth status
+      tags:
+      - auth
+  /boot-status:
+    get:
+      description: 'Public snapshot: initializing flag, phase, instance id.'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Boot status
+      tags:
+      - system
+  /client-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List client routes
+      tags:
+      - client-routes
+  /client-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create client route
+      tags:
+      - client-routes
+  /client-routes/delete:
+    post:
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete client route
+      tags:
+      - client-routes
+  /client-routes/toggle:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle client route
+      tags:
+      - client-routes
+  /client-routes/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update client route
+      tags:
+      - client-routes
+  /connections:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Connections list
+      tags:
+      - connections
+  /control/restart:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Restart tunnel
+      tags:
+      - control
+  /control/restart-all:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Restart all enabled tunnels
+      tags:
+      - control
+  /control/start:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start tunnel
+      tags:
+      - control
+  /control/stop:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Stop tunnel
+      tags:
+      - control
+  /control/toggle-default-route:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle default route
+      tags:
+      - control
+  /control/toggle-enabled:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle tunnel autostart
+      tags:
+      - control
+  /diagnostics/result:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Download diagnostics report
+      tags:
+      - diagnostics
+  /diagnostics/run:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Run diagnostics
+      tags:
+      - diagnostics
+  /diagnostics/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Diagnostics status
+      tags:
+      - diagnostics
+  /diagnostics/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Diagnostics SSE stream
+      tags:
+      - diagnostics
+  /dns-check/probe:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: DNS check probe (CORS)
+      tags:
+      - dns-check
+  /dns-check/start:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start DNS check
+      tags:
+      - dns-check
+  /dns-routes/bulk-backend:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Bulk set DNS route backend
+      tags:
+      - dns-routes
+  /dns-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/create-batch:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create DNS route lists (batch)
+      tags:
+      - dns-routes
+  /dns-routes/delete:
+    post:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Delete DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/delete-batch:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Delete DNS route lists (batch)
+      tags:
+      - dns-routes
+  /dns-routes/get:
+    get:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get DNS route list
+      tags:
+      - dns-routes
+  /dns-routes/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List DNS route lists
+      tags:
+      - dns-routes
+  /dns-routes/refresh:
+    post:
+      parameters:
+      - description: List id (omit for all)
+        in: query
+        name: id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh DNS route subscriptions
+      tags:
+      - dns-routes
+  /dns-routes/set-enabled:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Set DNS route list enabled
+      tags:
+      - dns-routes
+  /dns-routes/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update DNS route list
+      tags:
+      - dns-routes
+  /events:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: Server-Sent Events
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: SSE event stream
+      tags:
+      - events
+  /external-tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List external tunnels
+      tags:
+      - tunnels
+  /external-tunnels/adopt:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: interface
+        required: true
+        type: string
+      - description: Tunnel config body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.AdoptRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Adopt external tunnel
+      tags:
+      - tunnels
+  /health:
+    get:
+      description: Cheap check for frontend pollers; no NDMS or I/O.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok, version
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Health / liveness
+      tags:
+      - system
+  /hook/ndms:
+    post:
+      consumes:
+      - application/x-www-form-urlencoded
+      description: 'Called from router scripts (public). Form fields: type, id, system_name,
+        layer, etc.'
+      parameters:
+      - description: Event type (iflayerchanged, ifcreated, ...)
+        in: formData
+        name: type
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: NDMS shell hook
+      tags:
+      - hook
+  /hydraroute/config:
+    get:
+      description: Available when HydraRoute service is wired on the device.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get HydraRoute config
+      tags:
+      - hydraroute
+  /hydraroute/config/update:
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update HydraRoute config
+      tags:
+      - hydraroute
+  /hydraroute/geo-files:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List HydraRoute geo files
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/add:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add HydraRoute geo file
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/delete:
+    delete:
+      parameters:
+      - description: File path
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete HydraRoute geo file
+      tags:
+      - hydraroute
+  /hydraroute/geo-files/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh HydraRoute geo file(s)
+      tags:
+      - hydraroute
+  /hydraroute/geo-tags:
+    get:
+      parameters:
+      - description: Geo file path
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: HydraRoute geo tags
+      tags:
+      - hydraroute
+  /hydraroute/ipset-usage:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute ipset usage
+      tags:
+      - hydraroute
+  /hydraroute/oversized-tags:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute oversized geo tags
+      tags:
+      - hydraroute
+  /hydraroute/policy-order:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set HydraRoute policy order
+      tags:
+      - hydraroute
+  /import/conf:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Import tunnel config
+      tags:
+      - import
+  /logs:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get logs
+      tags:
+      - logs
+  /logs/clear:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Clear logs
+      tags:
+      - logs
+  /managed-server:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed WireGuard server
+      tags:
+      - managed-server
+  /managed-server/asc:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed server ASC
+      tags:
+      - managed-server
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server ASC
+      tags:
+      - managed-server
+  /managed-server/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create managed server
+      tags:
+      - managed-server
+  /managed-server/delete:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed server
+      tags:
+      - managed-server
+  /managed-server/enabled:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Enable/disable managed server
+      tags:
+      - managed-server
+  /managed-server/nat:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server NAT
+      tags:
+      - managed-server
+  /managed-server/peers:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/conf:
+    get:
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Peer WireGuard conf
+      tags:
+      - managed-server
+  /managed-server/peers/delete:
+    delete:
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/toggle:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed server peer
+      tags:
+      - managed-server
+  /managed-server/peers/update:
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Peer public key
+        in: query
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed server peer
+      tags:
+      - managed-server
+  /managed-server/policies:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List IP policy profiles
+      tags:
+      - managed-server
+  /managed-server/policy:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed server hotspot policy
+      tags:
+      - managed-server
+  /managed-server/stats:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Managed server stats
+      tags:
+      - managed-server
+  /managed-server/suggest-address:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Suggest managed server address
+      tags:
+      - managed-server
+  /managed-server/update:
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed server
+      tags:
+      - managed-server
+  /ndms/save-status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SaveStatusDTO'
+      security:
+      - CookieAuth: []
+      summary: NDMS save coordinator status
+      tags:
+      - ndms
+  /pingcheck/check-now:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Trigger ping check now
+      tags:
+      - pingcheck
+  /pingcheck/logs:
+    get:
+      parameters:
+      - description: Filter by tunnel id
+        in: query
+        name: tunnelId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Ping check logs
+      tags:
+      - pingcheck
+  /pingcheck/logs/clear:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Clear ping check logs
+      tags:
+      - pingcheck
+  /pingcheck/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Ping check status
+      tags:
+      - pingcheck
+  /proxy/apply:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Force apply device proxy
+      tags:
+      - device-proxy
+  /proxy/config:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get device proxy config
+      tags:
+      - device-proxy
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Save device proxy config
+      tags:
+      - device-proxy
+  /proxy/listen-choices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Device proxy listen choices
+      tags:
+      - device-proxy
+  /proxy/outbounds:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List device proxy outbounds
+      tags:
+      - device-proxy
+  /proxy/runtime:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Device proxy runtime state
+      tags:
+      - device-proxy
+  /proxy/runtime/select:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Select device proxy outbound
+      tags:
+      - device-proxy
+  /routing/access-policies:
+    get:
+      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: OS4 access policies stub
+      tags:
+      - routing
+  /routing/client-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List client routes
+      tags:
+      - client-routes
+  /routing/dns-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List DNS route lists
+      tags:
+      - dns-routes
+  /routing/policy-devices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List policy devices
+      tags:
+      - access-policy
+  /routing/policy-interfaces:
+    get:
+      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: OS4 policy interfaces stub
+      tags:
+      - routing
+  /routing/refresh:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Invalidate routing caches
+      tags:
+      - routing
+  /routing/resolve:
+    get:
+      parameters:
+      - description: Hostname to resolve
+        in: query
+        name: domain
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ResolveResponse'
+      security:
+      - CookieAuth: []
+      summary: Resolve domain
+      tags:
+      - routing
+  /routing/static-routes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List static routes
+      tags:
+      - static-routes
+  /routing/tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: Routing tunnel catalog
+      tags:
+      - routing
+  /servers:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List VPN server interfaces
+      tags:
+      - servers
+  /servers/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Servers composite snapshot
+      tags:
+      - servers
+  /servers/config:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Server RC config for export
+      tags:
+      - servers
+  /servers/get:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get VPN server by name
+      tags:
+      - servers
+  /servers/mark:
+    delete:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unmark server interface
+      tags:
+      - servers
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Mark server interface
+      tags:
+      - servers
+  /servers/marked:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List marked server interface ids
+      tags:
+      - servers
+  /servers/wan-ip:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: WAN IP for server conf
+      tags:
+      - servers
+  /settings/get:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get settings
+      tags:
+      - settings
+  /settings/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update settings
+      tags:
+      - settings
+  /signature/capture:
+    get:
+      parameters:
+      - description: Domain name
+        in: query
+        name: domain
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Signature capture
+      tags:
+      - signature
+  /singbox/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Install sing-box
+      tags:
+      - singbox
+  /singbox/status:
+    get:
+      description: Available when sing-box integration is enabled in the build.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Sing-box status
+      tags:
+      - singbox
+  /singbox/tunnels:
+    delete:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete sing-box tunnel
+      tags:
+      - singbox
+    get:
+      parameters:
+      - description: When set, returns single tunnel
+        in: query
+        name: tag
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List or get sing-box tunnel(s)
+      tags:
+      - singbox
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add sing-box tunnel(s)
+      tags:
+      - singbox
+    put:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update sing-box tunnel
+      tags:
+      - singbox
+  /singbox/tunnels/delay-check:
+    post:
+      parameters:
+      - description: Tunnel tag
+        in: query
+        name: tag
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Sing-box delay check
+      tags:
+      - singbox
+  /singbox/tunnels/test/speed/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Sing-box tunnel speed test stream
+      tags:
+      - singbox
+  /static-routes/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create static route
+      tags:
+      - static-routes
+  /static-routes/delete:
+    post:
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete static route
+      tags:
+      - static-routes
+  /static-routes/import:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Import static routes
+      tags:
+      - static-routes
+  /static-routes/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List static routes
+      tags:
+      - static-routes
+  /static-routes/set-enabled:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: List id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set static route enabled
+      tags:
+      - static-routes
+  /static-routes/update:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update static route
+      tags:
+      - static-routes
+  /status/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: All tunnel statuses
+      tags:
+      - status
+  /status/get:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Tunnel status
+      tags:
+      - status
+  /system-tunnels:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List system WireGuard tunnels
+      tags:
+      - system-tunnels
+  /system-tunnels/asc:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get system tunnel ASC params
+      tags:
+      - system-tunnels
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set system tunnel ASC params
+      tags:
+      - system-tunnels
+  /system-tunnels/get:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get system tunnel
+      tags:
+      - system-tunnels
+  /system-tunnels/hidden:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List hidden system tunnels
+      tags:
+      - system-tunnels
+  /system-tunnels/hide:
+    delete:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unhide system tunnel
+      tags:
+      - system-tunnels
+    post:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Hide system tunnel
+      tags:
+      - system-tunnels
+  /system-tunnels/test-connectivity:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System tunnel connectivity test
+      tags:
+      - system-tunnels
+  /system-tunnels/test-ip:
+    get:
+      parameters:
+      - description: NDMS interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System tunnel IP check
+      tags:
+      - system-tunnels
+  /system-tunnels/test-speed:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: System tunnel speed test (SSE)
+      tags:
+      - system-tunnels
+  /system/all-interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: All interfaces
+      tags:
+      - system
+  /system/hydraroute-control:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute control (system)
+      tags:
+      - system
+  /system/hydraroute-status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: HydraRoute status (system)
+      tags:
+      - system
+  /system/info:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: System info
+      tags:
+      - system
+  /system/restart:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Restart daemon
+      tags:
+      - system
+  /system/update/apply:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Apply system update
+      tags:
+      - update
+  /system/update/changelog:
+    get:
+      parameters:
+      - description: From version
+        in: query
+        name: from
+        type: string
+      - description: To version
+        in: query
+        name: to
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update changelog
+      tags:
+      - update
+  /system/update/check:
+    get:
+      parameters:
+      - description: Force refresh from upstream
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update check
+      tags:
+      - update
+  /system/wan-interfaces:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: WAN interfaces
+      tags:
+      - system
+  /terminal/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Install terminal (ttyd)
+      tags:
+      - terminal
+  /terminal/start:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Start terminal
+      tags:
+      - terminal
+  /terminal/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Terminal status
+      tags:
+      - terminal
+  /terminal/stop:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Stop terminal
+      tags:
+      - terminal
+  /terminal/ws:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: WebSocket upgrade
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Terminal WebSocket
+      tags:
+      - terminal
+  /test/connectivity:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Connectivity check
+      tags:
+      - test
+  /test/ip:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        type: string
+      - description: Check service id
+        in: query
+        name: service
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: IP leak check
+      tags:
+      - test
+  /test/ip/services:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: IP check services
+      tags:
+      - test
+  /test/speed:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Speed test (sync)
+      tags:
+      - test
+  /test/speed/servers:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Speed test servers
+      tags:
+      - test
+  /test/speed/stream:
+    get:
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: SSE stream
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: Speed test stream
+      tags:
+      - test
+  /tunnels/all:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Composite tunnels snapshot
+      tags:
+      - tunnels
+  /tunnels/create:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create tunnel
+      tags:
+      - tunnels
+  /tunnels/delete:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete tunnel
+      tags:
+      - tunnels
+  /tunnels/export:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Export tunnel config
+      tags:
+      - tunnels
+  /tunnels/export-all:
+    get:
+      produces:
+      - application/zip
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - CookieAuth: []
+      summary: Export all tunnels (zip)
+      tags:
+      - tunnels
+  /tunnels/get:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get tunnel
+      tags:
+      - tunnels
+  /tunnels/list:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+      security:
+      - CookieAuth: []
+      summary: List tunnels
+      tags:
+      - tunnels
+  /tunnels/pingcheck:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Configure per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+  /tunnels/pingcheck/remove:
+    post:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Remove per-tunnel NDMS ping-check
+      tags:
+      - pingcheck
+  /tunnels/replace:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Replace tunnel from conf
+      tags:
+      - tunnels
+  /tunnels/traffic:
+    get:
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: 1h or 24h
+        in: query
+        name: period
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Tunnel traffic history
+      tags:
+      - tunnels
+  /tunnels/update:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Tunnel id
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update tunnel
+      tags:
+      - tunnels
+  /wan/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: WAN status
+      tags:
+      - wan
+securityDefinitions:
+  CookieAuth:
+    description: Session cookie set by POST /auth/login. Omit for public routes.
+    in: cookie
+    name: awg_session
+    type: apiKey
+swagger: "2.0"

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1,5 +1,186 @@
 basePath: /api
 definitions:
+  api.APIEnvelope:
+    properties:
+      data:
+        type: object
+      message:
+        example: ok
+        type: string
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.APIErrorEnvelope:
+    properties:
+      code:
+        example: BAD_REQUEST
+        type: string
+      error:
+        example: true
+        type: boolean
+      message:
+        example: invalid request
+        type: string
+    type: object
+  api.AWGInterfaceDTO:
+    properties:
+      address:
+        example: 10.0.0.2/32
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      h1:
+        example: "1"
+        type: string
+      h2:
+        example: "2"
+        type: string
+      h3:
+        example: "3"
+        type: string
+      h4:
+        example: "4"
+        type: string
+      jc:
+        example: 4
+        type: integer
+      jmax:
+        example: 70
+        type: integer
+      jmin:
+        example: 40
+        type: integer
+      mtu:
+        example: 1420
+        type: integer
+      privateKey:
+        example: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        type: string
+      s1:
+        example: 0
+        type: integer
+      s2:
+        example: 0
+        type: integer
+      s3:
+        example: 0
+        type: integer
+      s4:
+        example: 0
+        type: integer
+    type: object
+  api.AWGPeerDTO:
+    properties:
+      allowedIPs:
+        example:
+        - 0.0.0.0/0
+        items:
+          type: string
+        type: array
+      endpoint:
+        example: vpn.example.com:51820
+        type: string
+      persistentKeepalive:
+        example: 25
+        type: integer
+      publicKey:
+        example: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+        type: string
+    type: object
+  api.AWGTunnelDTO:
+    properties:
+      backend:
+        example: nativewg
+        type: string
+      defaultRoute:
+        example: false
+        type: boolean
+      enabled:
+        example: true
+        type: boolean
+      id:
+        example: tun_abc123
+        type: string
+      interface:
+        $ref: '#/definitions/api.AWGInterfaceDTO'
+      interfaceName:
+        example: nwg0
+        type: string
+      name:
+        example: My VPN
+        type: string
+      peer:
+        $ref: '#/definitions/api.AWGPeerDTO'
+      state:
+        example: connected
+        type: string
+      stateInfo:
+        $ref: '#/definitions/api.TunnelStateInfoDTO'
+      type:
+        enum:
+        - awg
+        - wg
+        example: awg
+        type: string
+    type: object
+  api.AccessPoliciesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.AccessPolicyDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.AccessPolicyDTO:
+    properties:
+      description:
+        example: Default policy
+        type: string
+      deviceCount:
+        example: 5
+        type: integer
+      interfaces:
+        items:
+          $ref: '#/definitions/api.AccessPolicyInterfaceDTO'
+        type: array
+      name:
+        example: default
+        type: string
+      standalone:
+        example: false
+        type: boolean
+    type: object
+  api.AccessPolicyInterfaceDTO:
+    properties:
+      denied:
+        example: false
+        type: boolean
+      label:
+        example: My VPN
+        type: string
+      name:
+        example: nwg0
+        type: string
+      order:
+        example: 1
+        type: integer
+    type: object
+  api.AddPeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      tunnelIP:
+        example: 10.10.0.2/32
+        type: string
+    type: object
   api.AdoptRequest:
     properties:
       content:
@@ -7,12 +188,1063 @@ definitions:
       name:
         type: string
     type: object
+  api.AllInterfacesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.RouterInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.AuthStatusResponse:
+    properties:
+      authDisabled:
+        example: false
+        type: boolean
+      authenticated:
+        example: true
+        type: boolean
+      expiresIn:
+        example: 3600
+        type: integer
+      login:
+        example: admin
+        type: string
+    type: object
+  api.BootStatusResponse:
+    properties:
+      initializing:
+        example: false
+        type: boolean
+      instanceId:
+        example: a1b2c3d4e5f6
+        type: string
+      phase:
+        example: ready
+        type: string
+      remainingSeconds:
+        example: 0
+        type: integer
+    type: object
+  api.ChangelogData:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/api.ChangelogEntryDTO'
+        type: array
+    type: object
+  api.ChangelogEntryDTO:
+    properties:
+      date:
+        example: "2024-01-15"
+        type: string
+      groups:
+        items:
+          $ref: '#/definitions/api.ChangelogGroupDTO'
+        type: array
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.ChangelogGroupDTO:
+    properties:
+      heading:
+        example: Bug Fixes
+        type: string
+      items:
+        example:
+        - Fixed tunnel restart loop
+        items:
+          type: string
+        type: array
+    type: object
+  api.ChangelogResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ChangelogData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ClientRouteDTO:
+    properties:
+      clientHostname:
+        example: My-Phone
+        type: string
+      clientIp:
+        example: 192.168.1.100
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      fallback:
+        example: drop
+        type: string
+      id:
+        example: cr_001
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.ClientRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.ClientRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConnectionProtocolsDTO:
+    properties:
+      icmp:
+        example: 2
+        type: integer
+      tcp:
+        example: 28
+        type: integer
+      udp:
+        example: 12
+        type: integer
+    type: object
+  api.ConnectionStatsDTO:
+    properties:
+      direct:
+        example: 30
+        type: integer
+      protocols:
+        $ref: '#/definitions/api.ConnectionProtocolsDTO'
+      total:
+        example: 42
+        type: integer
+      tunneled:
+        example: 12
+        type: integer
+    type: object
+  api.ConnectionsData:
+    properties:
+      connections:
+        items:
+          $ref: '#/definitions/api.ConntrackConnectionDTO'
+        type: array
+      fetchedAt:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      pagination:
+        $ref: '#/definitions/api.ConnectionsPaginationDTO'
+      stats:
+        $ref: '#/definitions/api.ConnectionStatsDTO'
+      tunnels:
+        type: object
+    type: object
+  api.ConnectionsPaginationDTO:
+    properties:
+      limit:
+        example: 50
+        type: integer
+      offset:
+        example: 0
+        type: integer
+      returned:
+        example: 42
+        type: integer
+      total:
+        example: 42
+        type: integer
+    type: object
+  api.ConnectionsResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.ConnectionsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConnectivityResultData:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      latency:
+        example: 42
+        type: integer
+      reason:
+        example: ""
+        type: string
+    type: object
+  api.ConnectivityResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ConnectivityResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ConntrackConnectionDTO:
+    properties:
+      bytes:
+        example: 4096
+        type: integer
+      clientMac:
+        example: aa:bb:cc:dd:ee:ff
+        type: string
+      clientName:
+        example: My Phone
+        type: string
+      dst:
+        example: 8.8.8.8
+        type: string
+      dstPort:
+        example: 443
+        type: integer
+      interface:
+        example: nwg0
+        type: string
+      packets:
+        example: 15
+        type: integer
+      protocol:
+        example: tcp
+        type: string
+      src:
+        example: 192.168.1.100
+        type: string
+      srcPort:
+        example: 54321
+        type: integer
+      state:
+        example: ESTABLISHED
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.CreateServerRequestDTO:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      description:
+        example: My WG Server
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      endpoint:
+        example: 203.0.113.42:51821
+        type: string
+      listenPort:
+        example: 51821
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+    type: object
+  api.DNSRouteSettingsDTO:
+    properties:
+      autoRefreshEnabled:
+        example: true
+        type: boolean
+      refreshDailyTime:
+        example: "03:00"
+        type: string
+      refreshIntervalHours:
+        example: 24
+        type: integer
+      refreshMode:
+        example: interval
+        type: string
+    type: object
+  api.DeviceProxyAuthDTO:
+    properties:
+      enabled:
+        example: false
+        type: boolean
+      password:
+        example: ""
+        type: string
+      username:
+        example: ""
+        type: string
+    type: object
+  api.DeviceProxyConfigData:
+    properties:
+      auth:
+        $ref: '#/definitions/api.DeviceProxyAuthDTO'
+      enabled:
+        example: false
+        type: boolean
+      listenAll:
+        example: true
+        type: boolean
+      listenInterface:
+        example: br0
+        type: string
+      port:
+        example: 1080
+        type: integer
+      selectedOutbound:
+        example: proxy-01
+        type: string
+    type: object
+  api.DeviceProxyOutboundDTO:
+    properties:
+      detail:
+        example: proxy.example.com:443
+        type: string
+      kind:
+        example: singbox
+        type: string
+      label:
+        example: proxy-01 (VLESS)
+        type: string
+      tag:
+        example: proxy-01
+        type: string
+    type: object
+  api.DeviceProxyRuntimeData:
+    properties:
+      activeTag:
+        example: proxy-01
+        type: string
+      alive:
+        example: true
+        type: boolean
+      defaultTag:
+        example: proxy-01
+        type: string
+    type: object
+  api.DiagnosticsStatusData:
+    properties:
+      progress:
+        example: ""
+        type: string
+      status:
+        example: idle
+        type: string
+    type: object
+  api.DiagnosticsStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DiagnosticsStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsCheckResultDTO:
+    properties:
+      detail:
+        example: ""
+        type: string
+      id:
+        example: dns_leak
+        type: string
+      message:
+        example: No DNS leak detected
+        type: string
+      status:
+        example: ok
+        type: string
+      title:
+        example: DNS Leak Test
+        type: string
+    type: object
+  api.DnsCheckStartData:
+    properties:
+      checks:
+        items:
+          $ref: '#/definitions/api.DnsCheckResultDTO'
+        type: array
+      clientIP:
+        example: 192.168.1.100
+        type: string
+      hostname:
+        example: my-phone.local
+        type: string
+    type: object
+  api.DnsCheckStartResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.DnsCheckStartData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsRouteDTO:
+    properties:
+      backend:
+        example: ndms
+        type: string
+      createdAt:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      domains:
+        example:
+        - example.com
+        items:
+          type: string
+        type: array
+      enabled:
+        example: true
+        type: boolean
+      id:
+        example: dns_xyz789
+        type: string
+      manualDomains:
+        example:
+        - corp.internal
+        items:
+          type: string
+        type: array
+      name:
+        example: Work VPN
+        type: string
+      routes:
+        items:
+          $ref: '#/definitions/api.DnsRouteTargetDTO'
+        type: array
+      subscriptions:
+        items:
+          $ref: '#/definitions/api.DnsRouteSubscriptionDTO'
+        type: array
+      updatedAt:
+        example: "2024-01-15T12:00:00Z"
+        type: string
+    type: object
+  api.DnsRouteResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DnsRouteDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.DnsRouteSubscriptionDTO:
+    properties:
+      lastCount:
+        example: 1500
+        type: integer
+      lastFetched:
+        example: "2024-01-15T02:00:00Z"
+        type: string
+      name:
+        example: Block list
+        type: string
+      url:
+        example: https://example.com/list.txt
+        type: string
+    type: object
+  api.DnsRouteTargetDTO:
+    properties:
+      fallback:
+        example: auto
+        type: string
+      interface:
+        example: nwg0
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.DnsRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.DnsRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ExternalTunnelDTO:
+    properties:
+      endpoint:
+        example: ext.example.com:51820
+        type: string
+      interfaceName:
+        example: Wireguard2
+        type: string
+      isAWG:
+        example: true
+        type: boolean
+      publicKey:
+        example: KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK=
+        type: string
+      rxBytes:
+        example: 1048576
+        type: integer
+      tunnelNumber:
+        example: 2
+        type: integer
+      txBytes:
+        example: 524288
+        type: integer
+    type: object
+  api.ExternalTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.ExternalTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.HealthData:
+    properties:
+      ok:
+        example: true
+        type: boolean
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.HealthResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.HealthData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.HydraRouteConfigData:
+    properties:
+      autoStart:
+        example: true
+        type: boolean
+      cidr:
+        example: true
+        type: boolean
+      clearIPSet:
+        example: false
+        type: boolean
+      conntrackFlush:
+        example: true
+        type: boolean
+      directRouteEnabled:
+        example: false
+        type: boolean
+      geoIPFiles:
+        example:
+        - /opt/etc/hrneo/geoip.db
+        items:
+          type: string
+        type: array
+      geoSiteFiles:
+        example:
+        - /opt/etc/hrneo/geosite.db
+        items:
+          type: string
+        type: array
+      globalRouting:
+        example: false
+        type: boolean
+      ipsetEnableTimeout:
+        example: false
+        type: boolean
+      ipsetMaxElem:
+        example: 65536
+        type: integer
+      ipsetTimeout:
+        example: 0
+        type: integer
+      log:
+        example: warn
+        type: string
+      logFile:
+        example: /var/log/hrneo.log
+        type: string
+      policyOrder:
+        example:
+        - default
+        items:
+          type: string
+        type: array
+    type: object
+  api.HydraRouteConfigResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.HydraRouteConfigData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.HydraRouteStatusData:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      running:
+        example: true
+        type: boolean
+      version:
+        example: 0.3.1
+        type: string
+    type: object
+  api.HydraRouteStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.HydraRouteStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.IPCheckServiceDTO:
+    properties:
+      label:
+        example: ipinfo.io
+        type: string
+      url:
+        example: https://ipinfo.io/ip
+        type: string
+    type: object
+  api.IPResultData:
+    properties:
+      directIp:
+        example: 203.0.113.1
+        type: string
+      endpointIp:
+        example: 203.0.113.42
+        type: string
+      ipChanged:
+        example: true
+        type: boolean
+      vpnIp:
+        example: 185.220.101.1
+        type: string
+    type: object
+  api.IPResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.IPResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.IPServicesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.IPCheckServiceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.LogEntryDTO:
+    properties:
+      action:
+        example: connect
+        type: string
+      group:
+        example: tunnel
+        type: string
+      level:
+        example: info
+        type: string
+      message:
+        example: Tunnel connected
+        type: string
+      subgroup:
+        example: tun_abc123
+        type: string
+      target:
+        example: vpn.example.com:51820
+        type: string
+      timestamp:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.LoggingSettingsDTO:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      logLevel:
+        example: info
+        type: string
+      maxAge:
+        example: 7
+        type: integer
+    type: object
   api.LoginRequest:
     properties:
       login:
         type: string
       password:
         type: string
+    type: object
+  api.LoginResponseRaw:
+    properties:
+      login:
+        example: admin
+        type: string
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.LogsData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      logs:
+        items:
+          $ref: '#/definitions/api.LogEntryDTO'
+        type: array
+      total:
+        example: 42
+        type: integer
+    type: object
+  api.LogsResponseEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.LogsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ManagedPeerStatsDTO:
+    properties:
+      endpoint:
+        example: 5.6.7.8:54321
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF=
+        type: string
+      rxBytes:
+        example: 2097152
+        type: integer
+      txBytes:
+        example: 1048576
+        type: integer
+    type: object
+  api.ManagedServerStatsDTO:
+    properties:
+      peers:
+        items:
+          $ref: '#/definitions/api.ManagedPeerStatsDTO'
+        type: array
+      status:
+        example: up
+        type: string
+    type: object
+  api.MonitoringCellDTO:
+    properties:
+      activeForRestart:
+        example: false
+        type: boolean
+      isSelf:
+        example: false
+        type: boolean
+      latencyMs:
+        example: 42
+        type: integer
+      ok:
+        example: true
+        type: boolean
+      targetId:
+        example: target_google
+        type: string
+      ts:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+    type: object
+  api.MonitoringHistoryResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.MonitoringSampleDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.MonitoringSampleDTO:
+    properties:
+      latencyMs:
+        example: 42
+        type: integer
+      ok:
+        example: true
+        type: boolean
+      ts:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.MonitoringSnapshotData:
+    properties:
+      cells:
+        items:
+          $ref: '#/definitions/api.MonitoringCellDTO'
+        type: array
+      targets:
+        items:
+          $ref: '#/definitions/api.MonitoringTargetDTO'
+        type: array
+      tunnels:
+        items:
+          $ref: '#/definitions/api.MonitoringTunnelDTO'
+        type: array
+      updatedAt:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+    type: object
+  api.MonitoringSnapshotResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.MonitoringSnapshotData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.MonitoringTargetDTO:
+    properties:
+      host:
+        example: https://www.google.com
+        type: string
+      id:
+        example: target_google
+        type: string
+      name:
+        example: Google
+        type: string
+    type: object
+  api.MonitoringTunnelDTO:
+    properties:
+      id:
+        example: tun_abc123
+        type: string
+      ifaceName:
+        example: nwg0
+        type: string
+      name:
+        example: My VPN
+        type: string
+      pingcheckTarget:
+        example: target_google
+        type: string
+      selfMethod:
+        example: http
+        type: string
+      selfTarget:
+        example: target_self_tun_abc123
+        type: string
+    type: object
+  api.NativePingCheckStatusDTO:
+    properties:
+      bound:
+        example: true
+        type: boolean
+      exists:
+        example: true
+        type: boolean
+      failCount:
+        example: 0
+        type: integer
+      host:
+        example: https://www.google.com
+        type: string
+      interval:
+        example: 30
+        type: integer
+      maxFails:
+        example: 3
+        type: integer
+      minSuccess:
+        example: 1
+        type: integer
+      mode:
+        example: connect
+        type: string
+      restart:
+        example: true
+        type: boolean
+      status:
+        example: alive
+        type: string
+      successCount:
+        example: 120
+        type: integer
+      timeout:
+        example: 5
+        type: integer
+    type: object
+  api.NativePingCheckStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.NativePingCheckStatusDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PingCheckDefaultsDTO:
+    properties:
+      deadInterval:
+        example: 120
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      interval:
+        example: 30
+        type: integer
+      method:
+        example: http
+        type: string
+      target:
+        example: https://www.google.com
+        type: string
+    type: object
+  api.PingCheckSettingsDTO:
+    properties:
+      defaults:
+        $ref: '#/definitions/api.PingCheckDefaultsDTO'
+      enabled:
+        example: true
+        type: boolean
+    type: object
+  api.PingCheckStatusData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      tunnels:
+        items:
+          $ref: '#/definitions/api.TunnelPingStatusDTO'
+        type: array
+    type: object
+  api.PingCheckStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.PingCheckStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PingLogEntryDTO:
+    properties:
+      error:
+        example: ""
+        type: string
+      failCount:
+        example: 0
+        type: integer
+      latency:
+        example: 35
+        type: integer
+      stateChange:
+        example: ""
+        type: string
+      success:
+        example: true
+        type: boolean
+      threshold:
+        example: 3
+        type: integer
+      timestamp:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.PingLogsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.PingLogEntryDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.PolicyGlobalInterfaceDTO:
+    properties:
+      label:
+        example: My VPN
+        type: string
+      name:
+        example: nwg0
+        type: string
+      up:
+        example: true
+        type: boolean
+    type: object
+  api.PolicyInterfacesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.PolicyGlobalInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyConfigResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DeviceProxyConfigData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyListenChoicesData:
+    properties:
+      lanIP:
+        example: 192.168.1.1
+        type: string
+      singboxRunning:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyListenChoicesResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ProxyListenChoicesData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyOutboundsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.DeviceProxyOutboundDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ProxyRuntimeResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.DeviceProxyRuntimeData'
+      success:
+        example: true
+        type: boolean
     type: object
   api.ResolveResponse:
     properties:
@@ -25,6 +1257,35 @@ definitions:
           type: string
         type: array
     type: object
+  api.RouterInterfaceDTO:
+    properties:
+      label:
+        example: Home Network
+        type: string
+      name:
+        example: br0
+        type: string
+      up:
+        example: true
+        type: boolean
+    type: object
+  api.RoutingRefreshData:
+    properties:
+      missing:
+        example:
+        - ""
+        items:
+          type: string
+        type: array
+    type: object
+  api.RoutingRefreshResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.RoutingRefreshData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.SaveStatusDTO:
     properties:
       lastError:
@@ -35,6 +1296,965 @@ definitions:
         type: integer
       state:
         type: string
+    type: object
+  api.ServerSettingsDTO:
+    properties:
+      interface:
+        example: ""
+        type: string
+      port:
+        example: 8080
+        type: integer
+    type: object
+  api.ServersAllData:
+    properties:
+      managedStats:
+        $ref: '#/definitions/api.ManagedServerStatsDTO'
+      servers:
+        items:
+          $ref: '#/definitions/api.WireguardServerDTO'
+        type: array
+      wanIP:
+        example: 203.0.113.42
+        type: string
+    type: object
+  api.ServersAllResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ServersAllData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SettingsData:
+    properties:
+      authEnabled:
+        example: false
+        type: boolean
+      disableMemorySaving:
+        example: false
+        type: boolean
+      dnsRoute:
+        $ref: '#/definitions/api.DNSRouteSettingsDTO'
+      logging:
+        $ref: '#/definitions/api.LoggingSettingsDTO'
+      pingCheck:
+        $ref: '#/definitions/api.PingCheckSettingsDTO'
+      schemaVersion:
+        example: 3
+        type: integer
+      server:
+        $ref: '#/definitions/api.ServerSettingsDTO'
+      updates:
+        $ref: '#/definitions/api.UpdateSettingsDTO'
+    type: object
+  api.SettingsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SettingsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SignatureCaptureData:
+    properties:
+      ok:
+        example: true
+        type: boolean
+      packets:
+        $ref: '#/definitions/api.SignaturePacketsDTO'
+      source:
+        example: Wireguard0
+        type: string
+      warning:
+        example: ""
+        type: string
+    type: object
+  api.SignatureCaptureResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SignatureCaptureData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SignaturePacketsDTO:
+    properties:
+      i1:
+        example: 0a1b2c3d
+        type: string
+      i2:
+        example: 4e5f6a7b
+        type: string
+      i3:
+        example: 8c9d0e1f
+        type: string
+      i4:
+        example: 2a3b4c5d
+        type: string
+      i5:
+        example: 6e7f8a9b
+        type: string
+    type: object
+  api.SingboxStatusData:
+    properties:
+      features:
+        example:
+        - with_quic
+        items:
+          type: string
+        type: array
+      installed:
+        example: true
+        type: boolean
+      pid:
+        example: 12345
+        type: integer
+      proxyComponent:
+        example: true
+        type: boolean
+      running:
+        example: true
+        type: boolean
+      tunnelCount:
+        example: 2
+        type: integer
+      version:
+        example: 1.9.3
+        type: string
+    type: object
+  api.SingboxStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxTunnelConnectivity:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      latency:
+        example: 42
+        type: integer
+    type: object
+  api.SingboxTunnelDTO:
+    properties:
+      connectivity:
+        $ref: '#/definitions/api.SingboxTunnelConnectivity'
+      fingerprint:
+        example: chrome
+        type: string
+      listenPort:
+        example: 7891
+        type: integer
+      port:
+        example: 443
+        type: integer
+      protocol:
+        example: vless
+        type: string
+      proxyInterface:
+        example: br0
+        type: string
+      running:
+        example: true
+        type: boolean
+      security:
+        example: reality
+        type: string
+      server:
+        example: proxy.example.com
+        type: string
+      sni:
+        example: cdn.example.com
+        type: string
+      tag:
+        example: proxy-01
+        type: string
+      transport:
+        example: tcp
+        type: string
+    type: object
+  api.SingboxTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestInfoData:
+    properties:
+      available:
+        example: true
+        type: boolean
+      servers:
+        items:
+          $ref: '#/definitions/api.SpeedTestServerDTO'
+        type: array
+    type: object
+  api.SpeedTestInfoResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SpeedTestInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestResultData:
+    properties:
+      bandwidth:
+        example: 52428800
+        type: number
+      bytes:
+        example: 157286400
+        type: integer
+      direction:
+        example: download
+        type: string
+      duration:
+        example: 3
+        type: number
+      retransmits:
+        example: 0
+        type: integer
+      server:
+        example: speedtest.msk.ru
+        type: string
+    type: object
+  api.SpeedTestResultResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SpeedTestResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SpeedTestServerDTO:
+    properties:
+      host:
+        example: speedtest.msk.ru
+        type: string
+      label:
+        example: Moscow, RU
+        type: string
+      port:
+        example: 5201
+        type: integer
+    type: object
+  api.StaticRouteDTO:
+    properties:
+      createdAt:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      fallback:
+        example: ""
+        type: string
+      id:
+        example: sr_001
+        type: string
+      name:
+        example: Office subnets
+        type: string
+      subnets:
+        example:
+        - 192.168.10.0/24
+        items:
+          type: string
+        type: array
+      tunnelID:
+        example: tun_abc123
+        type: string
+      updatedAt:
+        example: "2024-01-15T12:00:00Z"
+        type: string
+    type: object
+  api.StaticRoutesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.StaticRouteDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoBackendAvailability:
+    properties:
+      kernel:
+        example: false
+        type: boolean
+      nativewg:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoData:
+    properties:
+      activeBackend:
+        example: nativewg
+        type: string
+      backendAvailability:
+        $ref: '#/definitions/api.SystemInfoBackendAvailability'
+      bootInProgress:
+        example: false
+        type: boolean
+      disableMemorySaving:
+        example: false
+        type: boolean
+      firmwareVersion:
+        example: 4.2.1
+        type: string
+      gcMemLimit:
+        example: 128MiB
+        type: string
+      goArch:
+        example: arm64
+        type: string
+      goOS:
+        example: linux
+        type: string
+      goVersion:
+        example: go1.23.0
+        type: string
+      gogc:
+        example: "25"
+        type: string
+      isAarch64:
+        example: true
+        type: boolean
+      isLowMemory:
+        example: false
+        type: boolean
+      isOS5:
+        example: true
+        type: boolean
+      keeneticOS:
+        example: ndms
+        type: string
+      kernelModuleExists:
+        example: true
+        type: boolean
+      kernelModuleLoaded:
+        example: false
+        type: boolean
+      kernelModuleModel:
+        example: MT7981
+        type: string
+      kernelModuleVersion:
+        example: ""
+        type: string
+      routerIP:
+        example: 192.168.1.1
+        type: string
+      singbox:
+        $ref: '#/definitions/api.SystemInfoSingbox'
+      supportsExtendedASC:
+        example: true
+        type: boolean
+      supportsHRanges:
+        example: true
+        type: boolean
+      supportsPingCheck:
+        example: true
+        type: boolean
+      totalMemoryMB:
+        example: 512
+        type: integer
+      version:
+        example: 2.5.0
+        type: string
+    type: object
+  api.SystemInfoResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SystemInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SystemInfoSingbox:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      version:
+        example: 1.9.3
+        type: string
+    type: object
+  api.SystemTunnelDTO:
+    properties:
+      connected:
+        example: true
+        type: boolean
+      description:
+        example: Home Server
+        type: string
+      id:
+        example: Wireguard0
+        type: string
+      interfaceName:
+        example: Wireguard0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      peer:
+        $ref: '#/definitions/api.SystemTunnelPeerDTO'
+      status:
+        example: up
+        type: string
+    type: object
+  api.SystemTunnelPeerDTO:
+    properties:
+      endpoint:
+        example: vpn2.example.com:51820
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=
+        type: string
+      rxBytes:
+        example: 2097152
+        type: integer
+      txBytes:
+        example: 1048576
+        type: integer
+    type: object
+  api.SystemTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SystemTunnelDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TerminalStartData:
+    properties:
+      port:
+        example: 7681
+        type: integer
+    type: object
+  api.TerminalStartResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TerminalStartData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TerminalStatusResponse:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      running:
+        example: false
+        type: boolean
+      sessionActive:
+        example: false
+        type: boolean
+    type: object
+  api.TunnelControlData:
+    properties:
+      id:
+        example: tun_abc123
+        type: string
+      status:
+        example: connected
+        type: string
+    type: object
+  api.TunnelControlResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelControlData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDeleteResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelDeleteResultData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDeleteResultData:
+    properties:
+      success:
+        example: true
+        type: boolean
+      tunnelId:
+        example: tun_abc123
+        type: string
+      verified:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelDetailResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.AWGTunnelDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelListItemDTO:
+    properties:
+      address:
+        example: 10.0.0.2/32
+        type: string
+      awgVersion:
+        enum:
+        - wg
+        - awg1.0
+        - awg1.5
+        - awg2.0
+        example: awg2.0
+        type: string
+      backend:
+        enum:
+        - nativewg
+        - kernel
+        example: nativewg
+        type: string
+      defaultRoute:
+        example: false
+        type: boolean
+      enabled:
+        example: true
+        type: boolean
+      endpoint:
+        example: vpn.example.com:51820
+        type: string
+      hasAddressConflict:
+        example: false
+        type: boolean
+      id:
+        example: tun_abc123
+        type: string
+      interfaceName:
+        example: nwg0
+        type: string
+      ispInterface:
+        example: PPPoE0
+        type: string
+      ispInterfaceLabel:
+        example: WAN
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      name:
+        example: My AWG Tunnel
+        type: string
+      ndmsName:
+        example: Wireguard0
+        type: string
+      pingCheck:
+        $ref: '#/definitions/api.TunnelPingCheckStatus'
+      resolvedIspInterface:
+        example: PPPoE0
+        type: string
+      resolvedIspInterfaceLabel:
+        example: WAN
+        type: string
+      rxBytes:
+        example: 10485760
+        type: integer
+      startedAt:
+        example: "2024-01-15T10:00:00Z"
+        type: string
+      status:
+        enum:
+        - connected
+        - disconnected
+        - error
+        - disabled
+        example: connected
+        type: string
+      txBytes:
+        example: 5242880
+        type: integer
+      type:
+        enum:
+        - awg
+        - wg
+        example: awg
+        type: string
+    type: object
+  api.TunnelListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.TunnelListItemDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelPingCheckStatus:
+    properties:
+      failCount:
+        example: 0
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      restartCount:
+        example: 0
+        type: integer
+      status:
+        example: alive
+        type: string
+    type: object
+  api.TunnelPingStatusDTO:
+    properties:
+      backend:
+        example: nativewg
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      failCount:
+        example: 0
+        type: integer
+      failThreshold:
+        example: 3
+        type: integer
+      lastLatency:
+        example: 35
+        type: integer
+      method:
+        example: http
+        type: string
+      restartCount:
+        example: 0
+        type: integer
+      status:
+        example: alive
+        type: string
+      tunnelId:
+        example: tun_abc123
+        type: string
+      tunnelName:
+        example: My VPN
+        type: string
+    type: object
+  api.TunnelStateInfoDTO:
+    properties:
+      hasHandshake:
+        example: true
+        type: boolean
+      interfaceUp:
+        example: true
+        type: boolean
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      processRunning:
+        example: true
+        type: boolean
+      rxBytes:
+        example: 10485760
+        type: integer
+      state:
+        example: 3
+        type: integer
+      txBytes:
+        example: 5242880
+        type: integer
+    type: object
+  api.TunnelTrafficData:
+    properties:
+      points:
+        items:
+          $ref: '#/definitions/api.TunnelTrafficPoint'
+        type: array
+      stats:
+        $ref: '#/definitions/api.TunnelTrafficStats'
+    type: object
+  api.TunnelTrafficPoint:
+    properties:
+      rx:
+        example: 1024000
+        type: integer
+      t:
+        example: 1705312200
+        type: integer
+      tx:
+        example: 512000
+        type: integer
+    type: object
+  api.TunnelTrafficResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelTrafficData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelTrafficStats:
+    properties:
+      avgRx:
+        example: 524288
+        type: number
+      avgTx:
+        example: 262144
+        type: number
+      currentRx:
+        example: 102400
+        type: number
+      currentTx:
+        example: 51200
+        type: number
+      peakRate:
+        example: 1048576
+        type: number
+      points:
+        example: 60
+        type: integer
+    type: object
+  api.TunnelsAllResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.TunnelsAllSnapshotData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.TunnelsAllSnapshotData:
+    properties:
+      external:
+        items:
+          $ref: '#/definitions/api.ExternalTunnelDTO'
+        type: array
+      system:
+        items:
+          $ref: '#/definitions/api.SystemTunnelDTO'
+        type: array
+      tunnels:
+        items:
+          $ref: '#/definitions/api.TunnelListItemDTO'
+        type: array
+    type: object
+  api.UpdateApplyData:
+    properties:
+      status:
+        example: updating
+        type: string
+    type: object
+  api.UpdateApplyResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.UpdateApplyData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.UpdateCheckResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.UpdateInfoData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.UpdateInfoData:
+    properties:
+      available:
+        example: false
+        type: boolean
+      checkedAt:
+        example: "2024-01-15T10:00:00Z"
+        type: string
+      checking:
+        example: false
+        type: boolean
+      currentVersion:
+        example: 2.5.0
+        type: string
+      latestVersion:
+        example: 2.5.0
+        type: string
+    type: object
+  api.UpdatePeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      tunnelIP:
+        example: 10.10.0.2/32
+        type: string
+    type: object
+  api.UpdateServerRequestDTO:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      description:
+        example: My WG Server
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      endpoint:
+        example: 203.0.113.42:51821
+        type: string
+      listenPort:
+        example: 51821
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+    type: object
+  api.UpdateSettingsDTO:
+    properties:
+      checkEnabled:
+        example: true
+        type: boolean
+    type: object
+  api.WANIPData:
+    properties:
+      ip:
+        example: 203.0.113.42
+        type: string
+    type: object
+  api.WANIPResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.WANIPData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WANInterfaceDTO:
+    properties:
+      label:
+        example: Home Internet
+        type: string
+      name:
+        example: ISP1
+        type: string
+      state:
+        example: up
+        type: string
+    type: object
+  api.WANInterfacesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.WANInterfaceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WANStatusEnvelope:
+    properties:
+      data:
+        properties:
+          anyWANUp:
+            example: true
+            type: boolean
+        type: object
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.WireguardServerDTO:
+    properties:
+      address:
+        example: 10.0.1.1
+        type: string
+      connected:
+        example: true
+        type: boolean
+      description:
+        example: Wireguard VPN Server
+        type: string
+      id:
+        example: Wireguard0
+        type: string
+      interfaceName:
+        example: Wireguard0
+        type: string
+      listenPort:
+        example: 51820
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      peers:
+        items:
+          $ref: '#/definitions/api.WireguardServerPeerDTO'
+        type: array
+      publicKey:
+        example: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE=
+        type: string
+      status:
+        example: up
+        type: string
+    type: object
+  api.WireguardServerPeerDTO:
+    properties:
+      allowedIPs:
+        example:
+        - 10.0.1.2/32
+        items:
+          type: string
+        type: array
+      description:
+        example: Phone
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      endpoint:
+        example: 1.2.3.4:12345
+        type: string
+      lastHandshake:
+        example: "2024-01-15T10:30:00Z"
+        type: string
+      online:
+        example: true
+        type: boolean
+      publicKey:
+        example: DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD=
+        type: string
+      rxBytes:
+        example: 1048576
+        type: integer
+      txBytes:
+        example: 524288
+        type: integer
     type: object
 info:
   contact: {}
@@ -62,8 +2282,10 @@ paths:
       - access-policy
   /access-policies/assign:
     delete:
+      description: Removes the policy binding for the LAN device identified by MAC.
+        The device falls back to the default policy.
       parameters:
-      - description: Device MAC
+      - description: Device MAC address
         in: query
         name: mac
         required: true
@@ -76,14 +2298,34 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Unassign device from policy
       tags:
-      - access-policy
+      - access-policies
     post:
       consumes:
       - application/json
+      description: Binds the LAN device identified by MAC to the named policy. Replaces
+        any existing assignment.
+      parameters:
+      - description: '{mac, policy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -92,11 +2334,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Assign device to policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/create:
     post:
       consumes:
@@ -116,8 +2368,10 @@ paths:
       - access-policy
   /access-policies/delete:
     delete:
+      description: Removes the named access policy. Bound LAN devices revert to the
+        default policy.
       parameters:
-      - description: Policy name
+      - description: Policy name (e.g. Policy0)
         in: query
         name: name
         required: true
@@ -130,11 +2384,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
       summary: Delete access policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/description:
     post:
       consumes:
@@ -205,6 +2469,7 @@ paths:
       - access-policy
   /access-policies/permit:
     delete:
+      description: Removes the named interface from the policy.
       parameters:
       - description: Policy name
         in: query
@@ -224,14 +2489,34 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Remove permitted interface
+      summary: Deny interface for policy
       tags:
-      - access-policy
+      - access-policies
     post:
       consumes:
       - application/json
+      description: Adds the named interface to the policy at the given order (lower
+        = higher priority).
+      parameters:
+      - description: '{name, interface, order}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -240,11 +2525,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Permit interface on policy
+      summary: Permit interface for policy
       tags:
-      - access-policy
+      - access-policies
   /access-policies/standalone:
     post:
       consumes:
@@ -279,25 +2574,21 @@ paths:
       - application/json
       responses:
         "200":
-          description: success, login
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.LoginResponseRaw'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "401":
           description: Unauthorized
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "503":
           description: Service Unavailable
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Login
       tags:
       - auth
@@ -309,8 +2600,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Logout
       tags:
       - auth
@@ -320,10 +2618,17 @@ paths:
       - application/json
       responses:
         "200":
-          description: authenticated, login, expiresIn, authDisabled
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.AuthStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Auth status
       tags:
       - auth
@@ -336,8 +2641,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.BootStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Boot status
       tags:
       - system
@@ -349,10 +2661,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List client routes
@@ -368,8 +2685,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create client route
@@ -389,8 +2713,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete client route
@@ -412,8 +2743,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle client route
@@ -435,8 +2773,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update client route
@@ -450,8 +2795,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ConnectionsResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Connections list
@@ -471,8 +2823,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart tunnel
@@ -486,10 +2845,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart all enabled tunnels
@@ -509,8 +2873,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start tunnel
@@ -530,8 +2901,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelControlResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Stop tunnel
@@ -551,8 +2929,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle default route
@@ -572,8 +2957,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle tunnel autostart
@@ -588,6 +2980,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Download diagnostics report
@@ -601,8 +3001,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Run diagnostics
@@ -616,8 +3023,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DiagnosticsStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Diagnostics status
@@ -632,6 +3046,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Diagnostics SSE stream
@@ -645,8 +3067,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: DNS check probe (CORS)
       tags:
       - dns-check
@@ -658,8 +3087,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsCheckStartResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start DNS check
@@ -675,10 +3111,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Bulk set DNS route backend
@@ -694,8 +3135,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create DNS route list
@@ -711,8 +3159,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create DNS route lists (batch)
@@ -732,10 +3187,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete DNS route list
@@ -751,10 +3211,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete DNS route lists (batch)
@@ -774,8 +3239,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get DNS route list
@@ -789,10 +3261,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.DnsRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List DNS route lists
@@ -811,8 +3288,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Refresh DNS route subscriptions
@@ -834,10 +3318,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set DNS route list enabled
@@ -859,8 +3348,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.DnsRouteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update DNS route list
@@ -875,6 +3371,14 @@ paths:
           description: Server-Sent Events
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: SSE event stream
@@ -888,9 +3392,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              type: object
-            type: array
+            $ref: '#/definitions/api.ExternalTunnelsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List external tunnels
@@ -918,8 +3428,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Adopt external tunnel
@@ -932,10 +3449,17 @@ paths:
       - application/json
       responses:
         "200":
-          description: ok, version
+          description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HealthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: Health / liveness
       tags:
       - system
@@ -957,8 +3481,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       summary: NDMS shell hook
       tags:
       - hook
@@ -971,8 +3502,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HydraRouteConfigResponse'
       security:
       - CookieAuth: []
       summary: Get HydraRoute config
@@ -982,14 +3512,30 @@ paths:
     put:
       consumes:
       - application/json
+      description: Persists the HydraRoute (HrNeo) config and schedules a neo restart.
+        The cached status becomes stale and is invalidated via SSE.
+      parameters:
+      - description: hydraroute.Config
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.HydraRouteConfigData'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HydraRouteConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update HydraRoute config
@@ -1031,8 +3577,10 @@ paths:
       - hydraroute
   /hydraroute/geo-files/delete:
     delete:
+      description: Removes the tracked geo data file at the given path and re-syncs
+        the geo file list to config.
       parameters:
-      - description: File path
+      - description: Filesystem path of the geo file
         in: query
         name: path
         required: true
@@ -1042,6 +3590,16 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1146,8 +3704,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Import tunnel config
@@ -1161,8 +3726,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.LogsResponseEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get logs
@@ -1176,15 +3748,24 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Clear logs
       tags:
       - logs
-  /managed-server:
+  /managed-servers:
     get:
+      description: Returns every managed server (id, address, listen port, peers,
+        ASC, NAT, enabled flag, ...). Always a JSON array, never null.
       produces:
       - application/json
       responses:
@@ -1193,29 +3774,28 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Get managed WireGuard server
-      tags:
-      - managed-server
-  /managed-server/asc:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "405":
+          description: Method Not Allowed
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
-      summary: Get managed server ASC
+      summary: List managed servers
       tags:
-      - managed-server
+      - managed-servers
     post:
       consumes:
       - application/json
+      description: Creates a new managed WireGuard server. The id is allocated server-side
+        (next free Wireguard{N} slot).
+      parameters:
+      - description: Address, mask, port, ASC, name
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateServerRequestDTO'
       produces:
       - application/json
       responses:
@@ -1224,20 +3804,13 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server ASC
-      tags:
-      - managed-server
-  /managed-server/create:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1245,14 +3818,32 @@ paths:
       - CookieAuth: []
       summary: Create managed server
       tags:
-      - managed-server
-  /managed-server/delete:
+      - managed-servers
+  /managed-servers/{id}:
     delete:
+      description: Removes the named managed server along with all its peers. Returns
+        the fresh ServersSnapshot.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1260,64 +3851,13 @@ paths:
       - CookieAuth: []
       summary: Delete managed server
       tags:
-      - managed-server
-  /managed-server/enabled:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Enable/disable managed server
-      tags:
-      - managed-server
-  /managed-server/nat:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server NAT
-      tags:
-      - managed-server
-  /managed-server/peers:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Add managed server peer
-      tags:
-      - managed-server
-  /managed-server/peers/conf:
+      - managed-servers
     get:
+      description: Returns a single managed server by id (Wireguard{N}).
       parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
+      - description: Server id (e.g. Wireguard0)
+        in: path
+        name: id
         required: true
         type: string
       produces:
@@ -1328,59 +3868,38 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Peer WireGuard conf
-      tags:
-      - managed-server
-  /managed-server/peers/delete:
-    delete:
-      parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
-      summary: Delete managed server peer
+      summary: Get managed server
       tags:
-      - managed-server
-  /managed-server/peers/toggle:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Toggle managed server peer
-      tags:
-      - managed-server
-  /managed-server/peers/update:
+      - managed-servers
     put:
       consumes:
       - application/json
+      description: Updates a managed server's address, listen port, name, and/or other
+        top-level fields. Returns the fresh ServersSnapshot.
       parameters:
-      - description: Peer public key
-        in: query
-        name: pubkey
+      - description: Server id
+        in: path
+        name: id
         required: true
         type: string
+      - description: Update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateServerRequestDTO'
       produces:
       - application/json
       responses:
@@ -1389,84 +3908,18 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Update managed server peer
-      tags:
-      - managed-server
-  /managed-server/policies:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List IP policy profiles
-      tags:
-      - managed-server
-  /managed-server/policy:
-    post:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "400":
+          description: Bad Request
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Set managed server hotspot policy
-      tags:
-      - managed-server
-  /managed-server/stats:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "404":
+          description: Not Found
           schema:
             additionalProperties: true
             type: object
-      security:
-      - CookieAuth: []
-      summary: Managed server stats
-      tags:
-      - managed-server
-  /managed-server/suggest-address:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Suggest managed server address
-      tags:
-      - managed-server
-  /managed-server/update:
-    put:
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -1474,7 +3927,581 @@ paths:
       - CookieAuth: []
       summary: Update managed server
       tags:
-      - managed-server
+      - managed-servers
+  /managed-servers/{id}/asc:
+    get:
+      consumes:
+      - application/json
+      description: GET reads, PUT writes the AWG signature/obfuscation params for
+        the named managed server. PUT body is the raw ASC JSON object.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: ASC params (PUT only)
+        in: body
+        name: body
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get/set managed-server ASC params
+      tags:
+      - managed-servers
+    put:
+      consumes:
+      - application/json
+      description: GET reads, PUT writes the AWG signature/obfuscation params for
+        the named managed server. PUT body is the raw ASC JSON object.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: ASC params (PUT only)
+        in: body
+        name: body
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get/set managed-server ASC params
+      tags:
+      - managed-servers
+  /managed-servers/{id}/enabled:
+    post:
+      consumes:
+      - application/json
+      description: Brings the named managed server interface up or down (and persists
+        the desired state).
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server enabled
+      tags:
+      - managed-servers
+  /managed-servers/{id}/nat:
+    post:
+      consumes:
+      - application/json
+      description: Enables or disables NAT (masquerade) on the named managed server
+        interface.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server NAT
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers:
+    post:
+      consumes:
+      - application/json
+      description: Adds a new peer to the named managed server. The pubkey is generated
+        server-side if absent.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.AddPeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add managed-server peer
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}:
+    delete:
+      description: Removes the peer identified by pubkey from the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete managed-server peer
+      tags:
+      - managed-servers
+    put:
+      consumes:
+      - application/json
+      description: Updates fields (name, allowed-ips, ...) of the peer identified
+        by pubkey on the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: Peer update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdatePeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update managed-server peer
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}/conf:
+    get:
+      description: Returns the WireGuard client .conf for the peer identified by pubkey
+        on the named managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Generate peer .conf
+      tags:
+      - managed-servers
+  /managed-servers/{id}/peers/{pubkey}/toggle:
+    post:
+      consumes:
+      - application/json
+      description: Enables or disables the peer identified by pubkey on the named
+        managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Peer public key (URL-encoded)
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: '{enabled: bool}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Toggle managed-server peer enabled
+      tags:
+      - managed-servers
+  /managed-servers/{id}/policy:
+    post:
+      consumes:
+      - application/json
+      description: Updates the IP hotspot policy bound to the managed server interface.
+        The policy must exist (see /managed-servers/policies).
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: '{policy: string}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Set managed-server IP policy
+      tags:
+      - managed-servers
+  /managed-servers/{id}/stats:
+    get:
+      description: Returns per-peer runtime stats (handshake, rx/tx) for the named
+        managed server.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get managed-server peer stats
+      tags:
+      - managed-servers
+  /managed-servers/policies:
+    get:
+      description: Returns the global router catalog of IP Policy profiles for use
+        by the per-server policy dropdown. Always a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List IP Policy profiles
+      tags:
+      - managed-servers
+  /managed-servers/suggest-address:
+    get:
+      description: Returns a free private /24 (address, mask) for the create-server
+        UI. Avoids collisions with already-used managed-server subnets.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Suggest managed-server address
+      tags:
+      - managed-servers
+  /monitoring/history:
+    get:
+      description: Returns up to `limit` (default 60) most-recent samples for a single
+        (target, tunnelId) pair, oldest-first.
+      parameters:
+      - description: Target identifier
+        in: query
+        name: target
+        required: true
+        type: string
+      - description: Tunnel identifier
+        in: query
+        name: tunnelId
+        required: true
+        type: string
+      - description: Max samples to return (default 60)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MonitoringHistoryResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get monitoring history
+      tags:
+      - monitoring
+  /monitoring/matrix:
+    get:
+      description: Returns the latest cross-tunnel × cross-target latency/loss matrix
+        snapshot. Responds 503 until the monitoring service has finished bootstrap.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MonitoringSnapshotResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get monitoring matrix snapshot
+      tags:
+      - monitoring
   /ndms/save-status:
     get:
       produces:
@@ -1484,6 +4511,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.SaveStatusDTO'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: NDMS save coordinator status
@@ -1497,8 +4532,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Trigger ping check now
@@ -1517,10 +4559,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.PingLogsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Ping check logs
@@ -1534,8 +4581,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Clear ping check logs
@@ -1549,8 +4603,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PingCheckStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Ping check status
@@ -1564,8 +4625,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Force apply device proxy
@@ -1579,8 +4647,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get device proxy config
@@ -1595,8 +4670,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyConfigResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Save device proxy config
@@ -1610,8 +4692,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyListenChoicesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Device proxy listen choices
@@ -1625,10 +4714,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ProxyOutboundsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List device proxy outbounds
@@ -1642,8 +4736,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyRuntimeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Device proxy runtime state
@@ -1659,8 +4760,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ProxyRuntimeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Select device proxy outbound
@@ -1675,8 +4783,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.AccessPoliciesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: OS4 access policies stub
@@ -1690,10 +4805,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.ClientRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List client routes
@@ -1707,10 +4827,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.DnsRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List DNS route lists
@@ -1742,8 +4867,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PolicyInterfacesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: OS4 policy interfaces stub
@@ -1757,8 +4889,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.RoutingRefreshResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Invalidate routing caches
@@ -1779,6 +4918,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.ResolveResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Resolve domain
@@ -1792,10 +4939,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List static routes
@@ -1812,89 +4964,46 @@ paths:
             items:
               type: object
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Routing tunnel catalog
       tags:
       - routing
-  /servers:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List VPN server interfaces
-      tags:
-      - servers
   /servers/all:
     get:
+      description: 'Returns the composite servers snapshot: WireGuard servers list,
+        managed server, stats and WAN IP.'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Servers composite snapshot
-      tags:
-      - servers
-  /servers/config:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
+            $ref: '#/definitions/api.ServersAllResponse'
+        "500":
+          description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: Server RC config for export
-      tags:
-      - servers
-  /servers/get:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Get VPN server by name
+      summary: Get all servers snapshot
       tags:
       - servers
   /servers/mark:
     delete:
+      description: POST marks the named WG interface as a server (visible under Servers,
+        hidden from Tunnels). DELETE unmarks (returns it to the Tunnels list). Both
+        return the fresh ServersSnapshot.
       parameters:
-      - description: NDMS interface name
+      - description: Interface name (e.g. Wireguard0)
         in: query
         name: name
         required: true
@@ -1907,14 +5016,27 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Unmark server interface
+      summary: Mark/unmark interface as server
       tags:
       - servers
     post:
+      description: POST marks the named WG interface as a server (visible under Servers,
+        hidden from Tunnels). DELETE unmarks (returns it to the Tunnels list). Both
+        return the fresh ServersSnapshot.
       parameters:
-      - description: NDMS interface name
+      - description: Interface name (e.g. Wireguard0)
         in: query
         name: name
         required: true
@@ -1927,69 +5049,139 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
       security:
       - CookieAuth: []
-      summary: Mark server interface
+      summary: Mark/unmark interface as server
       tags:
       - servers
   /servers/marked:
     get:
+      description: Returns the list of interface IDs that have been marked as servers.
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              type: string
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: List marked server interface ids
+      summary: Get marked server interfaces
       tags:
       - servers
   /servers/wan-ip:
     get:
+      description: Returns the router's external WAN IP address.
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.WANIPResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: WAN IP for server conf
+      summary: Get WAN IP
       tags:
       - servers
   /settings/get:
     get:
+      description: Returns the full Settings object (server, pingCheck, logging, dnsRoute,
+        managed, apiKey, ...).
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SettingsResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get settings
+      tags:
+      - settings
+  /settings/regenerate-api-key:
+    post:
+      description: 'Generates a fresh UUID v4 via crypto/rand, stores it into Settings.ApiKey,
+        and returns the updated Settings. The new key takes effect immediately as
+        a `Authorization: Bearer <key>` substitute for the session cookie.'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SettingsResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Regenerate API key
       tags:
       - settings
   /settings/update:
     post:
       consumes:
       - application/json
+      description: Persists Settings. Sub-structs (server, pingCheck, logging, dnsRoute,
+        managedServers, ...) preserved when zero/nil. ApiKey preserved when empty
+        (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled,
+        disableMemorySaving, onboardingCompleted) MUST be sent on every save.
+      parameters:
+      - description: Settings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SettingsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update settings
@@ -2009,15 +5201,62 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SignatureCaptureResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Signature capture
       tags:
       - signature
-  /singbox/install:
+  /singbox/awg-outbounds/tags:
+    get:
+      description: Returns the catalog of AWG-direct outbound tags currently exposed
+        to sing-box (one per managed/system AWG tunnel). Used by the singbox-router
+        rule editor outbound dropdown.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+        "405":
+          description: Method Not Allowed
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - CookieAuth: []
+      summary: List AWG outbound tags
+      tags:
+      - singbox
+  /singbox/control:
     post:
+      consumes:
+      - application/json
+      description: Starts, stops, or restarts the sing-box engine. Returns the fresh
+        status snapshot. Mirrors /system/hydraroute-control.
+      parameters:
+      - description: '{action: start|stop|restart}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
@@ -2026,11 +5265,1344 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Control sing-box process
+      tags:
+      - singbox
+  /singbox/install:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Install sing-box
       tags:
       - singbox
+  /singbox/router/disable:
+    post:
+      description: Stops the singbox-router engine and uninstalls iptables/policy
+        rules. Idempotent.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Disable singbox-router
+      tags:
+      - singbox-router
+  /singbox/router/dns/globals:
+    get:
+      description: 'Returns the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get singbox-router DNS globals
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: 'Persists the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      parameters:
+      - description: '{final, strategy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS globals
+      tags:
+      - singbox-router
+    put:
+      consumes:
+      - application/json
+      description: 'Persists the global DNS settings: `final` (default server tag)
+        and `strategy` (ipv4_only / prefer_ipv4 / etc.).'
+      parameters:
+      - description: '{final, strategy}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS globals
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/add:
+    post:
+      consumes:
+      - application/json
+      description: Appends a new DNS routing rule. The rule's server tag must already
+        exist.
+      parameters:
+      - description: router.DNSRule
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the DNS rule at the given index (0-based priority slot).
+      parameters:
+      - description: '{index}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/list:
+    get:
+      description: Returns all DNS routing rules in priority (top-first) order. Always
+        a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router DNS rules
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/move:
+    post:
+      consumes:
+      - application/json
+      description: Moves the DNS rule from index `from` to index `to` (both 0-based).
+      parameters:
+      - description: '{from, to}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Move singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/rules/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the DNS rule at the given index (0-based priority slot)
+        with the provided one.
+      parameters:
+      - description: '{index, rule}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS rule
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/add:
+    post:
+      consumes:
+      - application/json
+      description: Registers a new DNS upstream (tag must be unique).
+      parameters:
+      - description: router.DNSServer
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the DNS upstream identified by tag. Refuses if any DNS
+        rule references it; pass force=true to override.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/list:
+    get:
+      description: Returns all configured DNS upstreams (tag, address, type, ...).
+        Always a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router DNS servers
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the DNS upstream identified by tag with the provided one.
+      parameters:
+      - description: '{tag, server}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router DNS server
+      tags:
+      - singbox-router
+  /singbox/router/enable:
+    post:
+      description: Starts the singbox-router engine and installs iptables/policy rules.
+        Returns 400 with code POLICY_NOT_CONFIGURED or POLICY_MISSING when the router
+        policy mode is incomplete.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Enable singbox-router
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/add:
+    post:
+      consumes:
+      - application/json
+      description: Creates a new composite outbound. The base outbounds it references
+        must already exist.
+      parameters:
+      - description: router.Outbound
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the composite outbound identified by tag. Refuses if any
+        rule references it; pass force=true to override.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/list:
+    get:
+      description: Returns all composite outbounds (sing-box selectors/urltests over
+        multiple base outbounds).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router outbounds
+      tags:
+      - singbox-router
+  /singbox/router/outbounds/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the composite outbound identified by tag with the provided
+        one.
+      parameters:
+      - description: '{tag, outbound}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router outbound
+      tags:
+      - singbox-router
+  /singbox/router/policies:
+    get:
+      description: Returns all NDMS policies known to the singbox-router engine. Always
+        a JSON array, never null.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router policies
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: Creates a new NDMS policy with the given description. Returns the
+        created policy.
+      parameters:
+      - description: '{description}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Create singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices:
+    get:
+      description: Returns the LAN devices currently bound to the named policy. Always
+        a JSON array, never null.
+      parameters:
+      - description: Policy name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router policy devices
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices/bind:
+    post:
+      consumes:
+      - application/json
+      description: Binds the LAN device (MAC) to the named policy. Replaces any existing
+        binding.
+      parameters:
+      - description: '{mac, policyName}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Bind device to singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/policy-devices/unbind:
+    post:
+      consumes:
+      - application/json
+      description: Removes any policy binding for the LAN device identified by MAC.
+      parameters:
+      - description: '{mac}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Unbind device from singbox-router policy
+      tags:
+      - singbox-router
+  /singbox/router/presets/apply:
+    post:
+      consumes:
+      - application/json
+      description: Materialises the preset (id) into rules + rulesets, routing matched
+        traffic via the selected outbound. Existing rules with the same tag are overwritten.
+      parameters:
+      - description: '{id, outbound}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Apply singbox-router preset
+      tags:
+      - singbox-router
+  /singbox/router/presets/list:
+    get:
+      description: Returns the catalog of built-in presets the user can apply (each
+        preset = a curated bundle of rules + rulesets).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router presets
+      tags:
+      - singbox-router
+  /singbox/router/rules/add:
+    post:
+      consumes:
+      - application/json
+      description: Appends a new routing rule. Rule conditions reference rulesets/outbounds
+        that must already exist.
+      parameters:
+      - description: router.Rule
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the rule at the given index (0-based priority slot).
+      parameters:
+      - description: '{index}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/list:
+    get:
+      description: Returns all routing rules in priority (top-first) order.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router rules
+      tags:
+      - singbox-router
+  /singbox/router/rules/move:
+    post:
+      consumes:
+      - application/json
+      description: Moves the rule from index `from` to index `to` (both 0-based).
+        Adjusts other rules' indices accordingly.
+      parameters:
+      - description: '{from, to}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Move singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rules/update:
+    post:
+      consumes:
+      - application/json
+      description: Replaces the rule at index with the provided one. Index is the
+        priority slot (0-based).
+      parameters:
+      - description: '{index, rule}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router rule
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/add:
+    post:
+      consumes:
+      - application/json
+      description: Registers a new ruleset. For remote rulesets the file is downloaded
+        synchronously.
+      parameters:
+      - description: router.RuleSet
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Add singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/delete:
+    post:
+      consumes:
+      - application/json
+      description: Removes the ruleset identified by tag. Refuses if any rule references
+        it; pass force=true to ignore references.
+      parameters:
+      - description: '{tag, force}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Delete singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/list:
+    get:
+      description: Returns all configured rulesets (downloaded geo files / inline
+        lists), with their tag, type, and freshness metadata.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: List singbox-router rulesets
+      tags:
+      - singbox-router
+  /singbox/router/rulesets/refresh:
+    post:
+      consumes:
+      - application/json
+      description: Re-downloads the remote ruleset identified by tag and updates its
+        content/timestamp.
+      parameters:
+      - description: '{tag}'
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Refresh singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/settings:
+    get:
+      description: Reads the current singbox-router settings (policy mode, defaults,
+        ...).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get singbox-router settings
+      tags:
+      - singbox-router
+    post:
+      consumes:
+      - application/json
+      description: Persists singbox-router settings. The router is restarted only
+        when fields that affect the running config change.
+      parameters:
+      - description: storage.SingboxRouterSettings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router settings
+      tags:
+      - singbox-router
+    put:
+      consumes:
+      - application/json
+      description: Persists singbox-router settings. The router is restarted only
+        when fields that affect the running config change.
+      parameters:
+      - description: storage.SingboxRouterSettings
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Update singbox-router settings
+      tags:
+      - singbox-router
+  /singbox/router/status:
+    get:
+      description: Returns the singbox-router status snapshot (running, mode, policy/iptables
+        state, rule/ruleset/outbound counts).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "405":
+          description: Method Not Allowed
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - CookieAuth: []
+      summary: Get sing-box router status
+      tags:
+      - singbox-router
   /singbox/status:
     get:
       description: Available when sing-box integration is enabled in the build.
@@ -2040,8 +6612,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box status
@@ -2055,8 +6634,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete sing-box tunnel
@@ -2074,8 +6660,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxTunnelsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List or get sing-box tunnel(s)
@@ -2090,8 +6683,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add sing-box tunnel(s)
@@ -2106,8 +6706,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update sing-box tunnel
@@ -2127,8 +6734,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box delay check
@@ -2143,6 +6757,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Sing-box tunnel speed test stream
@@ -2158,8 +6780,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create static route
@@ -2179,8 +6808,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete static route
@@ -2196,8 +6832,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Import static routes
@@ -2211,10 +6854,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List static routes
@@ -2236,8 +6884,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set static route enabled
@@ -2253,8 +6908,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.StaticRoutesListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update static route
@@ -2268,10 +6930,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: All tunnel statuses
@@ -2291,8 +6958,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Tunnel status
@@ -2300,25 +6974,29 @@ paths:
       - status
   /system-tunnels:
     get:
+      description: Returns all WireGuard tunnels managed by the router OS itself (non-hidden).
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.SystemTunnelsResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: List system WireGuard tunnels
+      summary: List system tunnels
       tags:
       - system-tunnels
   /system-tunnels/asc:
     get:
+      description: Reads AWG signature/obfuscation parameters for the named system
+        (NativeWG / kernel-WG) tunnel.
       parameters:
-      - description: NDMS interface name
+      - description: Tunnel name
         in: query
         name: name
         required: true
@@ -2328,6 +7006,16 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
@@ -2337,157 +7025,44 @@ paths:
       tags:
       - system-tunnels
     post:
+      consumes:
+      - application/json
+      description: Persists AWG signature/obfuscation parameters for the named system
+        tunnel. Body is the raw ASC JSON object.
       parameters:
-      - description: NDMS interface name
+      - description: Tunnel name
         in: query
         name: name
         required: true
         type: string
+      - description: ASC params
+        in: body
+        name: body
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
       produces:
       - application/json
       responses:
         "200":
           description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties: true
             type: object
       security:
       - CookieAuth: []
       summary: Set system tunnel ASC params
-      tags:
-      - system-tunnels
-  /system-tunnels/get:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Get system tunnel
-      tags:
-      - system-tunnels
-  /system-tunnels/hidden:
-    get:
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              type: string
-            type: array
-      security:
-      - CookieAuth: []
-      summary: List hidden system tunnels
-      tags:
-      - system-tunnels
-  /system-tunnels/hide:
-    delete:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Unhide system tunnel
-      tags:
-      - system-tunnels
-    post:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: Hide system tunnel
-      tags:
-      - system-tunnels
-  /system-tunnels/test-connectivity:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: System tunnel connectivity test
-      tags:
-      - system-tunnels
-  /system-tunnels/test-ip:
-    get:
-      parameters:
-      - description: NDMS interface name
-        in: query
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      security:
-      - CookieAuth: []
-      summary: System tunnel IP check
-      tags:
-      - system-tunnels
-  /system-tunnels/test-speed:
-    get:
-      produces:
-      - text/event-stream
-      responses:
-        "200":
-          description: SSE stream
-          schema:
-            type: string
-      security:
-      - CookieAuth: []
-      summary: System tunnel speed test (SSE)
       tags:
       - system-tunnels
   /system/all-interfaces:
@@ -2498,10 +7073,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.AllInterfacesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: All interfaces
@@ -2517,8 +7097,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute control (system)
@@ -2532,8 +7119,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.HydraRouteStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute status (system)
@@ -2547,8 +7141,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SystemInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: System info
@@ -2562,8 +7163,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Restart daemon
@@ -2577,8 +7185,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.UpdateApplyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Apply system update
@@ -2602,8 +7217,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ChangelogResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update changelog
@@ -2622,8 +7244,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.UpdateCheckResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update check
@@ -2637,10 +7266,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.WANInterfacesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: WAN interfaces
@@ -2654,8 +7288,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TerminalStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Install terminal (ttyd)
@@ -2669,8 +7310,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TerminalStartResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Start terminal
@@ -2684,8 +7332,20 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.TerminalStatusResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Terminal status
@@ -2699,8 +7359,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Stop terminal
@@ -2715,6 +7382,14 @@ paths:
           description: WebSocket upgrade
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Terminal WebSocket
@@ -2734,8 +7409,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ConnectivityResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Connectivity check
@@ -2758,8 +7440,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.IPResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: IP leak check
@@ -2773,10 +7462,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.IPServicesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: IP check services
@@ -2790,8 +7484,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SpeedTestResultResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test (sync)
@@ -2805,8 +7506,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SpeedTestInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test servers
@@ -2821,6 +7529,14 @@ paths:
           description: SSE stream
           schema:
             type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Speed test stream
@@ -2834,8 +7550,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelsAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Composite tunnels snapshot
@@ -2851,8 +7574,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create tunnel
@@ -2872,8 +7602,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelDeleteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete tunnel
@@ -2894,6 +7631,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Export tunnel config
@@ -2908,6 +7653,14 @@ paths:
           description: OK
           schema:
             type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Export all tunnels (zip)
@@ -2927,8 +7680,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelDetailResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get tunnel
@@ -2942,10 +7702,15 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.TunnelListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List tunnels
@@ -2965,8 +7730,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.NativePingCheckStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get per-tunnel NDMS ping-check
@@ -2987,8 +7759,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Configure per-tunnel NDMS ping-check
@@ -3008,8 +7787,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Remove per-tunnel NDMS ping-check
@@ -3031,8 +7817,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Replace tunnel from conf
@@ -3057,8 +7850,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.TunnelTrafficResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Tunnel traffic history
@@ -3080,8 +7880,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update tunnel
@@ -3095,8 +7902,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.WANStatusEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: WAN status

--- a/internal/staticroute/impl_test.go
+++ b/internal/staticroute/impl_test.go
@@ -117,8 +117,9 @@ func TestDefaultIfaceExists_NonExistent(t *testing.T) {
 }
 
 func TestDefaultIfaceExists_Loopback(t *testing.T) {
-	if !defaultIfaceExists("lo") {
-		t.Error("loopback interface should exist")
+	// Linux: "lo"; BSD/macOS: "lo0"
+	if !defaultIfaceExists("lo") && !defaultIfaceExists("lo0") {
+		t.Error("loopback interface should exist (lo on Linux, lo0 on Darwin/BSD)")
 	}
 }
 

--- a/openapi.md
+++ b/openapi.md
@@ -1,0 +1,96 @@
+# OpenAPI / Swagger: краткий гайд
+
+Проект генерирует OpenAPI (Swagger) YAML из Go-аннотаций через `swag`.
+
+## 1) Как аннотировать хендлеры
+
+- Добавляй swagger-комментарии над именованными функциями/методами в `internal/api/*`.
+- Типичный блок:
+  - `@Summary`, `@Tags`
+  - `@Accept` / `@Produce`
+  - `@Param` (query/path/body)
+  - `@Success` / `@Failure`
+  - `@Security CookieAuth` для защищенных роутов
+  - `@Router /path [method]`
+- Глобальные метаданные API и схема cookie-безопасности находятся в `cmd/awg-manager/docs.go`.
+
+Пример:
+
+```go
+// GetSystemInfo godoc
+// @Summary      Системная информация
+// @Tags         system
+// @Produce      json
+// @Security     CookieAuth
+// @Success      200 {object} map[string]interface{}
+// @Failure      500 {object} response.ErrorResponse
+// @Router       /system/info [get]
+func (h *SystemHandler) Info(w http.ResponseWriter, r *http.Request) {
+	// handler logic
+}
+```
+
+## 2) Где раздается YAML
+
+- Runtime-эндпоинт: `GET /api/openapi.yaml`
+- Регистрируется в `internal/server/server.go`.
+- Файл вшивается из `internal/openapi/swagger.yaml` через `internal/openapi/embed.go`.
+
+## 3) Как открыть Swagger UI
+
+- Запусти backend (daemon) и frontend dev-сервер.
+- Открой страницу: `/dev/api-docs`
+- Исходник страницы: `frontend/src/routes/dev/api-docs/+page.svelte`
+- UI получает спеку с `/api/openapi.yaml` (через Vite proxy).
+
+## 4) Как собрать/пересобрать OpenAPI YAML
+
+Из корня репозитория:
+
+```bash
+go generate ./cmd/awg-manager
+```
+
+Команда запускает зафиксированную версию `swag` из `cmd/awg-manager/docs.go` и перезаписывает:
+
+- `internal/openapi/swagger.yaml`
+
+Запускай это перед коммитом, если менялись API-аннотации.
+
+## 5) Как поднять mock-сервер на 8080
+
+Запуск Prism напрямую по спеке (без изменений в коде):
+
+```bash
+cd frontend
+npm run mock
+```
+
+Проверка напрямую:
+
+- `http://127.0.0.1:8080/<path-из-openapi>`
+
+Чтобы фронт на `/api/...` работал с Prism и Swagger UI открывался без backend:
+
+```bash
+cd frontend
+npm run dev:mock
+```
+
+Команда `dev:mock`:
+- делает `sync:openapi` (копирует `../internal/openapi/swagger.yaml` в `frontend/static/openapi.yaml`);
+- запускает Vite с `VITE_API_STRIP_PREFIX=1` (роуты `/api/*` переписываются в `/*` для Prism).
+
+или вручную включить в `frontend/.env`:
+
+```bash
+VITE_API_TARGET=http://127.0.0.1:8080
+VITE_API_STRIP_PREFIX=1
+```
+
+и перезапустить `npm run dev`.
+
+Примечания:
+
+- Prism mock не выполняет backend-логику, а отдает ответы на основе примеров/схем OpenAPI.
+- Убедись, что backend не занят на `8080` (или используй другой порт Prism).


### PR DESCRIPTION
1. Добавлен сервер Prism, позволяющий раздавать локалько на порту 8080 моковый бэкенд, генерируемый по swagger файлу
2. Добавлен openapi генератор через swag, работающий по аннотациям
3. Прописаны аннотации и DTO для большинства эндпоинтов, которые требуются для минимального запуска UI
4. Добавлены npm скрипты mock для запуска мокового бэкенда локально, yarn:mock для запуска фронтенда, который зацепится на этот бэкенд
5. Исправлен запуск тестов на mac os в связи с отсутствием loopback интерфейса "lo" и добавлен фикс для "lo0"
6. Добавлен .env файл, позволяющий при запуске через vite отлаживать фронтенд, целпяясь на бэкенд роутера напрямую без необходимости предварительной развертки
7. Добавлена страница /dev/api-docs для фронтенда, который сервит страницу с openapi документацией, а так же api эндпоинт /api/openapi.yaml, возвращающий файл в нотации openapi
8. Фикс ширины полей в настройках
9. Исправлен визуал внешний туннелей во вкладке AWG