### PR TITLE
fix(dnsroute): tooltip дедупа CIDR показывает имя списка, а не ID

### DIFF
--- a/internal/dnsroute/cidr.go
+++ b/internal/dnsroute/cidr.go
@@ -34,7 +34,7 @@ func candidateInHoles(c *net.IPNet, holes []*net.IPNet) bool {
 	return false
 }
 
-func dedupSubnets(input []string, currentListID string, existingLists []DomainList) ([]string, DedupeReport) {
+func dedupSubnets(input []string, currentListID, currentListName string, existingLists []DomainList) ([]string, DedupeReport) {
 	report := DedupeReport{TotalInput: len(input)}
 	if len(input) == 0 {
 		return nil, report
@@ -107,14 +107,14 @@ func dedupSubnets(input []string, currentListID string, existingLists []DomainLi
 			if k.raw == normalized {
 				report.TotalRemoved++
 				report.ExactDupes++
-				report.Items = append(report.Items, DedupeItem{Domain: normalized, Reason: "exact", CoveredBy: k.raw, ListID: currentListID})
+				report.Items = append(report.Items, DedupeItem{Domain: normalized, Reason: "exact", CoveredBy: k.raw, ListID: currentListID, ListName: currentListName})
 				removed = true
 				break
 			}
 			if cidrCovers(k.net, n) {
 				report.TotalRemoved++
 				report.WildcardDupes++
-				report.Items = append(report.Items, DedupeItem{Domain: normalized, Reason: "subnet_covered", CoveredBy: k.raw, ListID: currentListID})
+				report.Items = append(report.Items, DedupeItem{Domain: normalized, Reason: "subnet_covered", CoveredBy: k.raw, ListID: currentListID, ListName: currentListName})
 				removed = true
 				break
 			}
@@ -124,7 +124,7 @@ func dedupSubnets(input []string, currentListID string, existingLists []DomainLi
 		}
 
 		kept = append(kept, normalized)
-		keptParsed = append(keptParsed, parsedSubnet{raw: normalized, net: n, listID: currentListID})
+		keptParsed = append(keptParsed, parsedSubnet{raw: normalized, net: n, listID: currentListID, listName: currentListName})
 	}
 
 	report.TotalKept = len(kept)

--- a/internal/dnsroute/cidr_test.go
+++ b/internal/dnsroute/cidr_test.go
@@ -127,7 +127,7 @@ func TestDedupSubnets_ExactDupe(t *testing.T) {
 	existing := []DomainList{
 		{ID: "list1", Name: "List 1", Subnets: []string{"10.0.0.0/24"}},
 	}
-	kept, report := dedupSubnets([]string{"10.0.0.0/24"}, "list2", existing)
+	kept, report := dedupSubnets([]string{"10.0.0.0/24"}, "list2", "List Two", existing)
 	if len(kept) != 0 {
 		t.Errorf("expected 0 kept, got %d: %v", len(kept), kept)
 	}
@@ -143,7 +143,7 @@ func TestDedupSubnets_CoveredByParent(t *testing.T) {
 	existing := []DomainList{
 		{ID: "list1", Name: "List 1", Subnets: []string{"10.0.0.0/16"}},
 	}
-	kept, report := dedupSubnets([]string{"10.0.1.0/24"}, "list2", existing)
+	kept, report := dedupSubnets([]string{"10.0.1.0/24"}, "list2", "List Two", existing)
 	if len(kept) != 0 {
 		t.Errorf("expected 0 kept, got %d: %v", len(kept), kept)
 	}
@@ -158,7 +158,7 @@ func TestDedupSubnets_CoveredByParent(t *testing.T) {
 func TestDedupSubnets_InternalDedup(t *testing.T) {
 	// Within the same batch: 10.0.0.0/16 covers 10.0.1.0/24 and 10.0.2.0/24
 	input := []string{"10.0.0.0/16", "10.0.1.0/24", "10.0.2.0/24"}
-	kept, report := dedupSubnets(input, "list1", nil)
+	kept, report := dedupSubnets(input, "list1", "List One", nil)
 	if len(kept) != 1 {
 		t.Errorf("expected 1 kept, got %d: %v", len(kept), kept)
 	}
@@ -168,10 +168,20 @@ func TestDedupSubnets_InternalDedup(t *testing.T) {
 	if report.TotalRemoved != 2 {
 		t.Errorf("expected 2 removed, got %d", report.TotalRemoved)
 	}
+	// Each removed item must carry the current list's name so the UI tooltip
+	// shows "covered by ... (List One)" instead of falling back to the raw ID.
+	for _, it := range report.Items {
+		if it.ListID != "list1" {
+			t.Errorf("ListID = %q, want list1", it.ListID)
+		}
+		if it.ListName != "List One" {
+			t.Errorf("ListName = %q, want \"List One\"", it.ListName)
+		}
+	}
 }
 
 func TestDedupSubnets_InvalidCIDR(t *testing.T) {
-	kept, report := dedupSubnets([]string{"not-a-cidr", "10.0.0.0/24"}, "list1", nil)
+	kept, report := dedupSubnets([]string{"not-a-cidr", "10.0.0.0/24"}, "list1", "List One", nil)
 	if len(kept) != 1 {
 		t.Errorf("expected 1 kept, got %d: %v", len(kept), kept)
 	}
@@ -188,7 +198,7 @@ func TestDedupSubnets_IPv6(t *testing.T) {
 	existing := []DomainList{
 		{ID: "list1", Name: "List 1", Subnets: []string{"fd00::/48"}},
 	}
-	kept, report := dedupSubnets([]string{"fd00::/64"}, "list2", existing)
+	kept, report := dedupSubnets([]string{"fd00::/64"}, "list2", "List Two", existing)
 	if len(kept) != 0 {
 		t.Errorf("expected 0 kept, got %d: %v", len(kept), kept)
 	}
@@ -207,7 +217,7 @@ func TestDedupSubnets_ParentWithExcludeAllowsChild(t *testing.T) {
 		},
 	}
 
-	kept, report := dedupSubnets([]string{"10.0.0.0/24"}, "list_b", existing)
+	kept, report := dedupSubnets([]string{"10.0.0.0/24"}, "list_b", "List B", existing)
 
 	if len(kept) != 1 || kept[0] != "10.0.0.0/24" {
 		t.Fatalf("expected 10.0.0.0/24 to survive, got kept=%v", kept)
@@ -227,7 +237,7 @@ func TestDedupSubnets_ExcludeSubtree(t *testing.T) {
 		},
 	}
 
-	kept, report := dedupSubnets([]string{"10.0.5.0/24"}, "list_b", existing)
+	kept, report := dedupSubnets([]string{"10.0.5.0/24"}, "list_b", "List B", existing)
 
 	if len(kept) != 1 {
 		t.Fatalf("expected 10.0.5.0/24 to survive (under exclude subtree), got %v", kept)

--- a/internal/dnsroute/impl.go
+++ b/internal/dnsroute/impl.go
@@ -883,7 +883,7 @@ func (s *ServiceImpl) dedup(list *DomainList) {
 	keptDomains, domainReport := idx.CheckBatch(list.Domains, list.ID, names)
 
 	// Deduplicate subnets.
-	keptSubnets, subnetReport := dedupSubnets(list.Subnets, list.ID, data.Lists)
+	keptSubnets, subnetReport := dedupSubnets(list.Subnets, list.ID, list.Name, data.Lists)
 
 	// Merge reports.
 	report := DedupeReport{

--- a/internal/dnsroute/impl_test.go
+++ b/internal/dnsroute/impl_test.go
@@ -602,7 +602,7 @@ func TestServiceCreate_SplitsAndDedupsMixedExcludes(t *testing.T) {
 	}
 
 	// Sub-subnet inside the CIDR-form hole — should survive.
-	keptSubs, _ := dedupSubnets([]string{"10.0.0.0/24"}, "list_b", []DomainList{listA})
+	keptSubs, _ := dedupSubnets([]string{"10.0.0.0/24"}, "list_b", "List B", []DomainList{listA})
 	if len(keptSubs) != 1 || keptSubs[0] != "10.0.0.0/24" {
 		t.Fatalf("expected 10.0.0.0/24 to survive, got %v", keptSubs)
 	}


### PR DESCRIPTION
## Проблема

В карточке Discord-списка tooltip «N убрано» показывал внутренние идентификаторы вида `list_22` вместо человеческого имени:

```
35.207.0.0/16 — покрыт 35.192.0.0/12 (list_22)
35.212.0.0/16 — покрыт 35.208.0.0/12 (list_22)
…
```

## Причина

`internal/dnsroute/cidr.go:dedupSubnets()` — когда CIDR-дубль обнаружен **внутри той же списка** (текущего, что редактируется), `DedupeItem.ListName` оставался пустым. Фронт (`DnsRouteCard.svelte:116`) фоллбэчит на `listId` через `i.listName || i.listId`.

Domain-дедуп (`dedup.go`) уже делал правильно через `listNames` map.

## Фикс

Прокинул `currentListName` в `dedupSubnets(...)` и проставляю его в same-list `DedupeItem` и в `keptParsed`. Один callsite в `impl.go` передаёт `list.Name`. 8 тестов обновлены, добавлен регрессионный тест на `ListName` в `TestDedupSubnets_InternalDedup`.