### PR TITLE
feat(singbox-router): typed swagger DTOs (final sweep PR)

### DIFF
--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -12,6 +12,240 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// ── Response DTOs ────────────────────────────────────────────────
+
+// SingboxRouterIssueDTO mirrors router.Issue (one entry of Status.Issues).
+type SingboxRouterIssueDTO struct {
+	Severity  string `json:"severity" example:"warning"`
+	Kind      string `json:"kind" example:"missing-outbound"`
+	RuleIndex int    `json:"ruleIndex,omitempty" example:"0"`
+	Tag       string `json:"tag,omitempty" example:"selector"`
+	Message   string `json:"message" example:"outbound 'selector' is referenced but does not exist"`
+}
+
+// SingboxRouterStatusData mirrors router.Status.
+type SingboxRouterStatusData struct {
+	Enabled                bool                    `json:"enabled" example:"true"`
+	Installed              bool                    `json:"installed" example:"true"`
+	NetfilterAvailable     bool                    `json:"netfilterAvailable" example:"true"`
+	NetfilterComponentName string                  `json:"netfilterComponentName,omitempty" example:"iptables-mod-tproxy"`
+	TProxyTargetAvailable  bool                    `json:"tproxyTargetAvailable" example:"true"`
+	PolicyName             string                  `json:"policyName" example:"awgm-router"`
+	PolicyMark             string                  `json:"policyMark,omitempty" example:"0xffffaaa"`
+	PolicyExists           bool                    `json:"policyExists" example:"true"`
+	DeviceCount            int                     `json:"deviceCount" example:"3"`
+	RuleCount              int                     `json:"ruleCount" example:"12"`
+	RuleSetCount           int                     `json:"ruleSetCount" example:"4"`
+	OutboundAWGCount       int                     `json:"outboundAwgCount" example:"2"`
+	OutboundCompositeCount int                     `json:"outboundCompositeCount" example:"1"`
+	Final                  string                  `json:"final" example:"direct"`
+	Issues                 []SingboxRouterIssueDTO `json:"issues,omitempty"`
+}
+
+// SingboxRouterStatusResponse is the envelope for GET /singbox/router/status.
+type SingboxRouterStatusResponse struct {
+	Success bool                    `json:"success" example:"true"`
+	Data    SingboxRouterStatusData `json:"data"`
+}
+
+// SingboxRouterSettingsData mirrors storage.SingboxRouterSettings.
+type SingboxRouterSettingsData struct {
+	Enabled         bool   `json:"enabled" example:"true"`
+	PolicyName      string `json:"policyName" example:"awgm-router"`
+	RefreshMode     string `json:"refreshMode,omitempty" example:"interval"`
+	RefreshInterval int    `json:"refreshIntervalHours,omitempty" example:"24"`
+	RefreshDaily    string `json:"refreshDailyTime,omitempty" example:"03:00"`
+}
+
+// SingboxRouterSettingsResponse is the envelope for GET /singbox/router/settings.
+type SingboxRouterSettingsResponse struct {
+	Success bool                      `json:"success" example:"true"`
+	Data    SingboxRouterSettingsData `json:"data"`
+}
+
+// SingboxRouterRuleDTO mirrors router.Rule (a routing rule in priority order).
+type SingboxRouterRuleDTO struct {
+	DomainSuffix []string `json:"domain_suffix,omitempty" example:".example.com"`
+	IPCIDR       []string `json:"ip_cidr,omitempty" example:"10.0.0.0/8"`
+	SourceIPCIDR []string `json:"source_ip_cidr,omitempty" example:"192.168.1.100/32"`
+	Port         []int    `json:"port,omitempty" example:"443"`
+	RuleSet      []string `json:"rule_set,omitempty" example:"geosite-cn"`
+	Protocol     string   `json:"protocol,omitempty" example:"tcp"`
+	Action       string   `json:"action" example:"route"`
+	Outbound     string   `json:"outbound,omitempty" example:"selector"`
+}
+
+// SingboxRouterRulesListResponse is the envelope for GET /singbox/router/rules/list.
+type SingboxRouterRulesListResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    []SingboxRouterRuleDTO `json:"data"`
+}
+
+// SingboxRouterRuleSetDTO mirrors router.RuleSet.
+type SingboxRouterRuleSetDTO struct {
+	Tag            string `json:"tag" example:"geosite-cn"`
+	Type           string `json:"type" example:"remote"`
+	Format         string `json:"format" example:"binary"`
+	URL            string `json:"url,omitempty" example:"https://cdn.example.com/geosite-cn.srs"`
+	UpdateInterval string `json:"update_interval,omitempty" example:"24h"`
+	DownloadDetour string `json:"download_detour,omitempty" example:"direct"`
+	Path           string `json:"path,omitempty" example:"/opt/etc/singbox/rulesets/geosite-cn.srs"`
+}
+
+// SingboxRouterRuleSetsListResponse is the envelope for GET /singbox/router/rulesets/list.
+type SingboxRouterRuleSetsListResponse struct {
+	Success bool                      `json:"success" example:"true"`
+	Data    []SingboxRouterRuleSetDTO `json:"data"`
+}
+
+// SingboxRouterOutboundDTO mirrors router.Outbound (composite outbound).
+type SingboxRouterOutboundDTO struct {
+	Type          string   `json:"type" example:"selector"`
+	Tag           string   `json:"tag" example:"my-selector"`
+	BindInterface string   `json:"bind_interface,omitempty" example:"awg-vpn0"`
+	Outbounds     []string `json:"outbounds,omitempty" example:"awg-vpn0"`
+	URL           string   `json:"url,omitempty" example:"https://www.gstatic.com/generate_204"`
+	Interval      string   `json:"interval,omitempty" example:"3m"`
+	Tolerance     int      `json:"tolerance,omitempty" example:"50"`
+	Default       string   `json:"default,omitempty" example:"awg-vpn0"`
+	Strategy      string   `json:"strategy,omitempty" example:"prefer_ipv4"`
+}
+
+// SingboxRouterOutboundsListResponse is the envelope for GET /singbox/router/outbounds/list.
+type SingboxRouterOutboundsListResponse struct {
+	Success bool                       `json:"success" example:"true"`
+	Data    []SingboxRouterOutboundDTO `json:"data"`
+}
+
+// SingboxRouterPresetRuleRefDTO mirrors internalpresets.RuleRef.
+type SingboxRouterPresetRuleRefDTO struct {
+	Tag string `json:"tag" example:"geosite-cn"`
+}
+
+// SingboxRouterPresetRuleLinkDTO mirrors internalpresets.RuleLink.
+type SingboxRouterPresetRuleLinkDTO struct {
+	RuleSet      []string `json:"rule_set,omitempty" example:"geosite-cn"`
+	DomainSuffix []string `json:"domain_suffix,omitempty" example:".cn"`
+	Action       string   `json:"action,omitempty" example:"route"`
+}
+
+// SingboxRouterPresetDTO mirrors router.Preset (one entry of the preset catalog).
+type SingboxRouterPresetDTO struct {
+	ID        string                           `json:"id" example:"china-direct"`
+	Name      string                           `json:"name" example:"China Direct"`
+	IconSlug  string                           `json:"iconSlug,omitempty" example:"china"`
+	RuleSets  []SingboxRouterPresetRuleRefDTO  `json:"ruleSets"`
+	Rules     []SingboxRouterPresetRuleLinkDTO `json:"rules"`
+	Notice    string                           `json:"notice,omitempty" example:"Routes mainland China traffic via the direct outbound."`
+	Featured  bool                             `json:"featured,omitempty" example:"true"`
+	Sensitive bool                             `json:"sensitive,omitempty" example:"false"`
+}
+
+// SingboxRouterPresetsListResponse is the envelope for GET /singbox/router/presets/list.
+type SingboxRouterPresetsListResponse struct {
+	Success bool                     `json:"success" example:"true"`
+	Data    []SingboxRouterPresetDTO `json:"data"`
+}
+
+// SingboxRouterPolicyInfoDTO mirrors router.PolicyInfo (NDMS policy projection).
+type SingboxRouterPolicyInfoDTO struct {
+	Name         string `json:"name" example:"Policy0"`
+	Description  string `json:"description" example:"Default policy"`
+	Mark         string `json:"mark,omitempty" example:"0xffffaaa"`
+	DeviceCount  int    `json:"deviceCount" example:"3"`
+	IsOurDefault bool   `json:"isOurDefault" example:"false"`
+}
+
+// SingboxRouterPoliciesListResponse is the envelope for GET /singbox/router/policies.
+type SingboxRouterPoliciesListResponse struct {
+	Success bool                         `json:"success" example:"true"`
+	Data    []SingboxRouterPolicyInfoDTO `json:"data"`
+}
+
+// SingboxRouterPolicyResponse is the envelope for POST /singbox/router/policies (single policy).
+type SingboxRouterPolicyResponse struct {
+	Success bool                       `json:"success" example:"true"`
+	Data    SingboxRouterPolicyInfoDTO `json:"data"`
+}
+
+// SingboxRouterPolicyDeviceDTO mirrors router.PolicyDevice.
+type SingboxRouterPolicyDeviceDTO struct {
+	MAC   string `json:"mac" example:"aa:bb:cc:dd:ee:ff"`
+	IP    string `json:"ip" example:"192.168.1.100"`
+	Name  string `json:"name,omitempty" example:"My Phone"`
+	Bound bool   `json:"bound" example:"true"`
+}
+
+// SingboxRouterPolicyDevicesListResponse is the envelope for GET /singbox/router/policy-devices.
+type SingboxRouterPolicyDevicesListResponse struct {
+	Success bool                           `json:"success" example:"true"`
+	Data    []SingboxRouterPolicyDeviceDTO `json:"data"`
+}
+
+// ── Request DTOs ─────────────────────────────────────────────────
+
+// SingboxRouterRuleUpdateRequest is the body for POST /singbox/router/rules/update.
+type SingboxRouterRuleUpdateRequest struct {
+	Index int                  `json:"index" example:"0"`
+	Rule  SingboxRouterRuleDTO `json:"rule"`
+}
+
+// SingboxRouterRuleDeleteRequest is the body for POST /singbox/router/rules/delete.
+type SingboxRouterRuleDeleteRequest struct {
+	Index int `json:"index" example:"0"`
+}
+
+// SingboxRouterRuleMoveRequest is the body for POST /singbox/router/rules/move.
+type SingboxRouterRuleMoveRequest struct {
+	From int `json:"from" example:"3"`
+	To   int `json:"to" example:"0"`
+}
+
+// SingboxRouterRuleSetDeleteRequest is the body for POST /singbox/router/rulesets/delete.
+type SingboxRouterRuleSetDeleteRequest struct {
+	Tag   string `json:"tag" example:"geosite-cn"`
+	Force bool   `json:"force" example:"false"`
+}
+
+// SingboxRouterRuleSetRefreshRequest is the body for POST /singbox/router/rulesets/refresh.
+type SingboxRouterRuleSetRefreshRequest struct {
+	Tag string `json:"tag" example:"geosite-cn"`
+}
+
+// SingboxRouterOutboundUpdateRequest is the body for POST /singbox/router/outbounds/update.
+type SingboxRouterOutboundUpdateRequest struct {
+	Tag      string                   `json:"tag" example:"my-selector"`
+	Outbound SingboxRouterOutboundDTO `json:"outbound"`
+}
+
+// SingboxRouterOutboundDeleteRequest is the body for POST /singbox/router/outbounds/delete.
+type SingboxRouterOutboundDeleteRequest struct {
+	Tag   string `json:"tag" example:"my-selector"`
+	Force bool   `json:"force" example:"false"`
+}
+
+// SingboxRouterApplyPresetRequest is the body for POST /singbox/router/presets/apply.
+type SingboxRouterApplyPresetRequest struct {
+	ID       string `json:"id" example:"china-direct"`
+	Outbound string `json:"outbound" example:"awg-vpn0"`
+}
+
+// SingboxRouterCreatePolicyRequest is the body for POST /singbox/router/policies.
+type SingboxRouterCreatePolicyRequest struct {
+	Description string `json:"description" example:"My VPN policy"`
+}
+
+// SingboxRouterBindDeviceRequest is the body for POST /singbox/router/policy-devices/bind.
+type SingboxRouterBindDeviceRequest struct {
+	MAC        string `json:"mac" example:"aa:bb:cc:dd:ee:ff"`
+	PolicyName string `json:"policyName" example:"Policy0"`
+}
+
+// SingboxRouterUnbindDeviceRequest is the body for POST /singbox/router/policy-devices/unbind.
+type SingboxRouterUnbindDeviceRequest struct {
+	MAC string `json:"mac" example:"aa:bb:cc:dd:ee:ff"`
+}
+
 type SingboxRouterHandler struct {
 	svc router.Service
 	log *logging.ScopedLogger
@@ -31,9 +265,9 @@ func NewSingboxRouterHandler(svc router.Service, appLogger logging.AppLogger) *S
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterStatusResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/status [get]
 func (h *SingboxRouterHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -55,10 +289,10 @@ func (h *SingboxRouterHandler) GetStatus(w http.ResponseWriter, r *http.Request)
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		400	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	OkResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/enable [post]
 func (h *SingboxRouterHandler) Enable(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -77,7 +311,7 @@ func (h *SingboxRouterHandler) Enable(w http.ResponseWriter, r *http.Request) {
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // Disable stops the singbox-router engine and uninstalls iptables/policy rules.
@@ -87,9 +321,9 @@ func (h *SingboxRouterHandler) Enable(w http.ResponseWriter, r *http.Request) {
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	OkResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/disable [post]
 func (h *SingboxRouterHandler) Disable(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -100,7 +334,7 @@ func (h *SingboxRouterHandler) Disable(w http.ResponseWriter, r *http.Request) {
 		response.InternalError(w, err.Error())
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // GetSettings reads singbox-router settings (policy-mode, defaults, etc.).
@@ -110,9 +344,9 @@ func (h *SingboxRouterHandler) Disable(w http.ResponseWriter, r *http.Request) {
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterSettingsResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/settings [get]
 func (h *SingboxRouterHandler) GetSettings(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -135,11 +369,11 @@ func (h *SingboxRouterHandler) GetSettings(w http.ResponseWriter, r *http.Reques
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"storage.SingboxRouterSettings"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		405		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterSettingsData	true	"Singbox-router settings payload"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/settings [post]
 //	@Router			/singbox/router/settings [put]
 func (h *SingboxRouterHandler) PutSettings(w http.ResponseWriter, r *http.Request) {
@@ -156,7 +390,7 @@ func (h *SingboxRouterHandler) PutSettings(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // ListRules returns all singbox-router routing rules in priority order.
@@ -166,9 +400,9 @@ func (h *SingboxRouterHandler) PutSettings(w http.ResponseWriter, r *http.Reques
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterRulesListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rules/list [get]
 func (h *SingboxRouterHandler) ListRules(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -191,10 +425,10 @@ func (h *SingboxRouterHandler) ListRules(w http.ResponseWriter, r *http.Request)
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"router.Rule"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleDTO	true	"Routing rule payload"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rules/add [post]
 func (h *SingboxRouterHandler) AddRule(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -210,7 +444,7 @@ func (h *SingboxRouterHandler) AddRule(w http.ResponseWriter, r *http.Request) {
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // UpdateRule replaces a rule at the given index with the provided one.
@@ -221,10 +455,10 @@ func (h *SingboxRouterHandler) AddRule(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{index, rule}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleUpdateRequest	true	"Index + replacement rule"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rules/update [post]
 func (h *SingboxRouterHandler) UpdateRule(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -243,7 +477,7 @@ func (h *SingboxRouterHandler) UpdateRule(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // DeleteRule removes the rule at the given index.
@@ -254,10 +488,10 @@ func (h *SingboxRouterHandler) UpdateRule(w http.ResponseWriter, r *http.Request
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{index}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleDeleteRequest	true	"Index of the rule to remove"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rules/delete [post]
 func (h *SingboxRouterHandler) DeleteRule(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -275,7 +509,7 @@ func (h *SingboxRouterHandler) DeleteRule(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // MoveRule moves the rule from one priority slot to another.
@@ -286,10 +520,10 @@ func (h *SingboxRouterHandler) DeleteRule(w http.ResponseWriter, r *http.Request
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{from, to}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleMoveRequest	true	"From-index and to-index"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rules/move [post]
 func (h *SingboxRouterHandler) MoveRule(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -308,7 +542,7 @@ func (h *SingboxRouterHandler) MoveRule(w http.ResponseWriter, r *http.Request) 
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // ListRuleSets returns all configured rulesets.
@@ -318,9 +552,9 @@ func (h *SingboxRouterHandler) MoveRule(w http.ResponseWriter, r *http.Request) 
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterRuleSetsListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rulesets/list [get]
 func (h *SingboxRouterHandler) ListRuleSets(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -343,10 +577,10 @@ func (h *SingboxRouterHandler) ListRuleSets(w http.ResponseWriter, r *http.Reque
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"router.RuleSet"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleSetDTO	true	"RuleSet payload"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rulesets/add [post]
 func (h *SingboxRouterHandler) AddRuleSet(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -362,7 +596,7 @@ func (h *SingboxRouterHandler) AddRuleSet(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // DeleteRuleSet removes the ruleset identified by tag.
@@ -373,11 +607,11 @@ func (h *SingboxRouterHandler) AddRuleSet(w http.ResponseWriter, r *http.Request
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{tag, force}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		409		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleSetDeleteRequest	true	"Tag + optional force flag"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		409		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rulesets/delete [post]
 func (h *SingboxRouterHandler) DeleteRuleSet(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -396,7 +630,7 @@ func (h *SingboxRouterHandler) DeleteRuleSet(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // RefreshRuleSet re-downloads the ruleset identified by tag.
@@ -407,10 +641,10 @@ func (h *SingboxRouterHandler) DeleteRuleSet(w http.ResponseWriter, r *http.Requ
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{tag}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterRuleSetRefreshRequest	true	"Ruleset tag to re-download"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/rulesets/refresh [post]
 func (h *SingboxRouterHandler) RefreshRuleSet(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -428,7 +662,7 @@ func (h *SingboxRouterHandler) RefreshRuleSet(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // ListOutbounds returns all composite outbounds.
@@ -438,9 +672,9 @@ func (h *SingboxRouterHandler) RefreshRuleSet(w http.ResponseWriter, r *http.Req
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterOutboundsListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/outbounds/list [get]
 func (h *SingboxRouterHandler) ListOutbounds(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -463,10 +697,10 @@ func (h *SingboxRouterHandler) ListOutbounds(w http.ResponseWriter, r *http.Requ
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"router.Outbound"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterOutboundDTO	true	"Composite outbound payload"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/outbounds/add [post]
 func (h *SingboxRouterHandler) AddOutbound(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -482,7 +716,7 @@ func (h *SingboxRouterHandler) AddOutbound(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // UpdateOutbound replaces the composite outbound identified by tag.
@@ -493,10 +727,10 @@ func (h *SingboxRouterHandler) AddOutbound(w http.ResponseWriter, r *http.Reques
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{tag, outbound}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterOutboundUpdateRequest	true	"Tag + replacement outbound"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/outbounds/update [post]
 func (h *SingboxRouterHandler) UpdateOutbound(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -515,7 +749,7 @@ func (h *SingboxRouterHandler) UpdateOutbound(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // DeleteOutbound removes the composite outbound identified by tag.
@@ -526,11 +760,11 @@ func (h *SingboxRouterHandler) UpdateOutbound(w http.ResponseWriter, r *http.Req
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{tag, force}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		409		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterOutboundDeleteRequest	true	"Tag + optional force flag"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		409		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/outbounds/delete [post]
 func (h *SingboxRouterHandler) DeleteOutbound(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -549,7 +783,7 @@ func (h *SingboxRouterHandler) DeleteOutbound(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // ListPresets returns the catalog of built-in singbox-router presets.
@@ -559,8 +793,8 @@ func (h *SingboxRouterHandler) DeleteOutbound(w http.ResponseWriter, r *http.Req
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		405	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterPresetsListResponse
+//	@Failure		405	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/presets/list [get]
 func (h *SingboxRouterHandler) ListPresets(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -578,10 +812,10 @@ func (h *SingboxRouterHandler) ListPresets(w http.ResponseWriter, r *http.Reques
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{id, outbound}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterApplyPresetRequest	true	"Preset id + target outbound"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/presets/apply [post]
 func (h *SingboxRouterHandler) ApplyPreset(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -600,7 +834,7 @@ func (h *SingboxRouterHandler) ApplyPreset(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
-	response.Success(w, nil)
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // PoliciesCollection routes by HTTP method:
@@ -625,8 +859,8 @@ func (h *SingboxRouterHandler) PoliciesCollection(w http.ResponseWriter, r *http
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	map[string]interface{}
-//	@Failure		500	{object}	map[string]interface{}
+//	@Success		200	{object}	SingboxRouterPoliciesListResponse
+//	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/policies [get]
 func (h *SingboxRouterHandler) listPolicies(w http.ResponseWriter, r *http.Request) {
 	policies, err := h.svc.ListPolicies(r.Context())
@@ -648,10 +882,10 @@ func (h *SingboxRouterHandler) listPolicies(w http.ResponseWriter, r *http.Reque
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{description}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterCreatePolicyRequest	true	"Policy description"
+//	@Success		200		{object}	SingboxRouterPolicyResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/policies [post]
 func (h *SingboxRouterHandler) createPolicy(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -677,9 +911,9 @@ func (h *SingboxRouterHandler) createPolicy(w http.ResponseWriter, r *http.Reque
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			name	query		string	true	"Policy name"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	SingboxRouterPolicyDevicesListResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/policy-devices [get]
 func (h *SingboxRouterHandler) ListPolicyDevices(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -710,10 +944,10 @@ func (h *SingboxRouterHandler) ListPolicyDevices(w http.ResponseWriter, r *http.
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{mac, policyName}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterBindDeviceRequest	true	"Device MAC + target policy name"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/policy-devices/bind [post]
 func (h *SingboxRouterHandler) BindDevice(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -732,7 +966,7 @@ func (h *SingboxRouterHandler) BindDevice(w http.ResponseWriter, r *http.Request
 		response.InternalError(w, err.Error())
 		return
 	}
-	response.Success(w, map[string]any{"success": true})
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 // UnbindDevice handles POST /api/singbox/router/policy-devices/unbind
@@ -743,10 +977,10 @@ func (h *SingboxRouterHandler) BindDevice(w http.ResponseWriter, r *http.Request
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			body	body		map[string]interface{}	true	"{mac}"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			body	body		SingboxRouterUnbindDeviceRequest	true	"Device MAC"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/policy-devices/unbind [post]
 func (h *SingboxRouterHandler) UnbindDevice(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -764,7 +998,7 @@ func (h *SingboxRouterHandler) UnbindDevice(w http.ResponseWriter, r *http.Reque
 		response.InternalError(w, err.Error())
 		return
 	}
-	response.Success(w, map[string]any{"success": true})
+	response.Success(w, map[string]bool{"ok": true})
 }
 
 func decodeBody(r *http.Request, dst any) error {

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1968,6 +1968,445 @@ definitions:
         example: ipv4_only
         type: string
     type: object
+  api.SingboxRouterApplyPresetRequest:
+    properties:
+      id:
+        example: china-direct
+        type: string
+      outbound:
+        example: awg-vpn0
+        type: string
+    type: object
+  api.SingboxRouterBindDeviceRequest:
+    properties:
+      mac:
+        example: aa:bb:cc:dd:ee:ff
+        type: string
+      policyName:
+        example: Policy0
+        type: string
+    type: object
+  api.SingboxRouterCreatePolicyRequest:
+    properties:
+      description:
+        example: My VPN policy
+        type: string
+    type: object
+  api.SingboxRouterIssueDTO:
+    properties:
+      kind:
+        example: missing-outbound
+        type: string
+      message:
+        example: outbound 'selector' is referenced but does not exist
+        type: string
+      ruleIndex:
+        example: 0
+        type: integer
+      severity:
+        example: warning
+        type: string
+      tag:
+        example: selector
+        type: string
+    type: object
+  api.SingboxRouterOutboundDTO:
+    properties:
+      bind_interface:
+        example: awg-vpn0
+        type: string
+      default:
+        example: awg-vpn0
+        type: string
+      interval:
+        example: 3m
+        type: string
+      outbounds:
+        example:
+        - awg-vpn0
+        items:
+          type: string
+        type: array
+      strategy:
+        example: prefer_ipv4
+        type: string
+      tag:
+        example: my-selector
+        type: string
+      tolerance:
+        example: 50
+        type: integer
+      type:
+        example: selector
+        type: string
+      url:
+        example: https://www.gstatic.com/generate_204
+        type: string
+    type: object
+  api.SingboxRouterOutboundDeleteRequest:
+    properties:
+      force:
+        example: false
+        type: boolean
+      tag:
+        example: my-selector
+        type: string
+    type: object
+  api.SingboxRouterOutboundUpdateRequest:
+    properties:
+      outbound:
+        $ref: '#/definitions/api.SingboxRouterOutboundDTO'
+      tag:
+        example: my-selector
+        type: string
+    type: object
+  api.SingboxRouterOutboundsListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterOutboundDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterPoliciesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterPolicyInfoDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterPolicyDeviceDTO:
+    properties:
+      bound:
+        example: true
+        type: boolean
+      ip:
+        example: 192.168.1.100
+        type: string
+      mac:
+        example: aa:bb:cc:dd:ee:ff
+        type: string
+      name:
+        example: My Phone
+        type: string
+    type: object
+  api.SingboxRouterPolicyDevicesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterPolicyDeviceDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterPolicyInfoDTO:
+    properties:
+      description:
+        example: Default policy
+        type: string
+      deviceCount:
+        example: 3
+        type: integer
+      isOurDefault:
+        example: false
+        type: boolean
+      mark:
+        example: "0xffffaaa"
+        type: string
+      name:
+        example: Policy0
+        type: string
+    type: object
+  api.SingboxRouterPolicyResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxRouterPolicyInfoDTO'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterPresetDTO:
+    properties:
+      featured:
+        example: true
+        type: boolean
+      iconSlug:
+        example: china
+        type: string
+      id:
+        example: china-direct
+        type: string
+      name:
+        example: China Direct
+        type: string
+      notice:
+        example: Routes mainland China traffic via the direct outbound.
+        type: string
+      ruleSets:
+        items:
+          $ref: '#/definitions/api.SingboxRouterPresetRuleRefDTO'
+        type: array
+      rules:
+        items:
+          $ref: '#/definitions/api.SingboxRouterPresetRuleLinkDTO'
+        type: array
+      sensitive:
+        example: false
+        type: boolean
+    type: object
+  api.SingboxRouterPresetRuleLinkDTO:
+    properties:
+      action:
+        example: route
+        type: string
+      domain_suffix:
+        example:
+        - .cn
+        items:
+          type: string
+        type: array
+      rule_set:
+        example:
+        - geosite-cn
+        items:
+          type: string
+        type: array
+    type: object
+  api.SingboxRouterPresetRuleRefDTO:
+    properties:
+      tag:
+        example: geosite-cn
+        type: string
+    type: object
+  api.SingboxRouterPresetsListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterPresetDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterRuleDTO:
+    properties:
+      action:
+        example: route
+        type: string
+      domain_suffix:
+        example:
+        - .example.com
+        items:
+          type: string
+        type: array
+      ip_cidr:
+        example:
+        - 10.0.0.0/8
+        items:
+          type: string
+        type: array
+      outbound:
+        example: selector
+        type: string
+      port:
+        example:
+        - 443
+        items:
+          type: integer
+        type: array
+      protocol:
+        example: tcp
+        type: string
+      rule_set:
+        example:
+        - geosite-cn
+        items:
+          type: string
+        type: array
+      source_ip_cidr:
+        example:
+        - 192.168.1.100/32
+        items:
+          type: string
+        type: array
+    type: object
+  api.SingboxRouterRuleDeleteRequest:
+    properties:
+      index:
+        example: 0
+        type: integer
+    type: object
+  api.SingboxRouterRuleMoveRequest:
+    properties:
+      from:
+        example: 3
+        type: integer
+      to:
+        example: 0
+        type: integer
+    type: object
+  api.SingboxRouterRuleSetDTO:
+    properties:
+      download_detour:
+        example: direct
+        type: string
+      format:
+        example: binary
+        type: string
+      path:
+        example: /opt/etc/singbox/rulesets/geosite-cn.srs
+        type: string
+      tag:
+        example: geosite-cn
+        type: string
+      type:
+        example: remote
+        type: string
+      update_interval:
+        example: 24h
+        type: string
+      url:
+        example: https://cdn.example.com/geosite-cn.srs
+        type: string
+    type: object
+  api.SingboxRouterRuleSetDeleteRequest:
+    properties:
+      force:
+        example: false
+        type: boolean
+      tag:
+        example: geosite-cn
+        type: string
+    type: object
+  api.SingboxRouterRuleSetRefreshRequest:
+    properties:
+      tag:
+        example: geosite-cn
+        type: string
+    type: object
+  api.SingboxRouterRuleSetsListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterRuleSetDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterRuleUpdateRequest:
+    properties:
+      index:
+        example: 0
+        type: integer
+      rule:
+        $ref: '#/definitions/api.SingboxRouterRuleDTO'
+    type: object
+  api.SingboxRouterRulesListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.SingboxRouterRuleDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterSettingsData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      policyName:
+        example: awgm-router
+        type: string
+      refreshDailyTime:
+        example: "03:00"
+        type: string
+      refreshIntervalHours:
+        example: 24
+        type: integer
+      refreshMode:
+        example: interval
+        type: string
+    type: object
+  api.SingboxRouterSettingsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxRouterSettingsData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterStatusData:
+    properties:
+      deviceCount:
+        example: 3
+        type: integer
+      enabled:
+        example: true
+        type: boolean
+      final:
+        example: direct
+        type: string
+      installed:
+        example: true
+        type: boolean
+      issues:
+        items:
+          $ref: '#/definitions/api.SingboxRouterIssueDTO'
+        type: array
+      netfilterAvailable:
+        example: true
+        type: boolean
+      netfilterComponentName:
+        example: iptables-mod-tproxy
+        type: string
+      outboundAwgCount:
+        example: 2
+        type: integer
+      outboundCompositeCount:
+        example: 1
+        type: integer
+      policyExists:
+        example: true
+        type: boolean
+      policyMark:
+        example: "0xffffaaa"
+        type: string
+      policyName:
+        example: awgm-router
+        type: string
+      ruleCount:
+        example: 12
+        type: integer
+      ruleSetCount:
+        example: 4
+        type: integer
+      tproxyTargetAvailable:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxRouterStatusData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.SingboxRouterUnbindDeviceRequest:
+    properties:
+      mac:
+        example: aa:bb:cc:dd:ee:ff
+        type: string
+    type: object
   api.SingboxStatusData:
     properties:
       features:
@@ -5943,18 +6382,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Disable singbox-router
@@ -6346,23 +6782,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Enable singbox-router
@@ -6375,31 +6807,27 @@ paths:
       description: Creates a new composite outbound. The base outbounds it references
         must already exist.
       parameters:
-      - description: router.Outbound
+      - description: Composite outbound payload
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterOutboundDTO'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add singbox-router outbound
@@ -6412,36 +6840,31 @@ paths:
       description: Removes the composite outbound identified by tag. Refuses if any
         rule references it; pass force=true to override.
       parameters:
-      - description: '{tag, force}'
+      - description: Tag + optional force flag
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterOutboundDeleteRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "409":
           description: Conflict
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete singbox-router outbound
@@ -6457,18 +6880,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterOutboundsListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router outbounds
@@ -6481,31 +6901,27 @@ paths:
       description: Replaces the composite outbound identified by tag with the provided
         one.
       parameters:
-      - description: '{tag, outbound}'
+      - description: Tag + replacement outbound
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterOutboundUpdateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update singbox-router outbound
@@ -6521,13 +6937,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterPoliciesListResponse'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router policies
@@ -6539,31 +6953,27 @@ paths:
       description: Creates a new NDMS policy with the given description. Returns the
         created policy.
       parameters:
-      - description: '{description}'
+      - description: Policy description
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterCreatePolicyRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterPolicyResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Create singbox-router policy
@@ -6585,18 +6995,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterPolicyDevicesListResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router policy devices
@@ -6609,31 +7016,27 @@ paths:
       description: Binds the LAN device (MAC) to the named policy. Replaces any existing
         binding.
       parameters:
-      - description: '{mac, policyName}'
+      - description: Device MAC + target policy name
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterBindDeviceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Bind device to singbox-router policy
@@ -6645,31 +7048,27 @@ paths:
       - application/json
       description: Removes any policy binding for the LAN device identified by MAC.
       parameters:
-      - description: '{mac}'
+      - description: Device MAC
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterUnbindDeviceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Unbind device from singbox-router policy
@@ -6682,31 +7081,27 @@ paths:
       description: Materialises the preset (id) into rules + rulesets, routing matched
         traffic via the selected outbound. Existing rules with the same tag are overwritten.
       parameters:
-      - description: '{id, outbound}'
+      - description: Preset id + target outbound
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterApplyPresetRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Apply singbox-router preset
@@ -6722,13 +7117,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterPresetsListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router presets
@@ -6741,31 +7134,27 @@ paths:
       description: Appends a new routing rule. Rule conditions reference rulesets/outbounds
         that must already exist.
       parameters:
-      - description: router.Rule
+      - description: Routing rule payload
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleDTO'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add singbox-router rule
@@ -6777,31 +7166,27 @@ paths:
       - application/json
       description: Removes the rule at the given index (0-based priority slot).
       parameters:
-      - description: '{index}'
+      - description: Index of the rule to remove
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleDeleteRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete singbox-router rule
@@ -6816,18 +7201,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterRulesListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router rules
@@ -6840,31 +7222,27 @@ paths:
       description: Moves the rule from index `from` to index `to` (both 0-based).
         Adjusts other rules' indices accordingly.
       parameters:
-      - description: '{from, to}'
+      - description: From-index and to-index
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleMoveRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Move singbox-router rule
@@ -6877,31 +7255,27 @@ paths:
       description: Replaces the rule at index with the provided one. Index is the
         priority slot (0-based).
       parameters:
-      - description: '{index, rule}'
+      - description: Index + replacement rule
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleUpdateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update singbox-router rule
@@ -6914,31 +7288,27 @@ paths:
       description: Registers a new ruleset. For remote rulesets the file is downloaded
         synchronously.
       parameters:
-      - description: router.RuleSet
+      - description: RuleSet payload
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleSetDTO'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Add singbox-router ruleset
@@ -6951,36 +7321,31 @@ paths:
       description: Removes the ruleset identified by tag. Refuses if any rule references
         it; pass force=true to ignore references.
       parameters:
-      - description: '{tag, force}'
+      - description: Tag + optional force flag
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleSetDeleteRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "409":
           description: Conflict
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Delete singbox-router ruleset
@@ -6996,18 +7361,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterRuleSetsListResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: List singbox-router rulesets
@@ -7020,31 +7382,27 @@ paths:
       description: Re-downloads the remote ruleset identified by tag and updates its
         content/timestamp.
       parameters:
-      - description: '{tag}'
+      - description: Ruleset tag to re-download
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterRuleSetRefreshRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Refresh singbox-router ruleset
@@ -7060,18 +7418,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterSettingsResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get singbox-router settings
@@ -7083,36 +7438,31 @@ paths:
       description: Persists singbox-router settings. The router is restarted only
         when fields that affect the running config change.
       parameters:
-      - description: storage.SingboxRouterSettings
+      - description: Singbox-router settings payload
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterSettingsData'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update singbox-router settings
@@ -7124,36 +7474,31 @@ paths:
       description: Persists singbox-router settings. The router is restarted only
         when fields that affect the running config change.
       parameters:
-      - description: storage.SingboxRouterSettings
+      - description: Singbox-router settings payload
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
-          type: object
+          $ref: '#/definitions/api.SingboxRouterSettingsData'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Update singbox-router settings
@@ -7169,18 +7514,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.SingboxRouterStatusResponse'
         "405":
           description: Method Not Allowed
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get sing-box router status


### PR DESCRIPTION
## Сводка

**Финальный PR в swagger-sweep'е.** Закрывает домен `singbox-router` — заменяет все 92 generic `map[string]interface{}` аннотации в `singbox_router.go` (26 хендлеров: status / settings / rules / rulesets / outbounds / presets / policies / policy-devices) типизированными DTO. После мерджа во всём `internal/api/*.go` остаётся **0 generic** аннотаций; Prism mock возвращает реалистичный JSON для каждого эндпоинта в spec'е.

## Итог всего sweep'а

| PR | Файл(ы) | Generic |
|---|---|---:|
| #21 | `accesspolicy.go` | 25 |
| #22 | `awg_outbounds`/`settings`/`servers`/`singbox`/`hydraroute` | 18 |
| #23 | `managed.go` + `managed_peers.go` | 57 |
| #24 | `singbox_router_dns.go` | 43 |
| **этот** | `singbox_router.go` | **92** |
| **Итого** | | **235 → 0** |

## Новые типы (31 schema)

**Status / Settings:**
- `SingboxRouterStatusData` / `SingboxRouterStatusResponse` + nested `SingboxRouterIssueDTO`
- `SingboxRouterSettingsData` / `SingboxRouterSettingsResponse`

**Rules:**
- `SingboxRouterRuleDTO` / `SingboxRouterRulesListResponse`
- `SingboxRouterRuleUpdateRequest{Index, Rule}` / `SingboxRouterRuleDeleteRequest{Index}` / `SingboxRouterRuleMoveRequest{From, To}`

**RuleSets:**
- `SingboxRouterRuleSetDTO` / `SingboxRouterRuleSetsListResponse`
- `SingboxRouterRuleSetDeleteRequest{Tag, Force}` / `SingboxRouterRuleSetRefreshRequest{Tag}`

**Outbounds:**
- `SingboxRouterOutboundDTO` / `SingboxRouterOutboundsListResponse`
- `SingboxRouterOutboundUpdateRequest{Tag, Outbound}` / `SingboxRouterOutboundDeleteRequest{Tag, Force}`

**Presets:**
- `SingboxRouterPresetDTO` / `SingboxRouterPresetsListResponse` + nested `SingboxRouterPresetRuleRefDTO` / `SingboxRouterPresetRuleLinkDTO`
- `SingboxRouterApplyPresetRequest{ID, Outbound}`

**Policies:**
- `SingboxRouterPolicyInfoDTO` / `SingboxRouterPoliciesListResponse` / `SingboxRouterPolicyResponse`
- `SingboxRouterCreatePolicyRequest{Description}`

**Policy devices:**
- `SingboxRouterPolicyDeviceDTO` / `SingboxRouterPolicyDevicesListResponse`
- `SingboxRouterBindDeviceRequest{MAC, PolicyName}` / `SingboxRouterUnbindDeviceRequest{MAC}`

## Поведенческое выравнивание

Все 16 mutation handlers до этого PR возвращали **либо `data: null`, либо `{success: true}`** (последнее — двойная обёртка: `response.Success` сам заворачивает в `{success, data}`, поэтому реально шёл `{success: true, data: {success: true}}` — фронт всё равно никогда не смотрел в `data.success`). Выровнял все 16 на общий `OkResponse{ok: true}` shape. Фронт игнорирует тело на каждом из 16 вызовов (`await this.request(...)` без сохранения, потом `refetch`), так что изменение wire-only — UI трогать не нужно.

## OpenAPI

- `internal/openapi/swagger.yaml` регенерирован через `go generate`. Добавились 31 новый schema. После мерджа `additionalProperties: {}` в spec'е больше нигде не остаётся

## Проверки

- `go build ./...` — clean
- `go vet ./...` — clean
- `go generate ./cmd/awg-manager` — clean
- Локальный Prism mock на `:8080`:
  - `GET /singbox/router/status` → реалистичная `StatusData` с примером `Issue` (`severity: warning`, `kind: missing-outbound`, `message: "outbound 'selector' is referenced but does not exist"`)
  - `GET /singbox/router/rules/list` → массив с типизированным `RuleDTO`
  - `GET /singbox/router/presets/list` → каталог с nested `RuleRefDTO` / `RuleLinkDTO`
  - `GET /singbox/router/policies` → массив `PolicyInfoDTO`