### PR TITLE
some fixes

### DIFF
--- a/frontend/src/lib/components/accesspolicy/PolicyEditView.svelte
+++ b/frontend/src/lib/components/accesspolicy/PolicyEditView.svelte
@@ -140,7 +140,6 @@
 					bind:value={description}
 					onblur={saveDescription}
 					maxlength={MAX_LEN}
-					pattern="[a-zA-Z0-9_-]+"
 				/>
 				<span class="field-hint">Латинские буквы, цифры, дефисы, подчёркивания</span>
 			</label>

--- a/frontend/src/lib/components/singbox-routing/RulesSubTab.svelte
+++ b/frontend/src/lib/components/singbox-routing/RulesSubTab.svelte
@@ -67,6 +67,63 @@
 		},
 	]);
 
+	const firstUserRuleIndex = $derived.by(() => {
+		const idx = rules.findIndex((r) => !isSystem(r));
+		return idx === -1 ? rules.length : idx;
+	});
+
+	async function moveRule(from: number, to: number): Promise<void> {
+		if (movingIndex !== null) return;
+		if (from < firstUserRuleIndex || to < firstUserRuleIndex) return;
+		if (from < 0 || from >= rules.length || to < 0 || to >= rules.length) return;
+		if (from === to) return;
+
+		movingIndex = from;
+		try {
+			await api.singboxRouterMoveRule(from, to);
+			await refresh();
+		} catch (e) {
+			notifications.error((e as Error).message);
+		} finally {
+			movingIndex = null;
+		}
+	}
+
+	function onDragStart(i: number, e: DragEvent): void {
+		if (isSystem(rules[i])) return;
+		if (i < firstUserRuleIndex) return;
+		draggingIndex = i;
+		e.dataTransfer?.setData('text/plain', String(i));
+		if (e.dataTransfer) {
+			e.dataTransfer.effectAllowed = 'move';
+		}
+	}
+
+	function onDragOver(i: number, e: DragEvent): void {
+		if (draggingIndex === null) return;
+		if (i < firstUserRuleIndex) return;
+		e.preventDefault();
+		dragOverIndex = i;
+		if (e.dataTransfer) {
+			e.dataTransfer.dropEffect = 'move';
+		}
+	}
+
+	async function onDrop(i: number, e: DragEvent): Promise<void> {
+		e.preventDefault();
+		const from = draggingIndex;
+		draggingIndex = null;
+		dragOverIndex = null;
+		if (from === null) return;
+		if (i < firstUserRuleIndex) return;
+		await moveRule(from, i);
+	}
+
+	function onDragEnd(): void {
+		draggingIndex = null;
+		dragOverIndex = null;
+	}
+
 	function actionVariant(
 		r: SingboxRouterRule,
 	): 'success' | 'error' | 'muted' {
@@ -106,6 +163,9 @@
 	let prefillRuleSet = $state<string | null>(null);
 	let deleteIndex = $state<number | null>(null);
 	let deletingBusy = $state(false);
+	let movingIndex = $state<number | null>(null);
+	let draggingIndex = $state<number | null>(null);
+	let dragOverIndex = $state<number | null>(null);
 
 	function openAdd(): void {
 		editIndex = null;
@@ -155,9 +215,10 @@
 		</div>
 	</div>
 
-	<div class="table">
+	<div class="table" role="list">
 		<div class="t-head">
 			<div class="col-idx">#</div>
+			<div class="col-order">Порядок</div>
 			<div class="col-action">Действие</div>
 			<div class="col-match">Matchers</div>
 			<div class="col-out">Outbound</div>
@@ -169,8 +230,44 @@
 		{:else}
 			{#each rules as r, i (i)}
 				{@const sys = isSystem(r)}
-				<div class="t-row" class:system={sys}>
+				<div
+					class="t-row"
+					class:system={sys}
+					class:dragging={draggingIndex === i}
+					class:drag-over={dragOverIndex === i && draggingIndex !== i}
+					role="listitem"
+					tabindex="-1"
+					ondragover={(e) => onDragOver(i, e)}
+					ondrop={(e) => onDrop(i, e)}
+					ondragend={onDragEnd}
+				>
 					<div class="col-idx mono">{i}</div>
+					<div class="col-order">
+						{#if !sys}
+							<span
+								class="drag-handle"
+								title="Перетащить"
+								role="button"
+								aria-label={`Перетащить правило #${i}`}
+								tabindex="-1"
+								draggable={movingIndex === null}
+								ondragstart={(e) => onDragStart(i, e)}
+								ondragend={onDragEnd}
+							>⋮⋮</span>
+							<button
+								class="move-btn"
+								title="Выше"
+								disabled={movingIndex !== null || i <= firstUserRuleIndex}
+								onclick={() => moveRule(i, i - 1)}
+							>↑</button>
+							<button
+								class="move-btn"
+								title="Ниже"
+								disabled={movingIndex !== null || i >= rules.length - 1}
+								onclick={() => moveRule(i, i + 1)}
+							>↓</button>
+						{/if}
+					</div>
 					<div class="col-action">
 						<Badge variant={actionVariant(r)} size="sm" uppercase mono>
 							{actionLabel(r)}
@@ -313,7 +410,7 @@
 	.t-head,
 	.t-row {
 		display: grid;
-		grid-template-columns: 36px 80px 1fr 160px 72px;
+		grid-template-columns: 36px 64px 80px 1fr 160px 72px;
 		gap: 0.625rem;
 		align-items: center;
 		padding: 0.5rem 0.875rem;
@@ -336,6 +433,30 @@
 	.t-row.system {
 		opacity: 0.7;
 	}
+	.drag-handle {
+		cursor: grab;
+		color: var(--color-text-muted);
+		user-select: none;
+		line-height: 1;
+		padding: 0 0.125rem;
+	}
+	.drag-handle:active {
+		cursor: grabbing;
+	}
+	.col-order {
+		display: flex;
+		gap: 0.25rem;
+		justify-content: center;
+		align-items: center;
+	}
+	.t-row.dragging {
+		opacity: 0.45;
+	}
+	.t-row.drag-over {
+		outline: 1px dashed var(--color-accent);
+		outline-offset: -2px;
+		background: var(--color-bg-tertiary);
+	}
 	.col-idx {
 		color: var(--color-text-muted);
 	}
@@ -350,6 +471,25 @@
 		display: flex;
 		gap: 0.25rem;
 		justify-content: flex-end;
+	}
+	.move-btn {
+		width: 1.5rem;
+		height: 1.5rem;
+		border: 1px solid var(--color-border);
+		border-radius: 0.375rem;
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-secondary);
+		cursor: pointer;
+		font-size: 0.75rem;
+		line-height: 1;
+	}
+	.move-btn:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-text-primary);
+	}
+	.move-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 	.mono {
 		font-family: var(--font-mono, ui-monospace, monospace);
@@ -372,7 +512,7 @@
 	@media (max-width: 720px) {
 		.t-head,
 		.t-row {
-			grid-template-columns: 28px 70px 1fr 60px;
+			grid-template-columns: 28px 52px 70px 1fr 60px;
 		}
 		.col-out {
 			display: none;

--- a/frontend/src/routes/routing/AccessPoliciesTab.svelte
+++ b/frontend/src/routes/routing/AccessPoliciesTab.svelte
@@ -4,7 +4,7 @@
     import { Modal, StoreStatusBadge, Button } from '$lib/components/ui';
     import { PolicyTable, PolicyCreateModal, PolicyEditView } from '$lib/components/accesspolicy';
     import { notifications } from '$lib/stores/notifications';
-    import { accessPoliciesStore, policyDevicesStore, policyInterfacesStore } from '$lib/stores/routing';
+    import { accessPoliciesStore, policyDevicesStore, policyInterfacesStore, invalidateAllRouting } from '$lib/stores/routing';
 
     interface Props {
         accessPolicies: AccessPolicy[];
@@ -22,8 +22,9 @@
     let editingPolicyData = $state<AccessPolicy | null>(null);
     let policySelectionMode = $state(false);
     let policySelected = $state<Set<string>>(new Set());
-    let policyBulkLoading = $state(false);
-    let policyBulkDeleteConfirm = $state(false);
+	let policyBulkLoading = $state(false);
+	let policyBulkDeleteConfirm = $state(false);
+	let policyRefreshing = $state(false);
 
     let policyCount = $derived(accessPolicies.length);
 
@@ -62,6 +63,24 @@
 
     // No-op: SSE updates the store; PolicyEditView expects an async callback
     async function refreshPolicyData() {}
+
+    async function refreshPolicies() {
+        if (policyRefreshing) return;
+        policyRefreshing = true;
+        try {
+            const res = await api.refreshRouting();
+            invalidateAllRouting();
+            if (res.missing?.includes('accessPolicies')) {
+                notifications.warning('Не удалось обновить политики доступа');
+            } else {
+                notifications.success('Политики обновлены');
+            }
+        } catch (e) {
+            notifications.error(`Ошибка обновления политик: ${(e as Error).message}`);
+        } finally {
+            policyRefreshing = false;
+        }
+    }
 
     function handleDeviceAssigned(_mac: string, _policyName: string) {
         // SSE will push updated policyDevices and accessPolicies
@@ -122,6 +141,15 @@
                 <StoreStatusBadge store={accessPoliciesStore} />
                 <StoreStatusBadge store={policyDevicesStore} />
                 <StoreStatusBadge store={policyInterfacesStore} />
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={refreshPolicies}
+                    disabled={policyRefreshing}
+                    loading={policyRefreshing}
+                >
+                    Обновить
+                </Button>
                 {#if accessPolicies.length > 0}
                     <Button variant="ghost" size="sm" onclick={() => { policySelectionMode = true; policySelected = new Set(); }}>Выбрать</Button>
                 {/if}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -920,6 +920,15 @@ func (s *ServiceImpl) computeIssues(cfg *RouterConfig) []Issue {
 			}
 		}
 	}
+	// Subscription composites live in 40-subscriptions.json owned by subscription slot.
+	// Their tags are valid route targets but invisible to a router-only view of cfg.Outbounds.
+	if s.deps.SubscriptionComposites != nil {
+		for _, o := range s.deps.SubscriptionComposites.ListSubscriptionComposites() {
+			if o.Tag != "" {
+				outboundTags[o.Tag] = struct{}{}
+			}
+		}
+	}
 	for i, r := range cfg.Route.Rules {
 		if r.Action == "route" && r.Outbound != "" && r.Outbound != "direct" {
 			if _, ok := outboundTags[r.Outbound]; !ok {


### PR DESCRIPTION
Набор правок:

- [fix regex browser.console](https://github.com/hoaxisr/awg-manager/pull/101/commits/14b8715ecb490e576aef92484c4669af5e575e24)
Это безопасный маленький патч: HTML pattern не является единственной защитой, потому что сохранение уже проверяется через descriptionValid, а при ошибке вызывается notifications.error(...) и значение откатывается к policy.description. Удаление атрибута не ослабляет фактическую логику сохранения, зато убирает браузерную regex-ошибку.

---

- [fix issues visual fail subs bug](https://github.com/hoaxisr/awg-manager/pull/101/commits/d891e05e04fbfe3e5a13ab9e38e863b09703d32f)
Патч исправляющий ругань роутера на незадействованные в подписки outbounds.
<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/a4e51966-ae69-4e67-a269-acfb72476895" />

---

- [feat(router): add rule ordering controls](https://github.com/hoaxisr/awg-manager/pull/101/commits/9493d3cfb4d1e82c935fdc21a764cf76e0d6f210)
Добавлено управление приоритетом правил sing-box Router.
В sing-box порядок правил важен: правила обрабатываются сверху вниз, и применяется первое подходящее правило. Раньше в UI можно было добавлять, редактировать и удалять правила, но нельзя было менять их последовательность, из-за чего пользователь не мог явно управлять приоритетом маршрутизации.
Что сделано:
добавлена колонка управления порядком правил;
добавлены кнопки ↑/↓ для пошагового перемещения правила;
добавлен drag-and-drop через отдельный drag-handle;
системные правила sniff и hijack-dns остаются закреплёнными сверху;
пользовательские правила нельзя переместить выше системных;
изменение порядка сохраняется через существующий backend MoveRule;
после перемещения UI перечитывает актуальный порядок правил;
исправлены Svelte a11y warnings для drag-and-drop элементов.
<img width="2035" height="1251" alt="image" src="https://github.com/user-attachments/assets/0c469a0b-f038-4663-9ad5-2ca9a96da21e" />

---

- [fix(routing): refresh access policies from Keenetic](https://github.com/hoaxisr/awg-manager/pull/101/commits/05d1f458900a9f2e4eb8b15a4e37355c6be707c1)
Добавлена локальная кнопка обновления на вкладке «Политики доступа».
Обычный frontend refetch мог получать устаревшие данные из backend NDMS-кэша, поэтому кнопка теперь использует общий routing refresh, который инвалидирует кэши Keenetic/NDMS и затем перечитывает актуальные политики, устройства и интерфейсы.
<img width="2035" height="1250" alt="image" src="https://github.com/user-attachments/assets/9ac44542-9983-4c86-bc9c-af7592147a88" />
