### PR TITLE
feat(diagnostics): add AWGProxyModule report-only collector

### DIFF
--- a/internal/diagnostics/anonymize.go
+++ b/internal/diagnostics/anonymize.go
@@ -125,12 +125,22 @@ func (a *anonymizer) registerFromReport(report *Report) {
 	// Register public IPs found in ip route / ip addr output
 	a.registerPublicIPsFromOutput(report.WAN.IPRouteTable)
 	a.registerPublicIPsFromOutput(report.WAN.IPAddr)
+
+	// AWGProxyModule fields are free-text and may contain endpoint IPs.
+	a.registerPublicIPsFromOutput(report.AWGProxyModule.RawList)
+	for _, line := range report.AWGProxyModule.DmesgLines {
+		a.registerPublicIPsFromOutput(line)
+	}
 }
 
 func (a *anonymizer) registerPublicIPsFromOutput(output string) {
 	for _, word := range strings.Fields(output) {
-		// Strip /prefix if present
+		// Strip /prefix if present (CIDR notation)
 		ipStr := strings.Split(word, "/")[0]
+		// Strip :port if present (host:port notation)
+		if host, _, err := net.SplitHostPort(ipStr); err == nil {
+			ipStr = host
+		}
 		if ip := net.ParseIP(ipStr); ip != nil {
 			a.registerIP(ipStr)
 		}

--- a/internal/diagnostics/collectors.go
+++ b/internal/diagnostics/collectors.go
@@ -581,6 +581,50 @@ func sanitizeConfig(stored *storage.AWGTunnel) string {
 	return sb.String()
 }
 
+// collectAWGProxyModule reads kmod awg-proxy state and greps dmesg.
+// Never panics on missing /proc files (kernel-backend without proxy);
+// returns Loaded=false in that case. dmesg is grepped without a time
+// window because the kernel does not expose reliable timestamps in our
+// environment, and the support team wants the complete error history.
+func (r *Runner) collectAWGProxyModule(ctx context.Context) AWGProxyModule {
+	mod := AWGProxyModule{}
+
+	// /proc/awg_proxy/version → Loaded + Version
+	if versionData, err := os.ReadFile("/proc/awg_proxy/version"); err == nil {
+		mod.Loaded = true
+		mod.Version = strings.TrimSpace(string(versionData))
+	}
+
+	// /proc/awg_proxy/list → RawList + EndpointCount
+	if listData, err := os.ReadFile("/proc/awg_proxy/list"); err == nil {
+		mod.RawList = string(listData)
+		count := 0
+		for _, line := range strings.Split(mod.RawList, "\n") {
+			if strings.TrimSpace(line) != "" {
+				count++
+			}
+		}
+		mod.EndpointCount = count
+	}
+
+	// dmesg | grep -i awg_proxy — every matched line. No tail, no time
+	// window: the kernel does not expose reliable timestamps in our
+	// environment, and support wants full error history.
+	if result, err := exec.Shell(ctx, "dmesg | grep -i awg_proxy"); err == nil {
+		raw := strings.TrimSpace(result.Stdout)
+		if raw != "" {
+			for _, line := range strings.Split(raw, "\n") {
+				line = strings.TrimSpace(line)
+				if line != "" {
+					mod.DmesgLines = append(mod.DmesgLines, line)
+				}
+			}
+		}
+	}
+
+	return mod
+}
+
 // bootHealthInput is the per-tunnel slice needed by computeBootHealth.
 // Extracted from awgStore + stateMgr; isolated into its own struct so
 // computeBootHealth can be tested without mocks.

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -27,8 +27,9 @@ type Report struct {
 	Route       RouteInfoMeta      `json:"route"`
 	System      SystemInfo         `json:"system"`
 	WAN         WANInfo            `json:"wan"`
-	BootHealth  BootHealth         `json:"bootHealth"`
-	Tunnels     []TunnelInfo       `json:"tunnels"`
+	BootHealth      BootHealth         `json:"bootHealth"`
+	AWGProxyModule  AWGProxyModule     `json:"awgProxyModule"`
+	Tunnels         []TunnelInfo       `json:"tunnels"`
 	Tests       []TestResult       `json:"tests"`
 	Logs        []logging.LogEntry `json:"logs"`
 }
@@ -92,6 +93,16 @@ type TunnelBootIssue struct {
 	AutoStart       bool   `json:"autoStart"`
 	StoredStartedAt string `json:"storedStartedAt,omitempty"`
 	Reason          string `json:"reason"` // "never_started"
+}
+
+// AWGProxyModule — состояние kmod awg-proxy (включая dmesg-сигналы).
+// Заполняется collectAWGProxyModule. Всё в этой секции anonymized.
+type AWGProxyModule struct {
+	Loaded        bool     `json:"loaded"`
+	Version       string   `json:"version,omitempty"`
+	EndpointCount int      `json:"endpointCount"`
+	RawList       string   `json:"rawList,omitempty"`
+	DmesgLines    []string `json:"dmesgLines,omitempty"`
 }
 
 // TunnelInfo contains per-tunnel diagnostics.
@@ -570,6 +581,9 @@ func (r *Runner) executeStream(ctx context.Context) {
 
 	r.emitPhase("collect_boot_health", "Проверка boot-состояния...")
 	report.BootHealth = r.collectBootHealth(ctx)
+
+	r.emitPhase("collect_proxy_module", "Состояние awg-proxy...")
+	report.AWGProxyModule = r.collectAWGProxyModule(ctx)
 
 	r.emitPhase("collect_tunnels", "Сбор информации о туннелях...")
 	report.Tunnels = r.collectTunnels(ctx)

--- a/internal/diagnostics/tests_test.go
+++ b/internal/diagnostics/tests_test.go
@@ -1,6 +1,7 @@
 package diagnostics
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,5 +113,40 @@ func TestBootHealth_DisabledTunnelExcluded(t *testing.T) {
 	}
 	if len(bh.NotStartedOnBoot) != 0 {
 		t.Errorf("NotStartedOnBoot=%v, want []", bh.NotStartedOnBoot)
+	}
+}
+
+func TestAnonymize_AWGProxyModule_MasksRawListIPs(t *testing.T) {
+	report := &Report{
+		AWGProxyModule: AWGProxyModule{
+			Loaded:        true,
+			Version:       "1.2",
+			EndpointCount: 1,
+			RawList:       "203.0.113.42:51820 -> 127.0.0.1:7891 rx=1024 tx=512\n",
+			DmesgLines: []string{
+				"[12345.678] awg_proxy: client at 127.0.0.1:7891",
+				"[12345.679] awg_proxy: send to 198.51.100.5:443 failed: -110",
+			},
+		},
+	}
+	anonymize(report)
+
+	if strings.Contains(report.AWGProxyModule.RawList, "203.0.113.42") {
+		t.Errorf("RawList still contains public IP: %q", report.AWGProxyModule.RawList)
+	}
+	for _, line := range report.AWGProxyModule.DmesgLines {
+		if strings.Contains(line, "198.51.100.5") {
+			t.Errorf("DmesgLines still contains public IP: %q", line)
+		}
+	}
+	// Private IPs (127.0.0.1) MUST remain — see isPrivateIP() contract.
+	hasPrivate := false
+	for _, line := range report.AWGProxyModule.DmesgLines {
+		if strings.Contains(line, "127.0.0.1") {
+			hasPrivate = true
+		}
+	}
+	if !hasPrivate {
+		t.Errorf("expected 127.0.0.1 to remain in dmesg lines (private IPs must not be masked)")
 	}
 }


### PR DESCRIPTION
## Сводка

Третий PR из 5 в sweep'е. Добавляет **report-only** коллектор `AWGProxyModule`, фиксирующий состояние kmod awg-proxy для команды поддержки. В UI ничего не появляется — данные пишутся только в файл отчёта.

## Изменения

**Тип (`internal/diagnostics/diagnostics.go`):**
- `AWGProxyModule` с полями `Loaded`, `Version`, `EndpointCount`, `RawList`, `DmesgLines`
- `Report.AWGProxyModule` поле, JSON-тег `awgProxyModule`, после `BootHealth`

**Коллектор (`internal/diagnostics/collectors.go`):**
- `collectAWGProxyModule(ctx)` читает:
  - `/proc/awg_proxy/version` → `Loaded` + `Version`
  - `/proc/awg_proxy/list` → `RawList` (целиком) + `EndpointCount` (непустые строки)
  - `dmesg | grep -i awg_proxy` → `DmesgLines[]` (все matched строки целиком). Без time-window — ядро в нашем окружении не отдаёт надёжные timestamp, плюс саппорту нужна полная история ошибок.
- Никогда не падает: если `/proc/awg_proxy/version` отсутствует (kernel-backend без proxy) → `Loaded=false`, остальные поля nil/пусты, dmesg всё равно собирается (там могут быть ошибки попытки загрузки).

**Wiring:**
- В `executeStream` новая phase `collect_proxy_module` между `collect_boot_health` и `collect_tunnels`

**Анонимизация (`internal/diagnostics/anonymize.go`):**
- В `registerFromReport` добавлены сканы `AWGProxyModule.RawList` и каждой строки `DmesgLines` на public-IP'ы (через `registerPublicIPsFromOutput`)
- `registerPublicIPsFromOutput` расширена — теперь корректно стрипает `:port` через `net.SplitHostPort` (без этого IP вида `203.0.113.42:51820` молча пропускались). Backward-compatible: при отсутствии порта поведение не меняется. Это также чинит давний gap для существующего `t.Proxy.RawListEntry` пути.
- Public IP заменяются на `PUBLIC-IP-N` aliases. Private IP (`127.0.0.1`, RFC1918) остаются как есть — они помогают саппорту понять локальное состояние.

**Тест:**
- `TestAnonymize_AWGProxyModule_MasksRawListIPs` — проверяет что `203.0.113.42` и `198.51.100.5` маскированы, а `127.0.0.1` остаётся.

## Поведение в API

`GET /api/diagnostics/result` теперь содержит секцию `awgProxyModule` в JSON-отчёте. Для текущих клиентов это просто новое поле в объекте, ничего не ломает.