### PR TITLE
feat: уровни использования UI (Базовый / Расширенный / Продвинутый)

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -1,0 +1,103 @@
+// Stateful mock proxy: sits between Vite and Prism.
+// - Holds usageLevel in memory; persists across GET/POST.
+// - Forwards all other requests transparently.
+// - Streams /events normally (Prism handles SSE shape).
+// Default upstream: http://127.0.0.1:8080 (Prism). Listen: 8081.
+
+import http from 'node:http';
+
+const UPSTREAM = process.env.UPSTREAM ?? 'http://127.0.0.1:8080';
+const PORT = Number(process.env.PORT ?? 8081);
+const VALID = new Set(['basic', 'advanced', 'expert']);
+
+// In-memory state. Default 'basic' so the welcome banner + minimal nav
+// are visible on first load (the more interesting case to inspect).
+let usageLevel = 'basic';
+
+async function fetchJSON(path, init) {
+	const r = await fetch(`${UPSTREAM}${path}`, init);
+	const text = await r.text();
+	try {
+		return { status: r.status, body: JSON.parse(text) };
+	} catch {
+		return { status: r.status, body: text };
+	}
+}
+
+function send(res, status, body, contentType = 'application/json') {
+	res.writeHead(status, { 'Content-Type': contentType });
+	res.end(typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+const server = http.createServer((req, res) => {
+	const url = new URL(req.url, `http://${req.headers.host}`);
+	const path = url.pathname;
+
+	if (req.method === 'GET' && path === '/settings/get') {
+		fetchJSON('/settings/get').then(({ status, body }) => {
+			if (body && typeof body === 'object' && body.data) {
+				body.data.usageLevel = usageLevel;
+			}
+			send(res, status, body);
+		});
+		return;
+	}
+
+	if (req.method === 'POST' && path === '/settings/update') {
+		let raw = '';
+		req.on('data', (c) => (raw += c));
+		req.on('end', async () => {
+			try {
+				const payload = JSON.parse(raw);
+				if (typeof payload.usageLevel === 'string') {
+					if (!VALID.has(payload.usageLevel)) {
+						send(res, 400, {
+							success: false,
+							error: 'invalid usageLevel',
+							code: 'INVALID_USAGE_LEVEL',
+						});
+						return;
+					}
+					usageLevel = payload.usageLevel;
+				}
+				const { status, body } = await fetchJSON('/settings/get');
+				if (body && typeof body === 'object' && body.data) {
+					body.data.usageLevel = usageLevel;
+				}
+				send(res, status, body);
+				console.log(`[mock-proxy] usageLevel → ${usageLevel}`);
+			} catch (e) {
+				send(res, 500, { success: false, error: String(e) });
+			}
+		});
+		return;
+	}
+
+	// Pass-through for everything else (including /events SSE).
+	const upstream = new URL(UPSTREAM);
+	const proxyReq = http.request(
+		{
+			hostname: upstream.hostname,
+			port: upstream.port,
+			path: req.url,
+			method: req.method,
+			headers: { ...req.headers, host: upstream.host },
+		},
+		(proxyRes) => {
+			res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+			proxyRes.pipe(res);
+		},
+	);
+	proxyReq.on('error', (e) => {
+		if (!res.headersSent) {
+			send(res, 502, { error: String(e) });
+		} else {
+			res.end();
+		}
+	});
+	req.pipe(proxyReq);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+	console.log(`mock-proxy on http://127.0.0.1:${PORT} → ${UPSTREAM} (usageLevel=${usageLevel})`);
+});

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -545,7 +545,7 @@ label {
 
 .setting-row > *:first-child {
 	min-width: 0;
-	flex: 1 1 220px;
+	flex: 1 1 0;
 }
 
 .setting-row:first-child {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -417,10 +417,33 @@ label {
 	min-width: 280px;
 	max-width: 400px;
 	animation: slideIn 0.2s ease;
-	cursor: pointer;
 	font: inherit;
 	color: inherit;
 	text-align: left;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.toast-message {
+	flex: 1;
+	background: transparent;
+	border: 0;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+	padding: 0;
+	font: inherit;
+}
+
+.toast-action {
+	color: var(--accent);
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.toast-action:hover {
+	text-decoration: underline;
 }
 
 .toast-dismiss-all {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -200,6 +200,11 @@ html, body {
   line-height: 1.5;
   background: var(--color-bg-primary);
   color: var(--color-text-primary);
+  overflow-x: hidden;
+}
+
+.setting-description {
+  overflow-wrap: anywhere;
 }
 
 #app {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -540,6 +540,12 @@ label {
 	justify-content: space-between;
 	gap: 1rem;
 	padding: 0.875rem 0;
+	flex-wrap: wrap;
+}
+
+.setting-row > *:first-child {
+	min-width: 0;
+	flex: 1 1 220px;
 }
 
 .setting-row:first-child {
@@ -957,6 +963,17 @@ label {
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 0.5rem;
+	}
+}
+
+@media (max-width: 640px) {
+	.setting-row {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
+	}
+	.setting-row > *:first-child {
+		flex: initial;
 	}
 }
 

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -2,6 +2,58 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { LegacyTabs, LegacyTab, IconButton, SaveStatusIndicator } from '$lib/components/ui';
+	import { usageLevel } from '$lib/stores/settings';
+	import { isSectionVisible, type Section } from '$lib/types/usageLevel';
+
+	type NavItem = {
+		section: Section;
+		href: string;
+		label: string;
+		matches: (path: string) => boolean;
+	};
+
+	const NAV_ITEMS: NavItem[] = [
+		{
+			section: 'tunnels',
+			href: '/',
+			label: 'ТУННЕЛИ',
+			matches: (p) =>
+				p === '/' || p.startsWith('/tunnels') || p.startsWith('/system-tunnels'),
+		},
+		{
+			section: 'servers',
+			href: '/servers',
+			label: 'СЕРВЕРЫ',
+			matches: (p) => p.startsWith('/servers'),
+		},
+		{
+			section: 'routing',
+			href: '/routing',
+			label: 'МАРШРУТИЗАЦИЯ',
+			matches: (p) => p.startsWith('/routing'),
+		},
+		{
+			section: 'monitoring',
+			href: '/monitoring',
+			label: 'МОНИТОРИНГ',
+			matches: (p) =>
+				p.startsWith('/monitoring') ||
+				p.startsWith('/pingcheck') ||
+				p.startsWith('/connections'),
+		},
+		{
+			section: 'diagnostics',
+			href: '/diagnostics',
+			label: 'ДИАГНОСТИКА',
+			matches: (p) => p.startsWith('/diagnostics') || p.startsWith('/logs'),
+		},
+		{
+			section: 'settings',
+			href: '/settings',
+			label: 'НАСТРОЙКИ',
+			matches: (p) => p.startsWith('/settings'),
+		},
+	];
 
 	interface Props {
 		authenticated: boolean;
@@ -31,20 +83,13 @@
 		onOpenDonate,
 	}: Props = $props();
 
+	const visibleItems = $derived(
+		NAV_ITEMS.filter((item) => isSectionVisible($usageLevel, item.section)),
+	);
+
 	const currentRoute = $derived.by(() => {
 		const path = $page.url.pathname;
-		if (path === '/' || path.startsWith('/tunnels') || path.startsWith('/system-tunnels')) return '/';
-		if (path.startsWith('/servers')) return '/servers';
-		if (path.startsWith('/routing')) return '/routing';
-		if (
-			path.startsWith('/monitoring') ||
-			path.startsWith('/pingcheck') ||
-			path.startsWith('/connections')
-		)
-			return '/monitoring';
-		if (path.startsWith('/diagnostics') || path.startsWith('/logs')) return '/diagnostics';
-		if (path.startsWith('/settings')) return '/settings';
-		return '';
+		return visibleItems.find((item) => item.matches(path))?.href ?? '';
 	});
 
 	function navigate(value: string) {
@@ -59,6 +104,18 @@
 
 	function toggleMobileMenu() {
 		mobileMenuOpen = !mobileMenuOpen;
+	}
+
+	function prettyMobileLabel(upperLabel: string): string {
+		const map: Record<string, string> = {
+			ТУННЕЛИ: 'Туннели',
+			СЕРВЕРЫ: 'Серверы',
+			МАРШРУТИЗАЦИЯ: 'Маршрутизация',
+			МОНИТОРИНГ: 'Мониторинг',
+			ДИАГНОСТИКА: 'Диагностика',
+			НАСТРОЙКИ: 'Настройки',
+		};
+		return map[upperLabel] ?? upperLabel;
 	}
 </script>
 
@@ -110,12 +167,9 @@
 		{#if authenticated}
 			<nav class="nav" aria-label="Главная навигация">
 				<LegacyTabs value={currentRoute} onChange={navigate} variant="underline">
-					<LegacyTab value="/">ТУННЕЛИ</LegacyTab>
-					<LegacyTab value="/servers">СЕРВЕРЫ</LegacyTab>
-					<LegacyTab value="/routing">МАРШРУТИЗАЦИЯ</LegacyTab>
-					<LegacyTab value="/monitoring">МОНИТОРИНГ</LegacyTab>
-					<LegacyTab value="/diagnostics">ДИАГНОСТИКА</LegacyTab>
-					<LegacyTab value="/settings">НАСТРОЙКИ</LegacyTab>
+					{#each visibleItems as item (item.section)}
+						<LegacyTab value={item.href}>{item.label}</LegacyTab>
+					{/each}
 				</LegacyTabs>
 			</nav>
 		{:else}
@@ -127,7 +181,7 @@
 				<span class="user-chip">{username}</span>
 			{/if}
 
-			{#if authenticated}
+			{#if authenticated && isSectionVisible($usageLevel, 'terminal')}
 				<IconButton ariaLabel="Терминал" href="/terminal">
 					<svg
 						viewBox="0 0 24 24"
@@ -265,59 +319,14 @@
 			aria-label="Закрыть меню"
 		></button>
 		<nav class="mobile-nav" aria-label="Мобильная навигация">
-			<a
-				href="/"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname === '/' ||
-					$page.url.pathname.startsWith('/tunnels') ||
-					$page.url.pathname.startsWith('/system-tunnels')}
-				onclick={closeMobileMenu}
-			>
-				Туннели
-			</a>
-			<a
-				href="/servers"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname.startsWith('/servers')}
-				onclick={closeMobileMenu}
-			>
-				Серверы
-			</a>
-			<a
-				href="/routing"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname.startsWith('/routing')}
-				onclick={closeMobileMenu}
-			>
-				Маршрутизация
-			</a>
-			<a
-				href="/monitoring"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname.startsWith('/monitoring') ||
-					$page.url.pathname.startsWith('/pingcheck') ||
-					$page.url.pathname.startsWith('/connections')}
-				onclick={closeMobileMenu}
-			>
-				Мониторинг
-			</a>
-			<a
-				href="/diagnostics"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname.startsWith('/diagnostics') ||
-					$page.url.pathname.startsWith('/logs')}
-				onclick={closeMobileMenu}
-			>
-				Диагностика
-			</a>
-			<a
-				href="/settings"
-				class="mobile-nav-link"
-				class:active={$page.url.pathname.startsWith('/settings')}
-				onclick={closeMobileMenu}
-			>
-				Настройки
-			</a>
+			{#each visibleItems as item (item.section)}
+				<a
+					href={item.href}
+					class="mobile-nav-link"
+					class:active={item.matches($page.url.pathname)}
+					onclick={closeMobileMenu}>{prettyMobileLabel(item.label)}</a
+				>
+			{/each}
 		</nav>
 	{/if}
 </header>

--- a/frontend/src/lib/components/layout/PageContainer.svelte
+++ b/frontend/src/lib/components/layout/PageContainer.svelte
@@ -27,9 +27,17 @@
     margin: 0 auto;
     padding: 1.5rem;
     width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
   }
 
   .width-narrow { max-width: 960px; }
   .width-wide { max-width: 1440px; }
   .width-full { max-width: 100%; }
+
+  @media (max-width: 640px) {
+    .page-container {
+      padding: 0.75rem;
+    }
+  }
 </style>

--- a/frontend/src/lib/components/layout/WelcomeBanner.svelte
+++ b/frontend/src/lib/components/layout/WelcomeBanner.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { usageLevel } from '$lib/stores/settings';
+
+	const STORAGE_KEY = 'awgm.welcomeBannerDismissed';
+
+	let dismissed = $state(true);
+
+	onMount(() => {
+		dismissed = localStorage.getItem(STORAGE_KEY) === '1';
+	});
+
+	const visible = $derived($usageLevel === 'basic' && !dismissed);
+
+	function dismiss() {
+		localStorage.setItem(STORAGE_KEY, '1');
+		dismissed = true;
+	}
+</script>
+
+{#if visible}
+	<div class="welcome-banner" role="status">
+		<div class="banner-icon" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<circle cx="12" cy="12" r="10" />
+				<line x1="12" y1="8" x2="12" y2="12" />
+				<circle cx="12" cy="16" r="0.8" fill="currentColor" />
+			</svg>
+		</div>
+		<div class="banner-body">
+			<strong>Вы в Базовом режиме</strong>
+			<p>
+				Доступны только туннели и диагностика. Чтобы открыть серверы, маршрутизацию,
+				мониторинг и другие возможности — выберите более высокий уровень в
+				<a href="/settings">Настройках</a>.
+			</p>
+		</div>
+		<button
+			type="button"
+			class="banner-close"
+			aria-label="Скрыть подсказку"
+			onclick={dismiss}
+		>
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<line x1="18" y1="6" x2="6" y2="18" />
+				<line x1="6" y1="6" x2="18" y2="18" />
+			</svg>
+		</button>
+	</div>
+{/if}
+
+<style>
+	.welcome-banner {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		padding: 0.875rem 1rem;
+		margin-bottom: 1rem;
+		background: var(--color-info-tint, var(--color-bg-tertiary));
+		border: 1px solid var(--color-info, var(--color-border-strong));
+		border-radius: var(--radius-md);
+		color: var(--color-text-primary);
+	}
+	.banner-icon {
+		flex-shrink: 0;
+		color: var(--color-info, var(--color-accent));
+	}
+	.banner-icon svg {
+		width: 20px;
+		height: 20px;
+	}
+	.banner-body {
+		flex: 1;
+	}
+	.banner-body strong {
+		display: block;
+		margin-bottom: 0.125rem;
+	}
+	.banner-body p {
+		margin: 0;
+		font-size: 0.875rem;
+		color: var(--color-text-secondary);
+	}
+	.banner-body a {
+		color: var(--color-accent);
+		text-decoration: underline;
+	}
+	.banner-close {
+		flex-shrink: 0;
+		background: transparent;
+		border: 0;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		padding: 0.25rem;
+		border-radius: var(--radius-sm);
+	}
+	.banner-close:hover {
+		color: var(--color-text-primary);
+		background: var(--color-bg-hover);
+	}
+	.banner-close svg {
+		width: 16px;
+		height: 16px;
+	}
+</style>

--- a/frontend/src/lib/components/layout/index.ts
+++ b/frontend/src/lib/components/layout/index.ts
@@ -4,3 +4,4 @@ export type { PageWidth } from './PageContainer.svelte';
 export { default as LoadingSpinner } from './LoadingSpinner.svelte';
 export { default as EmptyState } from './EmptyState.svelte';
 export { default as AppHeader } from './AppHeader.svelte';
+export { default as WelcomeBanner } from './WelcomeBanner.svelte';

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -8,6 +8,8 @@
 		singboxInstalling: boolean;
 		singboxInstallError: string | null;
 		oninstallSingbox: () => void;
+		showSingbox?: boolean;
+		showHydra?: boolean;
 	}
 
 	let {
@@ -16,6 +18,8 @@
 		singboxInstalling,
 		singboxInstallError,
 		oninstallSingbox,
+		showSingbox = true,
+		showHydra = true,
 	}: Props = $props();
 
 	const singboxInstalled = $derived(singboxStatus?.installed ?? false);
@@ -24,76 +28,82 @@
 	const hydraRunning = $derived(hydraStatus?.running ?? false);
 </script>
 
-<div class="card">
-	<div class="section-label">Интеграции</div>
+{#if showSingbox || showHydra}
+	<div class="card">
+		<div class="section-label">Интеграции</div>
 
-	<div class="setting-row">
-		<div class="integration-item">
-			<StatusDot
-				variant={singboxInstalled && singboxRunning ? 'success' : 'muted'}
-				size="md"
-				ariaLabel={singboxInstalled && singboxRunning ? 'Sing-box работает' : 'Sing-box остановлен'}
-			/>
-			<div class="integration-meta">
-				<span class="font-medium">Sing-box</span>
-				{#if singboxInstalled && singboxStatus}
-					<span class="integration-sub">
-						v{singboxStatus.version ?? '?'}
-						{#if singboxRunning && singboxStatus.pid}· pid {singboxStatus.pid}{:else if !singboxRunning}· остановлен{/if}
-					</span>
-					{#if !singboxRunning && singboxStatus.lastError}
-						<span class="setting-description error" title={singboxStatus.lastError}>{singboxStatus.lastError}</span>
-					{/if}
+		{#if showSingbox}
+			<div class="setting-row">
+				<div class="integration-item">
+					<StatusDot
+						variant={singboxInstalled && singboxRunning ? 'success' : 'muted'}
+						size="md"
+						ariaLabel={singboxInstalled && singboxRunning ? 'Sing-box работает' : 'Sing-box остановлен'}
+					/>
+					<div class="integration-meta">
+						<span class="font-medium">Sing-box</span>
+						{#if singboxInstalled && singboxStatus}
+							<span class="integration-sub">
+								v{singboxStatus.version ?? '?'}
+								{#if singboxRunning && singboxStatus.pid}· pid {singboxStatus.pid}{:else if !singboxRunning}· остановлен{/if}
+							</span>
+							{#if !singboxRunning && singboxStatus.lastError}
+								<span class="setting-description error" title={singboxStatus.lastError}>{singboxStatus.lastError}</span>
+							{/if}
+						{:else}
+							<span class="setting-description">
+								Поддержка VLESS/Reality, Hysteria2, NaiveProxy. Требует Entware на внешнем носителе.
+							</span>
+							{#if singboxInstallError}
+								<span class="setting-description error">{singboxInstallError}</span>
+							{/if}
+						{/if}
+					</div>
+				</div>
+				{#if singboxInstalled}
+					<Button variant="ghost" size="sm" href="/?tab=singbox">Открыть</Button>
 				{:else}
-					<span class="setting-description">
-						Поддержка VLESS/Reality, Hysteria2, NaiveProxy. Требует Entware на внешнем носителе.
-					</span>
-					{#if singboxInstallError}
-						<span class="setting-description error">{singboxInstallError}</span>
-					{/if}
+					<Button variant="primary" size="sm" onclick={oninstallSingbox} loading={singboxInstalling}>
+						{singboxInstalling ? 'Установка...' : 'Установить'}
+					</Button>
 				{/if}
 			</div>
-		</div>
-		{#if singboxInstalled}
-			<Button variant="ghost" size="sm" href="/?tab=singbox">Открыть</Button>
-		{:else}
-			<Button variant="primary" size="sm" onclick={oninstallSingbox} loading={singboxInstalling}>
-				{singboxInstalling ? 'Установка...' : 'Установить'}
-			</Button>
 		{/if}
-	</div>
 
-	<div class="setting-row">
-		<div class="integration-item">
-			<StatusDot
-				variant={hydraInstalled && hydraRunning ? 'success' : 'muted'}
-				size="md"
-				ariaLabel={hydraInstalled && hydraRunning ? 'HydraRoute работает' : 'HydraRoute остановлен'}
-			/>
-			<div class="integration-meta">
-				<span class="font-medium">HydraRoute Neo</span>
+		{#if showHydra}
+			<div class="setting-row">
+				<div class="integration-item">
+					<StatusDot
+						variant={hydraInstalled && hydraRunning ? 'success' : 'muted'}
+						size="md"
+						ariaLabel={hydraInstalled && hydraRunning ? 'HydraRoute работает' : 'HydraRoute остановлен'}
+					/>
+					<div class="integration-meta">
+						<span class="font-medium">HydraRoute Neo</span>
+						{#if hydraInstalled}
+							<span class="integration-sub">{hydraRunning ? 'работает' : 'остановлен'}</span>
+						{:else}
+							<span class="integration-sub">не установлен</span>
+						{/if}
+					</div>
+				</div>
 				{#if hydraInstalled}
-					<span class="integration-sub">{hydraRunning ? 'работает' : 'остановлен'}</span>
+					<Button variant="ghost" size="sm" href="/routing?tab=hrneo">Открыть</Button>
 				{:else}
-					<span class="integration-sub">не установлен</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						href="https://github.com/Ground-Zerro/HydraRoute"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Установить
+					</Button>
 				{/if}
 			</div>
-		</div>
-		{#if hydraInstalled}
-			<Button variant="ghost" size="sm" href="/routing?tab=hrneo">Открыть</Button>
-		{:else}
-			<Button
-				variant="ghost"
-				size="sm"
-				href="https://github.com/Ground-Zerro/HydraRoute"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				Установить
-			</Button>
 		{/if}
 	</div>
-</div>
+{/if}
 
 <style>
 	.integration-item {

--- a/frontend/src/lib/components/settings/SystemInfoGrid.svelte
+++ b/frontend/src/lib/components/settings/SystemInfoGrid.svelte
@@ -41,6 +41,8 @@
 		font-size: 0.8125rem;
 		font-family: var(--font-mono);
 		color: var(--color-text-secondary);
+		text-align: right;
+		word-break: break-word;
 	}
 
 	.info-link {

--- a/frontend/src/lib/components/settings/UsageLevelCard.svelte
+++ b/frontend/src/lib/components/settings/UsageLevelCard.svelte
@@ -64,13 +64,11 @@
 	}
 </script>
 
-<div class="card usage-level-card">
-	<div class="card-head">
-		<h2>Уровень использования</h2>
-		<p class="muted">
-			Скрывает разделы, которые вам не нужны. Данные при понижении уровня не удаляются.
-		</p>
-	</div>
+<div class="card">
+	<div class="section-label">Уровень использования</div>
+	<p class="card-hint">
+		Скрывает разделы, которые вам не нужны. Данные при понижении уровня не удаляются.
+	</p>
 
 	<div
 		class="level-grid"
@@ -139,36 +137,22 @@
 </Modal>
 
 <style>
-	.usage-level-card {
-		margin-bottom: 1rem;
-	}
-	.card-head {
-		margin-bottom: 1rem;
-	}
-	.card-head h2 {
-		margin: 0 0 0.25rem 0;
-	}
-	.muted {
+	.card-hint {
 		color: var(--color-text-muted);
-		font-size: 0.875rem;
-		margin: 0;
+		font-size: 0.8125rem;
+		margin: 0 0 0.75rem 0;
 	}
 
 	.level-grid {
 		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: 0.75rem;
-	}
-	@media (max-width: 640px) {
-		.level-grid {
-			grid-template-columns: 1fr;
-		}
+		grid-template-columns: 1fr;
+		gap: 0.5rem;
 	}
 
 	.level-card {
 		position: relative;
 		text-align: left;
-		padding: 1rem;
+		padding: 0.75rem 1rem;
 		background: var(--color-bg-tertiary);
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius-md);
@@ -177,8 +161,7 @@
 		cursor: pointer;
 		transition:
 			border-color var(--t-fast) ease,
-			background var(--t-fast) ease,
-			transform var(--t-fast) ease;
+			background var(--t-fast) ease;
 	}
 	.level-card:hover:not(:disabled):not(.selected) {
 		background: var(--color-bg-hover);

--- a/frontend/src/lib/components/settings/UsageLevelCard.svelte
+++ b/frontend/src/lib/components/settings/UsageLevelCard.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+	import { Modal } from '$lib/components/ui';
+	import type { UsageLevel } from '$lib/types/usageLevel';
+	import { USAGE_LEVEL_LABELS } from '$lib/types/usageLevel';
+
+	interface Props {
+		value: UsageLevel;
+		saving: boolean;
+		onSelect: (level: UsageLevel) => void | Promise<void>;
+	}
+
+	let { value, saving, onSelect }: Props = $props();
+
+	type LevelOption = {
+		value: UsageLevel;
+		title: string;
+		summary: string;
+		includes: string[];
+	};
+
+	const OPTIONS: LevelOption[] = [
+		{
+			value: 'basic',
+			title: USAGE_LEVEL_LABELS.basic,
+			summary: 'Только туннели',
+			includes: [
+				'AmneziaWG туннели',
+				'Системные WireGuard туннели',
+				'Диагностика',
+			],
+		},
+		{
+			value: 'advanced',
+			title: USAGE_LEVEL_LABELS.advanced,
+			summary: 'Туннели, серверы, маршрутизация',
+			includes: [
+				'Всё из Базового',
+				'Sing-box туннели',
+				'Серверы (managed WireGuard)',
+				'Маршрутизация: политики, клиенты, DNS, IP, Device Proxy',
+				'Мониторинг',
+				'Веб-терминал',
+			],
+		},
+		{
+			value: 'expert',
+			title: USAGE_LEVEL_LABELS.expert,
+			summary: 'Все функции',
+			includes: ['Всё из Расширенного', 'HR Neo', 'Sing-box Router'],
+		},
+	];
+
+	let infoFor = $state<UsageLevel | null>(null);
+	const infoOpt = $derived(infoFor ? OPTIONS.find((o) => o.value === infoFor) : null);
+
+	function selectLevel(level: UsageLevel) {
+		if (level === value || saving) return;
+		void onSelect(level);
+	}
+
+	function openInfo(e: Event, level: UsageLevel) {
+		e.stopPropagation();
+		infoFor = level;
+	}
+</script>
+
+<div class="card">
+	<div class="card-head">
+		<h2>Уровень использования</h2>
+		<p class="muted">
+			Скрывает разделы, которые вам не нужны. Данные при понижении уровня не удаляются.
+		</p>
+	</div>
+
+	<div
+		class="level-grid"
+		role="radiogroup"
+		aria-label="Уровень использования"
+		aria-busy={saving}
+	>
+		{#each OPTIONS as opt (opt.value)}
+			{@const selected = value === opt.value}
+			<button
+				type="button"
+				role="radio"
+				aria-checked={selected}
+				class="level-card"
+				class:selected
+				disabled={saving}
+				onclick={() => selectLevel(opt.value)}
+			>
+				<span
+					class="info-btn"
+					role="button"
+					tabindex="0"
+					aria-label={`Подробнее про уровень «${opt.title}»`}
+					onclick={(e) => openInfo(e, opt.value)}
+					onkeydown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							openInfo(e, opt.value);
+						}
+					}}
+				>
+					<svg viewBox="0 0 24 24" aria-hidden="true">
+						<circle cx="12" cy="12" r="10" />
+						<line x1="12" y1="11" x2="12" y2="17" />
+						<circle cx="12" cy="7.5" r="0.8" />
+					</svg>
+				</span>
+
+				<div class="level-title">{opt.title}</div>
+				<div class="level-summary">{opt.summary}</div>
+
+				{#if selected}
+					<span class="level-check" aria-hidden="true">
+						<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12" /></svg>
+					</span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+</div>
+
+<Modal
+	open={infoFor !== null}
+	title={infoOpt ? `Уровень: ${infoOpt.title}` : ''}
+	size="md"
+	onclose={() => (infoFor = null)}
+>
+	{#if infoOpt}
+		<p>{infoOpt.summary}</p>
+		<h3>Что включает</h3>
+		<ul>
+			{#each infoOpt.includes as item}
+				<li>{item}</li>
+			{/each}
+		</ul>
+	{/if}
+</Modal>
+
+<style>
+	.card-head {
+		margin-bottom: 1rem;
+	}
+	.card-head h2 {
+		margin: 0 0 0.25rem 0;
+	}
+	.muted {
+		color: var(--color-text-muted);
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	.level-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.75rem;
+	}
+	@media (max-width: 640px) {
+		.level-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.level-card {
+		position: relative;
+		text-align: left;
+		padding: 1rem;
+		background: var(--color-bg-tertiary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+		transition:
+			border-color var(--t-fast) ease,
+			background var(--t-fast) ease,
+			transform var(--t-fast) ease;
+	}
+	.level-card:hover:not(:disabled):not(.selected) {
+		background: var(--color-bg-hover);
+		border-color: var(--color-border-strong);
+	}
+	.level-card:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+	.level-card.selected {
+		border-color: var(--color-accent);
+		background: var(--color-accent-tint);
+	}
+	.level-card:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.level-title {
+		font-weight: 600;
+		font-size: 1rem;
+		margin-bottom: 0.25rem;
+	}
+	.level-summary {
+		color: var(--color-text-muted);
+		font-size: 0.8125rem;
+	}
+
+	.level-check {
+		position: absolute;
+		top: 0.5rem;
+		right: 0.5rem;
+		width: 18px;
+		height: 18px;
+		color: var(--color-accent);
+	}
+	.level-check svg {
+		width: 100%;
+		height: 100%;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 2;
+	}
+
+	.info-btn {
+		position: absolute;
+		top: 0.5rem;
+		left: 0.5rem;
+		width: 18px;
+		height: 18px;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+	}
+	.info-btn:hover {
+		color: var(--color-text-primary);
+	}
+	.info-btn:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+	.info-btn svg {
+		width: 14px;
+		height: 14px;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 2;
+	}
+</style>

--- a/frontend/src/lib/components/settings/UsageLevelCard.svelte
+++ b/frontend/src/lib/components/settings/UsageLevelCard.svelte
@@ -170,6 +170,8 @@
 		align-items: center;
 		justify-content: space-between;
 		width: 100%;
+		min-width: 0;
+		gap: 0.5rem;
 		background: transparent;
 		border: 0;
 		padding: 0;
@@ -178,6 +180,10 @@
 		font: inherit;
 		cursor: pointer;
 		text-align: left;
+	}
+	.collapsible-header > .section-label {
+		min-width: 0;
+		flex-shrink: 1;
 	}
 	.collapsible-header:focus-visible {
 		outline: 2px solid var(--color-accent);
@@ -193,6 +199,10 @@
 	}
 	.current-level {
 		color: var(--color-text-secondary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 8rem;
 	}
 	.chevron {
 		width: 14px;

--- a/frontend/src/lib/components/settings/UsageLevelCard.svelte
+++ b/frontend/src/lib/components/settings/UsageLevelCard.svelte
@@ -53,6 +53,8 @@
 	let infoFor = $state<UsageLevel | null>(null);
 	const infoOpt = $derived(infoFor ? OPTIONS.find((o) => o.value === infoFor) : null);
 
+	let expanded = $state(false);
+
 	function selectLevel(level: UsageLevel) {
 		if (level === value || saving) return;
 		void onSelect(level);
@@ -65,58 +67,84 @@
 </script>
 
 <div class="card">
-	<div class="section-label">Уровень использования</div>
-	<p class="card-hint">
-		Скрывает разделы, которые вам не нужны. Данные при понижении уровня не удаляются.
-	</p>
-
-	<div
-		class="level-grid"
-		role="radiogroup"
-		aria-label="Уровень использования"
-		aria-busy={saving}
+	<button
+		type="button"
+		class="collapsible-header"
+		aria-expanded={expanded}
+		aria-controls="usage-level-body"
+		onclick={() => (expanded = !expanded)}
 	>
-		{#each OPTIONS as opt (opt.value)}
-			{@const selected = value === opt.value}
-			<button
-				type="button"
-				role="radio"
-				aria-checked={selected}
-				class="level-card"
-				class:selected
-				disabled={saving}
-				onclick={() => selectLevel(opt.value)}
+		<span class="section-label">Уровень использования</span>
+		<span class="header-meta">
+			<span class="current-level">{USAGE_LEVEL_LABELS[value]}</span>
+			<svg
+				class="chevron"
+				class:open={expanded}
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				aria-hidden="true"
 			>
-				<span
-					class="info-btn"
-					role="button"
-					tabindex="0"
-					aria-label={`Подробнее про уровень «${opt.title}»`}
-					onclick={(e) => openInfo(e, opt.value)}
-					onkeydown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ') {
-							openInfo(e, opt.value);
-						}
-					}}
-				>
-					<svg viewBox="0 0 24 24" aria-hidden="true">
-						<circle cx="12" cy="12" r="10" />
-						<line x1="12" y1="11" x2="12" y2="17" />
-						<circle cx="12" cy="7.5" r="0.8" />
-					</svg>
-				</span>
+				<polyline points="6 9 12 15 18 9" />
+			</svg>
+		</span>
+	</button>
 
-				<div class="level-title">{opt.title}</div>
-				<div class="level-summary">{opt.summary}</div>
+	{#if expanded}
+		<div id="usage-level-body" class="collapsible-body">
+			<p class="card-hint">
+				Скрывает разделы, которые вам не нужны. Данные при понижении уровня не удаляются.
+			</p>
 
-				{#if selected}
-					<span class="level-check" aria-hidden="true">
-						<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12" /></svg>
-					</span>
-				{/if}
-			</button>
-		{/each}
-	</div>
+			<div
+				class="level-grid"
+				role="radiogroup"
+				aria-label="Уровень использования"
+				aria-busy={saving}
+			>
+				{#each OPTIONS as opt (opt.value)}
+					{@const selected = value === opt.value}
+					<button
+						type="button"
+						role="radio"
+						aria-checked={selected}
+						class="level-card"
+						class:selected
+						disabled={saving}
+						onclick={() => selectLevel(opt.value)}
+					>
+						<span
+							class="info-btn"
+							role="button"
+							tabindex="0"
+							aria-label={`Подробнее про уровень «${opt.title}»`}
+							onclick={(e) => openInfo(e, opt.value)}
+							onkeydown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									openInfo(e, opt.value);
+								}
+							}}
+						>
+							<svg viewBox="0 0 24 24" aria-hidden="true">
+								<circle cx="12" cy="12" r="10" />
+								<line x1="12" y1="11" x2="12" y2="17" />
+								<circle cx="12" cy="7.5" r="0.8" />
+							</svg>
+						</span>
+
+						<div class="level-title">{opt.title}</div>
+
+						{#if selected}
+							<span class="level-check" aria-hidden="true">
+								<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12" /></svg>
+							</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+	{/if}
 </div>
 
 <Modal
@@ -137,6 +165,47 @@
 </Modal>
 
 <style>
+	.collapsible-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		margin: 0;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+		text-align: left;
+	}
+	.collapsible-header:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+		border-radius: var(--radius-sm);
+	}
+	.header-meta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		color: var(--color-text-muted);
+		font-size: 0.8125rem;
+	}
+	.current-level {
+		color: var(--color-text-secondary);
+	}
+	.chevron {
+		width: 14px;
+		height: 14px;
+		transition: transform var(--t-fast) ease;
+	}
+	.chevron.open {
+		transform: rotate(180deg);
+	}
+
+	.collapsible-body {
+		margin-top: 0.75rem;
+	}
 	.card-hint {
 		color: var(--color-text-muted);
 		font-size: 0.8125rem;
@@ -145,14 +214,19 @@
 
 	.level-grid {
 		display: grid;
-		grid-template-columns: 1fr;
+		grid-template-columns: repeat(3, 1fr);
 		gap: 0.5rem;
+	}
+	@media (max-width: 480px) {
+		.level-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	.level-card {
 		position: relative;
-		text-align: left;
-		padding: 0.75rem 1rem;
+		text-align: center;
+		padding: 0.625rem 0.5rem;
 		background: var(--color-bg-tertiary);
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius-md);
@@ -182,27 +256,20 @@
 
 	.level-title {
 		font-weight: 600;
-		font-size: 1rem;
-		margin-bottom: 0.25rem;
-		padding-right: 1.75rem;
-	}
-	.level-summary {
-		color: var(--color-text-muted);
-		font-size: 0.8125rem;
-		padding-right: 1.75rem;
+		font-size: 0.875rem;
+		padding: 0 1.25rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.level-check {
 		position: absolute;
-		top: 0.5rem;
-		left: 0.5rem;
-		width: 18px;
-		height: 18px;
+		top: 0.375rem;
+		left: 0.375rem;
+		width: 14px;
+		height: 14px;
 		color: var(--color-accent);
-	}
-	.level-card.selected .level-title,
-	.level-card.selected .level-summary {
-		padding-left: 1.75rem;
 	}
 	.level-check svg {
 		width: 100%;
@@ -214,10 +281,10 @@
 
 	.info-btn {
 		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-		width: 18px;
-		height: 18px;
+		top: 0.375rem;
+		right: 0.375rem;
+		width: 14px;
+		height: 14px;
 		color: var(--color-text-muted);
 		cursor: pointer;
 		display: inline-flex;
@@ -233,8 +300,8 @@
 		outline-offset: 2px;
 	}
 	.info-btn svg {
-		width: 14px;
-		height: 14px;
+		width: 12px;
+		height: 12px;
 		fill: none;
 		stroke: currentColor;
 		stroke-width: 2;

--- a/frontend/src/lib/components/settings/UsageLevelCard.svelte
+++ b/frontend/src/lib/components/settings/UsageLevelCard.svelte
@@ -64,7 +64,7 @@
 	}
 </script>
 
-<div class="card">
+<div class="card usage-level-card">
 	<div class="card-head">
 		<h2>Уровень использования</h2>
 		<p class="muted">
@@ -139,6 +139,9 @@
 </Modal>
 
 <style>
+	.usage-level-card {
+		margin-bottom: 1rem;
+	}
 	.card-head {
 		margin-bottom: 1rem;
 	}
@@ -198,19 +201,25 @@
 		font-weight: 600;
 		font-size: 1rem;
 		margin-bottom: 0.25rem;
+		padding-right: 1.75rem;
 	}
 	.level-summary {
 		color: var(--color-text-muted);
 		font-size: 0.8125rem;
+		padding-right: 1.75rem;
 	}
 
 	.level-check {
 		position: absolute;
 		top: 0.5rem;
-		right: 0.5rem;
+		left: 0.5rem;
 		width: 18px;
 		height: 18px;
 		color: var(--color-accent);
+	}
+	.level-card.selected .level-title,
+	.level-card.selected .level-summary {
+		padding-left: 1.75rem;
 	}
 	.level-check svg {
 		width: 100%;
@@ -223,7 +232,7 @@
 	.info-btn {
 		position: absolute;
 		top: 0.5rem;
-		left: 0.5rem;
+		right: 0.5rem;
 		width: 18px;
 		height: 18px;
 		color: var(--color-text-muted);

--- a/frontend/src/lib/components/settings/index.ts
+++ b/frontend/src/lib/components/settings/index.ts
@@ -3,4 +3,5 @@ export { default as LoggingSettings } from './LoggingSettings.svelte';
 export { default as UpdateSection } from './UpdateSection.svelte';
 export { default as DnsRouteSettings } from './DnsRouteSettings.svelte';
 export { default as IntegrationsCard } from './IntegrationsCard.svelte';
+export { default as UsageLevelCard } from './UsageLevelCard.svelte';
 export { default as SettingsFooter } from './SettingsFooter.svelte';

--- a/frontend/src/lib/stores/notifications.ts
+++ b/frontend/src/lib/stores/notifications.ts
@@ -2,11 +2,22 @@ import { writable } from 'svelte/store';
 
 export type NotificationType = 'success' | 'error' | 'info' | 'warning';
 
+export interface NotificationAction {
+	label: string;
+	href: string;
+}
+
 export interface Notification {
 	id: string;
 	type: NotificationType;
 	message: string;
 	duration?: number;
+	action?: NotificationAction;
+}
+
+interface AddOptions {
+	duration?: number;
+	action?: NotificationAction;
 }
 
 function createNotificationStore() {
@@ -14,14 +25,21 @@ function createNotificationStore() {
 
 	let counter = 0;
 
-	function add(type: NotificationType, message: string, duration = 5000) {
+	function add(type: NotificationType, message: string, opts: AddOptions = {}) {
 		const id = `notification-${++counter}`;
-		const notification: Notification = { id, type, message, duration };
+		const notification: Notification = {
+			id,
+			type,
+			message,
+			duration: opts.duration,
+			action: opts.action,
+		};
 
 		update((n) => [...n, notification]);
 
-		if (duration > 0) {
-			setTimeout(() => remove(id), duration);
+		const dur = opts.duration ?? 5000;
+		if (dur > 0) {
+			setTimeout(() => remove(id), dur);
 		}
 
 		return id;
@@ -35,14 +53,25 @@ function createNotificationStore() {
 		update(() => []);
 	}
 
+	// Backwards-compatible API: callers may pass either a number (legacy
+	// duration-only) or an options object {duration, action}.
+	function shorthand(type: NotificationType, defaultDur: number) {
+		return (message: string, opts?: number | AddOptions) => {
+			if (typeof opts === 'number') {
+				return add(type, message, { duration: opts });
+			}
+			return add(type, message, { duration: defaultDur, ...opts });
+		};
+	}
+
 	return {
 		subscribe,
-		success: (message: string, duration?: number) => add('success', message, duration ?? 5000),
-		error: (message: string, duration?: number) => add('error', message, duration ?? 10000),
-		info: (message: string, duration?: number) => add('info', message, duration ?? 5000),
-		warning: (message: string, duration?: number) => add('warning', message, duration ?? 8000),
+		success: shorthand('success', 5000),
+		error: shorthand('error', 10000),
+		info: shorthand('info', 5000),
+		warning: shorthand('warning', 8000),
 		remove,
-		clearAll
+		clearAll,
 	};
 }
 

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1,0 +1,36 @@
+// Minimal global cache for Settings + a derived UsageLevel store.
+// Loaded once from /+layout.svelte after authentication; updated by:
+//   1. UsageLevelCard after a successful api.updateSettings() call
+//   2. The settings page after any of its save flows (write-through)
+//   3. The SSE handler for resource:invalidated{resource:"settings"}
+//      which calls reloadSettings() (see Task 9)
+// Pages that don't care about UsageLevel can keep loading settings their
+// own way — this store coexists with that pattern.
+
+import { writable, derived, get } from 'svelte/store';
+import type { Settings } from '$lib/types';
+import { type UsageLevel } from '$lib/types/usageLevel';
+import { api } from '$lib/api/client';
+
+export const settings = writable<Settings | null>(null);
+
+// Safe fallback: when the store is empty we return 'advanced' so the UI
+// doesn't flicker by hiding things it should show.
+export const usageLevel = derived(
+	settings,
+	($s): UsageLevel => ($s?.usageLevel ?? 'advanced'),
+);
+
+export function setSettings(s: Settings) {
+	settings.set(s);
+}
+
+export async function reloadSettings(): Promise<Settings | null> {
+	try {
+		const s = await api.getSettings();
+		settings.set(s);
+		return s;
+	} catch {
+		return get(settings);
+	}
+}

--- a/frontend/src/lib/stores/storeRegistry.ts
+++ b/frontend/src/lib/stores/storeRegistry.ts
@@ -14,6 +14,7 @@ export type ResourceKey =
 	| 'sysInfo'                     // ResourceSysInfo
 	| 'pingcheck'                   // ResourcePingcheck
 	| 'saveStatus'                  // ResourceSaveStatus
+	| 'settings'                    // ResourceSettings
 	| 'routing.dnsRoutes'           // ResourceRoutingDnsRoutes
 	| 'routing.staticRoutes'        // ResourceRoutingStaticRoutes
 	| 'routing.accessPolicies'      // ResourceRoutingAccessPolicies

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { UsageLevel } from './types/usageLevel';
+
 // ─────────────────────────────────────────────
 // #region Tunnels — config, state, list items
 // ─────────────────────────────────────────────
@@ -634,6 +636,7 @@ export interface Settings {
 	disableMemorySaving: boolean;
 	updates: UpdateSettings;
 	dnsRoute: DNSRouteSettings;
+	usageLevel: UsageLevel;
 	hiddenSystemTunnels?: string[];
 }
 

--- a/frontend/src/lib/types/usageLevel.ts
+++ b/frontend/src/lib/types/usageLevel.ts
@@ -1,0 +1,97 @@
+// Single source of truth for which sections / sub-tabs are visible at each
+// usage level. Imported by AppHeader, +layout.svelte (route guard),
+// routing/+page.svelte (sub-tabs), UsageLevelCard, and WelcomeBanner.
+
+export type UsageLevel = 'basic' | 'advanced' | 'expert';
+
+export const USAGE_LEVELS: UsageLevel[] = ['basic', 'advanced', 'expert'];
+
+export const USAGE_LEVEL_LABELS: Record<UsageLevel, string> = {
+	basic: 'Базовый',
+	advanced: 'Расширенный',
+	expert: 'Продвинутый',
+};
+
+export type Section =
+	| 'tunnels'
+	| 'systemTunnels'
+	| 'singboxTunnels'
+	| 'servers'
+	| 'routing'
+	| 'monitoring'
+	| 'diagnostics'
+	| 'settings'
+	| 'terminal';
+
+export type RoutingSubTab =
+	| 'accessPolicies'
+	| 'clientRoutes'
+	| 'dnsRoutes'
+	| 'ipRoutes'
+	| 'deviceProxy'
+	| 'hrNeo'
+	| 'singboxRouter';
+
+const SECTION_MIN_LEVEL: Record<Section, UsageLevel> = {
+	tunnels: 'basic',
+	systemTunnels: 'basic',
+	diagnostics: 'basic',
+	settings: 'basic',
+	singboxTunnels: 'advanced',
+	servers: 'advanced',
+	routing: 'advanced',
+	monitoring: 'advanced',
+	terminal: 'advanced',
+};
+
+const ROUTING_SUBTAB_MIN_LEVEL: Record<RoutingSubTab, UsageLevel> = {
+	accessPolicies: 'advanced',
+	clientRoutes: 'advanced',
+	dnsRoutes: 'advanced',
+	ipRoutes: 'advanced',
+	deviceProxy: 'advanced',
+	hrNeo: 'expert',
+	singboxRouter: 'expert',
+};
+
+const LEVEL_RANK: Record<UsageLevel, number> = { basic: 0, advanced: 1, expert: 2 };
+
+export function isSectionVisible(level: UsageLevel, section: Section): boolean {
+	return LEVEL_RANK[level] >= LEVEL_RANK[SECTION_MIN_LEVEL[section]];
+}
+
+export function isRoutingSubTabVisible(level: UsageLevel, tab: RoutingSubTab): boolean {
+	return LEVEL_RANK[level] >= LEVEL_RANK[ROUTING_SUBTAB_MIN_LEVEL[tab]];
+}
+
+// Map a URL pathname to its Section. null = unknown path; the route guard
+// must skip those (404 / dev pages remain accessible).
+export function pathToSection(pathname: string): Section | null {
+	if (pathname === '/' || pathname.startsWith('/tunnels')) return 'tunnels';
+	if (pathname.startsWith('/system-tunnels')) return 'systemTunnels';
+	if (pathname.startsWith('/singbox')) return 'singboxTunnels';
+	if (pathname.startsWith('/servers')) return 'servers';
+	if (pathname.startsWith('/routing')) return 'routing';
+	if (
+		pathname.startsWith('/monitoring') ||
+		pathname.startsWith('/pingcheck') ||
+		pathname.startsWith('/connections')
+	)
+		return 'monitoring';
+	if (pathname.startsWith('/diagnostics') || pathname.startsWith('/logs')) return 'diagnostics';
+	if (pathname.startsWith('/settings')) return 'settings';
+	if (pathname.startsWith('/terminal')) return 'terminal';
+	return null;
+}
+
+export const SECTION_LABELS: Record<Section, string> = {
+	tunnels: 'Туннели',
+	systemTunnels: 'Системные туннели',
+	singboxTunnels: 'Sing-box',
+	servers: 'Серверы',
+	routing: 'Маршрутизация',
+	monitoring: 'Мониторинг',
+	diagnostics: 'Диагностика',
+	settings: 'Настройки',
+	terminal: 'Терминал',
+};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -295,9 +295,21 @@
 				</button>
 			{/if}
 			{#each $notifications as notification (notification.id)}
-				<button class="toast toast-{notification.type}" onclick={() => notifications.remove(notification.id)}>
-					{notification.message}
-				</button>
+				<div class="toast toast-{notification.type}">
+					<button
+						type="button"
+						class="toast-message"
+						onclick={() => notifications.remove(notification.id)}
+						aria-label="Закрыть уведомление"
+					>{notification.message}</button>
+					{#if notification.action}
+						<a
+							class="toast-action"
+							href={notification.action.href}
+							onclick={() => notifications.remove(notification.id)}
+						>{notification.action.label}</a>
+					{/if}
+				</div>
 			{/each}
 		</div>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { get } from 'svelte/store';
 	import type { Snippet } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { theme } from '$lib/stores/theme';
 	import { auth, isAuthenticated, isLoading } from '$lib/stores/auth';
 	import { notifications } from '$lib/stores/notifications';
@@ -20,7 +22,13 @@
 	import { singboxRouter } from '$lib/stores/singboxRouter';
 	import { invalidateResource, invalidateAll } from '$lib/stores/storeRegistry';
 	import { setDeviceProxyMissingTarget, clearDeviceProxyMissingTarget } from '$lib/stores/deviceproxy';
-	import { settings as settingsStore, reloadSettings } from '$lib/stores/settings';
+	import { settings as settingsStore, reloadSettings, usageLevel } from '$lib/stores/settings';
+	import {
+		isSectionVisible,
+		pathToSection,
+		SECTION_LABELS,
+		USAGE_LEVEL_LABELS,
+	} from '$lib/types/usageLevel';
 	import type { UpdateInfo } from '$lib/types';
 	import LoginForm from '$lib/components/LoginForm.svelte';
 	import { Modal } from '$lib/components/ui';
@@ -230,6 +238,22 @@
 		if ($isAuthenticated && get(settingsStore) === null) {
 			void reloadSettings();
 		}
+	});
+
+	// Route guard: redirect away from sections hidden at the current usage level.
+	$effect(() => {
+		if (!$isAuthenticated) return;
+		if ($settingsStore === null) return; // settings not loaded yet
+		const path = $page.url.pathname;
+		const section = pathToSection(path);
+		if (!section) return; // unknown path — let SvelteKit handle
+		if (isSectionVisible($usageLevel, section)) return;
+
+		notifications.warning(
+			`Раздел «${SECTION_LABELS[section]}» недоступен в режиме «${USAGE_LEVEL_LABELS[$usageLevel]}». Изменить уровень в Настройках.`,
+			{ action: { label: 'Настройки', href: '/settings' }, duration: 8000 },
+		);
+		void goto('/', { replaceState: true });
 	});
 
 	onMount(async () => {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -241,17 +241,26 @@
 	});
 
 	// Route guard: redirect away from sections hidden at the current usage level.
+	let lastWarnedPath = $state<string | null>(null);
+
 	$effect(() => {
-		if (!$isAuthenticated) return;
-		if ($settingsStore === null) return; // settings not loaded yet
+		if (!$isAuthenticated) {
+			lastWarnedPath = null;
+			return;
+		}
+		if ($settingsStore === null) return;
 		const path = $page.url.pathname;
 		const section = pathToSection(path);
-		if (!section) return; // unknown path — let SvelteKit handle
-		if (isSectionVisible($usageLevel, section)) return;
+		if (!section || isSectionVisible($usageLevel, section)) {
+			lastWarnedPath = null;
+			return;
+		}
+		if (lastWarnedPath === path) return;
+		lastWarnedPath = path;
 
 		notifications.warning(
 			`Раздел «${SECTION_LABELS[section]}» недоступен в режиме «${USAGE_LEVEL_LABELS[$usageLevel]}». Изменить уровень в Настройках.`,
-			{ action: { label: 'Настройки', href: '/settings' }, duration: 8000 },
+			{ action: { label: 'Настройки', href: '/settings' } },
 		);
 		void goto('/', { replaceState: true });
 	});

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
 	import { singboxRouter } from '$lib/stores/singboxRouter';
 	import { invalidateResource, invalidateAll } from '$lib/stores/storeRegistry';
 	import { setDeviceProxyMissingTarget, clearDeviceProxyMissingTarget } from '$lib/stores/deviceproxy';
+	import { settings as settingsStore, reloadSettings } from '$lib/stores/settings';
 	import type { UpdateInfo } from '$lib/types';
 	import LoginForm from '$lib/components/LoginForm.svelte';
 	import { Modal } from '$lib/components/ui';
@@ -157,6 +158,10 @@
 				if (data.resource === 'deviceproxy.config') {
 					clearDeviceProxyMissingTarget();
 				}
+				// Settings is not a PollingStore — explicit reload.
+				if (data.resource === 'settings') {
+					void reloadSettings();
+				}
 			},
 
 			// Device-proxy: selected outbound was deleted — show a banner in the tab.
@@ -217,6 +222,13 @@
 			api.checkUpdate().then(info => updateInfo = info).catch(() => null);
 		} else {
 			updateInfo = null;
+		}
+	});
+
+	// Load settings store on first authentication (not a PollingStore).
+	$effect(() => {
+		if ($isAuthenticated && get(settingsStore) === null) {
+			void reloadSettings();
 		}
 	});
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,6 +12,8 @@
 	import { singboxStatus, singboxTunnels } from '$lib/stores/singbox';
 	import { SingboxInstallBanner, SingboxTunnelCard, SingboxGhostTerminal } from '$lib/components/singbox';
 	import { feedTraffic } from '$lib/stores/traffic';
+	import { usageLevel } from '$lib/stores/settings';
+	import { isSectionVisible } from '$lib/types/usageLevel';
 
 	type TunnelTab = 'awg' | 'singbox';
 
@@ -171,10 +173,21 @@
 	// Tabs
 	let activeTab = $state<TunnelTab>('awg');
 
-	const tunnelTabs = $derived([
-		{ id: 'awg', label: 'AWG', badge: awgList.length + systemList.length },
-		{ id: 'singbox', label: 'Sing-box', badge: singboxTunnelsList.length },
-	]);
+	const tunnelTabs = $derived(
+		[
+			{ id: 'awg', label: 'AWG', badge: awgList.length + systemList.length },
+			isSectionVisible($usageLevel, 'singboxTunnels')
+				? { id: 'singbox', label: 'Sing-box', badge: singboxTunnelsList.length }
+				: null,
+		].filter((t): t is { id: string; label: string; badge: number } => t !== null),
+	);
+
+	// Auto-switch off sing-box tab if it becomes hidden (basic mode).
+	$effect(() => {
+		if (!tunnelTabs.find((t) => t.id === activeTab)) {
+			activeTab = 'awg';
+		}
+	});
 
 	onMount(() => {
 		// URL query wins over sessionStorage — lets other pages

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { api } from '$lib/api/client';
 	import { TunnelCard, ExternalTunnelCard, AdoptTunnelDialog, SystemTunnelCard, TunnelReferencedModal } from '$lib/components/tunnels';
-	import { PageContainer, LoadingSpinner } from '$lib/components/layout';
+	import { PageContainer, LoadingSpinner, WelcomeBanner } from '$lib/components/layout';
 	import { Modal, StoreStatusBadge, TrafficChartModal, Button, Badge, Tabs } from '$lib/components/ui';
 	import { singboxStatus, singboxTunnels } from '$lib/stores/singbox';
 	import { SingboxInstallBanner, SingboxTunnelCard, SingboxGhostTerminal } from '$lib/components/singbox';
@@ -315,6 +315,7 @@
 </svelte:head>
 
 <PageContainer width="full">
+	<WelcomeBanner />
 	{#if loading}
 		<div class="py-12">
 			<LoadingSpinner size="lg" message="Загрузка туннелей..." />

--- a/frontend/src/routes/routing/+page.svelte
+++ b/frontend/src/routes/routing/+page.svelte
@@ -17,6 +17,8 @@
     import { DeviceProxyTab } from '$lib/components/deviceproxy';
     import { deviceProxyConfig, deviceProxyRuntime } from '$lib/stores/deviceproxy';
     import SingboxRouterTab from './SingboxRouterTab.svelte';
+    import { isRoutingSubTabVisible, type RoutingSubTab, type UsageLevel } from '$lib/types/usageLevel';
+    import { usageLevel } from '$lib/stores/settings';
 
     // Per-section polling stores — subscribe here so all 8 fetch while
     // the routing page is open. Unsubscribed on destroy to stop polling.
@@ -44,7 +46,9 @@
     $effect(() => {
         const t = $page.url.searchParams.get('tab');
         if (t === 'hrneo' || t === 'dns' || t === 'ip' || t === 'policy' || t === 'clientvpn' || t === 'deviceproxy' || t === 'singbox') {
-            activeTab = t;
+            if (tabVisible(t)) {
+                activeTab = t;
+            }
         }
     });
     let isOS5 = $derived($systemInfo.data?.isOS5 ?? false);
@@ -155,6 +159,22 @@
         badgeTone?: 'default' | 'success' | 'warning' | 'muted';
     };
 
+    const TAB_TO_SUBTAB: Record<string, RoutingSubTab> = {
+        policy: 'accessPolicies',
+        clientvpn: 'clientRoutes',
+        dns: 'dnsRoutes',
+        ip: 'ipRoutes',
+        deviceproxy: 'deviceProxy',
+        hrneo: 'hrNeo',
+        singbox: 'singboxRouter',
+    };
+
+    function tabVisible(localId: string, level?: UsageLevel): boolean {
+        const sub = TAB_TO_SUBTAB[localId];
+        const lvl = level ?? $usageLevel;
+        return sub ? isRoutingSubTabVisible(lvl, sub) : true;
+    }
+
     const singboxRouterStatus = singboxRouterStore.status;
     let singboxRuleCount = $derived($singboxRouterStatus?.ruleCount ?? 0);
 
@@ -170,7 +190,9 @@
             { id: 'clientvpn', label: 'VPN для устройств', badge: clientRouteCount },
             deviceProxyTab,
             singboxInstalled ? { id: 'singbox', label: 'Sing-box Router', badge: singboxRuleCount } : null,
-        ] as (TabItem | null)[]).filter((t): t is TabItem => t !== null)
+        ] as (TabItem | null)[])
+            .filter((t): t is TabItem => t !== null)
+            .filter((t) => tabVisible(t.id))
     );
 
     // If the user deep-linked / had the tab active and sing-box disappeared
@@ -179,6 +201,17 @@
         if (!$systemInfo.data) return;
         if (!singboxInstalled && (activeTab === 'deviceproxy' || activeTab === 'singbox')) {
             activeTab = 'dns';
+        }
+    });
+
+    // If the active tab becomes invisible (user lowered usage level while the
+    // HR NEO or Sing-box Router tab was active), pick the first visible tab.
+    $effect(() => {
+        if (!tabItems.find((it) => it.id === activeTab)) {
+            const next = tabItems[0]?.id;
+            if (next) {
+                activeTab = next as typeof activeTab;
+            }
         }
     });
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -21,13 +21,22 @@
 		UpdateInfo,
 		HydraRouteStatus,
 	} from "$lib/types";
-	import { USAGE_LEVEL_LABELS, type UsageLevel } from "$lib/types/usageLevel";
+	import {
+		USAGE_LEVEL_LABELS,
+		isSectionVisible,
+		isRoutingSubTabVisible,
+		type UsageLevel,
+	} from "$lib/types/usageLevel";
+	import { usageLevel } from "$lib/stores/settings";
 
 	let systemInfo: SystemInfo | null = $state(null);
 	let settings = $state<Settings | null>(null);
 	let loading = $state(true);
 	let saving = $state(false);
 	const origin = $derived(typeof window !== "undefined" ? window.location.origin : "");
+	const showSingboxIntegration = $derived(isSectionVisible($usageLevel, "singboxTunnels"));
+	const showHydraIntegration = $derived(isRoutingSubTabVisible($usageLevel, "hrNeo"));
+	const showDnsRouteCard = $derived(isRoutingSubTabVisible($usageLevel, "dnsRoutes"));
 	let updateInfo: UpdateInfo | null = $state(null);
 	let restarting = $state(false);
 	let restartConfirmOpen = $state(false);
@@ -277,6 +286,8 @@
 					{singboxInstalling}
 					{singboxInstallError}
 					oninstallSingbox={installSingbox}
+					showSingbox={showSingboxIntegration}
+					showHydra={showHydraIntegration}
 				/>
 			</aside>
 
@@ -325,7 +336,7 @@
 					/>
 				</div>
 
-				{#if systemInfo.isOS5}
+				{#if systemInfo.isOS5 && showDnsRouteCard}
 					<div class="card">
 						<div class="section-label">DNS-маршрутизация</div>
 						<DnsRouteSettings

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -262,12 +262,6 @@
 			<LoadingSpinner size="md" />
 		</div>
 	{:else if settings && systemInfo}
-		<UsageLevelCard
-			value={settings.usageLevel}
-			{saving}
-			onSelect={selectUsageLevel}
-		/>
-
 		<div class="settings-grid">
 			<aside class="settings-left">
 				<SystemInfoGrid {systemInfo} />
@@ -287,6 +281,12 @@
 			</aside>
 
 			<main class="settings-right">
+				<UsageLevelCard
+					value={settings.usageLevel}
+					{saving}
+					onSelect={selectUsageLevel}
+				/>
+
 				<div class="card">
 					<div class="section-label">Доступ</div>
 					<div class="setting-row">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -479,11 +479,14 @@
 		display: inline-flex;
 		gap: 0.5rem;
 		align-items: center;
-		flex-shrink: 0;
+		flex-shrink: 1;
+		min-width: 0;
+		flex-wrap: wrap;
 	}
 
 	.api-key-input {
 		width: 22rem;
+		min-width: 0;
 		max-width: 100%;
 		padding: 0.375rem 0.5rem;
 		font-family: var(--font-mono, ui-monospace, monospace);

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -348,6 +348,7 @@
 					</div>
 				{/if}
 
+				{#if $usageLevel === "expert"}
 				<div class="card">
 					<div class="section-label">Расширенные</div>
 					<div class="setting-row">
@@ -371,6 +372,7 @@
 						</div>
 					</div>
 				</div>
+				{/if}
 			</main>
 		</div>
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -12,13 +12,16 @@
 		DnsRouteSettings,
 		IntegrationsCard,
 		SettingsFooter,
+		UsageLevelCard,
 	} from "$lib/components/settings";
+	import { setSettings as setGlobalSettings } from "$lib/stores/settings";
 	import type {
 		SystemInfo,
 		Settings,
 		UpdateInfo,
 		HydraRouteStatus,
 	} from "$lib/types";
+	import type { UsageLevel } from "$lib/types/usageLevel";
 
 	let systemInfo: SystemInfo | null = $state(null);
 	let settings = $state<Settings | null>(null);
@@ -109,6 +112,7 @@
 		saving = true;
 		try {
 			settings = await api.updateSettings({ ...settings, authEnabled: enabled });
+			setGlobalSettings(settings);
 			notifications.success(enabled ? "Авторизация включена" : "Авторизация отключена");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
@@ -125,6 +129,7 @@
 			// over plain HTTP (router LAN context), so the backend produces
 			// the UUID via crypto/rand and persists it in one round-trip.
 			settings = await api.regenerateApiKey();
+			setGlobalSettings(settings);
 			notifications.success("API ключ сгенерирован");
 		} catch {
 			notifications.error("Ошибка генерации ключа");
@@ -141,6 +146,7 @@
 				...settings,
 				logging: { ...settings.logging, enabled },
 			});
+			setGlobalSettings(settings);
 			notifications.success(enabled ? "Логирование включено" : "Логирование отключено");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
@@ -154,6 +160,7 @@
 		saving = true;
 		try {
 			settings = await api.updateSettings(settings);
+			setGlobalSettings(settings);
 			notifications.success("Настройки логирования сохранены");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
@@ -178,6 +185,7 @@
 					refreshMode: settings.dnsRoute.refreshMode || "interval",
 				},
 			});
+			setGlobalSettings(settings);
 			notifications.success(enabled ? "Автообновление подписок включено" : "Автообновление подписок отключено");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
@@ -191,6 +199,7 @@
 		saving = true;
 		try {
 			settings = await api.updateSettings(settings);
+			setGlobalSettings(settings);
 			notifications.success("Настройки автообновления сохранены");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
@@ -207,9 +216,24 @@
 				...settings,
 				updates: { ...settings.updates, checkEnabled: enabled },
 			});
+			setGlobalSettings(settings);
 			notifications.success(enabled ? "Автопроверка обновлений включена" : "Автопроверка обновлений отключена");
 		} catch {
 			notifications.error("Ошибка сохранения настроек");
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function selectUsageLevel(level: UsageLevel) {
+		if (!settings) return;
+		saving = true;
+		try {
+			settings = await api.updateSettings({ ...settings, usageLevel: level });
+			setGlobalSettings(settings);
+			notifications.success(`Уровень: ${level}`);
+		} catch {
+			notifications.error("Не удалось сохранить уровень");
 		} finally {
 			saving = false;
 		}
@@ -238,6 +262,12 @@
 			<LoadingSpinner size="md" />
 		</div>
 	{:else if settings && systemInfo}
+		<UsageLevelCard
+			value={settings.usageLevel}
+			{saving}
+			onSelect={selectUsageLevel}
+		/>
+
 		<div class="settings-grid">
 			<aside class="settings-left">
 				<SystemInfoGrid {systemInfo} />

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -21,7 +21,7 @@
 		UpdateInfo,
 		HydraRouteStatus,
 	} from "$lib/types";
-	import type { UsageLevel } from "$lib/types/usageLevel";
+	import { USAGE_LEVEL_LABELS, type UsageLevel } from "$lib/types/usageLevel";
 
 	let systemInfo: SystemInfo | null = $state(null);
 	let settings = $state<Settings | null>(null);
@@ -231,7 +231,7 @@
 		try {
 			settings = await api.updateSettings({ ...settings, usageLevel: level });
 			setGlobalSettings(settings);
-			notifications.success(`Уровень: ${level}`);
+			notifications.success(`Уровень: ${USAGE_LEVEL_LABELS[level]}`);
 		} catch {
 			notifications.error("Не удалось сохранить уровень");
 		} finally {

--- a/internal/api/publish.go
+++ b/internal/api/publish.go
@@ -12,6 +12,7 @@ const (
 	ResourceSysInfo                 = "sysInfo"
 	ResourcePingcheck               = "pingcheck"
 	ResourceSaveStatus              = "saveStatus"
+	ResourceSettings                = "settings"
 	ResourceRoutingDnsRoutes        = "routing.dnsRoutes"
 	ResourceRoutingStaticRoutes     = "routing.staticRoutes"
 	ResourceRoutingAccessPolicies   = "routing.accessPolicies"

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -55,7 +55,7 @@ type DNSRouteSettingsDTO struct {
 
 // SettingsData is the payload for GET /settings/get.
 type SettingsData struct {
-	SchemaVersion       int                  `json:"schemaVersion" example:"3"`
+	SchemaVersion       int                  `json:"schemaVersion" example:"16"`
 	AuthEnabled         bool                 `json:"authEnabled" example:"false"`
 	Server              ServerSettingsDTO    `json:"server"`
 	PingCheck           PingCheckSettingsDTO `json:"pingCheck"`
@@ -63,6 +63,10 @@ type SettingsData struct {
 	DisableMemorySaving bool                 `json:"disableMemorySaving" example:"false"`
 	Updates             UpdateSettingsDTO    `json:"updates"`
 	DnsRoute            DNSRouteSettingsDTO  `json:"dnsRoute"`
+	// UsageLevel controls which UI sections are visible to the user.
+	// Filtering is frontend-only — the API does not enforce it.
+	// enums: basic,advanced,expert
+	UsageLevel string `json:"usageLevel" example:"advanced" enums:"basic,advanced,expert"`
 }
 
 // SettingsResponse is the envelope for GET /settings/get.
@@ -140,7 +144,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 // Update saves settings.
 //
 //	@Summary		Update settings
-//	@Description	Persists Settings. Sub-structs (server, pingCheck, logging, dnsRoute, managedServers, ...) preserved when zero/nil. ApiKey preserved when empty (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled, disableMemorySaving, onboardingCompleted) MUST be sent on every save.
+//	@Description	Persists Settings. Sub-structs (server, pingCheck, logging, dnsRoute, managedServers, ...) preserved when zero/nil. ApiKey preserved when empty (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled, disableMemorySaving) MUST be sent on every save.
 //	@Tags			settings
 //	@Accept			json
 //	@Produce		json
@@ -172,7 +176,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	//
 	// Policy: for every top-level sub-struct or slice field, restore from
 	// existing if the incoming value is zero. Top-level bool flags
-	// (AuthEnabled, DisableMemorySaving, OnboardingCompleted) cannot be
+	// (AuthEnabled, DisableMemorySaving) cannot be
 	// defended this way — "false" and "not sent" are indistinguishable —
 	// so the caller is expected to always send the full object.
 	if settings.Server == (storage.ServerSettings{}) {
@@ -209,6 +213,20 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// matches the behavior of other secret fields.
 	if settings.ApiKey == "" {
 		settings.ApiKey = oldSettings.ApiKey
+	}
+
+	// UsageLevel is a top-level string but treated like a sub-struct: an
+	// empty value (omitted from payload) restores from existing rather
+	// than silently resetting to "basic". A non-empty value is validated;
+	// invalid input rejected with 400 so a typo does not silently turn
+	// into "advanced".
+	if settings.UsageLevel == "" {
+		settings.UsageLevel = oldSettings.UsageLevel
+	} else if storage.NormalizeUsageLevel(settings.UsageLevel) != settings.UsageLevel {
+		response.ErrorWithStatus(w, http.StatusBadRequest,
+			"invalid usageLevel: must be one of basic, advanced, expert",
+			"INVALID_USAGE_LEVEL")
+		return
 	}
 
 	// Detect ping check toggle change before saving

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -89,6 +90,7 @@ type SettingsHandler struct {
 	pingCheckSnapshot func()
 	logsSnapshot      func()
 	log               *logging.ScopedLogger
+	bus               *events.Bus
 }
 
 // NewSettingsHandler creates a new settings handler.
@@ -114,6 +116,10 @@ func (h *SettingsHandler) SetPingCheckSnapshot(fn func()) { h.pingCheckSnapshot 
 
 // SetLogsSnapshot sets the function that publishes a logs snapshot.
 func (h *SettingsHandler) SetLogsSnapshot(fn func()) { h.logsSnapshot = fn }
+
+// SetEventBus wires the SSE bus so settings mutations broadcast a
+// resource:invalidated hint to all connected clients.
+func (h *SettingsHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 
 // Get returns current settings.
 //
@@ -309,6 +315,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.Success(w, settings)
+	publishInvalidated(h.bus, ResourceSettings, "updated")
 }
 
 // RegenerateApiKey generates a fresh UUID v4 server-side, persists it
@@ -351,6 +358,7 @@ func (h *SettingsHandler) RegenerateApiKey(w http.ResponseWriter, r *http.Reques
 
 	h.log.Info("api-key", "", "API key regenerated")
 	response.Success(w, settings)
+	publishInvalidated(h.bus, ResourceSettings, "api-key-rotated")
 }
 
 // generateUUIDv4 produces an RFC 4122 v4 UUID using crypto/rand.

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// newSettingsHandlerForTest returns a SettingsHandler backed by an
+// isolated SettingsStore in a temp directory. The store is preloaded so
+// defaults (including the v16 UsageLevel) are populated.
+//
+// nil AppLogger is intentionally passed — see internal/logging/applogger.go:
+// "Safe to use with nil appLogger — all methods become no-ops."
+func newSettingsHandlerForTest(t *testing.T) (*SettingsHandler, *storage.SettingsStore) {
+	t.Helper()
+	tmp := t.TempDir()
+	store := storage.NewSettingsStore(tmp)
+	if _, err := store.Load(); err != nil {
+		t.Fatalf("seed Load: %v", err)
+	}
+	h := NewSettingsHandler(store, nil)
+	return h, store
+}
+
+// TestUpdateUsageLevelAccepted verifies that a valid usageLevel value
+// (here: "expert") is accepted and persisted by the Update handler.
+func TestUpdateUsageLevelAccepted(t *testing.T) {
+	h, store := newSettingsHandlerForTest(t)
+	current, _ := store.Get()
+	// store.Get() returns a pointer into the cache; copy by value so
+	// payload mutations do not retroactively alias the cached state read
+	// back as oldSettings inside the handler.
+	payload := *current
+	payload.UsageLevel = storage.UsageLevelExpert
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/settings/update", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := store.Get()
+	if got.UsageLevel != storage.UsageLevelExpert {
+		t.Errorf("UsageLevel after update = %q, want expert", got.UsageLevel)
+	}
+}
+
+// TestUpdateUsageLevelInvalidRejected verifies that an unknown
+// usageLevel value is rejected with 400 and the INVALID_USAGE_LEVEL
+// error code, instead of being silently coerced to a default.
+func TestUpdateUsageLevelInvalidRejected(t *testing.T) {
+	h, _ := newSettingsHandlerForTest(t)
+	body := []byte(`{
+		"schemaVersion": 16,
+		"authEnabled": false,
+		"server": {"port": 2222, "interface": "br0"},
+		"pingCheck": {"enabled": false, "defaults": {"method":"http","target":"8.8.8.8","interval":45,"deadInterval":120,"failThreshold":3}},
+		"logging": {"enabled": true, "maxAge": 2},
+		"disableMemorySaving": false,
+		"updates": {"checkEnabled": true},
+		"dnsRoute": {"autoRefreshEnabled": false},
+		"usageLevel": "garbage",
+		"singboxRouter": {"enabled": false, "policyName": "", "refreshMode": "interval", "refreshIntervalHours": 24}
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/settings/update", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "INVALID_USAGE_LEVEL") {
+		t.Errorf("body missing error code:\n%s", rec.Body.String())
+	}
+}
+
+// TestUpdateUsageLevelEmptyPreserves verifies that a payload with an
+// empty usageLevel preserves the previously stored value (defense for
+// partial updates that omit the field).
+func TestUpdateUsageLevelEmptyPreserves(t *testing.T) {
+	h, store := newSettingsHandlerForTest(t)
+
+	// Pre-seed with expert. Copy by value before mutating + saving so we
+	// own a stable snapshot independent of the cache pointer aliasing.
+	current, _ := store.Get()
+	seed := *current
+	seed.UsageLevel = storage.UsageLevelExpert
+	if err := store.Save(&seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Build a payload that omits usageLevel (empty string) — defense
+	// logic should restore it from the saved value.
+	payload := seed
+	payload.UsageLevel = ""
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/settings/update", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := store.Get()
+	if got.UsageLevel != storage.UsageLevelExpert {
+		t.Errorf("UsageLevel = %q after empty update, want expert (preserved)", got.UsageLevel)
+	}
+}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1752,12 +1752,23 @@ definitions:
       pingCheck:
         $ref: '#/definitions/api.PingCheckSettingsDTO'
       schemaVersion:
-        example: 3
+        example: 16
         type: integer
       server:
         $ref: '#/definitions/api.ServerSettingsDTO'
       updates:
         $ref: '#/definitions/api.UpdateSettingsDTO'
+      usageLevel:
+        description: |-
+          UsageLevel controls which UI sections are visible to the user.
+          Filtering is frontend-only — the API does not enforce it.
+          enums: basic,advanced,expert
+        enum:
+        - basic
+        - advanced
+        - expert
+        example: advanced
+        type: string
     type: object
   api.SettingsResponse:
     properties:
@@ -6234,7 +6245,7 @@ paths:
       description: Persists Settings. Sub-structs (server, pingCheck, logging, dnsRoute,
         managedServers, ...) preserved when zero/nil. ApiKey preserved when empty
         (rotate via /settings/regenerate-api-key). Top-level bool flags (authEnabled,
-        disableMemorySaving, onboardingCompleted) MUST be sent on every save.
+        disableMemorySaving) MUST be sent on every save.
       parameters:
       - description: Full settings object
         in: body

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -402,6 +402,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	settingsHandler := api.NewSettingsHandler(s.settings, appLog)
 	settingsHandler.SetTunnelStore(s.tunnels)
 	settingsHandler.SetPingCheckService(s.pingCheckService)
+	settingsHandler.SetEventBus(s.bus)
 	importHandler := api.NewImportHandler(s.tunnelService, s.tunnels, appLog)
 	importHandler.SetSettingsStore(s.settings)
 	importHandler.SetPingCheckService(s.pingCheckService)

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	CurrentSchemaVersion = 15
+	CurrentSchemaVersion = 16
 	DefaultPort          = 2222
 	DefaultInterface     = "br0"
 )
@@ -103,6 +103,9 @@ func (s *SettingsStore) Load() (*Settings, error) {
 		if settings.SchemaVersion < 15 {
 			s.migrateToV15(&settings)
 		}
+		if settings.SchemaVersion < 16 {
+			s.migrateToV16(&settings)
+		}
 		// Save migrated settings
 		if err := s.saveUnlocked(&settings); err != nil {
 			return nil, err
@@ -118,6 +121,7 @@ func (s *SettingsStore) defaultSettings() *Settings {
 	return &Settings{
 		SchemaVersion: CurrentSchemaVersion,
 		AuthEnabled:   false,
+		UsageLevel:    UsageLevelBasic,
 		Server: ServerSettings{
 			Port:      DefaultPort,
 			Interface: DefaultInterface,
@@ -210,9 +214,10 @@ func (s *SettingsStore) migrateToV6(settings *Settings) {
 	settings.SchemaVersion = 6
 }
 
-// migrateToV7 migrates settings from v6 to v7.
+// migrateToV7 was a version bump for an experimental field that was
+// removed before reaching production. Kept as a no-op so the schema
+// ladder remains contiguous.
 func (s *SettingsStore) migrateToV7(settings *Settings) {
-	// OnboardingCompleted defaults to false (zero value) — no action needed
 	settings.SchemaVersion = 7
 }
 
@@ -271,6 +276,16 @@ func (s *SettingsStore) migrateToV15(settings *Settings) {
 	settings.SingboxRouter.PolicyName = ""
 	settings.SingboxRouter.Enabled = false
 	settings.SchemaVersion = 15
+}
+
+// migrateToV16 introduces UsageLevel. Any user reaching this migration
+// already has a working settings file (the file existed on disk before
+// the upgrade), so they are an existing user — set advanced. Fresh
+// installs never run this migration: defaultSettings() ships v16 with
+// usageLevel="basic".
+func (s *SettingsStore) migrateToV16(settings *Settings) {
+	settings.UsageLevel = UsageLevelAdvanced
+	settings.SchemaVersion = 16
 }
 
 // migrateManagedServers moves a legacy singular managedServer into the

--- a/internal/storage/settings_test.go
+++ b/internal/storage/settings_test.go
@@ -253,3 +253,86 @@ func TestSettingsMigrationV8_SchemaVersion(t *testing.T) {
 		t.Errorf("SchemaVersion = %d, want %d", settings.SchemaVersion, CurrentSchemaVersion)
 	}
 }
+
+func TestLoadFreshInstallSetsBasic(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewSettingsStore(tmpDir)
+
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if settings.UsageLevel != UsageLevelBasic {
+		t.Errorf("fresh install UsageLevel = %q, want %q", settings.UsageLevel, UsageLevelBasic)
+	}
+	if settings.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("fresh install SchemaVersion = %d, want %d", settings.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	// Verify the value was persisted on disk too.
+	data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"usageLevel": "basic"`) {
+		t.Errorf("settings.json missing basic usageLevel:\n%s", data)
+	}
+}
+
+func TestLoadUpgradeFromV15SetsAdvanced(t *testing.T) {
+	tmpDir := t.TempDir()
+	v15 := `{
+		"schemaVersion": 15,
+		"authEnabled": false,
+		"onboardingCompleted": true,
+		"server": {"port": 2222, "interface": "br0"},
+		"pingCheck": {"enabled": false, "defaults": {"method":"http","target":"8.8.8.8","interval":45,"deadInterval":120,"failThreshold":3}},
+		"logging": {"enabled": true, "maxAge": 2},
+		"disableMemorySaving": false,
+		"updates": {"checkEnabled": true},
+		"dnsRoute": {"autoRefreshEnabled": false, "refreshIntervalHours": 0},
+		"singboxRouter": {"enabled": false, "policyName": "", "refreshMode": "interval", "refreshIntervalHours": 24}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), []byte(v15), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	store := NewSettingsStore(tmpDir)
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if settings.UsageLevel != UsageLevelAdvanced {
+		t.Errorf("upgrade UsageLevel = %q, want %q", settings.UsageLevel, UsageLevelAdvanced)
+	}
+	if settings.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("upgrade SchemaVersion = %d, want %d", settings.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	// Verify legacy field was dropped from the persisted file.
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if strings.Contains(string(data), "onboardingCompleted") {
+		t.Errorf("legacy onboardingCompleted field still present:\n%s", data)
+	}
+}
+
+func TestNormalizeUsageLevel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"basic", "basic"},
+		{"advanced", "advanced"},
+		{"expert", "expert"},
+		{"", "advanced"},
+		{"garbage", "advanced"},
+		{"BASIC", "advanced"}, // case-sensitive
+	}
+	for _, tc := range tests {
+		got := NormalizeUsageLevel(tc.in)
+		if got != tc.want {
+			t.Errorf("NormalizeUsageLevel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -15,7 +15,7 @@ type Settings struct {
 	DisableMemorySaving bool              `json:"disableMemorySaving"` // false = auto, true = soft mode
 	Updates             UpdateSettings    `json:"updates"`
 	DNSRoute            DNSRouteSettings  `json:"dnsRoute"`
-	OnboardingCompleted    bool              `json:"onboardingCompleted"`
+	UsageLevel             string            `json:"usageLevel"`
 	ServerInterfaces       []string          `json:"serverInterfaces,omitempty"`
 	ManagedServers         []ManagedServer   `json:"managedServers,omitempty"`
 	// ManagedServer is retained for one release as the migration source.

--- a/internal/storage/usage_level.go
+++ b/internal/storage/usage_level.go
@@ -1,0 +1,23 @@
+package storage
+
+// UsageLevel values controlling UI section visibility. The backend stores
+// the value but never enforces it — filtering is frontend-only. Validation
+// lives in NormalizeUsageLevel: unknown values fall back to advanced
+// rather than errors, so a bad settings.json never bricks the daemon.
+const (
+	UsageLevelBasic    = "basic"
+	UsageLevelAdvanced = "advanced"
+	UsageLevelExpert   = "expert"
+)
+
+// NormalizeUsageLevel returns v if it is one of the known levels, otherwise
+// UsageLevelAdvanced. Used as the safe fallback for empty or corrupt
+// values read from disk.
+func NormalizeUsageLevel(v string) string {
+	switch v {
+	case UsageLevelBasic, UsageLevelAdvanced, UsageLevelExpert:
+		return v
+	default:
+		return UsageLevelAdvanced
+	}
+}


### PR DESCRIPTION
## Что добавлено

Селектор уровня использования в Настройках, прогрессивно скрывает разделы UI, которые не нужны на текущем уровне. Backend хранит выбор, не блокирует API.

### Уровни и состав

| Раздел / возможность | Базовый | Расширенный | Продвинутый |
|---|:---:|:---:|:---:|
| AmneziaWG туннели | ✓ | ✓ | ✓ |
| Системные туннели (NativeWG) | ✓ | ✓ | ✓ |
| Sing-box туннели | — | ✓ | ✓ |
| Серверы (managed WireGuard) | — | ✓ | ✓ |
| Маршрутизация: политики, клиенты, DNS, IP, Device Proxy | — | ✓ | ✓ |
| Маршрутизация: HR Neo, Sing-box Router | — | — | ✓ |
| Мониторинг (трафик, pingcheck, соединения) | — | ✓ | ✓ |
| Диагностика | ✓ | ✓ | ✓ |
| Веб-терминал | — | ✓ | ✓ |
| Настройки → Интеграции (Sing-box) | — | ✓ | ✓ |
| Настройки → Интеграции (HydraRoute Neo) | — | — | ✓ |
| Настройки → DNS-маршрутизация | — | ✓ | ✓ |
| Настройки → API Key | — | — | ✓ |

### Defaults

- Свежая установка → \`basic\`. На главной показывается приветственный баннер с подсказкой про Настройки.
- Апгрейд существующего конфига → \`advanced\` (миграция \`schemaVersion 15 → 16\`).

### Backend

- \`Settings.UsageLevel\` (\`basic\` / \`advanced\` / \`expert\`), миграция \`migrateToV16\`.
- \`POST /settings/update\` принимает \`usageLevel\`, валидирует через \`NormalizeUsageLevel\`, отдаёт 400 \`INVALID_USAGE_LEVEL\` на невалидном значении. Defense-in-depth: пустая строка → значение из текущего конфига.
- SSE \`resource:invalidated{settings}\` после \`Update\` и \`RegenerateApiKey\`.
- Удалено deprecated поле \`OnboardingCompleted\` (было непустым только в комментариях / swagger description).
- Swagger перегенерирован.

### Frontend

- \`lib/types/usageLevel.ts\` — единая карта видимости (sections + routing sub-tabs + label-ы), функции \`isSectionVisible\`, \`isRoutingSubTabVisible\`, \`pathToSection\`.
- \`lib/stores/settings.ts\` — глобальный кеш \`Settings\` + derived \`usageLevel\` + \`setSettings\` / \`reloadSettings\`.
- \`+layout.svelte\`: первичная загрузка после авторизации, обработчик SSE для перезагрузки при изменении.
- Route guard в \`+layout.svelte\`: при заходе на скрытый раздел — редирект на \`/\` + toast «Раздел недоступен в режиме X. Изменить в Настройках» с кнопкой-ссылкой. Дебаунс по pathname, чтобы не плодить повторные toast-ы.
- \`AppHeader\`: декларативный \`NAV_ITEMS\` + фильтр через \`isSectionVisible\`. Иконка терминала тоже скрывается на Basic.
- \`routing/+page.svelte\`: вкладки HR Neo и Sing-box Router скрыты вне Expert. Прямые ссылки \`?tab=hrneo\` на Advanced игнорируются. Авто-переключение, если текущая вкладка стала невидимой.
- \`+page.svelte\` (главная): вкладка \`Sing-box\` в туннелях скрыта на Basic.
- Новый компонент \`UsageLevelCard\` (карточка в Настройках, collapsable, три кликабельных карточки уровней + модалка с описанием по \`i\`-иконке).
- Новый компонент \`WelcomeBanner\` (главная страница, только на Basic, dismissable через \`localStorage\`).
- Уведомления: расширены опциональным полем \`action: { label, href }\` для toast-ов.
- Удалены frontend-рудименты Onboarding.

### Mobile

- \`body { overflow-x: hidden }\`, \`.setting-row { flex-wrap: wrap; min-width: 0 }\` + вертикальный стек на узких экранах.
- \`.api-key-row\` \`flex-shrink: 1\` (был \`0\`) — исправлен горизонтальный overflow всей страницы.
- \`.setting-description { overflow-wrap: anywhere }\` — длинные \`<code>\` (URL, Bearer-заголовок) переносятся.
- \`PageContainer\` — уменьшенный padding на ≤640px.