### PR TITLE
fix: post-review backlog cleanup

### DIFF
--- a/frontend/src/lib/components/singbox-routing/SingboxRoutingPage.svelte
+++ b/frontend/src/lib/components/singbox-routing/SingboxRoutingPage.svelte
@@ -146,10 +146,14 @@
 	const wizRulesStore = singboxRouter.rules;
 	const wizOutboundsStore = singboxRouter.outbounds;
 	const wizSettingsStore = singboxRouter.settings;
+	// Settings is null until loadAll() (called from sub-tabs onMount) has
+	// completed at least once. Gate the WizardEntry on that to avoid a
+	// brief flash on initial page paint when stores still hold defaults.
 	const isEmpty = $derived(
+		$wizSettingsStore !== null &&
 		($wizRulesStore?.length ?? 0) === 0 &&
 		($wizOutboundsStore?.length ?? 0) === 0 &&
-		(!$wizSettingsStore?.policyName || $wizSettingsStore.policyName === '')
+		(!$wizSettingsStore.policyName || $wizSettingsStore.policyName === '')
 	);
 </script>
 

--- a/internal/diagnostics/tests.go
+++ b/internal/diagnostics/tests.go
@@ -963,10 +963,16 @@ func findTunnelDNS(dnsList string) string {
 	return ""
 }
 
+// cgnatNet is the carrier-grade NAT range (RFC 6598). Pre-parsed once
+// at package init so isCGNAT calls don't re-parse the literal each time.
+var cgnatNet = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
 // isCGNAT checks if the IP is in the 100.64.0.0/10 range (RFC 6598).
 func isCGNAT(ip net.IP) bool {
-	_, cgnat, _ := net.ParseCIDR("100.64.0.0/10")
-	return cgnat.Contains(ip)
+	return cgnatNet.Contains(ip)
 }
 
 func (r *Runner) testRestartCycle(ctx context.Context, t TunnelInfo) TestResult {
@@ -999,16 +1005,22 @@ func (r *Runner) testRestartCycle(ctx context.Context, t TunnelInfo) TestResult 
 	}
 	startDuration := time.Since(startStart)
 
-	// Wait for handshake (up to 15s)
+	// Wait for handshake (up to 15s) — abort early on context cancellation
+	// so an HTTP timeout doesn't keep the loop spinning.
 	handshakeOK := false
+waitLoop:
 	for i := 0; i < 15; i++ {
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			break waitLoop
+		case <-time.After(time.Second):
+		}
 		result, err := exec.Run(ctx, "/opt/sbin/awg", "show", t.InterfaceName)
 		if err == nil && strings.Contains(result.Stdout, "latest handshake:") {
 			hs := extractField(result.Stdout, "latest handshake:")
 			if hs != "" && hs != "(none)" {
 				handshakeOK = true
-				break
+				break waitLoop
 			}
 		}
 	}

--- a/internal/singbox/router/inspector_ruleset.go
+++ b/internal/singbox/router/inspector_ruleset.go
@@ -40,6 +40,10 @@ type ruleSetCache struct {
 
 	mu      sync.Mutex
 	entries map[string]ruleSetCacheEntry
+	// urlLocks serialises downloads per URL so two concurrent Inspect
+	// calls don't both fetch the same remote rule-set. Lazily populated
+	// on first getOrDownload per URL.
+	urlLocks map[string]*sync.Mutex
 }
 
 type ruleSetCacheEntry struct {
@@ -58,11 +62,27 @@ func newRuleSetCache(cacheDir string) *ruleSetCache {
 	return &ruleSetCache{
 		cacheDir: cacheDir,
 		entries:  make(map[string]ruleSetCacheEntry),
+		urlLocks: make(map[string]*sync.Mutex),
 	}
 }
 
+// urlLock returns (creating if needed) the per-URL serialisation mutex.
+// Holding this mutex from cache-check through download-and-publish makes
+// concurrent getOrDownload calls for the same URL deduplicate to one
+// download.
+func (c *ruleSetCache) urlLock(url string) *sync.Mutex {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if l, ok := c.urlLocks[url]; ok {
+		return l
+	}
+	l := &sync.Mutex{}
+	c.urlLocks[url] = l
+	return l
+}
+
 // httpClient is package-level so tests can swap it via the unexported
-// ruleSetHTTPClient hook.
+// ruleSetHTTPClient hook. Do not swap from tests using t.Parallel().
 var ruleSetHTTPClient = &http.Client{Timeout: ruleSetDownloadTimeout}
 
 // getOrDownload returns the local file path for url, downloading and
@@ -77,6 +97,13 @@ func (c *ruleSetCache) getOrDownload(url, format string) (string, error) {
 		ext = ".json"
 	}
 	filename := cacheKey + ext
+
+	// Serialise downloads of the same URL — without this, two concurrent
+	// Inspect calls would both go to the network. Different URLs still
+	// download in parallel.
+	urlMu := c.urlLock(url)
+	urlMu.Lock()
+	defer urlMu.Unlock()
 
 	c.mu.Lock()
 	if entry, ok := c.entries[url]; ok && time.Now().Before(entry.expiresAt) {
@@ -145,7 +172,8 @@ func (c *ruleSetCache) getOrDownload(url, format string) (string, error) {
 
 // ruleSetMatchExec is the injectable exec hook for tests. Production
 // path runs sing-box for real. Tests assign a fake function that
-// returns canned stdout/stderr/err.
+// returns canned stdout/stderr/err. Do not swap from tests using
+// t.Parallel() — there is no mutex protecting the swap.
 var ruleSetMatchExec = func(binary string, args []string) (stdout, stderr string, err error) {
 	cmd := exec.Command(binary, args...)
 	var so, se bytes.Buffer


### PR DESCRIPTION
- diagnostics: testRestartCycle handshake-wait loop now respects ctx cancellation
- diagnostics: pre-parse CGNAT CIDR once (was re-parsed per call)
- singbox-router: per-URL mutex on rule_set cache deduplicates concurrent downloads
- singbox-router: comment that ruleSetMatchExec/ruleSetHTTPClient must not be swapped from t.Parallel() tests
- ui: gate isEmpty / WizardEntry on settings load to avoid flash on initial paint