### PR TITLE
fix(singbox): hide ghost-terminal import when not installed

### DIFF
--- a/frontend/src/lib/components/singbox/SingboxGhostTerminal.svelte
+++ b/frontend/src/lib/components/singbox/SingboxGhostTerminal.svelte
@@ -56,6 +56,7 @@
 		</span>
 	</div>
 
+	{#if singboxInstalled}
 	<div class="term-singbox">
 		<textarea
 			class="term-singbox-input"
@@ -93,6 +94,7 @@
 			{/if}
 		{/if}
 	</div>
+	{/if}
 </div>
 
 <style>


### PR DESCRIPTION
textarea for import proxy conf disabled if sing-box binary is not installed