### PR TITLE
fix(singbox): show real install status in ghost terminal

### DIFF
--- a/frontend/src/lib/components/singbox/SingboxGhostTerminal.svelte
+++ b/frontend/src/lib/components/singbox/SingboxGhostTerminal.svelte
@@ -19,6 +19,7 @@
 	let result = $state<SingboxImportResponse | null>(null);
 
 	const singboxVersion = $derived($systemInfo.data?.singbox?.version ?? '');
+	const singboxInstalled = $derived($systemInfo.data?.singbox?.installed ?? false);
 
 	async function submit(): Promise<void> {
 		importing = true;
@@ -47,7 +48,11 @@
 	<div class="term-status">
 		<span class="term-prompt">$ sing-box status</span>
 		<span class="term-info">
-			{singboxVersion ? singboxVersion + ' · ' : ''}installed · 0 туннелей
+			{#if singboxInstalled}
+				{singboxVersion ? singboxVersion + ' · ' : ''}installed
+			{:else}
+				not installed
+			{/if}
 		</span>
 	</div>
 


### PR DESCRIPTION
not installed fix for no sing-box binary in /opt/etc/awg-manager/singbox 