### PR TITLE
feat(diagnostics): extend proxy_health Detail with rx/tx/bind

### DIFF
--- a/internal/diagnostics/tests.go
+++ b/internal/diagnostics/tests.go
@@ -898,10 +898,19 @@ func (r *Runner) testProxyHealth(t TunnelInfo) TestResult {
 	}
 
 	var details []string
-	details = append(details, fmt.Sprintf("proxy 127.0.0.1:%d", t.Proxy.ListenPort))
 	if t.Proxy.Version != "" {
 		details = append(details, "v"+t.Proxy.Version)
 	}
+	if t.Proxy.RxBytes != "" {
+		details = append(details, "rx "+t.Proxy.RxBytes)
+	}
+	if t.Proxy.TxBytes != "" {
+		details = append(details, "tx "+t.Proxy.TxBytes)
+	}
+	if t.Proxy.BindIface != "" {
+		details = append(details, "bind="+t.Proxy.BindIface)
+	}
+	details = append(details, fmt.Sprintf("listen=127.0.0.1:%d", t.Proxy.ListenPort))
 
 	if !t.Proxy.RouteMatch && t.Proxy.WantedISP != "" {
 		details = append(details, fmt.Sprintf("WAN mismatch: actual=%s, wanted=%s", t.Proxy.ActualRouteIface, t.Proxy.WantedISP))


### PR DESCRIPTION
## Сводка

Четвёртый PR из 5 в sweep'е. Расширяет PASS-Detail per-tunnel теста `proxy_health` дополнительными полями (rx/tx/bind), которые уже собираются в `ProxyInfo` коллектором, но не доходили до пользователя. Логика PASS/FAIL/SKIP не меняется.

## До → После

```
БЫЛО:  proxy 127.0.0.1:7891; v1.2[; WAN mismatch: actual=..., wanted=...]
СТАЛО: v1.2; rx 2.1MB; tx 580KB; bind=ppp0; listen=127.0.0.1:7891[; WAN mismatch: ...]
```

Порядок: version (identity) → rx/tx (activity) → bind (egress iface) → listen (internal port) → опциональный WAN-mismatch suffix.

## Изменения

`internal/diagnostics/tests.go`, функция `testProxyHealth`:
- Каждое из `Version`, `RxBytes`, `TxBytes`, `BindIface` добавляется в Detail только если непустое (защита от пустых артефактов вроде `bind=`)
- `ListenPort` всегда выводится в `listen=127.0.0.1:N` форме
- WAN mismatch suffix остаётся как был

## Frontend impact

Никаких изменений во фронте не требуется — `DiagnosticsTestItem.svelte` рендерит `Detail` как есть. Новая строка появится в UI автоматически на следующей сборке.