### PR TITLE
fix(css): чекбокс в IpRouteImportModal схлопывал layout (ширина 482px)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -235,7 +235,11 @@ a:hover {
 }
 
 /* Form elements */
-input, textarea, select {
+/* Form-control reset for text-shaped inputs only. Checkbox/radio keep
+ * their native rendering — applying width:100% / padding / bg here
+ * stretched checkboxes to fill the parent flex row and broke layouts
+ * that mix a checkbox with text content (e.g. import preview rows). */
+input:not([type="checkbox"]):not([type="radio"]), textarea, select {
 	width: 100%;
 	padding: 0.5rem 0.75rem;
 	background: var(--bg-secondary);
@@ -246,7 +250,7 @@ input, textarea, select {
 	transition: border-color 0.15s ease;
 }
 
-input:focus, textarea:focus, select:focus {
+input:not([type="checkbox"]):not([type="radio"]):focus, textarea:focus, select:focus {
 	outline: none;
 	border-color: var(--accent);
 }


### PR DESCRIPTION
## Проблема

В модалке «Загрузить набор маршрутов» после загрузки JSON layout схлопывался: имена справа от чекбокса, кнопка туннеля «VIVO» вклинивалась в строку «7 подсетей», в превью появлялся горизонтальный скролл.

См. issue #47.

## Root cause

Глобальный reset в \`frontend/src/app.css:238\`:

\`\`\`css
input, textarea, select {
    width: 100%;
    padding: 0.5rem 0.75rem;
    background: var(--bg-secondary);
    ...
}
\`\`\`

применялся и к нативным \`<input type="checkbox">\`. В \`.import-item\` (flex row) чекбокс растягивался до ~482px (см. computed style ниже) и вытеснял \`.import-item-info\` до \`width: 0px\` и \`.tunnel-name-btn\` до 10px:

| Элемент | width до фикса | width после |
|---|---|---|
| INPUT (checkbox) | 482.5px | 13px (нативно) |
| .import-item-info | 0px | 469.5px |
| .tunnel-name-btn | 10.5px | flex grow |

## Фикс

Один селектор: исключить checkbox/radio из reset через \`:not([type="checkbox"]):not([type="radio"])\`. Стандартный паттерн (Tailwind preflight делает то же самое).

## Зона риска

Никаких — чекбокс/radio теперь рендерятся нативно, как ожидалось. Кастомные обёртки (Toggle/FormToggle) используют \`<span>\` поверх hidden input, не зависят от этого правила.

## Verify

- Перезапущен mock-stack, загружен JSON в IpRouteImportModal — layout корректный, имена слева от подсетей, кнопка туннеля справа, без overflow.
- \`npm run check\` — 0 errors / 0 warnings.