### PR TITLE
feat(managed): typed swagger DTOs for managed-servers domain

### DIFF
--- a/internal/api/clientroutes.go
+++ b/internal/api/clientroutes.go
@@ -177,7 +177,7 @@ func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/toggle [post]
 func (h *ClientRouteHandler) HandleToggle(w http.ResponseWriter, r *http.Request) {
-	req, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
+	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -350,7 +350,7 @@ func (h *DNSRouteHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/dns-routes/set-enabled [post]
 func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
-	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
+	body, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}

--- a/internal/api/managed.go
+++ b/internal/api/managed.go
@@ -46,6 +46,81 @@ type ManagedServerResponse struct {
 	Data    ManagedServerDTO `json:"data"`
 }
 
+// ManagedServersListResponse is the envelope for GET /managed-servers.
+type ManagedServersListResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    []ManagedServerDTO `json:"data"`
+}
+
+// ManagedPeerResponse is the envelope for endpoints that return a
+// single managed-server peer (POST /managed-servers/{id}/peers).
+type ManagedPeerResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    ManagedPeerDTO `json:"data"`
+}
+
+// ManagedServerStatsResponse is the envelope for GET /managed-servers/{id}/stats.
+// Reuses ManagedServerStatsDTO from servers.go (also referenced by ServersAllData).
+type ManagedServerStatsResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    ManagedServerStatsDTO `json:"data"`
+}
+
+// SuggestAddressData carries a free private /24 for the create-server UI.
+type SuggestAddressData struct {
+	Address string `json:"address" example:"10.10.0.1"`
+	Mask    string `json:"mask" example:"255.255.255.0"`
+}
+
+// SuggestAddressResponse is the envelope for GET /managed-servers/suggest-address.
+type SuggestAddressResponse struct {
+	Success bool               `json:"success" example:"true"`
+	Data    SuggestAddressData `json:"data"`
+}
+
+// PolicyOptionDTO mirrors managed.PolicyOption (router IP Policy profile entry).
+type PolicyOptionDTO struct {
+	ID          string `json:"id" example:"Policy0"`
+	Description string `json:"description" example:"Default policy"`
+}
+
+// PoliciesListResponse is the envelope for GET /managed-servers/policies.
+type PoliciesListResponse struct {
+	Success bool              `json:"success" example:"true"`
+	Data    []PolicyOptionDTO `json:"data"`
+}
+
+// ASCParamsResponse is the envelope for GET /managed-servers/{id}/asc.
+// The data field is the AWG signature/obfuscation params object — its
+// shape depends on the active signature preset, so it is intentionally
+// an opaque object in OpenAPI.
+type ASCParamsResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    map[string]interface{} `json:"data" swaggertype:"object"`
+}
+
+// PeerConfData carries a generated WireGuard client .conf as a string.
+type PeerConfData struct {
+	Conf string `json:"conf" example:"[Interface]\nPrivateKey = ..."`
+}
+
+// PeerConfResponse is the envelope for GET /managed-servers/{id}/peers/{pubkey}/conf.
+type PeerConfResponse struct {
+	Success bool         `json:"success" example:"true"`
+	Data    PeerConfData `json:"data"`
+}
+
+// EnabledToggleRequest is the body for endpoints that flip an enabled
+// flag (NAT, SetEnabled, TogglePeer).
+type EnabledToggleRequest struct {
+	Enabled bool `json:"enabled" example:"true"`
+}
+
+// SetServerPolicyRequest is the body for POST /managed-servers/{id}/policy.
+type SetServerPolicyRequest struct {
+	Policy string `json:"policy" example:"Policy0"`
+}
+
 // CreateServerRequestDTO is the swagger-visible body for POST /managed-servers.
 type CreateServerRequestDTO struct {
 	Address     string `json:"address" example:"10.10.0.1"`
@@ -395,8 +470,8 @@ func (h *ManagedServerHandler) Subtree(w http.ResponseWriter, r *http.Request) {
 //	@Tags			managed-servers
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
+//	@Success		200	{object}	ManagedServersListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
 //	@Router			/managed-servers [get]
 func (h *ManagedServerHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -414,9 +489,9 @@ func (h *ManagedServerHandler) List(w http.ResponseWriter, r *http.Request) {
 //	@Tags			managed-servers
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SuggestAddressResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/managed-servers/suggest-address [get]
 func (h *ManagedServerHandler) SuggestAddress(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -440,9 +515,9 @@ func (h *ManagedServerHandler) SuggestAddress(w http.ResponseWriter, r *http.Req
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	path		string	true	"Server id (e.g. Wireguard0)"
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		404	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
+//	@Success		200	{object}	ManagedServerResponse
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		405	{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id} [get]
 func (h *ManagedServerHandler) Get(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
@@ -466,9 +541,9 @@ func (h *ManagedServerHandler) Get(w http.ResponseWriter, r *http.Request, id st
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	path		string	true	"Server id"
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		404	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	ManagedServerStatsResponse
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/stats [get]
 func (h *ManagedServerHandler) Stats(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
@@ -494,9 +569,9 @@ func (h *ManagedServerHandler) Stats(w http.ResponseWriter, r *http.Request, id 
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			body	body		CreateServerRequestDTO	true	"Address, mask, port, ASC, name"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ManagedServerResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers [post]
 func (h *ManagedServerHandler) Create(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[managed.CreateServerRequest](w, r, http.MethodPost)
@@ -523,10 +598,10 @@ func (h *ManagedServerHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Security		CookieAuth
 //	@Param			id		path		string						true	"Server id"
 //	@Param			body	body		UpdateServerRequestDTO	true	"Update payload"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		404		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id} [put]
 func (h *ManagedServerHandler) Update(w http.ResponseWriter, r *http.Request, id string) {
 	req, ok := parseJSON[managed.UpdateServerRequest](w, r, http.MethodPut)
@@ -550,9 +625,9 @@ func (h *ManagedServerHandler) Update(w http.ResponseWriter, r *http.Request, id
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	path		string	true	"Server id"
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		404	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	ServersAllResponse
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id} [delete]
 func (h *ManagedServerHandler) Delete(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodDelete {
@@ -567,16 +642,6 @@ func (h *ManagedServerHandler) Delete(w http.ResponseWriter, r *http.Request, id
 	h.writeServersSnapshot(w, r)
 }
 
-// enabledToggle is the shared request body for NAT and SetEnabled.
-type enabledToggle struct {
-	Enabled bool `json:"enabled"`
-}
-
-// setPolicyRequest is the request body for /api/managed-servers/{id}/policy.
-type setPolicyRequest struct {
-	Policy string `json:"policy"`
-}
-
 // SetPolicy updates the ip hotspot policy for one managed server interface.
 // POST /api/managed-servers/{id}/policy
 //
@@ -587,13 +652,13 @@ type setPolicyRequest struct {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
-//	@Param			body	body		map[string]interface{}	true	"{policy: string}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SetServerPolicyRequest	true	"Policy id (router-side)"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/policy [post]
 func (h *ManagedServerHandler) SetPolicy(w http.ResponseWriter, r *http.Request, id string) {
-	req, ok := parseJSON[setPolicyRequest](w, r, http.MethodPost)
+	req, ok := parseJSON[SetServerPolicyRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}
@@ -615,9 +680,9 @@ func (h *ManagedServerHandler) SetPolicy(w http.ResponseWriter, r *http.Request,
 //	@Tags			managed-servers
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	PoliciesListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/managed-servers/policies [get]
 func (h *ManagedServerHandler) GetPolicies(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -645,13 +710,13 @@ func (h *ManagedServerHandler) GetPolicies(w http.ResponseWriter, r *http.Reques
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
-//	@Param			body	body		map[string]interface{}	true	"{enabled: bool}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		EnabledToggleRequest	true	"Enabled flag"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/nat [post]
 func (h *ManagedServerHandler) NAT(w http.ResponseWriter, r *http.Request, id string) {
-	req, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
+	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}
@@ -673,13 +738,13 @@ func (h *ManagedServerHandler) NAT(w http.ResponseWriter, r *http.Request, id st
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
-//	@Param			body	body		map[string]interface{}	true	"{enabled: bool}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		EnabledToggleRequest	true	"Enabled flag"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/enabled [post]
 func (h *ManagedServerHandler) SetEnabled(w http.ResponseWriter, r *http.Request, id string) {
-	req, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
+	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}
@@ -697,16 +762,16 @@ func (h *ManagedServerHandler) SetEnabled(w http.ResponseWriter, r *http.Request
 // PUT /api/managed-servers/{id}/asc — write params
 //
 //	@Summary		Get/set managed-server ASC params
-//	@Description	GET reads, PUT writes the AWG signature/obfuscation params for the named managed server. PUT body is the raw ASC JSON object.
+//	@Description	GET returns ASCParamsResponse with the current AWG signature/obfuscation params object. PUT writes new params (raw object whose shape depends on the active signature preset) and returns the fresh ServersSnapshot.
 //	@Tags			managed-servers
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			id		path		string					true	"Server id"
-//	@Param			body	body		map[string]interface{}	false	"ASC params (PUT only)"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			id		path		string	true	"Server id"
+//	@Param			body	body		object	false	"ASC params object (PUT only)"
+//	@Success		200		{object}	ASCParamsResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/asc [get]
 //	@Router			/managed-servers/{id}/asc [put]
 func (h *ManagedServerHandler) ASC(w http.ResponseWriter, r *http.Request, id string) {

--- a/internal/api/managed_peers.go
+++ b/internal/api/managed_peers.go
@@ -32,9 +32,9 @@ type UpdatePeerRequestDTO struct {
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
 //	@Param			body	body		AddPeerRequestDTO	true	"Peer payload"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ManagedPeerResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/peers [post]
 func (h *ManagedServerHandler) AddPeer(w http.ResponseWriter, r *http.Request, id string) {
 	req, ok := parseJSON[managed.AddPeerRequest](w, r, http.MethodPost)
@@ -62,10 +62,10 @@ func (h *ManagedServerHandler) AddPeer(w http.ResponseWriter, r *http.Request, i
 //	@Param			id		path		string						true	"Server id"
 //	@Param			pubkey	path		string						true	"Peer public key (URL-encoded)"
 //	@Param			body	body		UpdatePeerRequestDTO	true	"Peer update payload"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		404		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/peers/{pubkey} [put]
 func (h *ManagedServerHandler) UpdatePeer(w http.ResponseWriter, r *http.Request, id, pubkey string) {
 	req, ok := parseJSON[managed.UpdatePeerRequest](w, r, http.MethodPut)
@@ -90,9 +90,9 @@ func (h *ManagedServerHandler) UpdatePeer(w http.ResponseWriter, r *http.Request
 //	@Security		CookieAuth
 //	@Param			id		path		string	true	"Server id"
 //	@Param			pubkey	path		string	true	"Peer public key (URL-encoded)"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		404		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/peers/{pubkey} [delete]
 func (h *ManagedServerHandler) DeletePeer(w http.ResponseWriter, r *http.Request, id, pubkey string) {
 	if r.Method != http.MethodDelete {
@@ -107,12 +107,6 @@ func (h *ManagedServerHandler) DeletePeer(w http.ResponseWriter, r *http.Request
 	h.writeServersSnapshot(w, r)
 }
 
-// togglePeerRequest is the body for the toggle endpoint. Only carries
-// the new enabled state — the pubkey now travels in the URL.
-type togglePeerRequest struct {
-	Enabled bool `json:"enabled"`
-}
-
 // TogglePeer enables or disables a peer.
 // POST /api/managed-servers/{id}/peers/{pubkey}/toggle
 //
@@ -124,13 +118,13 @@ type togglePeerRequest struct {
 //	@Security		CookieAuth
 //	@Param			id		path		string					true	"Server id"
 //	@Param			pubkey	path		string					true	"Peer public key (URL-encoded)"
-//	@Param			body	body		map[string]interface{}	true	"{enabled: bool}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		EnabledToggleRequest	true	"Enabled flag"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/peers/{pubkey}/toggle [post]
 func (h *ManagedServerHandler) TogglePeer(w http.ResponseWriter, r *http.Request, id, pubkey string) {
-	req, ok := parseJSON[togglePeerRequest](w, r, http.MethodPost)
+	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}
@@ -152,9 +146,9 @@ func (h *ManagedServerHandler) TogglePeer(w http.ResponseWriter, r *http.Request
 //	@Security		CookieAuth
 //	@Param			id		path		string	true	"Server id"
 //	@Param			pubkey	path		string	true	"Peer public key (URL-encoded)"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		404		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	PeerConfResponse
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/managed-servers/{id}/peers/{pubkey}/conf [get]
 func (h *ManagedServerHandler) PeerConf(w http.ResponseWriter, r *http.Request, id, pubkey string) {
 	if r.Method != http.MethodGet {

--- a/internal/api/staticroute.go
+++ b/internal/api/staticroute.go
@@ -199,7 +199,7 @@ func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/set-enabled [post]
 func (h *StaticRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
-	body, ok := parseJSON[enabledToggle](w, r, http.MethodPost)
+	body, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -23,6 +23,14 @@ definitions:
         example: invalid request
         type: string
     type: object
+  api.ASCParamsResponse:
+    properties:
+      data:
+        type: object
+      success:
+        example: true
+        type: boolean
+    type: object
   api.AWGInterfaceDTO:
     properties:
       address:
@@ -713,6 +721,12 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.EnabledToggleRequest:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+    type: object
   api.ExternalTunnelDTO:
     properties:
       endpoint:
@@ -1032,6 +1046,38 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.ManagedPeerDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      enabled:
+        example: true
+        type: boolean
+      presharedKey:
+        example: JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ=
+        type: string
+      privateKey:
+        example: IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII=
+        type: string
+      publicKey:
+        example: HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH=
+        type: string
+      tunnelIP:
+        example: 10.10.0.2
+        type: string
+    type: object
+  api.ManagedPeerResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ManagedPeerDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.ManagedPeerStatsDTO:
     properties:
       endpoint:
@@ -1053,6 +1099,48 @@ definitions:
         example: 1048576
         type: integer
     type: object
+  api.ManagedServerDTO:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      dns:
+        example: 8.8.8.8
+        type: string
+      endpoint:
+        example: 203.0.113.42:51821
+        type: string
+      interfaceName:
+        example: Wireguard1
+        type: string
+      listenPort:
+        example: 51821
+        type: integer
+      mask:
+        example: 255.255.255.0
+        type: string
+      mtu:
+        example: 1420
+        type: integer
+      natEnabled:
+        example: true
+        type: boolean
+      peers:
+        items:
+          $ref: '#/definitions/api.ManagedPeerDTO'
+        type: array
+      policy:
+        example: default
+        type: string
+    type: object
+  api.ManagedServerResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ManagedServerDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.ManagedServerStatsDTO:
     properties:
       peers:
@@ -1062,6 +1150,24 @@ definitions:
       status:
         example: up
         type: string
+    type: object
+  api.ManagedServerStatsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ManagedServerStatsDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ManagedServersListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.ManagedServerDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
     type: object
   api.MonitoringCellDTO:
     properties:
@@ -1262,6 +1368,22 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.PeerConfData:
+    properties:
+      conf:
+        example: |-
+          [Interface]
+          PrivateKey = ...
+        type: string
+    type: object
+  api.PeerConfResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.PeerConfData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.PermitInterfaceRequest:
     properties:
       interface:
@@ -1358,6 +1480,16 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.PoliciesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.PolicyOptionDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
   api.PolicyDeviceDTO:
     properties:
       active:
@@ -1413,6 +1545,15 @@ definitions:
       success:
         example: true
         type: boolean
+    type: object
+  api.PolicyOptionDTO:
+    properties:
+      description:
+        example: Default policy
+        type: string
+      id:
+        example: Policy0
+        type: string
     type: object
   api.PolicyOrderData:
     properties:
@@ -1580,6 +1721,12 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  api.SetServerPolicyRequest:
+    properties:
+      policy:
+        example: Policy0
+        type: string
     type: object
   api.SetStandaloneRequest:
     properties:
@@ -1857,6 +2004,23 @@ definitions:
         items:
           $ref: '#/definitions/api.StaticRouteDTO'
         type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SuggestAddressData:
+    properties:
+      address:
+        example: 10.10.0.1
+        type: string
+      mask:
+        example: 255.255.255.0
+        type: string
+    type: object
+  api.SuggestAddressResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SuggestAddressData'
       success:
         example: true
         type: boolean
@@ -4153,13 +4317,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ManagedServersListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List managed servers
@@ -4183,18 +4345,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ManagedServerResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create managed server
@@ -4216,18 +4375,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete managed server
@@ -4247,18 +4403,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ManagedServerResponse'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get managed server
@@ -4287,23 +4440,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update managed server
@@ -4313,19 +4462,19 @@ paths:
     get:
       consumes:
       - application/json
-      description: GET reads, PUT writes the AWG signature/obfuscation params for
-        the named managed server. PUT body is the raw ASC JSON object.
+      description: GET returns ASCParamsResponse with the current AWG signature/obfuscation
+        params object. PUT writes new params (raw object whose shape depends on the
+        active signature preset) and returns the fresh ServersSnapshot.
       parameters:
       - description: Server id
         in: path
         name: id
         required: true
         type: string
-      - description: ASC params (PUT only)
+      - description: ASC params object (PUT only)
         in: body
         name: body
         schema:
-          additionalProperties: true
           type: object
       produces:
       - application/json
@@ -4333,18 +4482,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ASCParamsResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get/set managed-server ASC params
@@ -4353,19 +4499,19 @@ paths:
     put:
       consumes:
       - application/json
-      description: GET reads, PUT writes the AWG signature/obfuscation params for
-        the named managed server. PUT body is the raw ASC JSON object.
+      description: GET returns ASCParamsResponse with the current AWG signature/obfuscation
+        params object. PUT writes new params (raw object whose shape depends on the
+        active signature preset) and returns the fresh ServersSnapshot.
       parameters:
       - description: Server id
         in: path
         name: id
         required: true
         type: string
-      - description: ASC params (PUT only)
+      - description: ASC params object (PUT only)
         in: body
         name: body
         schema:
-          additionalProperties: true
           type: object
       produces:
       - application/json
@@ -4373,18 +4519,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ASCParamsResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get/set managed-server ASC params
@@ -4402,31 +4545,27 @@ paths:
         name: id
         required: true
         type: string
-      - description: '{enabled: bool}'
+      - description: Enabled flag
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.EnabledToggleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle managed-server enabled
@@ -4444,31 +4583,27 @@ paths:
         name: id
         required: true
         type: string
-      - description: '{enabled: bool}'
+      - description: Enabled flag
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.EnabledToggleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle managed-server NAT
@@ -4498,18 +4633,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ManagedPeerResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add managed-server peer
@@ -4535,18 +4667,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete managed-server peer
@@ -4580,23 +4709,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update managed-server peer
@@ -4623,18 +4748,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PeerConfResponse'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Generate peer .conf
@@ -4657,31 +4779,27 @@ paths:
         name: pubkey
         required: true
         type: string
-      - description: '{enabled: bool}'
+      - description: Enabled flag
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.EnabledToggleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Toggle managed-server peer enabled
@@ -4699,31 +4817,27 @@ paths:
         name: id
         required: true
         type: string
-      - description: '{policy: string}'
+      - description: Policy id (router-side)
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SetServerPolicyRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ServersAllResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set managed-server IP policy
@@ -4745,18 +4859,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ManagedServerStatsResponse'
         "404":
           description: Not Found
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get managed-server peer stats
@@ -4772,18 +4883,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.PoliciesListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List IP Policy profiles
@@ -4799,18 +4907,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SuggestAddressResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Suggest managed-server address


### PR DESCRIPTION
## Сводка

Третий PR в swagger-sweep'е после #21 (`accesspolicy`) и #22 (`5 small files`). Закрывает домен Managed Servers — заменяет все 57 generic `map[string]interface{}` аннотаций в `managed.go` (40) и `managed_peers.go` (17) типизированными DTO. После мерджа Prism mock возвращает реалистичный JSON для всех 18 хендлеров `/api/managed-servers/*`.

После этого PR остаётся 2 файла, 135 generic: `singbox_router.go` (92) + `singbox_router_dns.go` (43).

| Файл | Generic было | Стало |
|---|---:|---:|
| `managed.go` | 40 | 0 |
| `managed_peers.go` | 17 | 0 |

## Новые типы

**Response envelopes (managed.go):**
- `ManagedServersListResponse` — для `GET /managed-servers`
- `ManagedPeerResponse` — для `AddPeer` (single peer)
- `ManagedServerStatsResponse` — переиспользует `ManagedServerStatsDTO` из `servers.go` (он уже используется в `ServersAllData`, дублирование не понадобилось)
- `SuggestAddressData` / `SuggestAddressResponse`
- `PolicyOptionDTO` / `PoliciesListResponse`
- `ASCParamsResponse` — `data: object` (без конкретной схемы), потому что форма ASC params зависит от активного signature preset
- `PeerConfData` / `PeerConfResponse`

**Shared request types** (вынесены из анонимных struct'ов чтобы swag смог подцепить поля):
- `EnabledToggleRequest{Enabled}` — заменяет локальные `enabledToggle` и `togglePeerRequest`. Заодно мигрировал 3 чужих хендлера (`clientroutes`, `dnsroute`, `staticroute`), которые зависели от unexported `enabledToggle`, на общий exported тип
- `SetServerPolicyRequest{Policy}` — заменяет `setPolicyRequest`

## Reuse существующих типов

- `ServersAllResponse` для всех 9 mutation handlers, которые шлют `writeServersSnapshot` (`Update`, `Delete`, `SetPolicy`, `NAT`, `SetEnabled`, `ASC PUT`, `UpdatePeer`, `DeletePeer`, `TogglePeer`)
- `APIErrorEnvelope` для всех `@Failure`
- `ManagedServerResponse` / `ManagedPeerDTO` / `ManagedServerDTO` уже были в файле сверху

## OpenAPI

- `internal/openapi/swagger.yaml` регенерирован через `go generate`. Добавились 11 новых schemas; пути `/managed-servers/*` теперь показывают типизированные Request/Response с примерами в Swagger UI; `additionalProperties: {}` в этих путях больше нет

## Проверки

- `go build ./...` — clean
- `go vet ./...` — clean
- `go generate ./cmd/awg-manager` — clean
- Локальный Prism mock на `:8080`:
  - `GET /managed-servers` → массив с полным `ManagedServerDTO` (адрес, порт, peers, NAT, MTU, DNS)
  - `GET /managed-servers/{id}/stats` → `{status: "up", peers: [{publicKey, endpoint, rxBytes, txBytes, lastHandshake, online}]}`
  - `GET /managed-servers/policies` → `[{id: "Policy0", description: "Default policy"}]`