### PR TITLE
fix(ui): ConnectionsTable sticky header z-index + scroll-anchor comment

### DIFF
--- a/frontend/src/lib/components/routing/singboxRouter/ConnectionsTable.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/ConnectionsTable.svelte
@@ -139,6 +139,10 @@
 </div>
 
 <style>
+	/* Fixed height + overflow:auto creates the scrolling ancestor required
+	   by position:sticky on .t th below. If a parent ever wraps this in
+	   another scroll container, sticky will still work — but if a parent
+	   removes the height/overflow combo here, the header stops sticking. */
 	.wrap { overflow: auto; height: 540px; }
 	.t {
 		width: 100%;
@@ -164,7 +168,10 @@
 		text-transform: uppercase; letter-spacing: 0.04em;
 		color: var(--text-secondary, #b8b6b3);
 		background: var(--surface-1, #1f2425);
-		position: sticky; top: 0;
+		/* z-index lifts the header above tbody rows so they don't bleed
+		   through during scroll (sticky elements get a stacking context
+		   but tbody rows have z-index:auto by default). */
+		position: sticky; top: 0; z-index: 2;
 	}
 	.t .num { text-align: right; font-variant-numeric: tabular-nums; }
 	.sortable { cursor: pointer; user-select: none; }


### PR DESCRIPTION
## Что сделано

Узкий UX-фикс sticky-header'а в `ConnectionsTable.svelte`.

**Проблема**: при scroll'е таблицы sticky `<th>` корректно "приклеивался" к верху scroll-контейнера, но строки tbody могли просвечивать сквозь него — рядки получали `z-index: auto` (default = 0), а sticky элементы получают свой stacking context на том же уровне.

**Fix**: `z-index: 2` на `.t th` поднимает header над rows.

**Plus**: inline-комментарий на `.wrap` объясняет coupling между `height: 540px + overflow: auto` (создают scrolling ancestor) и `position: sticky` на `.t th`. Если parent однажды уберёт height-constraint — sticky тихо сломается. Комментарий явно предупреждает.

Single file, +8 LoC, no behavior change for existing render.