### PR TITLE
feat(systemtunnels): typed swagger DTOs (sweep gap fix)

### DIFF
--- a/internal/api/systemtunnels.go
+++ b/internal/api/systemtunnels.go
@@ -175,14 +175,14 @@ func (h *SystemTunnelsHandler) ASC(w http.ResponseWriter, r *http.Request) {
 // getASC reads AWG signature/obfuscation params for a system tunnel.
 //
 //	@Summary		Get system tunnel ASC params
-//	@Description	Reads AWG signature/obfuscation parameters for the named system (NativeWG / kernel-WG) tunnel.
+//	@Description	Reads AWG signature/obfuscation parameters for the named system (NativeWG / kernel-WG) tunnel. Data is the raw signature preset object whose shape depends on the active preset.
 //	@Tags			system-tunnels
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			name	query		string	true	"Tunnel name"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Success		200		{object}	ASCParamsResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/system-tunnels/asc [get]
 func (h *SystemTunnelsHandler) getASC(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")
@@ -200,16 +200,16 @@ func (h *SystemTunnelsHandler) getASC(w http.ResponseWriter, r *http.Request) {
 // setASC writes AWG signature/obfuscation params for a system tunnel.
 //
 //	@Summary		Set system tunnel ASC params
-//	@Description	Persists AWG signature/obfuscation parameters for the named system tunnel. Body is the raw ASC JSON object.
+//	@Description	Persists AWG signature/obfuscation parameters for the named system tunnel. Body is the raw ASC JSON object whose shape depends on the active signature preset.
 //	@Tags			system-tunnels
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Param			name	query		string					true	"Tunnel name"
-//	@Param			body	body		map[string]interface{}	true	"ASC params"
-//	@Success		200		{object}	map[string]interface{}
-//	@Failure		400		{object}	map[string]interface{}
-//	@Failure		500		{object}	map[string]interface{}
+//	@Param			name	query		string	true	"Tunnel name"
+//	@Param			body	body		object	true	"ASC params object"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/system-tunnels/asc [post]
 func (h *SystemTunnelsHandler) setASC(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -7919,7 +7919,8 @@ paths:
   /system-tunnels/asc:
     get:
       description: Reads AWG signature/obfuscation parameters for the named system
-        (NativeWG / kernel-WG) tunnel.
+        (NativeWG / kernel-WG) tunnel. Data is the raw signature preset object whose
+        shape depends on the active preset.
       parameters:
       - description: Tunnel name
         in: query
@@ -7932,18 +7933,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.ASCParamsResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Get system tunnel ASC params
@@ -7953,19 +7951,19 @@ paths:
       consumes:
       - application/json
       description: Persists AWG signature/obfuscation parameters for the named system
-        tunnel. Body is the raw ASC JSON object.
+        tunnel. Body is the raw ASC JSON object whose shape depends on the active
+        signature preset.
       parameters:
       - description: Tunnel name
         in: query
         name: name
         required: true
         type: string
-      - description: ASC params
+      - description: ASC params object
         in: body
         name: body
         required: true
         schema:
-          additionalProperties: true
           type: object
       produces:
       - application/json
@@ -7973,18 +7971,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
       summary: Set system tunnel ASC params


### PR DESCRIPTION
## Сводка

Закрывает 7 generic `map[string]interface{}` аннотаций на ASC-эндпоинтах `system-tunnels` (`getASC` + `setASC`), которые проскочили мимо 5 PR'ов sweep'а (#21-#25). После мерджа во всём `internal/api/*.go` — **0 generic** аннотаций end-to-end.

## Что меняется

Оба хендлера переиспользуют типы, добавленные в прошлых sweep PR'ах — без новых схем:

- **`getASC`** → `@Success` указывает на `ASCParamsResponse` (тот же тип, что используется для managed-server ASC GET). Семантика идентичная — `data` это opaque object signature preset'а
- **`setASC`** → `@Param body` указывает на `object` (raw signature-preset payload, как в managed-server ASC PUT); `@Success` указывает на `OkResponse`. Хендлер уже возвращал `{ok: true}`, так что behavior change нет

## OpenAPI

- `internal/openapi/swagger.yaml` регенерирован, без новых schemas (типы уже в spec'е).

## Итог всего sweep'а

| PR | Файл(ы) | Generic |
|---|---|---:|
| #21 | `accesspolicy.go` | 25 |
| #22 | 5 small files | 18 |
| #23 | `managed.go` + `managed_peers.go` | 57 |
| #24 | `singbox_router_dns.go` | 43 |
| #25 | `singbox_router.go` | 92 |
| **этот** | `systemtunnels.go` | 7 |
| **Итого** | | **242 → 0** |