### PR TITLE
feat(api): typed swagger DTOs sweep — 5 small files

### DIFF
--- a/internal/api/awg_outbounds.go
+++ b/internal/api/awg_outbounds.go
@@ -15,6 +15,14 @@ type AWGOutboundsService interface {
 	ListTags(ctx context.Context) ([]awgoutbounds.TagInfo, error)
 }
 
+// AWGOutboundTagDTO mirrors awgoutbounds.TagInfo for OpenAPI exposure.
+type AWGOutboundTagDTO struct {
+	Tag   string `json:"tag" example:"awg-vpn0"`
+	Label string `json:"label" example:"My VPN"`
+	Kind  string `json:"kind" example:"managed"`
+	Iface string `json:"iface" example:"t2s0"`
+}
+
 // AWGOutboundsHandler exposes the catalog of AWG-direct outbound tags
 // for the frontend (singbox-router rule editor outbound dropdown).
 type AWGOutboundsHandler struct {
@@ -32,7 +40,7 @@ func NewAWGOutboundsHandler(svc AWGOutboundsService) *AWGOutboundsHandler {
 //	@Tags			singbox
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}		map[string]interface{}
+//	@Success		200	{array}		AWGOutboundTagDTO
 //	@Failure		405	{string}	string
 //	@Failure		500	{string}	string
 //	@Router			/singbox/awg-outbounds/tags [get]

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -63,6 +63,90 @@ type GeoTagsResponse struct {
 	Data    []GeoTagDTO `json:"data"`
 }
 
+// GeoFileResponse is the envelope for endpoints that return a single
+// geo file entry (POST /hydraroute/geo-files/add).
+type GeoFileResponse struct {
+	Success bool            `json:"success" example:"true"`
+	Data    GeoFileEntryDTO `json:"data"`
+}
+
+// GeoFileUpdatedData reports how many geo files were re-downloaded by
+// POST /hydraroute/geo-files/update. The shape is the same whether the
+// caller targeted one path or all paths.
+type GeoFileUpdatedData struct {
+	Updated int `json:"updated" example:"1"`
+}
+
+// GeoFileUpdatedResponse is the envelope for POST /hydraroute/geo-files/update.
+type GeoFileUpdatedResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    GeoFileUpdatedData `json:"data"`
+}
+
+// IpsetUsageData mirrors hydraroute.IpsetUsage.
+type IpsetUsageData struct {
+	MaxElem int            `json:"maxElem" example:"65536"`
+	Usage   map[string]int `json:"usage"`
+}
+
+// IpsetUsageResponse is the envelope for GET /hydraroute/ipset-usage.
+type IpsetUsageResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    IpsetUsageData `json:"data"`
+}
+
+// PolicyOrderData reports the current HrNeo policy order.
+type PolicyOrderData struct {
+	Order []string `json:"order" example:"default"`
+}
+
+// PolicyOrderResponse is the envelope for POST /hydraroute/policy-order.
+type PolicyOrderResponse struct {
+	Success bool            `json:"success" example:"true"`
+	Data    PolicyOrderData `json:"data"`
+}
+
+// OversizedTagDTO mirrors hydraroute.OversizedTag.
+type OversizedTagDTO struct {
+	Name  string `json:"name" example:"netflix"`
+	Count int    `json:"count" example:"82000"`
+	File  string `json:"file" example:"/opt/etc/hrneo/geosite.db"`
+}
+
+// OversizedTagsData reports geoip tags excluded by HrNeo together with
+// the active IpsetMaxElem so the frontend can render the disabled-tags
+// pane and enforce picker limits.
+type OversizedTagsData struct {
+	Installed bool              `json:"installed" example:"true"`
+	MaxElem   int               `json:"maxelem" example:"65536"`
+	Tags      []OversizedTagDTO `json:"tags"`
+}
+
+// OversizedTagsResponse is the envelope for GET /hydraroute/oversized-tags.
+type OversizedTagsResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    OversizedTagsData `json:"data"`
+}
+
+// ── Request DTOs ─────────────────────────────────────────────────
+
+// AddGeoFileRequest is the body for POST /hydraroute/geo-files/add.
+type AddGeoFileRequest struct {
+	Type string `json:"type" example:"geosite"`
+	URL  string `json:"url" example:"https://cdn.example.com/geosite.db"`
+}
+
+// UpdateGeoFileRequest is the body for POST /hydraroute/geo-files/update.
+// Empty path triggers a bulk refresh of every tracked geo file.
+type UpdateGeoFileRequest struct {
+	Path string `json:"path" example:"/opt/etc/hrneo/geosite.db"`
+}
+
+// SetPolicyOrderRequest is the body for POST /hydraroute/policy-order.
+type SetPolicyOrderRequest struct {
+	Order []string `json:"order" example:"default"`
+}
+
 // HydraRouteHandler handles HydraRoute Neo settings API endpoints.
 type HydraRouteHandler struct {
 	svc *hydraroute.Service
@@ -146,7 +230,8 @@ func (h *HydraRouteHandler) UpdateConfig(w http.ResponseWriter, r *http.Request)
 //	@Tags			hydraroute
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	map[string]interface{}
+//	@Success		200	{object}	GeoFilesResponse
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/hydraroute/geo-files [get]
 func (h *HydraRouteHandler) ListGeoFiles(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -170,7 +255,10 @@ func (h *HydraRouteHandler) ListGeoFiles(w http.ResponseWriter, r *http.Request)
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Param			body	body		AddGeoFileRequest	true	"Geo file source descriptor"
+//	@Success		200		{object}	GeoFileResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/hydraroute/geo-files/add [post]
 func (h *HydraRouteHandler) AddGeoFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -215,9 +303,9 @@ func (h *HydraRouteHandler) AddGeoFile(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			path	query		string	true	"Filesystem path of the geo file"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/hydraroute/geo-files/delete [delete]
 func (h *HydraRouteHandler) DeleteGeoFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
@@ -247,17 +335,21 @@ func (h *HydraRouteHandler) DeleteGeoFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // UpdateGeoFile re-downloads a geo data file (or all files if path is empty).
 //
 //	@Summary		Refresh HydraRoute geo file(s)
+//	@Description	Empty path triggers a bulk refresh of every tracked geo file. Single path refreshes one file. Both branches return an updated count for caller-side feedback; the frontend refetches the list afterwards.
 //	@Tags			hydraroute
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Param			body	body		UpdateGeoFileRequest	true	"Path to refresh, or empty to refresh all"
+//	@Success		200		{object}	GeoFileUpdatedResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/hydraroute/geo-files/update [post]
 func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -265,9 +357,7 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var req struct {
-		Path string `json:"path"`
-	}
+	var req UpdateGeoFileRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		response.Error(w, "invalid request body: "+err.Error(), "BAD_REQUEST")
 		return
@@ -279,26 +369,20 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	updated := 0
 	if req.Path == "" {
 		count, err := gds.UpdateAll()
 		if err != nil {
 			response.Error(w, err.Error(), "GEO_UPDATE_ERROR")
 			return
 		}
-
-		if err := h.svc.SyncGeoFilesToConfig(); err != nil {
-			response.Error(w, "updated but failed to sync config: "+err.Error(), "SYNC_ERROR")
+		updated = count
+	} else {
+		if _, err := gds.Update(req.Path); err != nil {
+			response.Error(w, err.Error(), "GEO_UPDATE_ERROR")
 			return
 		}
-
-		response.Success(w, map[string]int{"updated": count})
-		return
-	}
-
-	entry, err := gds.Update(req.Path)
-	if err != nil {
-		response.Error(w, err.Error(), "GEO_UPDATE_ERROR")
-		return
+		updated = 1
 	}
 
 	if err := h.svc.SyncGeoFilesToConfig(); err != nil {
@@ -306,7 +390,7 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	response.Success(w, entry)
+	response.Success(w, map[string]int{"updated": updated})
 }
 
 // GetGeoTags returns the tag list for a specific geo data file.
@@ -351,7 +435,8 @@ func (h *HydraRouteHandler) GetGeoTags(w http.ResponseWriter, r *http.Request) {
 //	@Tags			hydraroute
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	IpsetUsageResponse
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/hydraroute/ipset-usage [get]
 func (h *HydraRouteHandler) GetIpsetUsage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -375,7 +460,10 @@ func (h *HydraRouteHandler) GetIpsetUsage(w http.ResponseWriter, r *http.Request
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Param			body	body		SetPolicyOrderRequest	true	"Ordered list of policy names"
+//	@Success		200		{object}	PolicyOrderResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/hydraroute/policy-order [post]
 func (h *HydraRouteHandler) SetPolicyOrder(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -383,9 +471,7 @@ func (h *HydraRouteHandler) SetPolicyOrder(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var req struct {
-		Order []string `json:"order"`
-	}
+	var req SetPolicyOrderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		response.Error(w, "invalid request body: "+err.Error(), "BAD_REQUEST")
 		return
@@ -410,7 +496,8 @@ func (h *HydraRouteHandler) SetPolicyOrder(w http.ResponseWriter, r *http.Reques
 //	@Tags			hydraroute
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
+//	@Success		200	{object}	OversizedTagsResponse
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/hydraroute/oversized-tags [get]
 func (h *HydraRouteHandler) GetOversizedTags(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -335,9 +335,9 @@ func (h *ServersHandler) Config(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			name	query		string	true	"Interface name (e.g. Wireguard0)"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/servers/mark [post]
 //	@Router			/servers/mark [delete]
 func (h *ServersHandler) Mark(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -145,7 +145,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"Settings"
+//	@Param			body	body		SettingsData	true	"Full settings object"
 //	@Success		200		{object}	SettingsResponse
 //	@Failure		400		{object}	APIErrorEnvelope
 //	@Failure		500		{object}	APIErrorEnvelope

--- a/internal/api/singbox.go
+++ b/internal/api/singbox.go
@@ -61,6 +61,11 @@ type SingboxTunnelsResponse struct {
 	Data    []SingboxTunnelDTO `json:"data"`
 }
 
+// SingboxControlRequest is the body for POST /singbox/control.
+type SingboxControlRequest struct {
+	Action string `json:"action" example:"start" enums:"start,stop,restart"`
+}
+
 // SingboxHandler serves /api/singbox/* routes.
 type SingboxHandler struct {
 	op           *singbox.Operator
@@ -169,19 +174,17 @@ func (h *SingboxHandler) Install(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{action: start|stop|restart}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxControlRequest	true	"Action to perform"
+//	@Success		200		{object}	SingboxStatusResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/control [post]
 func (h *SingboxHandler) Control(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
 		return
 	}
-	var req struct {
-		Action string `json:"action"`
-	}
+	var req SingboxControlRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		response.Error(w, "invalid request", "INVALID_REQUEST")
 		return

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -71,6 +71,21 @@ definitions:
         example: 0
         type: integer
     type: object
+  api.AWGOutboundTagDTO:
+    properties:
+      iface:
+        example: t2s0
+        type: string
+      kind:
+        example: managed
+        type: string
+      label:
+        example: My VPN
+        type: string
+      tag:
+        example: awg-vpn0
+        type: string
+    type: object
   api.AWGPeerDTO:
     properties:
       allowedIPs:
@@ -176,6 +191,15 @@ definitions:
       success:
         example: true
         type: boolean
+    type: object
+  api.AddGeoFileRequest:
+    properties:
+      type:
+        example: geosite
+        type: string
+      url:
+        example: https://cdn.example.com/geosite.db
+        type: string
     type: object
   api.AddPeerRequestDTO:
     properties:
@@ -723,6 +747,59 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.GeoFileEntryDTO:
+    properties:
+      path:
+        example: /opt/etc/hrneo/geosite.db
+        type: string
+      size:
+        example: 3145728
+        type: integer
+      tagCount:
+        example: 420
+        type: integer
+      type:
+        example: geosite
+        type: string
+      updated:
+        example: "2024-01-15T02:00:00Z"
+        type: string
+      url:
+        example: https://cdn.example.com/geosite.db
+        type: string
+    type: object
+  api.GeoFileResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.GeoFileEntryDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.GeoFileUpdatedData:
+    properties:
+      updated:
+        example: 1
+        type: integer
+    type: object
+  api.GeoFileUpdatedResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.GeoFileUpdatedData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.GeoFilesResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.GeoFileEntryDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
   api.HealthData:
     properties:
       ok:
@@ -860,6 +937,24 @@ definitions:
         items:
           $ref: '#/definitions/api.IPCheckServiceDTO'
         type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.IpsetUsageData:
+    properties:
+      maxElem:
+        example: 65536
+        type: integer
+      usage:
+        additionalProperties:
+          type: integer
+        type: object
+    type: object
+  api.IpsetUsageResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.IpsetUsageData'
       success:
         example: true
         type: boolean
@@ -1134,6 +1229,39 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.OversizedTagDTO:
+    properties:
+      count:
+        example: 82000
+        type: integer
+      file:
+        example: /opt/etc/hrneo/geosite.db
+        type: string
+      name:
+        example: netflix
+        type: string
+    type: object
+  api.OversizedTagsData:
+    properties:
+      installed:
+        example: true
+        type: boolean
+      maxelem:
+        example: 65536
+        type: integer
+      tags:
+        items:
+          $ref: '#/definitions/api.OversizedTagDTO'
+        type: array
+    type: object
+  api.OversizedTagsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.OversizedTagsData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.PermitInterfaceRequest:
     properties:
       interface:
@@ -1286,6 +1414,23 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.PolicyOrderData:
+    properties:
+      order:
+        example:
+        - default
+        items:
+          type: string
+        type: array
+    type: object
+  api.PolicyOrderResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.PolicyOrderData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.ProxyConfigResponse:
     properties:
       data:
@@ -1427,6 +1572,15 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.SetPolicyOrderRequest:
+    properties:
+      order:
+        example:
+        - default
+        items:
+          type: string
+        type: array
+    type: object
   api.SetStandaloneRequest:
     properties:
       enabled:
@@ -1504,6 +1658,16 @@ definitions:
         type: string
       i5:
         example: 6e7f8a9b
+        type: string
+    type: object
+  api.SingboxControlRequest:
+    properties:
+      action:
+        enum:
+        - start
+        - stop
+        - restart
+        example: start
         type: string
     type: object
   api.SingboxStatusData:
@@ -2187,6 +2351,12 @@ definitions:
       success:
         example: true
         type: boolean
+    type: object
+  api.UpdateGeoFileRequest:
+    properties:
+      path:
+        example: /opt/etc/hrneo/geosite.db
+        type: string
     type: object
   api.UpdateInfoData:
     properties:
@@ -3711,10 +3881,11 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              additionalProperties: true
-              type: object
-            type: array
+            $ref: '#/definitions/api.GeoFilesResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List HydraRoute geo files
@@ -3724,14 +3895,28 @@ paths:
     post:
       consumes:
       - application/json
+      parameters:
+      - description: Geo file source descriptor
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.AddGeoFileRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.GeoFileResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add HydraRoute geo file
@@ -3753,18 +3938,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete HydraRoute geo file
@@ -3774,14 +3956,31 @@ paths:
     post:
       consumes:
       - application/json
+      description: Empty path triggers a bulk refresh of every tracked geo file. Single
+        path refreshes one file. Both branches return an updated count for caller-side
+        feedback; the frontend refetches the list afterwards.
+      parameters:
+      - description: Path to refresh, or empty to refresh all
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateGeoFileRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.GeoFileUpdatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Refresh HydraRoute geo file(s)
@@ -3817,8 +4016,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.IpsetUsageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute ipset usage
@@ -3832,8 +4034,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OversizedTagsResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: HydraRoute oversized geo tags
@@ -3843,14 +4048,28 @@ paths:
     post:
       consumes:
       - application/json
+      parameters:
+      - description: Ordered list of policy names
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.SetPolicyOrderRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PolicyOrderResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set HydraRoute policy order
@@ -5182,18 +5401,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Mark/unmark interface as server
@@ -5215,18 +5431,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Mark/unmark interface as server
@@ -5328,13 +5541,12 @@ paths:
         (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled,
         disableMemorySaving, onboardingCompleted) MUST be sent on every save.
       parameters:
-      - description: Settings
+      - description: Full settings object
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SettingsData'
       produces:
       - application/json
       responses:
@@ -5395,8 +5607,7 @@ paths:
           description: OK
           schema:
             items:
-              additionalProperties: true
-              type: object
+              $ref: '#/definitions/api.AWGOutboundTagDTO'
             type: array
         "405":
           description: Method Not Allowed
@@ -5418,31 +5629,27 @@ paths:
       description: Starts, stops, or restarts the sing-box engine. Returns the fresh
         status snapshot. Mirrors /system/hydraroute-control.
       parameters:
-      - description: '{action: start|stop|restart}'
+      - description: Action to perform
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxControlRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxStatusResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Control sing-box process


### PR DESCRIPTION
## Summary

Second sweep PR in the swagger TODO push (after #21 `accesspolicy.go`). Replaces 18 generic `map[string]interface{}` swagger annotations across 5 smaller files with named typed DTOs — Prism mock now returns realistic JSON on every endpoint in these domains.

| File | Generic before | Now |
|---|---:|---:|
| `awg_outbounds.go` | 1 | 0 |
| `settings.go` | 1 | 0 |
| `servers.go` | 3 | 0 |
| `singbox.go` | 4 | 0 |
| `hydraroute.go` | 9 | 0 |

After this PR: 4 files remain (`singbox_router 92` + `singbox_router_dns 43` + `managed 40` + `managed_peers 17` = 192 generic). Each will be its own PR using the same template (named `*Request` types, shared `OkResponse`, typed `*Response` envelopes, `APIErrorEnvelope` for failures).

## New types

**Single-purpose DTOs:**
- `AWGOutboundTagDTO` (mirrors `awgoutbounds.TagInfo`)
- `GeoFileResponse` (single entry envelope)
- `GeoFileUpdatedData` / `GeoFileUpdatedResponse`
- `IpsetUsageData` / `IpsetUsageResponse`
- `OversizedTagDTO` / `OversizedTagsData` / `OversizedTagsResponse`
- `PolicyOrderData` / `PolicyOrderResponse`

**Request types** (extracted from anonymous structs so swag picks them up):
- `SingboxControlRequest{Action}`
- `AddGeoFileRequest{Type, URL}`
- `UpdateGeoFileRequest{Path}`
- `SetPolicyOrderRequest{Order}`

**Reused (already existed):**
- `OkResponse`, `APIErrorEnvelope`, `ServersAllResponse`, `SingboxStatusResponse`, `GeoFilesResponse`, `HydraRouteConfigResponse`, `SettingsData`

## Behavior changes (deliberate alignments)

- **`UpdateGeoFile`** — previously returned EITHER `{updated: int}` (bulk path) OR a single `GeoFileEntry` (single-file path). Frontend ignores the response body and refetches the list afterwards, so unify on `{updated: int}` for both branches.
- **`DeleteGeoFile`** — previously returned `data: null`. Aligned to the shared `OkResponse` shape (`data: {ok: true}`).

Both endpoints' frontend callers (`HrNeoGeoDataView.svelte`) discard the response body, so no UI changes are required.

## OpenAPI

- `internal/openapi/swagger.yaml` regenerated via `go generate`; emits 10 new schema definitions; zero `additionalProperties: {}` left across these 5 files' paths.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go generate ./cmd/awg-manager` — clean
- Local Prism mock smoke test on `:8080`:
  - `GET /singbox/awg-outbounds/tags` → `[{"iface":"t2s0","kind":"managed","label":"My VPN","tag":"awg-vpn0"}]`
  - `POST /singbox/control` → `{"data":{"installed":true,"running":true,"version":"1.9.3",...},"success":true}`
  - `GET /hydraroute/oversized-tags` → `{"data":{"installed":true,"maxelem":65536,"tags":[{"name":"netflix",...}]},"success":true}`

## Test plan

- [x] Open Swagger UI at `/dev/api-docs` and confirm `singbox`, `servers`, `hydraroute`, `settings` tags now show full schemas with examples for the touched endpoints
- [x] Run `npm run dev:mock` and exercise:
  - HrNeo UI: list / add / update / delete a geo file (mock should answer each call without 400s; shape doesn't matter to the UI but consistency does)
  - Sing-box settings page: toggle Start/Stop/Restart
  - Servers list: Mark/Unmark a tunnel
- [x] Smoke test against a real router — these are pure annotation + DTO changes plus two intentional response-body unifications described above; no functional regression expected