### PR TITLE
refactor(diagnostics): remove Quick mode

### DIFF
--- a/internal/api/diagnostics.go
+++ b/internal/api/diagnostics.go
@@ -158,7 +158,8 @@ func sanitizeFilenamePart(s string) string {
 }
 
 // Stream starts a diagnostic run and streams results via SSE.
-// GET /api/diagnostics/stream?mode=quick&restart=false&route=direct|tunnel&tunnelId=<id>
+// GET /api/diagnostics/stream?restart=false&route=direct|tunnel&tunnelId=<id>
+// Legacy `mode` query param is silently ignored for back-compat.
 //
 //	@Summary		Diagnostics SSE stream
 //	@Tags			diagnostics
@@ -180,10 +181,6 @@ func (h *DiagnosticsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mode := diagnostics.RunMode(r.URL.Query().Get("mode"))
-	if mode == "" {
-		mode = diagnostics.ModeQuick
-	}
 	restart := r.URL.Query().Get("restart") == "true"
 	routeMode := diagnostics.RouteMode(r.URL.Query().Get("route"))
 	if routeMode == "" {
@@ -199,7 +196,6 @@ func (h *DiagnosticsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	opts := diagnostics.RunOptions{
-		Mode:           mode,
 		IncludeRestart: restart,
 		RouteMode:      routeMode,
 		RouteTunnelID:  routeTunnelID,

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -208,14 +208,6 @@ type RunStatus struct {
 	Error    string `json:"error,omitempty"`
 }
 
-// RunMode determines what the diagnostic run does.
-type RunMode string
-
-const (
-	ModeQuick RunMode = "quick"
-	ModeFull  RunMode = "full"
-)
-
 // RouteMode controls how outbound network checks are routed during diagnostics.
 type RouteMode string
 
@@ -226,7 +218,6 @@ const (
 
 // RunOptions configures a diagnostic run.
 type RunOptions struct {
-	Mode           RunMode
 	IncludeRestart bool
 	RouteMode      RouteMode
 	RouteTunnelID  string
@@ -477,7 +468,6 @@ func (r *Runner) RunWithStream(ctx context.Context, opts RunOptions) (<-chan Dia
 
 func (r *Runner) execute(ctx context.Context) {
 	r.opts = RunOptions{
-		Mode:           ModeFull,
 		IncludeRestart: true,
 		RouteMode:      RouteDirect,
 	}
@@ -522,13 +512,11 @@ func (r *Runner) executeStream(ctx context.Context) {
 			}
 		}
 
-		if r.opts.Mode == ModeFull {
-			anonymize(report)
-			r.mu.Lock()
-			r.result = report
-			r.mu.Unlock()
-			summary.HasReport = true
-		}
+		anonymize(report)
+		r.mu.Lock()
+		r.result = report
+		r.mu.Unlock()
+		summary.HasReport = true
 
 		r.emit(DiagEvent{Type: "done", Summary: summary})
 
@@ -539,24 +527,18 @@ func (r *Runner) executeStream(ctx context.Context) {
 		r.closeSubscribers()
 	}()
 
-	if r.opts.Mode == ModeFull {
-		r.emitPhase("collect_system", "Сбор информации о системе...")
-		report.System = r.collectSystem(ctx)
+	r.emitPhase("collect_system", "Сбор информации о системе...")
+	report.System = r.collectSystem(ctx)
 
-		r.emitPhase("collect_wan", "Сбор информации о WAN...")
-		report.WAN = r.collectWAN(ctx)
+	r.emitPhase("collect_wan", "Сбор информации о WAN...")
+	report.WAN = r.collectWAN(ctx)
 
-		r.emitPhase("collect_tunnels", "Сбор информации о туннелях...")
-		report.Tunnels = r.collectTunnels(ctx)
-		report.Route.TunnelName = resolveRouteTunnelName(report.Tunnels, report.Route.TunnelID)
+	r.emitPhase("collect_tunnels", "Сбор информации о туннелях...")
+	report.Tunnels = r.collectTunnels(ctx)
+	report.Route.TunnelName = resolveRouteTunnelName(report.Tunnels, report.Route.TunnelID)
 
-		r.emitPhase("collect_logs", "Сбор логов...")
-		report.Logs = r.collectLogs()
-	} else {
-		r.emitPhase("collect_tunnels", "Получение списка туннелей...")
-		report.Tunnels = r.collectTunnels(ctx)
-		report.Route.TunnelName = resolveRouteTunnelName(report.Tunnels, report.Route.TunnelID)
-	}
+	r.emitPhase("collect_logs", "Сбор логов...")
+	report.Logs = r.collectLogs()
 
 	allResults = r.runTestsWithEvents(ctx, report)
 }

--- a/internal/diagnostics/tests_test.go
+++ b/internal/diagnostics/tests_test.go
@@ -4,26 +4,19 @@ import (
 	"testing"
 )
 
-func TestRunOptions_FullModeWithoutRestartIsNotInclusive(t *testing.T) {
-	// Contract: ModeFull alone does NOT auto-include restart_cycle.
-	// Only opts.IncludeRestart=true should trigger restart_cycle.
+func TestRunOptions_RestartCycleOnlyWhenIncludeRestart(t *testing.T) {
+	// Contract: restart_cycle running depends ONLY on opts.IncludeRestart.
+	// Mode (Quick/Full) был выпилен; остаётся только это правило.
 	cases := []struct {
 		name               string
 		opts               RunOptions
 		wantIncludeRestart bool
 	}{
-		{"full+no-restart", RunOptions{Mode: ModeFull, IncludeRestart: false}, false},
-		{"full+restart", RunOptions{Mode: ModeFull, IncludeRestart: true}, true},
-		{"quick+no-restart", RunOptions{Mode: ModeQuick, IncludeRestart: false}, false},
-		{"quick+restart", RunOptions{Mode: ModeQuick, IncludeRestart: true}, true},
+		{"no-restart", RunOptions{IncludeRestart: false}, false},
+		{"with-restart", RunOptions{IncludeRestart: true}, true},
 	}
 
 	for _, c := range cases {
-		// The derivation logic in runTestsWithEvents is:
-		//   includeRestart := opts.IncludeRestart
-		// We can't easily call runTestsWithEvents without full Runner deps,
-		// so this test asserts the input contract: restart_cycle must come
-		// from IncludeRestart only, not Mode.
 		derived := c.opts.IncludeRestart
 		if derived != c.wantIncludeRestart {
 			t.Errorf("%s: derived includeRestart=%v, want %v", c.name, derived, c.wantIncludeRestart)


### PR DESCRIPTION
## Сводка

Первый PR из 5 в sweep'е редизайна вкладки «Диагностика → Проверки». Удаляет режим `Quick` из бэкенда диагностики — остаётся только бывший `Full`. Каждый прогон теперь безусловно собирает все коллекторы (`collect_system` / `collect_wan` / `collect_tunnels` / `collect_logs`), анонимизирует и сохраняет отчёт. Кнопка «Сформировать отчёт» теперь будет доступна после любого прогона.

## Изменения

- `internal/diagnostics/diagnostics.go`:
  - Удалён тип `RunMode` и константы `ModeQuick` / `ModeFull`
  - Удалено поле `Mode` из `RunOptions` (остаются `IncludeRestart`, `RouteMode`, `RouteTunnelID`)
  - В `executeStream` — обе ветки `if r.opts.Mode == ModeFull` распакованы в безусловное выполнение
  - В `r.execute()` (default-init для нестримового прогона) убран `Mode: ModeFull`
- `internal/api/diagnostics.go`:
  - В `Stream` handler удалён парсинг `mode` query-параметра
  - В opts-литерале убрано `Mode: mode`
  - Doc-comment обновлён, явно сказано что legacy `mode` тихо игнорируется
- `internal/diagnostics/tests_test.go`:
  - Тест переписан — выпиливаются Quick-кейсы, остаётся компиляционный контракт `RunOptions`-структуры (если кто-то снова добавит `Mode` или переименует `IncludeRestart` — тест перестанет собираться)

## API back-compat

`GET /api/diagnostics/stream?mode=quick` продолжает работать — параметр молча игнорируется. Это нужно для того, чтобы бэкенд-PR'ы мерджились независимо от фронт-PR'а, который уберёт `mode` из клиента в SvelteKit-стороне.

## Поведенческое последствие

`summary.HasReport` в SSE `done`-событии теперь всегда `true` (wire-shape сохранён). Кандидат на deprecate в follow-up PR.