### PR TITLE
feat(diagnostics): add BootHealth collector

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -20,8 +20,9 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/accesspolicy"
 	"github.com/hoaxisr/awg-manager/internal/api"
-	"github.com/hoaxisr/awg-manager/internal/deviceproxy"
 	"github.com/hoaxisr/awg-manager/internal/auth"
+	"github.com/hoaxisr/awg-manager/internal/diagnostics"
+	"github.com/hoaxisr/awg-manager/internal/deviceproxy"
 	"github.com/hoaxisr/awg-manager/internal/cleanup"
 	"github.com/hoaxisr/awg-manager/internal/clientroute"
 	"github.com/hoaxisr/awg-manager/internal/connectivity"
@@ -111,6 +112,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to create data dir: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Record the exact moment main() enters the daemon path so BootHealth
+	// can compute uptime accurately. Must happen before any goroutines start.
+	diagnostics.SetProcessStartedAt(time.Now())
 
 	uptime := getUptime()
 

--- a/internal/diagnostics/collectors.go
+++ b/internal/diagnostics/collectors.go
@@ -580,3 +580,101 @@ func sanitizeConfig(stored *storage.AWGTunnel) string {
 	}
 	return sb.String()
 }
+
+// bootHealthInput is the per-tunnel slice needed by computeBootHealth.
+// Extracted from awgStore + stateMgr; isolated into its own struct so
+// computeBootHealth can be tested without mocks.
+type bootHealthInput struct {
+	ID              string
+	Name            string
+	Backend         string
+	Enabled         bool
+	AutoStart       bool
+	Status          string // "running" | "stopped" | etc.
+	StoredStartedAt string // RFC3339, may be empty
+}
+
+// bootHealthGracePeriod is how many seconds after daemon start we wait
+// before considering an enabled tunnel "not started".
+const bootHealthGracePeriod = 120
+
+// computeBootHealth is a pure function that computes BootHealth from inputs.
+// No I/O — all required data is passed in bootHealthInput.
+// This allows logic to be tested in isolation.
+func computeBootHealth(inputs []bootHealthInput) BootHealth {
+	now := time.Now()
+	uptimeSec := int(now.Sub(processStartedAt).Seconds())
+
+	bh := BootHealth{
+		DaemonStartedAt: processStartedAt,
+		DaemonUptimeSec: uptimeSec,
+		GracePeriodSec:  bootHealthGracePeriod,
+	}
+
+	expectedSet := make(map[string]bootHealthInput)
+	for _, in := range inputs {
+		if in.Enabled && in.AutoStart {
+			bh.ExpectedRunning = append(bh.ExpectedRunning, in.ID)
+			expectedSet[in.ID] = in
+		}
+		if in.Status == "running" {
+			bh.ActualRunning = append(bh.ActualRunning, in.ID)
+		}
+	}
+
+	if uptimeSec < bootHealthGracePeriod {
+		// grace period not yet elapsed — do not draw conclusions
+		return bh
+	}
+
+	actualSet := make(map[string]bool)
+	for _, id := range bh.ActualRunning {
+		actualSet[id] = true
+	}
+
+	for id, in := range expectedSet {
+		if actualSet[id] {
+			continue
+		}
+		bh.NotStartedOnBoot = append(bh.NotStartedOnBoot, TunnelBootIssue{
+			TunnelID:        in.ID,
+			TunnelName:      in.Name,
+			Backend:         in.Backend,
+			Enabled:         in.Enabled,
+			AutoStart:       in.AutoStart,
+			StoredStartedAt: in.StoredStartedAt,
+			Reason:          "never_started",
+		})
+	}
+
+	return bh
+}
+
+// collectBootHealth assembles a per-tunnel snapshot and computes BootHealth.
+// Uses TunnelService.List for state + TunnelStore for StartedAt.
+func (r *Runner) collectBootHealth(ctx context.Context) BootHealth {
+	tunnels, err := r.deps.TunnelService.List(ctx)
+	if err != nil {
+		// service unavailable — return minimally populated BootHealth
+		return computeBootHealth(nil)
+	}
+
+	inputs := make([]bootHealthInput, 0, len(tunnels))
+	for _, t := range tunnels {
+		var startedAt string
+		if stored, _ := r.deps.TunnelStore.Get(t.ID); stored != nil {
+			startedAt = stored.StartedAt
+		}
+		inputs = append(inputs, bootHealthInput{
+			ID:              t.ID,
+			Name:            t.Name,
+			Backend:         t.Backend,
+			Enabled:         t.Enabled,
+			AutoStart:       t.AutoStart,
+			Status:          t.State.String(),
+			StoredStartedAt: startedAt,
+		})
+	}
+
+	return computeBootHealth(inputs)
+}

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -27,6 +27,7 @@ type Report struct {
 	Route       RouteInfoMeta      `json:"route"`
 	System      SystemInfo         `json:"system"`
 	WAN         WANInfo            `json:"wan"`
+	BootHealth  BootHealth         `json:"bootHealth"`
 	Tunnels     []TunnelInfo       `json:"tunnels"`
 	Tests       []TestResult       `json:"tests"`
 	Logs        []logging.LogEntry `json:"logs"`
@@ -70,6 +71,27 @@ type WANInfo struct {
 type WANIfaceInfo struct {
 	Up    bool   `json:"up"`
 	Label string `json:"label"`
+}
+
+// BootHealth детектит регрессию "enabled-туннели не были перезапущены
+// при старте демона". Заполняется collectBootHealth.
+type BootHealth struct {
+	DaemonStartedAt  time.Time         `json:"daemonStartedAt"`
+	DaemonUptimeSec  int               `json:"daemonUptimeSec"`
+	GracePeriodSec   int               `json:"gracePeriodSec"`
+	ExpectedRunning  []string          `json:"expectedRunning"`
+	ActualRunning    []string          `json:"actualRunning"`
+	NotStartedOnBoot []TunnelBootIssue `json:"notStartedOnBoot,omitempty"`
+}
+
+type TunnelBootIssue struct {
+	TunnelID        string `json:"tunnelId"`
+	TunnelName      string `json:"tunnelName"`
+	Backend         string `json:"backend"`
+	Enabled         bool   `json:"enabled"`
+	AutoStart       bool   `json:"autoStart"`
+	StoredStartedAt string `json:"storedStartedAt,omitempty"`
+	Reason          string `json:"reason"` // "never_started"
 }
 
 // TunnelInfo contains per-tunnel diagnostics.
@@ -215,6 +237,19 @@ const (
 	RouteDirect RouteMode = "direct"
 	RouteTunnel RouteMode = "tunnel"
 )
+
+// processStartedAt записывает момент старта процесса демона. Используется
+// collectBootHealth чтобы понимать прошёл ли grace-период с boot.
+// По умолчанию инициализируется временем импорта пакета (это близко к
+// старту демона, потому что main.go импортирует пакет рано). Чтобы зафиксировать
+// точный момент старта main, вызови SetProcessStartedAt(time.Now()) из main.go.
+var processStartedAt = time.Now()
+
+// SetProcessStartedAt позволяет main установить точное время старта.
+// Тесты могут вызывать с фиксированным временем для детерминированности.
+func SetProcessStartedAt(t time.Time) {
+	processStartedAt = t
+}
 
 // RunOptions configures a diagnostic run.
 type RunOptions struct {
@@ -532,6 +567,9 @@ func (r *Runner) executeStream(ctx context.Context) {
 
 	r.emitPhase("collect_wan", "Сбор информации о WAN...")
 	report.WAN = r.collectWAN(ctx)
+
+	r.emitPhase("collect_boot_health", "Проверка boot-состояния...")
+	report.BootHealth = r.collectBootHealth(ctx)
 
 	r.emitPhase("collect_tunnels", "Сбор информации о туннелях...")
 	report.Tunnels = r.collectTunnels(ctx)

--- a/internal/diagnostics/tests_test.go
+++ b/internal/diagnostics/tests_test.go
@@ -2,6 +2,7 @@ package diagnostics
 
 import (
 	"testing"
+	"time"
 )
 
 func TestRunOptions_RestartCycleOnlyWhenIncludeRestart(t *testing.T) {
@@ -21,5 +22,95 @@ func TestRunOptions_RestartCycleOnlyWhenIncludeRestart(t *testing.T) {
 		if derived != c.wantIncludeRestart {
 			t.Errorf("%s: derived includeRestart=%v, want %v", c.name, derived, c.wantIncludeRestart)
 		}
+	}
+}
+
+func TestBootHealth_GraceNotElapsed(t *testing.T) {
+	// daemon только что стартовал — grace ещё не вышел, NotStartedOnBoot пусто.
+	old := processStartedAt
+	defer func() { processStartedAt = old }()
+	processStartedAt = time.Now() // 0 секунд назад
+
+	bh := computeBootHealth(
+		[]bootHealthInput{
+			{ID: "wg1", Name: "wg1", Backend: "kernel", Enabled: true, AutoStart: true,
+				Status: "stopped", StoredStartedAt: ""},
+		},
+	)
+
+	if bh.DaemonUptimeSec >= bh.GracePeriodSec {
+		t.Fatalf("test setup invalid: uptime %d >= grace %d",
+			bh.DaemonUptimeSec, bh.GracePeriodSec)
+	}
+	if len(bh.NotStartedOnBoot) != 0 {
+		t.Errorf("expected empty NotStartedOnBoot during grace, got %v", bh.NotStartedOnBoot)
+	}
+}
+
+func TestBootHealth_GraceElapsed_NeverStarted(t *testing.T) {
+	// grace вышел, enabled+autoStart-туннель не running => never_started issue.
+	old := processStartedAt
+	defer func() { processStartedAt = old }()
+	processStartedAt = time.Now().Add(-200 * time.Second) // > 120 grace
+
+	bh := computeBootHealth(
+		[]bootHealthInput{
+			{ID: "wg1", Name: "wg1", Backend: "kernel", Enabled: true, AutoStart: true,
+				Status: "stopped", StoredStartedAt: ""},
+			{ID: "wg2", Name: "wg2", Backend: "nativewg", Enabled: true, AutoStart: true,
+				Status: "running", StoredStartedAt: time.Now().Format(time.RFC3339)},
+		},
+	)
+
+	if got := bh.GracePeriodSec; got != 120 {
+		t.Errorf("GracePeriodSec=%d, want 120", got)
+	}
+	if got := len(bh.ExpectedRunning); got != 2 {
+		t.Errorf("ExpectedRunning len=%d, want 2", got)
+	}
+	if got := len(bh.ActualRunning); got != 1 || bh.ActualRunning[0] != "wg2" {
+		t.Errorf("ActualRunning=%v, want [wg2]", bh.ActualRunning)
+	}
+	if got := len(bh.NotStartedOnBoot); got != 1 {
+		t.Fatalf("NotStartedOnBoot len=%d, want 1", got)
+	}
+	issue := bh.NotStartedOnBoot[0]
+	if issue.TunnelID != "wg1" || issue.Reason != "never_started" {
+		t.Errorf("issue=%+v, want id=wg1 reason=never_started", issue)
+	}
+}
+
+func TestBootHealth_GraceElapsed_AllRunning(t *testing.T) {
+	// grace вышел, всё что должно — running => NotStartedOnBoot пуст.
+	old := processStartedAt
+	defer func() { processStartedAt = old }()
+	processStartedAt = time.Now().Add(-200 * time.Second)
+
+	bh := computeBootHealth(
+		[]bootHealthInput{
+			{ID: "wg1", Name: "wg1", Backend: "kernel", Enabled: true, AutoStart: true, Status: "running"},
+		},
+	)
+	if len(bh.NotStartedOnBoot) != 0 {
+		t.Errorf("expected empty NotStartedOnBoot, got %v", bh.NotStartedOnBoot)
+	}
+}
+
+func TestBootHealth_DisabledTunnelExcluded(t *testing.T) {
+	// Disabled-туннели НЕ должны попадать в ExpectedRunning.
+	old := processStartedAt
+	defer func() { processStartedAt = old }()
+	processStartedAt = time.Now().Add(-200 * time.Second)
+
+	bh := computeBootHealth(
+		[]bootHealthInput{
+			{ID: "wg1", Name: "wg1", Backend: "kernel", Enabled: false, AutoStart: false, Status: "stopped"},
+		},
+	)
+	if len(bh.ExpectedRunning) != 0 {
+		t.Errorf("ExpectedRunning=%v, want []", bh.ExpectedRunning)
+	}
+	if len(bh.NotStartedOnBoot) != 0 {
+		t.Errorf("NotStartedOnBoot=%v, want []", bh.NotStartedOnBoot)
 	}
 }


### PR DESCRIPTION
## Сводка

Второй PR из 5 в sweep'е редизайна вкладки «Диагностика → Проверки». Добавляет **report-only** коллектор `BootHealth`, который детектит регрессию: туннели, помеченные `Enabled && AutoStart`, не были запущены демоном на старте. В UI ничего не появляется — данные пишутся только в файл отчёта для команды поддержки.

## Изменения

**Типы (`internal/diagnostics/diagnostics.go`):**
- `BootHealth` с полями `DaemonStartedAt`, `DaemonUptimeSec`, `GracePeriodSec` (= 120), `ExpectedRunning`, `ActualRunning`, `NotStartedOnBoot []TunnelBootIssue`
- `TunnelBootIssue` с `TunnelID`, `Backend`, `Enabled/AutoStart`, `StoredStartedAt`, `Reason`
- `Report.BootHealth` поле, JSON-тег `bootHealth`

**Старт демона:**
- Package-var `processStartedAt = time.Now()` (по умолчанию — момент импорта пакета)
- Setter `SetProcessStartedAt(t time.Time)` для ранней фиксации в `main()`
- В `cmd/awg-manager/main.go` вызов `diagnostics.SetProcessStartedAt(time.Now())` сразу после `os.MkdirAll(dataDir)` — до запуска любых goroutine, чтобы uptime был точным

**Логика (`internal/diagnostics/collectors.go`):**
- `computeBootHealth` — pure-функция, считает `BootHealth` из `[]bootHealthInput`. Если `uptime < grace` — секция выводится без `NotStartedOnBoot` (грейс не вышел, рано делать вывод).
- `collectBootHealth` — I/O wrapper: `TunnelService.List` → state, `TunnelStore.Get` → `StartedAt`. Затем вызывает `computeBootHealth`.
- Single Reason `"never_started"` в v1 (тонкие кейсы вроде `stopped_after_boot` оставлены на будущее).

**Wiring:**
- В `executeStream` новая phase `collect_boot_health` между `collect_wan` и `collect_tunnels`.

**Тесты (`internal/diagnostics/tests_test.go`):**
- 4 новых теста на `computeBootHealth`: grace not elapsed / never_started / all running / disabled excluded
- Каждый сохраняет/восстанавливает `processStartedAt` через defer — race-detector clean

## Поведение в API

`GET /api/diagnostics/result` теперь содержит дополнительную секцию `bootHealth` в JSON — для текущих клиентов это просто новое поле в объекте, ничего не ломает.

## Out of scope (v1)

Различение `never_started` vs `stopped_after_boot` — single Reason покрывает регрессию, ради которой коллектор добавлен.