### PR TITLE
sing-router improve

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -103,6 +104,65 @@ func detectArch() string {
 		return "aarch64-3.10"
 	}
 	return ""
+}
+
+// deviceproxySubscriptionOutboundsAdapter adapts *subscription.Service to
+// the deviceproxy.SubscriptionOutboundsCatalog interface, exposing enabled
+// subscription selector/urltest outbounds as device-proxy targets without
+// creating a direct dependency from the subscription package on deviceproxy.
+type deviceproxySubscriptionOutboundsAdapter struct {
+	src *subscription.Service
+}
+
+func (a *deviceproxySubscriptionOutboundsAdapter) ListDeviceProxyOutbounds() []deviceproxy.SubscriptionOutboundInfo {
+	if a == nil || a.src == nil {
+		return nil
+	}
+	subs := a.src.List()
+	out := make([]deviceproxy.SubscriptionOutboundInfo, 0, len(subs))
+
+	for _, sub := range subs {
+		if !sub.Enabled || sub.SelectorTag == "" || len(sub.MemberTags) == 0 {
+			continue
+		}
+		label := strings.TrimSpace(sub.Label)
+		if label == "" {
+			label = sub.ID
+		}
+		active := sub.ActiveMember
+		if active == "" && len(sub.MemberTags) > 0 {
+			active = sub.MemberTags[0]
+		}
+		detail := active
+		for _, m := range sub.Members {
+			if m.Tag != active {
+				continue
+			}
+			parts := []string{}
+			if strings.TrimSpace(m.Label) != "" {
+				parts = append(parts, strings.TrimSpace(m.Label))
+			}
+			if m.Protocol != "" {
+				parts = append(parts, strings.ToUpper(m.Protocol))
+			}
+			if m.Server != "" {
+				parts = append(parts, fmt.Sprintf("%s:%d", m.Server, m.Port))
+			}
+			if len(parts) > 0 {
+				detail = strings.Join(parts, " · ")
+			}
+			break
+		}
+		out = append(out, deviceproxy.SubscriptionOutboundInfo{
+			Tag:    sub.SelectorTag,
+			Label:  label,
+			Detail: detail,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Label < out[j].Label
+	})
+	return out
 }
 
 func main() {
@@ -860,13 +920,17 @@ func main() {
 	deviceProxyStore := deviceproxy.NewStore(filepath.Join(*dataDir, "deviceproxy.json"))
 	deviceProxySingboxAdapter := deviceproxy.NewSingboxAdapter(singboxOp)
 	deviceProxySingboxAdapter.SetOrch(sbOrch)
+
+	subOutboundsAdapter := &deviceproxySubscriptionOutboundsAdapter{src: subSvc}
+
 	deviceProxySvc := deviceproxy.NewService(deviceproxy.Deps{
-		Store:        deviceProxyStore,
-		Singbox:      deviceProxySingboxAdapter,
-		NDMSQuery:    deviceproxy.NewNDMSAdapter(ndmsQueries),
-		Bus:          eventBus,
-		AWGOutbounds: &deviceproxyAWGOutboundsAdapter{src: awgoutboundsSvc},
-		AppLogger:    loggingService,
+		Store:                 deviceProxyStore,
+		Singbox:               deviceProxySingboxAdapter,
+		SubscriptionOutbounds: subOutboundsAdapter,
+		NDMSQuery:             deviceproxy.NewNDMSAdapter(ndmsQueries),
+		Bus:                   eventBus,
+		AWGOutbounds:          &deviceproxyAWGOutboundsAdapter{src: awgoutboundsSvc},
+		AppLogger:             loggingService,
 	})
 	// Reflect deviceproxy storage state into the orchestrator slot so
 	// the saved Enabled flag matches the on-disk active/disabled

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -55,6 +55,7 @@ import type {
 	SingboxImportResponse,
 	SingboxConfigPreview,
 	DeviceProxyConfig,
+	DeviceProxyInstance,
 	DeviceProxyOutbound,
 	DeviceProxyRuntime,
 	AWGTagInfo,
@@ -1362,6 +1363,50 @@ class ApiClient {
 	}> {
 		return this.request('/proxy/listen-choices');
 	}
+
+	// ─────────────────────────────────────────────
+	// #region Device Proxy — multi-instance
+	// ─────────────────────────────────────────────
+
+	async listDeviceProxyInstances(): Promise<DeviceProxyInstance[]> {
+		return this.request<DeviceProxyInstance[]>('/proxy/instances');
+	}
+
+	async getDeviceProxyInstance(id: string): Promise<DeviceProxyInstance> {
+		return this.request<DeviceProxyInstance>(`/proxy/instance?id=${encodeURIComponent(id)}`);
+	}
+
+	async saveDeviceProxyInstance(instance: DeviceProxyInstance): Promise<DeviceProxyInstance> {
+		return this.request<DeviceProxyInstance>('/proxy/instance', {
+			method: 'PUT',
+			body: JSON.stringify(instance)
+		});
+	}
+
+	async deleteDeviceProxyInstance(id: string): Promise<{ deleted: boolean }> {
+		return this.request<{ deleted: boolean }>(`/proxy/instance?id=${encodeURIComponent(id)}`, {
+			method: 'DELETE'
+		});
+	}
+
+	async applyDeviceProxyInstances(): Promise<{ applied: boolean }> {
+		return this.request<{ applied: boolean }>('/proxy/instances/apply', {
+			method: 'POST'
+		});
+	}
+
+	async getDeviceProxyInstanceRuntime(id: string): Promise<DeviceProxyRuntime> {
+		return this.request<DeviceProxyRuntime>(`/proxy/instance/runtime?id=${encodeURIComponent(id)}`);
+	}
+
+	async selectDeviceProxyInstanceRuntime(id: string, tag: string): Promise<{ active: string }> {
+		return this.request<{ active: string }>(`/proxy/instance/runtime/select?id=${encodeURIComponent(id)}`, {
+			method: 'POST',
+			body: JSON.stringify({ tag })
+		});
+	}
+
+	// #endregion
 
 	// #endregion
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -58,6 +58,7 @@ import type {
 	DeviceProxyInstance,
 	DeviceProxyOutbound,
 	DeviceProxyRuntime,
+	DeviceProxyInstanceIPCheckResult,
 	AWGTagInfo,
 	TunnelReferencedError,
 	MonitoringSnapshot,
@@ -1404,6 +1405,15 @@ class ApiClient {
 			method: 'POST',
 			body: JSON.stringify({ tag })
 		});
+	}
+
+	async checkDeviceProxyInstanceExternalIP(
+		id: string,
+		serviceURL?: string
+	): Promise<DeviceProxyInstanceIPCheckResult> {
+		let endpoint = `/proxy/instance/check-ip?id=${encodeURIComponent(id)}`;
+		if (serviceURL) endpoint += `&service=${encodeURIComponent(serviceURL)}`;
+		return this.request<DeviceProxyInstanceIPCheckResult>(endpoint);
 	}
 
 	// #endregion

--- a/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
@@ -312,6 +312,7 @@
 		gap: 0.125rem;
 		flex: 1;
 		min-width: 0;
+		overflow: hidden;
 	}
 
 	.option-name {
@@ -393,5 +394,79 @@
 	.badge-muted {
 		background: rgba(107, 114, 128, 0.15);
 		color: var(--color-text-muted);
+	}
+
+	@media (max-width: 640px) {
+		.card {
+			padding: 0.75rem;
+		}
+
+		.card-header {
+			align-items: flex-start;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		.section-title {
+			font-size: 0.9375rem;
+		}
+
+		.radio-list {
+			max-height: none;
+		}
+
+		.group-title {
+			font-size: 0.625rem;
+			padding-top: 0.375rem;
+		}
+
+		.option {
+			padding: 0.5rem 0.625rem;
+			gap: 0.5rem;
+			align-items: flex-start;
+		}
+
+		.option-name {
+			font-size: 0.8125rem;
+			white-space: normal;
+			overflow-wrap: anywhere;
+		}
+
+		.option-meta {
+			font-size: 0.625rem;
+			gap: 0.25rem;
+			align-items: flex-start;
+		}
+
+		.option-meta-text {
+			white-space: normal;
+			overflow: visible;
+			text-overflow: initial;
+			overflow-wrap: anywhere;
+			word-break: break-word;
+			line-height: 1.25;
+		}
+
+		.option-check {
+			width: 16px;
+			height: 16px;
+			margin-top: 0.125rem;
+		}
+
+		.detail-eye {
+			width: 16px;
+			height: 16px;
+			margin-top: 0.125rem;
+		}
+
+		.hint-row {
+			flex-direction: column;
+			align-items: flex-start;
+			padding: 0.5rem;
+		}
+
+		.hint-text {
+			font-size: 0.75rem;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
@@ -8,12 +8,95 @@
 		outbounds: DeviceProxyOutbound[];
 		runtime: DeviceProxyRuntime;
 		onSwitched: () => void;
+		onSelectRuntime?: (tag: string) => Promise<void>;
+		onApplyNow?: () => Promise<void>;
+		radioName?: string;
 	}
 
-	let { outbounds, runtime, onSwitched }: Props = $props();
+	let {
+		outbounds,
+		runtime,
+		onSwitched,
+		onSelectRuntime = async (tag: string) => { await api.selectDeviceProxyRuntime(tag); },
+		onApplyNow = async () => { await api.applyDeviceProxy(); },
+		radioName = 'device-proxy-active-tunnel'
+	}: Props = $props();
 
 	let switching = $state(false);
 	let applying = $state(false);
+	let revealedDetails = $state<Record<string, boolean>>({});
+
+	function isDetailRevealed(tag: string): boolean {
+		return !!revealedDetails[tag];
+	}
+
+	function toggleDetailReveal(event: MouseEvent, tag: string) {
+		event.preventDefault();
+		event.stopPropagation();
+		revealedDetails = { ...revealedDetails, [tag]: !revealedDetails[tag] };
+	}
+
+	function isSensitiveOutbound(ob: DeviceProxyOutbound): boolean {
+		return ob.kind === 'singbox' && ob.tag.startsWith('sub-') && hasEndpoint(ob.detail);
+	}
+
+	function hasEndpoint(detail: string): boolean {
+		return detail.split(' · ').some(isEndpointPart);
+	}
+
+	function maskDetail(detail: string): string {
+		if (!detail) return '';
+		return detail
+			.split(' · ')
+			.map((part) => (isEndpointPart(part) ? maskEndpoint(part) : part))
+			.join(' · ');
+	}
+
+	function isEndpointPart(part: string): boolean {
+		const trimmed = part.trim();
+		if (!trimmed) return false;
+
+		// host:port, domain:port, IPv4:port, [IPv6]:port
+		if (/^\[[0-9a-fA-F:]+\]:\d+$/.test(trimmed)) return true;
+		if (/^[a-zA-Z0-9.-]+\:\d+$/.test(trimmed)) return true;
+		if (/^\d{1,3}(\.\d{1,3}){3}:\d+$/.test(trimmed)) return true;
+
+		return false;
+	}
+
+	function maskEndpoint(endpoint: string): string {
+		const trimmed = endpoint.trim();
+
+		const ipv6 = trimmed.match(/^(\[[0-9a-fA-F:]+\])(:\d+)$/);
+		if (ipv6) {
+			return `[••••]${ipv6[2]}`;
+		}
+
+		const hostPort = trimmed.match(/^(.+?)(:\d+)$/);
+		if (!hostPort) return endpoint;
+
+		return `${maskHost(hostPort[1])}${hostPort[2]}`;
+	}
+
+	function maskHost(host: string): string {
+		if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+			const parts = host.split('.');
+			return `${parts[0]}.•••.•••.${parts[3]}`;
+		}
+
+		const parts = host.split('.');
+		if (parts.length < 2) {
+			return maskHostLabel(host);
+		}
+
+		const tld = parts.pop();
+		return `${parts.map(maskHostLabel).join('.')}.${tld}`;
+	}
+
+	function maskHostLabel(label: string): string {
+		if (label.length <= 2) return '••';
+		return `${label[0]}••${label[label.length - 1]}`;
+	}
 
 	async function handleSelect(tag: string) {
 		if (switching || !runtime.alive) return;
@@ -22,7 +105,7 @@
 
 		switching = true;
 		try {
-			await api.selectDeviceProxyRuntime(tag);
+			await onSelectRuntime(tag);
 			notifications.success(`Активный туннель: ${labelFor(tag)}`);
 			onSwitched();
 		} catch (e) {
@@ -36,7 +119,7 @@
 		if (applying) return;
 		applying = true;
 		try {
-			await api.applyDeviceProxy();
+			await onApplyNow();
 			notifications.success('Перезапуск выполнен, новая конфигурация активна');
 			onSwitched();
 		} catch (e) {
@@ -87,7 +170,7 @@
 				<label class="option" class:checked>
 					<input
 						type="radio"
-						name="device-proxy-active-tunnel"
+						name={radioName}
 						value={ob.tag}
 						checked={checked}
 						disabled={switching || !runtime.alive}
@@ -96,7 +179,35 @@
 					<span class="option-content">
 						<span class="option-name">{ob.label || ob.tag}</span>
 						{#if ob.detail || (ob.label && ob.label !== ob.tag)}
-							<span class="option-meta">{ob.tag}{ob.detail ? ' · ' + ob.detail : ''}</span>
+							{@const sensitive = isSensitiveOutbound(ob)}
+							<span class="option-meta">
+								<span class="option-meta-text">
+									{ob.tag}{ob.detail ? ' · ' + (sensitive && !isDetailRevealed(ob.tag) ? maskDetail(ob.detail) : ob.detail) : ''}
+								</span>
+								{#if sensitive}
+									<button
+										type="button"
+										class="detail-eye"
+										aria-label={isDetailRevealed(ob.tag) ? 'Скрыть адрес сервера' : 'Показать адрес сервера'}
+										title={isDetailRevealed(ob.tag) ? 'Скрыть адрес сервера' : 'Показать адрес сервера'}
+										onclick={(event) => toggleDetailReveal(event, ob.tag)}
+									>
+										{#if isDetailRevealed(ob.tag)}
+											<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+												<path d="M17.94 17.94A10.94 10.94 0 0 1 12 20C7 20 2.73 16.89 1 12a19.2 19.2 0 0 1 5.06-6.94"/>
+												<path d="M10.58 10.58A2 2 0 0 0 12 14a2 2 0 0 0 1.42-.58"/>
+												<path d="M9.9 4.24A10.75 10.75 0 0 1 12 4c5 0 9.27 3.11 11 8a19.2 19.2 0 0 1-2.22 3.59"/>
+												<line x1="1" y1="1" x2="23" y2="23"/>
+											</svg>
+										{:else}
+											<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+												<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+												<circle cx="12" cy="12" r="3"/>
+											</svg>
+										{/if}
+									</button>
+								{/if}
+							</span>
 						{/if}
 					</span>
 					<span class="option-check" aria-hidden="true">
@@ -213,12 +324,40 @@
 	}
 
 	.option-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		min-width: 0;
 		font-family: var(--font-mono);
 		font-size: 0.6875rem;
 		color: var(--color-text-muted);
+	}
+
+	.option-meta-text {
+		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.detail-eye {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		flex-shrink: 0;
+		border-radius: 4px;
+	}
+
+	.detail-eye:hover {
+		color: var(--color-text-primary);
+		background: var(--color-bg-hover);
 	}
 
 	.option-check {

--- a/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/ActiveTunnelCard.svelte
@@ -37,7 +37,7 @@
 	}
 
 	function isSensitiveOutbound(ob: DeviceProxyOutbound): boolean {
-		return ob.kind === 'singbox' && ob.tag.startsWith('sub-') && hasEndpoint(ob.detail);
+		return ob.kind === 'singbox' && hasEndpoint(ob.detail);
 	}
 
 	function hasEndpoint(detail: string): boolean {

--- a/frontend/src/lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte
@@ -85,6 +85,7 @@
 		font-size: 0.8125rem;
 		color: var(--color-text-secondary);
 		text-align: right;
+		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -94,5 +95,36 @@
 		display: flex;
 		gap: 0.5rem;
 		margin-top: 0.875rem;
+	}
+
+	@media (max-width: 640px) {
+		.card {
+			padding: 0.75rem;
+		}
+
+		.section-title {
+			font-size: 0.9375rem;
+		}
+
+		.info-row {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.25rem;
+		}
+
+		.info-key {
+			font-size: 0.625rem;
+		}
+
+		.info-val {
+			width: 100%;
+			text-align: left;
+			white-space: normal;
+			overflow-wrap: anywhere;
+		}
+
+		.actions {
+			flex-wrap: wrap;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte
@@ -2,16 +2,33 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { Button } from '$lib/components/ui';
 	import { copyToClipboard } from '$lib/utils/clipboard';
-	import type { DeviceProxyConfig } from '$lib/types';
+	import type { DeviceProxyConfig, DeviceProxyInstanceIPCheckResult } from '$lib/types';
 
 	interface Props {
 		config: DeviceProxyConfig;
 		resolvedListenIP: string;
 		bridgeLabel: string;
+		externalIP: DeviceProxyInstanceIPCheckResult | null;
+		externalIPError: string;
+		externalIPLoading: boolean;
+		externalIPCheckedAt: number | null;
+		onRefreshExternalIP: () => Promise<void>;
 		onOpenSettings: () => void;
 	}
 
-	let { config, resolvedListenIP, bridgeLabel, onOpenSettings }: Props = $props();
+	let {
+		config,
+		resolvedListenIP,
+		bridgeLabel,
+		externalIP,
+		externalIPError,
+		externalIPLoading,
+		externalIPCheckedAt,
+		onRefreshExternalIP,
+		onOpenSettings
+	}: Props = $props();
+
+	let revealExternalIP = $state(false);
 
 	const socksHostPort = $derived(`${resolvedListenIP}:${config.port}`);
 
@@ -33,18 +50,140 @@
 			notifications.error('Не удалось скопировать');
 		}
 	}
+
+	function toggleExternalIPReveal(event: MouseEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		revealExternalIP = !revealExternalIP;
+	}
+
+	function maskIP(ip: string): string {
+		const trimmed = ip.trim();
+		if (!trimmed) return '';
+		if (trimmed.includes(':')) {
+			const parts = trimmed.split(':').filter((x) => x.length > 0);
+			if (parts.length <= 2) return '••••:••••';
+			return `${parts[0]}:••••:••••:${parts[parts.length - 1]}`;
+		}
+		const parts = trimmed.split('.');
+		if (parts.length !== 4) return '•••';
+		return `${parts[0]}.${parts[1]}.•••.•••`;
+	}
+
+	function maskHostPort(value: string): string {
+		const trimmed = value.trim();
+		if (!trimmed) return '';
+
+		const ipv6 = trimmed.match(/^(\[[0-9a-fA-F:]+\])(:\d+)$/);
+		if (ipv6) {
+			return `[••••]${ipv6[2]}`;
+		}
+
+		const hostPort = trimmed.match(/^(.+?)(:\d+)$/);
+		if (!hostPort) return '•••';
+
+		return `${maskIP(hostPort[1])}${hostPort[2]}`;
+	}
+
+	function formatCheckedAt(ts: number | null): string {
+		if (!ts) return '';
+		const d = new Date(ts);
+		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+	}
+
+	function sourceLabel(service: string): string {
+		if (!service) return '';
+		try {
+			return new URL(service).hostname;
+		} catch {
+			return service;
+		}
+	}
 </script>
 
 <section class="card">
 	<h2 class="section-title">Подключение клиента</h2>
 
 	<div class="info-row">
-		<span class="info-key">SOCKS5</span>
-		<span class="info-val">{socksHostPort}</span>
+		<span class="info-key">СЛУШАТЬ</span>
+		<span class="info-val">{listenLabel}</span>
 	</div>
 	<div class="info-row">
-		<span class="info-key">Слушать на</span>
-		<span class="info-val">{listenLabel}</span>
+		<span class="info-key">SOCKS5</span>
+		<div class="ip-check-wrap">
+			<span class="info-val">
+				{revealExternalIP ? socksHostPort : maskHostPort(socksHostPort)}
+			</span>
+			<button
+				type="button"
+				class="detail-eye"
+				aria-label={revealExternalIP ? 'Скрыть SOCKS5 адрес' : 'Показать SOCKS5 адрес'}
+				title={revealExternalIP ? 'Скрыть SOCKS5 адрес' : 'Показать SOCKS5 адрес'}
+				onclick={toggleExternalIPReveal}
+			>
+				{#if revealExternalIP}
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d="M17.94 17.94A10.94 10.94 0 0 1 12 20C7 20 2.73 16.89 1 12a19.2 19.2 0 0 1 5.06-6.94"/>
+						<path d="M10.58 10.58A2 2 0 0 0 12 14a2 2 0 0 0 1.42-.58"/>
+						<path d="M9.9 4.24A10.75 10.75 0 0 1 12 4c5 0 9.27 3.11 11 8a19.2 19.2 0 0 1-2.22 3.59"/>
+						<line x1="1" y1="1" x2="23" y2="23"/>
+					</svg>
+				{:else}
+					<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+						<circle cx="12" cy="12" r="3"/>
+					</svg>
+				{/if}
+			</button>
+		</div>
+	</div>
+	<div class="info-row">
+		<div class="info-key-wrap">
+			<span class="info-key">Внешний IP</span>
+			{#if externalIPCheckedAt}
+				<span class="checked-at">
+					обновлено {formatCheckedAt(externalIPCheckedAt)}
+					{#if externalIP?.service}
+						· {sourceLabel(externalIP.service)}
+					{/if}
+				</span>
+			{/if}
+		</div>
+		<div class="ip-check-wrap">
+			{#if externalIP}
+				<span class="info-val">
+					{revealExternalIP ? externalIP.proxyIp : maskIP(externalIP.proxyIp)}
+				</span>
+				<button
+					type="button"
+					class="detail-eye"
+					aria-label={revealExternalIP ? 'Скрыть внешний IP' : 'Показать внешний IP'}
+					title={revealExternalIP ? 'Скрыть внешний IP' : 'Показать внешний IP'}
+					onclick={toggleExternalIPReveal}
+				>
+					{#if revealExternalIP}
+						<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<path d="M17.94 17.94A10.94 10.94 0 0 1 12 20C7 20 2.73 16.89 1 12a19.2 19.2 0 0 1 5.06-6.94"/>
+							<path d="M10.58 10.58A2 2 0 0 0 12 14a2 2 0 0 0 1.42-.58"/>
+							<path d="M9.9 4.24A10.75 10.75 0 0 1 12 4c5 0 9.27 3.11 11 8a19.2 19.2 0 0 1-2.22 3.59"/>
+							<line x1="1" y1="1" x2="23" y2="23"/>
+						</svg>
+					{:else}
+						<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+							<circle cx="12" cy="12" r="3"/>
+						</svg>
+					{/if}
+				</button>
+			{:else if externalIPError}
+				<span class="info-val info-error">{externalIPError}</span>
+			{:else}
+				<span class="info-val info-pending">Не проверен</span>
+			{/if}
+			<Button variant="ghost" size="sm" loading={externalIPLoading} onclick={onRefreshExternalIP}>
+				Проверить
+			</Button>
+		</div>
 	</div>
 
 	<div class="actions">
@@ -73,6 +212,47 @@
 		border-bottom: none;
 	}
 
+	.ip-check-wrap {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.info-key-wrap {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.checked-at {
+		font-size: 0.6875rem;
+		color: var(--color-text-muted);
+		text-transform: none;
+		letter-spacing: 0;
+	}
+
+	.detail-eye {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		flex-shrink: 0;
+		border-radius: 4px;
+	}
+
+	.detail-eye:hover {
+		color: var(--color-text-primary);
+		background: var(--color-bg-hover);
+	}
+
 	.info-key {
 		font-size: 0.6875rem;
 		text-transform: uppercase;
@@ -97,6 +277,14 @@
 		margin-top: 0.875rem;
 	}
 
+	.info-error {
+		color: var(--color-error);
+	}
+
+	.info-pending {
+		color: var(--color-text-muted);
+	}
+
 	@media (max-width: 640px) {
 		.card {
 			padding: 0.75rem;
@@ -116,6 +304,10 @@
 			font-size: 0.625rem;
 		}
 
+		.checked-at {
+			font-size: 0.625rem;
+		}
+
 		.info-val {
 			width: 100%;
 			text-align: left;
@@ -124,6 +316,11 @@
 		}
 
 		.actions {
+			flex-wrap: wrap;
+		}
+
+		.ip-check-wrap {
+			width: 100%;
 			flex-wrap: wrap;
 		}
 	}

--- a/frontend/src/lib/components/deviceproxy/SettingsCard.svelte
+++ b/frontend/src/lib/components/deviceproxy/SettingsCard.svelte
@@ -10,9 +10,21 @@
 		bridgeInterfaces: { id: string; label: string }[];
 		onSaved: (cfg: DeviceProxyConfig) => void;
 		onCancel?: () => void;
+		onSaveConfig?: (cfg: DeviceProxyConfig) => Promise<DeviceProxyConfig>;
+		title?: string;
+		description?: string;
 	}
 
-	let { config, outbounds, bridgeInterfaces, onSaved, onCancel }: Props = $props();
+	let {
+		config,
+		outbounds,
+		bridgeInterfaces,
+		onSaved,
+		onCancel,
+		onSaveConfig = api.saveDeviceProxyConfig.bind(api),
+		title = 'Настройки прокси-сервера',
+		description = 'Эти значения сохраняются в конфигурации и применяются при каждом запуске sing-box.'
+	}: Props = $props();
 
 	// Draft is a one-time snapshot of the prop. Edits survive store
 	// refreshes — reset() is the explicit resync affordance.
@@ -51,7 +63,7 @@
 	async function save() {
 		saving = true;
 		try {
-			const saved = await api.saveDeviceProxyConfig(draft);
+			const saved = await onSaveConfig(draft);
 			onSaved(saved);
 			notifications.success('Настройки сохранены');
 		} catch (e) {
@@ -74,7 +86,7 @@
 		// don't sneak into this save.
 		const payload = { ...config, enabled: next };
 		try {
-			const saved = await api.saveDeviceProxyConfig(payload);
+			const saved = await onSaveConfig(payload);
 			// Mirror into the draft so the toggle control reflects the
 			// new state immediately and the "Отменить" snapshot is
 			// aligned with what's persisted.
@@ -108,8 +120,8 @@
 </script>
 
 <section class="card">
-	<h2 class="section-title">Настройки прокси-сервера</h2>
-	<p class="section-desc">Эти значения сохраняются в конфигурации и применяются при каждом запуске sing-box.</p>
+	<h2 class="section-title">{title}</h2>
+	<p class="section-desc">{description}</p>
 
 	<div class="settings-stack">
 		<div class="setting-row">

--- a/frontend/src/lib/components/singbox-routing/DeviceProxySubTab.svelte
+++ b/frontend/src/lib/components/singbox-routing/DeviceProxySubTab.svelte
@@ -2,18 +2,19 @@
 	import { onMount, onDestroy } from 'svelte';
 	import {
 		deviceProxyConfig,
+		deviceProxyInstances,
 		deviceProxyOutbounds,
 		deviceProxyRuntime,
 		deviceProxyMissingTarget,
 	} from '$lib/stores/deviceproxy';
-	import { SideDrawer } from '$lib/components/ui';
+	import { SideDrawer, Button } from '$lib/components/ui';
 	import ActiveTunnelCard from '$lib/components/deviceproxy/ActiveTunnelCard.svelte';
 	import SettingsCard from '$lib/components/deviceproxy/SettingsCard.svelte';
 	import DeviceProxyStatRow from '$lib/components/deviceproxy/DeviceProxyStatRow.svelte';
 	import DeviceProxyClientInfoCard from '$lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
-	import type { DeviceProxyConfig } from '$lib/types';
+	import type { DeviceProxyConfig, DeviceProxyInstance, DeviceProxyRuntime } from '$lib/types';
 
 	interface ListenChoices {
 		lanIP: string;
@@ -21,89 +22,303 @@
 		singboxRunning: boolean;
 	}
 
+	type RuntimeById = Record<string, DeviceProxyRuntime>;
+	type ToggleById = Record<string, boolean>;
+	type CollapsedById = Record<string, boolean>;
+
 	let unsubConfig: (() => void) | null = null;
+	let unsubInstances: (() => void) | null = null;
 	let unsubOutbounds: (() => void) | null = null;
 	let unsubRuntime: (() => void) | null = null;
+
 	let choices = $state<ListenChoices | null>(null);
 	let settingsDrawerOpen = $state(false);
+	let selectedInstanceId = $state<string>('default');
+	let runtimes = $state<RuntimeById>({});
+	let toggling = $state<ToggleById>({});
+	let deletingId = $state<string | null>(null);
+	let runtimeIdsKey = $state('');
+	let runtimeRefreshKey = $state('');
+	let collapsedById = $state<CollapsedById>({});
+	const collapseStorageKey = 'deviceProxyCollapsedById';
 
 	onMount(() => {
+		// Keep legacy stores subscribed while frontend is being migrated.
 		unsubConfig = deviceProxyConfig.subscribe(() => {});
+		unsubInstances = deviceProxyInstances.subscribe(() => {});
 		unsubOutbounds = deviceProxyOutbounds.subscribe(() => {});
 		unsubRuntime = deviceProxyRuntime.subscribe(() => {});
 		api.getDeviceProxyListenChoices().then((v) => {
 			choices = v;
 		}).catch(() => {});
+
+		try {
+			const raw = localStorage.getItem(collapseStorageKey);
+			if (raw) {
+				const parsed = JSON.parse(raw) as CollapsedById;
+				if (parsed && typeof parsed === 'object') {
+					collapsedById = parsed;
+				}
+			}
+		} catch {
+			// Ignore storage errors.
+		}
 	});
+
 	onDestroy(() => {
 		unsubConfig?.();
+		unsubInstances?.();
 		unsubOutbounds?.();
 		unsubRuntime?.();
 	});
 
-	const configSnap = $derived($deviceProxyConfig);
+	const instancesSnap = $derived($deviceProxyInstances);
 	const outboundsSnap = $derived($deviceProxyOutbounds);
 	const runtimeSnap = $derived($deviceProxyRuntime);
 
-	const config = $derived<DeviceProxyConfig | null>(configSnap.data ?? null);
+	const instances = $derived<DeviceProxyInstance[]>(instancesSnap.data ?? []);
 	const outbounds = $derived(outboundsSnap.data ?? []);
-	const runtime = $derived(runtimeSnap.data ?? { alive: false, activeTag: '', defaultTag: '' });
-
 	const missingTag = $derived($deviceProxyMissingTarget);
+
+	const noTunnels = $derived(outbounds.length <= 1);
+
+	const selectedInstance = $derived.by(() => {
+		return instances.find((in_) => in_.id === selectedInstanceId) ?? null;
+	});
 
 	const bridgeInterfaces = $derived(
 		(choices?.bridges ?? [{ id: 'Bridge0', label: 'Bridge0' }]).map((b) => ({ id: b.id, label: b.label })),
 	);
 
-	const bridgeLabel = $derived.by(() => {
-		if (!config || !choices) return '';
-		const match = choices.bridges.find((b) => b.id === config.listenInterface);
-		return match?.label ?? config.listenInterface;
+	$effect(() => {
+		const ids = instances.map((in_) => in_.id).sort();
+		const nextKey = ids.join('|');
+		if (nextKey === runtimeIdsKey) return;
+
+		runtimeIdsKey = nextKey;
+		for (const id of ids) {
+			void refreshRuntime(id);
+		}
 	});
 
-	const resolvedListenIP = $derived.by(() => {
-		if (!config || !choices) return '';
+	$effect(() => {
+		const nextKey = String(runtimeSnap.lastFetchedAt);
+		if (nextKey === runtimeRefreshKey) return;
+
+		runtimeRefreshKey = nextKey;
+		if (runtimeSnap.lastFetchedAt === 0 || instances.length === 0) return;
+
+		void refreshAllRuntimes();
+	});
+
+	function runtimeFor(id: string): DeviceProxyRuntime {
+		return runtimes[id] ?? { alive: false, activeTag: '', defaultTag: '' };
+	}
+
+	async function refreshRuntime(id: string) {
+		try {
+			const runtime = await api.getDeviceProxyInstanceRuntime(id);
+			runtimes = { ...runtimes, [id]: runtime };
+		} catch {
+			// Instance may have been deleted between list refresh and runtime request.
+		}
+	}
+
+	async function refreshAllRuntimes() {
+		for (const in_ of instances) {
+			await refreshRuntime(in_.id);
+		}
+	}
+
+	function bridgeLabelFor(config: DeviceProxyConfig): string {
+		if (!choices) return '';
+		const match = choices.bridges.find((b) => b.id === config.listenInterface);
+		return match?.label ?? config.listenInterface;
+	}
+
+	function resolvedListenIPFor(config: DeviceProxyConfig): string {
+		if (!choices) return '';
 		if (config.listenAll) return choices.lanIP || '';
 		const match = choices.bridges.find((b) => b.id === config.listenInterface);
 		return match?.ip ?? '';
-	});
-
-	const activeLabel = $derived(runtime.activeTag || runtime.defaultTag);
-
-	const noTunnels = $derived(outbounds.length <= 1);
-
-	let toggling = $state(false);
-
-	function handleSwitched() {
-		deviceProxyRuntime.invalidate();
 	}
 
-	function handleSaved(_saved: DeviceProxyConfig) {
-		deviceProxyConfig.invalidate();
-		deviceProxyRuntime.invalidate();
-		settingsDrawerOpen = false;
+	function activeLabelFor(runtime: DeviceProxyRuntime): string {
+		return runtime.activeTag || runtime.defaultTag;
 	}
 
-	async function handleToggleEnabled() {
-		if (!config || toggling) return;
-		toggling = true;
-		const next = !config.enabled;
+	function configFromInstance(in_: DeviceProxyInstance): DeviceProxyConfig {
+		return {
+			enabled: in_.enabled,
+			listenAll: in_.listenAll,
+			listenInterface: in_.listenInterface,
+			port: in_.port,
+			auth: { ...in_.auth },
+			selectedOutbound: in_.selectedOutbound,
+		};
+	}
+
+	function mergeInstanceConfig(in_: DeviceProxyInstance, cfg: DeviceProxyConfig): DeviceProxyInstance {
+		return {
+			...in_,
+			enabled: cfg.enabled,
+			listenAll: cfg.listenAll,
+			listenInterface: cfg.listenInterface,
+			port: cfg.port,
+			auth: { ...cfg.auth },
+			selectedOutbound: cfg.selectedOutbound,
+		};
+	}
+
+	function upsertInstanceCache(saved: DeviceProxyInstance) {
+		const exists = instances.some((in_) => in_.id === saved.id);
+		const next = exists
+			? instances.map((in_) => (in_.id === saved.id ? saved : in_))
+			: [...instances, saved];
+		deviceProxyInstances.applyMutationResponse(next);
+	}
+
+	function removeInstanceCache(id: string) {
+		const next = instances.filter((in_) => in_.id !== id);
+		deviceProxyInstances.applyMutationResponse(next);
+	}
+
+	function nextFreePort(): number {
+		const used = new Set(instances.map((in_) => in_.port));
+		for (let p = 1099; p <= 65535; p++) {
+			if (!used.has(p)) return p;
+		}
+		return 1100;
+	}
+
+	function newInstance(): DeviceProxyInstance {
+		const n = Math.random().toString(36).slice(2, 8);
+		return {
+			id: `px-${n}`,
+			name: `Прокси ${instances.length + 1}`,
+			enabled: false,
+			listenAll: true,
+			listenInterface: '',
+			port: nextFreePort(),
+			auth: { enabled: false, username: '', password: '' },
+			selectedOutbound: 'direct',
+		};
+	}
+
+	async function createInstance() {
+		const in_ = newInstance();
 		try {
-			await api.saveDeviceProxyConfig({ ...config, enabled: next });
+			const saved = await api.saveDeviceProxyInstance(in_);
+			upsertInstanceCache(saved);
+			selectedInstanceId = saved.id;
+			settingsDrawerOpen = true;
 			deviceProxyConfig.invalidate();
 			deviceProxyRuntime.invalidate();
+			await refreshRuntime(saved.id);
+			notifications.success('Прокси создан');
+		} catch (e) {
+			notifications.error(`Не удалось создать прокси: ${(e as Error).message}`);
+		}
+	}
+
+	async function deleteInstance(in_: DeviceProxyInstance) {
+		if (in_.id === 'default') return;
+		if (!confirm(`Удалить "${in_.name || in_.id}"?`)) return;
+
+		deletingId = in_.id;
+		try {
+			await api.deleteDeviceProxyInstance(in_.id);
+			const remaining = instances.filter((x) => x.id !== in_.id);
+			removeInstanceCache(in_.id);
+			selectedInstanceId = remaining[0]?.id ?? 'default';
+			deviceProxyConfig.invalidate();
+			deviceProxyRuntime.invalidate();
+			notifications.success('Прокси удалён');
+		} catch (e) {
+			notifications.error(`Не удалось удалить: ${(e as Error).message}`);
+		} finally {
+			deletingId = null;
+		}
+	}
+
+	async function handleToggleEnabled(in_: DeviceProxyInstance) {
+		if (toggling[in_.id]) return;
+
+		toggling = { ...toggling, [in_.id]: true };
+		const next = !in_.enabled;
+		try {
+			const saved = await api.saveDeviceProxyInstance({ ...in_, enabled: next });
+			upsertInstanceCache(saved);
+			deviceProxyConfig.invalidate();
+			deviceProxyRuntime.invalidate();
+			await refreshRuntime(in_.id);
 			notifications.success(next ? 'Прокси включён' : 'Прокси выключен');
 		} catch (e) {
 			notifications.error(`Не удалось переключить: ${(e as Error).message}`);
 		} finally {
-			toggling = false;
+			toggling = { ...toggling, [in_.id]: false };
 		}
 	}
+
+	function openSettings(in_: DeviceProxyInstance) {
+		selectedInstanceId = in_.id;
+		settingsDrawerOpen = true;
+	}
+
+	function handleSavedInstance(saved: DeviceProxyInstance) {
+		upsertInstanceCache(saved);
+		selectedInstanceId = saved.id;
+		deviceProxyConfig.invalidate();
+		deviceProxyRuntime.invalidate();
+		void refreshRuntime(saved.id);
+		settingsDrawerOpen = false;
+	}
+
+	async function saveSelectedConfig(cfg: DeviceProxyConfig): Promise<DeviceProxyConfig> {
+		if (!selectedInstance) throw new Error('Прокси не выбран');
+		const saved = await api.saveDeviceProxyInstance(mergeInstanceConfig(selectedInstance, cfg));
+		handleSavedInstance(saved);
+		return configFromInstance(saved);
+	}
+
+	async function selectRuntime(in_: DeviceProxyInstance, tag: string) {
+		await api.selectDeviceProxyInstanceRuntime(in_.id, tag);
+		await refreshRuntime(in_.id);
+		deviceProxyRuntime.invalidate();
+	}
+
+	async function applyNow() {
+		await api.applyDeviceProxyInstances();
+		await refreshAllRuntimes();
+		deviceProxyInstances.invalidate();
+		deviceProxyConfig.invalidate();
+		deviceProxyRuntime.invalidate();
+	}
+
+	function handleSwitched(in_: DeviceProxyInstance) {
+		void refreshRuntime(in_.id);
+		deviceProxyRuntime.invalidate();
+	}
+
+	function isCollapsed(id: string): boolean {
+		return !!collapsedById[id];
+	}
+
+	function toggleCollapsed(id: string) {
+		const next = { ...collapsedById, [id]: !collapsedById[id] };
+		collapsedById = next;
+		try {
+			localStorage.setItem(collapseStorageKey, JSON.stringify(next));
+		} catch {
+			// Ignore storage errors.
+		}
+	}
+
 </script>
 
 {#if missingTag}
 	<div class="banner banner-error">
-		Прокси отключён: выбранный туннель "{missingTag}" был удалён. Выберите другой и включите заново.
+		Прокси отключён: выбранный туннель "{missingTag}" был удалён. Проверьте настройки нужного инстанса.
 	</div>
 {/if}
 
@@ -113,59 +328,122 @@
 	</div>
 {/if}
 
-{#if configSnap.status === 'loading'}
+<div class="toolbar">
+	<div>
+		<h2 class="page-title">Прокси</h2>
+		<p class="page-desc">Можно создать несколько SOCKS5 / HTTP прокси с разными портами и outbound.</p>
+	</div>
+	<Button variant="primary" size="sm" onclick={createInstance}>Добавить прокси</Button>
+</div>
+
+{#if instancesSnap.status === 'loading'}
 	<p>Загрузка…</p>
-{:else if config}
-	<DeviceProxyStatRow
-		{config}
-		{runtime}
-		{bridgeLabel}
-		{activeLabel}
-		{toggling}
-		onToggleEnabled={handleToggleEnabled}
-	/>
+{:else if instances.length === 0}
+	<div class="banner banner-info">
+		Прокси ещё не настроены.
+		<button type="button" class="link-btn" onclick={createInstance}>Создать прокси</button>
+	</div>
+{:else}
+	<div class="instances">
+		{#each instances as in_ (in_.id)}
+			{@const cfg = configFromInstance(in_)}
+			{@const runtime = runtimeFor(in_.id)}
+			{@const bridgeLabel = bridgeLabelFor(cfg)}
+			{@const resolvedListenIP = resolvedListenIPFor(cfg)}
+			{@const activeLabel = activeLabelFor(runtime)}
 
-	{#if config.enabled}
-		<div class="dashboard-grid">
-			<div class="dashboard-left">
-				<ActiveTunnelCard
-					{outbounds}
+			<section class="instance-card">
+				<div class="instance-header">
+					<div>
+						<h3>{in_.name || in_.id}</h3>
+						<div class="instance-meta">
+							<span>{in_.id}</span>
+							<span>{in_.auth.enabled ? 'с паролем' : 'без пароля'}</span>
+						</div>
+					</div>
+					<div class="instance-actions">
+						<Button
+							variant="ghost"
+							size="sm"
+							onclick={() => toggleCollapsed(in_.id)}
+						>
+							{isCollapsed(in_.id) ? 'Развернуть' : 'Свернуть'}
+						</Button>
+						<Button variant="ghost" size="sm" onclick={() => openSettings(in_)}>Настройки</Button>
+						{#if in_.id !== 'default'}
+							<Button
+								variant="ghost"
+								size="sm"
+								loading={deletingId === in_.id}
+								onclick={() => deleteInstance(in_)}
+							>
+								Удалить
+							</Button>
+						{/if}
+					</div>
+				</div>
+
+				<DeviceProxyStatRow
+					config={cfg}
 					{runtime}
-					onSwitched={handleSwitched}
-				/>
-			</div>
-			<div class="dashboard-right">
-				<DeviceProxyClientInfoCard
-					{config}
-					{resolvedListenIP}
 					{bridgeLabel}
-					onOpenSettings={() => (settingsDrawerOpen = true)}
+					{activeLabel}
+					toggling={!!toggling[in_.id]}
+					onToggleEnabled={() => handleToggleEnabled(in_)}
 				/>
-			</div>
-		</div>
-	{:else}
-		<div class="banner banner-info disabled-banner">
-			<span>Прокси выключен.</span>
-			<button type="button" class="link-btn" onclick={() => (settingsDrawerOpen = true)}>
-				Открыть настройки
-			</button>
-		</div>
-	{/if}
 
-	<SideDrawer
-		open={settingsDrawerOpen}
-		onClose={() => (settingsDrawerOpen = false)}
-		title="Настройки прокси"
-		width={560}
-	>
-		<SettingsCard
-			{config}
-			{outbounds}
-			{bridgeInterfaces}
-			onSaved={handleSaved}
-			onCancel={() => (settingsDrawerOpen = false)}
-		/>
-	</SideDrawer>
+				{#if !isCollapsed(in_.id) && in_.enabled}
+					<div class="dashboard-grid">
+						<div class="dashboard-left">
+							<ActiveTunnelCard
+								{outbounds}
+								{runtime}
+								radioName={`device-proxy-active-tunnel-${in_.id}`}
+								onSwitched={() => handleSwitched(in_)}
+								onSelectRuntime={(tag) => selectRuntime(in_, tag)}
+								onApplyNow={applyNow}
+							/>
+						</div>
+						<div class="dashboard-right">
+							<DeviceProxyClientInfoCard
+								config={cfg}
+								{resolvedListenIP}
+								{bridgeLabel}
+								onOpenSettings={() => openSettings(in_)}
+							/>
+						</div>
+					</div>
+				{:else if !isCollapsed(in_.id)}
+					<div class="banner banner-info disabled-banner">
+						<span>Прокси выключен.</span>
+						<button type="button" class="link-btn" onclick={() => openSettings(in_)}>
+							Открыть настройки
+						</button>
+					</div>
+				{/if}
+			</section>
+		{/each}
+	</div>
+
+	{#if selectedInstance}
+		<SideDrawer
+			open={settingsDrawerOpen}
+			onClose={() => (settingsDrawerOpen = false)}
+			title={`Настройки: ${selectedInstance.name || selectedInstance.id}`}
+			width={560}
+		>
+			<SettingsCard
+				config={configFromInstance(selectedInstance)}
+				{outbounds}
+				{bridgeInterfaces}
+				title={`Настройки: ${selectedInstance.name || selectedInstance.id}`}
+				description="Эти значения относятся только к выбранному proxy instance."
+				onSaveConfig={saveSelectedConfig}
+				onSaved={() => {}}
+				onCancel={() => (settingsDrawerOpen = false)}
+			/>
+		</SideDrawer>
+	{/if}
 {/if}
 
 <style>
@@ -175,15 +453,80 @@
 		margin-bottom: 0.75rem;
 		font-size: 0.875rem;
 	}
+
 	.banner-error {
 		border: 1px solid var(--color-error);
 		background: rgba(247, 118, 142, 0.08);
 		color: var(--color-error);
 	}
+
 	.banner-info {
 		border: 1px solid var(--color-border);
 		background: var(--color-bg-secondary);
 		color: var(--color-text-secondary);
+	}
+
+	.toolbar {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.page-title {
+		margin: 0 0 0.25rem 0;
+		font-size: 1.125rem;
+		font-weight: 600;
+	}
+
+	.page-desc {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+
+	.instances {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.instance-card {
+		padding: 1rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius);
+		background: var(--color-bg-primary);
+	}
+
+	.instance-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 0.875rem;
+	}
+
+	.instance-header h3 {
+		margin: 0 0 0.25rem 0;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.instance-meta {
+		display: flex;
+		gap: 0.625rem;
+		flex-wrap: wrap;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		color: var(--color-text-muted);
+	}
+
+	.instance-actions {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		justify-content: flex-end;
 	}
 
 	.disabled-banner {
@@ -191,6 +534,7 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 0.75rem;
+		margin-bottom: 0;
 	}
 
 	.link-btn {
@@ -219,6 +563,15 @@
 	}
 
 	@media (max-width: 900px) {
+		.toolbar,
+		.instance-header {
+			flex-direction: column;
+		}
+
+		.instance-actions {
+			justify-content: flex-start;
+		}
+
 		.dashboard-grid {
 			grid-template-columns: 1fr;
 		}

--- a/frontend/src/lib/components/singbox-routing/DeviceProxySubTab.svelte
+++ b/frontend/src/lib/components/singbox-routing/DeviceProxySubTab.svelte
@@ -14,7 +14,12 @@
 	import DeviceProxyClientInfoCard from '$lib/components/deviceproxy/DeviceProxyClientInfoCard.svelte';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
-	import type { DeviceProxyConfig, DeviceProxyInstance, DeviceProxyRuntime } from '$lib/types';
+	import type {
+		DeviceProxyConfig,
+		DeviceProxyInstance,
+		DeviceProxyInstanceIPCheckResult,
+		DeviceProxyRuntime
+	} from '$lib/types';
 
 	interface ListenChoices {
 		lanIP: string;
@@ -25,6 +30,10 @@
 	type RuntimeById = Record<string, DeviceProxyRuntime>;
 	type ToggleById = Record<string, boolean>;
 	type CollapsedById = Record<string, boolean>;
+	type ExternalIPById = Record<string, DeviceProxyInstanceIPCheckResult | null>;
+	type ExternalIPErrorById = Record<string, string>;
+	type ExternalIPLoadingById = Record<string, boolean>;
+	type ExternalIPCheckedAtById = Record<string, number>;
 
 	let unsubConfig: (() => void) | null = null;
 	let unsubInstances: (() => void) | null = null;
@@ -39,7 +48,12 @@
 	let deletingId = $state<string | null>(null);
 	let runtimeIdsKey = $state('');
 	let runtimeRefreshKey = $state('');
+	let externalIPInitKey = $state('');
 	let collapsedById = $state<CollapsedById>({});
+	let externalIPById = $state<ExternalIPById>({});
+	let externalIPErrorById = $state<ExternalIPErrorById>({});
+	let externalIPLoadingById = $state<ExternalIPLoadingById>({});
+	let externalIPCheckedAtById = $state<ExternalIPCheckedAtById>({});
 	const collapseStorageKey = 'deviceProxyCollapsedById';
 
 	onMount(() => {
@@ -102,6 +116,19 @@
 	});
 
 	$effect(() => {
+		const enabledIds = instances
+			.filter((in_) => in_.enabled)
+			.map((in_) => in_.id)
+			.sort();
+		const nextKey = enabledIds.join('|');
+		if (!nextKey || nextKey === externalIPInitKey) return;
+		externalIPInitKey = nextKey;
+		for (const id of enabledIds) {
+			void refreshExternalIP(id);
+		}
+	});
+
+	$effect(() => {
 		const nextKey = String(runtimeSnap.lastFetchedAt);
 		if (nextKey === runtimeRefreshKey) return;
 
@@ -127,6 +154,46 @@
 	async function refreshAllRuntimes() {
 		for (const in_ of instances) {
 			await refreshRuntime(in_.id);
+		}
+	}
+
+	function externalIPFor(id: string): DeviceProxyInstanceIPCheckResult | null {
+		return externalIPById[id] ?? null;
+	}
+
+	function externalIPErrorFor(id: string): string {
+		return externalIPErrorById[id] ?? '';
+	}
+
+	function externalIPLoadingFor(id: string): boolean {
+		return !!externalIPLoadingById[id];
+	}
+
+	function externalIPCheckedAtFor(id: string): number | null {
+		return externalIPCheckedAtById[id] ?? null;
+	}
+
+	async function refreshExternalIP(id: string) {
+		externalIPLoadingById = { ...externalIPLoadingById, [id]: true };
+		externalIPErrorById = { ...externalIPErrorById, [id]: '' };
+		try {
+			const data = await api.checkDeviceProxyInstanceExternalIP(id);
+			externalIPById = { ...externalIPById, [id]: data };
+			externalIPCheckedAtById = { ...externalIPCheckedAtById, [id]: Date.now() };
+		} catch (e) {
+			externalIPById = { ...externalIPById, [id]: null };
+			externalIPCheckedAtById = { ...externalIPCheckedAtById, [id]: 0 };
+			externalIPErrorById = { ...externalIPErrorById, [id]: (e as Error).message };
+		} finally {
+			externalIPLoadingById = { ...externalIPLoadingById, [id]: false };
+		}
+	}
+
+	async function refreshExternalIPAfterApply(id: string) {
+		await refreshExternalIP(id);
+		if (externalIPErrorFor(id)) {
+			await new Promise((resolve) => setTimeout(resolve, 1200));
+			await refreshExternalIP(id);
 		}
 	}
 
@@ -284,12 +351,21 @@
 	async function selectRuntime(in_: DeviceProxyInstance, tag: string) {
 		await api.selectDeviceProxyInstanceRuntime(in_.id, tag);
 		await refreshRuntime(in_.id);
+		await refreshExternalIP(in_.id);
 		deviceProxyRuntime.invalidate();
 	}
 
-	async function applyNow() {
+	async function applyNow(in_: DeviceProxyInstance) {
+		const runtime = runtimeFor(in_.id);
+		const active = runtime.activeTag || runtime.defaultTag;
+		if (active && active !== in_.selectedOutbound) {
+			const saved = await api.saveDeviceProxyInstance({ ...in_, selectedOutbound: active });
+			upsertInstanceCache(saved);
+		}
+
 		await api.applyDeviceProxyInstances();
 		await refreshAllRuntimes();
+		await refreshExternalIPAfterApply(in_.id);
 		deviceProxyInstances.invalidate();
 		deviceProxyConfig.invalidate();
 		deviceProxyRuntime.invalidate();
@@ -358,7 +434,21 @@
 						<h3>{in_.name || in_.id}</h3>
 						<div class="instance-meta">
 							<span>{in_.id}</span>
-							<span>{in_.auth.enabled ? 'с паролем' : 'без пароля'}</span>
+							<span class="auth-meta" class:auth-meta-enabled={in_.auth.enabled}>
+								{#if in_.auth.enabled}
+									<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+										<rect x="4" y="11" width="16" height="9" rx="2" ry="2"/>
+										<path d="M8 11V8a4 4 0 0 1 8 0v3"/>
+									</svg>
+									<span>с паролем</span>
+								{:else}
+									<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+										<rect x="4" y="11" width="16" height="9" rx="2" ry="2"/>
+										<path d="M16 11V8a4 4 0 0 0-7.2-2.4"/>
+									</svg>
+									<span>без пароля</span>
+								{/if}
+							</span>
 						</div>
 					</div>
 					<div class="instance-actions">
@@ -401,7 +491,7 @@
 								radioName={`device-proxy-active-tunnel-${in_.id}`}
 								onSwitched={() => handleSwitched(in_)}
 								onSelectRuntime={(tag) => selectRuntime(in_, tag)}
-								onApplyNow={applyNow}
+								onApplyNow={() => applyNow(in_)}
 							/>
 						</div>
 						<div class="dashboard-right">
@@ -409,6 +499,11 @@
 								config={cfg}
 								{resolvedListenIP}
 								{bridgeLabel}
+								externalIP={externalIPFor(in_.id)}
+								externalIPError={externalIPErrorFor(in_.id)}
+								externalIPLoading={externalIPLoadingFor(in_.id)}
+								externalIPCheckedAt={externalIPCheckedAtFor(in_.id)}
+								onRefreshExternalIP={() => refreshExternalIP(in_.id)}
 								onOpenSettings={() => openSettings(in_)}
 							/>
 						</div>
@@ -520,6 +615,16 @@
 		font-family: var(--font-mono);
 		font-size: 0.6875rem;
 		color: var(--color-text-muted);
+	}
+
+	.auth-meta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.auth-meta-enabled {
+		color: var(--color-text-secondary);
 	}
 
 	.instance-actions {

--- a/frontend/src/lib/stores/deviceproxy.ts
+++ b/frontend/src/lib/stores/deviceproxy.ts
@@ -5,17 +5,24 @@
 //   - runtime (5s poll): live selector.now + persisted default for
 //     the "Активный туннель" card; SSE-invalidated by
 //     resource:invalidated{resource:"deviceproxy.runtime"}.
+//   - instances (30s poll): list of all proxy instances for multi-instance UI.
 import { writable } from 'svelte/store';
 import { api } from '$lib/api/client';
 import { createPollingStore, type PollingStore } from './polling';
 import { registerStore } from './storeRegistry';
-import type { DeviceProxyConfig, DeviceProxyOutbound, DeviceProxyRuntime } from '$lib/types';
+import type { DeviceProxyConfig, DeviceProxyInstance, DeviceProxyOutbound, DeviceProxyRuntime } from '$lib/types';
 
 export const deviceProxyConfig: PollingStore<DeviceProxyConfig> = createPollingStore<DeviceProxyConfig>(
 	() => api.getDeviceProxyConfig(),
 	{ staleTime: 30_000, pollInterval: 30_000 },
 );
 registerStore('deviceproxy.config', deviceProxyConfig);
+
+export const deviceProxyInstances: PollingStore<DeviceProxyInstance[]> = createPollingStore<DeviceProxyInstance[]>(
+	() => api.listDeviceProxyInstances(),
+	{ staleTime: 30_000, pollInterval: 30_000 },
+);
+registerStore('deviceproxy.config', deviceProxyInstances);
 
 export const deviceProxyOutbounds: PollingStore<DeviceProxyOutbound[]> = createPollingStore<DeviceProxyOutbound[]>(
 	() => api.listDeviceProxyOutbounds(),
@@ -39,6 +46,7 @@ export function setDeviceProxyMissingTarget(wasTag: string): void {
 	deviceProxyMissingTarget.set(wasTag);
 	// Also kick both polling stores so the UI reflects the disabled state.
 	deviceProxyConfig.invalidate();
+	deviceProxyInstances.invalidate();
 	deviceProxyOutbounds.invalidate();
 }
 

--- a/frontend/src/lib/stores/storeRegistry.ts
+++ b/frontend/src/lib/stores/storeRegistry.ts
@@ -31,27 +31,29 @@ export type ResourceKey =
 	| 'singbox.router.rules';       // emitted by emitRulesEvent — triggers loadRulesSnapshot()
 
 /**
- * Resource key → polling store. Populated as stores are migrated to
- * createPollingStore (Phase B). The SSE `resource:invalidated` handler
- * looks up the store here and calls `.invalidate()`.
+ * Resource key → list of polling stores. Multiple stores can register under
+ * the same resource key (e.g. legacy deviceProxyConfig and new
+ * deviceProxyInstances both subscribe to "deviceproxy.config" invalidations).
+ * The SSE `resource:invalidated` handler iterates all registered stores and
+ * calls `.invalidate()` on each.
  */
-const registry = new Map<string, PollingStore<unknown>>();
+const registry = new Map<string, PollingStore<unknown>[]>();
 
 /**
  * Register a polling store under a resource key. Call this once per store,
  * typically at store construction. Subsequent `invalidateResource(key)` calls
- * will trigger an immediate refetch on that store. Typed by `ResourceKey`
- * so typos become compile errors rather than silent invalidation misses.
+ * will trigger an immediate refetch on all stores registered for that key.
+ * Typed by `ResourceKey` so typos become compile errors rather than silent
+ * invalidation misses.
  */
 export function registerStore<T>(resource: ResourceKey, store: PollingStore<T>): void {
-	if (import.meta.env.DEV && registry.has(resource)) {
-		console.warn(`storeRegistry: overwriting store for "${resource}"`);
-	}
-	registry.set(resource, store as PollingStore<unknown>);
+	const stores = registry.get(resource) ?? [];
+	stores.push(store as PollingStore<unknown>);
+	registry.set(resource, stores);
 }
 
 /**
- * Trigger `invalidate()` on the store registered under `resource`. No-op if
+ * Trigger `invalidate()` on all stores registered under `resource`. No-op if
  * no store is registered — either because the resource key is unknown, or
  * because the store has not been migrated to createPollingStore yet.
  *
@@ -60,7 +62,9 @@ export function registerStore<T>(resource: ResourceKey, store: PollingStore<T>):
  * is intentional.
  */
 export function invalidateResource(resource: string): void {
-	registry.get(resource)?.invalidate();
+	for (const store of registry.get(resource) ?? []) {
+		store.invalidate();
+	}
 }
 
 /**
@@ -70,7 +74,12 @@ export function invalidateResource(resource: string): void {
  * the outage.
  */
 export function invalidateAll(): void {
-	for (const store of registry.values()) {
-		store.invalidate();
+	const seen = new Set<PollingStore<unknown>>();
+	for (const stores of registry.values()) {
+		for (const store of stores) {
+			if (seen.has(store)) continue;
+			seen.add(store);
+			store.invalidate();
+		}
 	}
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -780,6 +780,11 @@ export interface DeviceProxyConfig {
 	selectedOutbound: string;
 }
 
+export interface DeviceProxyInstance extends DeviceProxyConfig {
+	id: string;
+	name: string;
+}
+
 export type DeviceProxyOutboundKind = 'direct' | 'singbox' | 'awg';
 
 export interface DeviceProxyOutbound {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -800,6 +800,13 @@ export interface DeviceProxyRuntime {
 	defaultTag: string;
 }
 
+export interface DeviceProxyInstanceIPCheckResult {
+	directIp: string;
+	proxyIp: string;
+	ipChanged: boolean;
+	service: string;
+}
+
 // #endregion
 
 // ─────────────────────────────────────────────

--- a/internal/api/deviceproxy.go
+++ b/internal/api/deviceproxy.go
@@ -30,6 +30,30 @@ type DeviceProxyConfigData struct {
 	SelectedOutbound string             `json:"selectedOutbound" example:"proxy-01"`
 }
 
+// DeviceProxyInstanceData mirrors deviceproxy.Instance for multi-instance API.
+type DeviceProxyInstanceData struct {
+	ID               string             `json:"id" example:"default"`
+	Name             string             `json:"name" example:"Прокси"`
+	Enabled          bool               `json:"enabled" example:"false"`
+	ListenAll        bool               `json:"listenAll" example:"true"`
+	ListenInterface  string             `json:"listenInterface" example:"br0"`
+	Port             int                `json:"port" example:"1099"`
+	Auth             DeviceProxyAuthDTO `json:"auth"`
+	SelectedOutbound string             `json:"selectedOutbound" example:"proxy-01"`
+}
+
+// ProxyInstancesResponse is the envelope for GET /proxy/instances.
+type ProxyInstancesResponse struct {
+	Success bool                      `json:"success" example:"true"`
+	Data    []DeviceProxyInstanceData `json:"data"`
+}
+
+// ProxyInstanceResponse is the envelope for GET/PUT /proxy/instance.
+type ProxyInstanceResponse struct {
+	Success bool                    `json:"success" example:"true"`
+	Data    DeviceProxyInstanceData `json:"data"`
+}
+
 // ProxyConfigResponse is the envelope for GET /proxy/config.
 type ProxyConfigResponse struct {
 	Success bool                  `json:"success" example:"true"`
@@ -86,6 +110,42 @@ func NewDeviceProxyHandler(svc *deviceproxy.Service, appLogger logging.AppLogger
 	return &DeviceProxyHandler{
 		svc: svc,
 		log: logging.NewScopedLogger(appLogger, logging.GroupRouting, logging.SubDeviceProxy),
+	}
+}
+
+// toDeviceProxyInstanceData converts internal instance to API DTO.
+func toDeviceProxyInstanceData(in deviceproxy.Instance) DeviceProxyInstanceData {
+	return DeviceProxyInstanceData{
+		ID:              in.ID,
+		Name:            in.Name,
+		Enabled:         in.Enabled,
+		ListenAll:       in.ListenAll,
+		ListenInterface: in.ListenInterface,
+		Port:            in.Port,
+		Auth: DeviceProxyAuthDTO{
+			Enabled:  in.Auth.Enabled,
+			Username: in.Auth.Username,
+			Password: in.Auth.Password,
+		},
+		SelectedOutbound: in.SelectedOutbound,
+	}
+}
+
+// fromDeviceProxyInstanceData converts API DTO to internal instance.
+func fromDeviceProxyInstanceData(in DeviceProxyInstanceData) deviceproxy.Instance {
+	return deviceproxy.Instance{
+		ID:              in.ID,
+		Name:            in.Name,
+		Enabled:         in.Enabled,
+		ListenAll:       in.ListenAll,
+		ListenInterface: in.ListenInterface,
+		Port:            in.Port,
+		Auth: deviceproxy.AuthSpec{
+			Enabled:  in.Auth.Enabled,
+			Username: in.Auth.Username,
+			Password: in.Auth.Password,
+		},
+		SelectedOutbound: in.SelectedOutbound,
 	}
 }
 
@@ -271,4 +331,254 @@ func (h *DeviceProxyHandler) ListenChoices(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	response.Success(w, choices)
+}
+
+// GetInstanceRuntime handles GET /api/proxy/instance/runtime?id=...
+//
+//	@Summary		Get device proxy instance runtime state
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ProxyRuntimeResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instance/runtime [get]
+func (h *DeviceProxyHandler) GetInstanceRuntime(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+
+	state, err := h.svc.GetInstanceRuntimeState(r.Context(), id)
+	if err != nil {
+		response.ErrorWithStatus(w, http.StatusNotFound, err.Error(), "INSTANCE_NOT_FOUND")
+		return
+	}
+
+	response.Success(w, state)
+}
+
+// SelectInstanceRuntime handles POST /api/proxy/instance/runtime/select.
+//
+//	@Summary		Select device proxy instance outbound
+//	@Tags			device-proxy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ProxyRuntimeResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		409	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instance/runtime/select [post]
+func (h *DeviceProxyHandler) SelectInstanceRuntime(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+
+	var body struct {
+		Tag string `json:"tag"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.Error(w, "invalid JSON", "INVALID_JSON")
+		return
+	}
+
+	if err := h.svc.SelectInstanceRuntimeOutbound(r.Context(), id, body.Tag); err != nil {
+		if errors.Is(err, deviceproxy.ErrOutboundUnavailable) {
+			response.Error(w, err.Error(), "OUTBOUND_UNAVAILABLE")
+			return
+		}
+		if errors.Is(err, singbox.ErrSingboxNotRunning) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "SINGBOX_DOWN")
+			return
+		}
+		response.Error(w, err.Error(), "RUNTIME_SELECT_FAILED")
+		return
+	}
+
+	response.Success(w, map[string]string{"active": body.Tag})
+}
+
+// ListInstances handles GET /api/proxy/instances.
+//
+//	@Summary		List device proxy instances
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ProxyInstancesResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instances [get]
+func (h *DeviceProxyHandler) ListInstances(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	snap := h.svc.GetSnapshot()
+	out := make([]DeviceProxyInstanceData, 0, len(snap.Instances))
+	for _, in := range snap.Instances {
+		out = append(out, toDeviceProxyInstanceData(in))
+	}
+	response.Success(w, out)
+}
+
+// GetInstance handles GET /api/proxy/instance?id=...
+//
+//	@Summary		Get one device proxy instance
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ProxyInstanceResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instance [get]
+func (h *DeviceProxyHandler) GetInstance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+
+	in, ok := h.svc.GetInstance(id)
+	if !ok {
+		response.ErrorWithStatus(w, http.StatusNotFound, "instance not found", "INSTANCE_NOT_FOUND")
+		return
+	}
+
+	response.Success(w, toDeviceProxyInstanceData(in))
+}
+
+// SaveInstance handles PUT /api/proxy/instance.
+//
+//	@Summary		Save one device proxy instance
+//	@Tags			device-proxy
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ProxyInstanceResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instance [put]
+func (h *DeviceProxyHandler) SaveInstance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	var body DeviceProxyInstanceData
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.Error(w, "invalid JSON", "INVALID_JSON")
+		return
+	}
+	if body.ID == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+
+	in := fromDeviceProxyInstanceData(body)
+	if err := h.svc.SaveInstance(r.Context(), in); err != nil {
+		if errors.Is(err, singbox.ErrSingboxNotRunning) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "SINGBOX_DOWN")
+			return
+		}
+		response.Error(w, err.Error(), "SAVE_INSTANCE_FAILED")
+		return
+	}
+
+	saved, ok := h.svc.GetInstance(body.ID)
+	if !ok {
+		response.Error(w, "saved instance not found", "INSTANCE_NOT_FOUND")
+		return
+	}
+	response.Success(w, toDeviceProxyInstanceData(saved))
+}
+
+// DeleteInstance handles DELETE /api/proxy/instance?id=...
+//
+//	@Summary		Delete one device proxy instance
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instance [delete]
+func (h *DeviceProxyHandler) DeleteInstance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+	if id == "default" {
+		response.Error(w, "default instance cannot be deleted", "DEFAULT_INSTANCE_PROTECTED")
+		return
+	}
+
+	if err := h.svc.DeleteInstance(r.Context(), id); err != nil {
+		if errors.Is(err, singbox.ErrSingboxNotRunning) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "SINGBOX_DOWN")
+			return
+		}
+		response.Error(w, err.Error(), "DELETE_INSTANCE_FAILED")
+		return
+	}
+
+	response.Success(w, map[string]bool{"deleted": true})
+}
+
+// ApplyInstances handles POST /api/proxy/instances/apply.
+//
+//	@Summary		Apply all device proxy instances
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/proxy/instances/apply [post]
+func (h *DeviceProxyHandler) ApplyInstances(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	if err := h.svc.ApplyInstances(r.Context()); err != nil {
+		if errors.Is(err, singbox.ErrSingboxNotRunning) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "SINGBOX_DOWN")
+			return
+		}
+		response.Error(w, err.Error(), "APPLY_INSTANCES_FAILED")
+		return
+	}
+
+	response.Success(w, map[string]bool{"applied": true})
 }

--- a/internal/api/deviceproxy.go
+++ b/internal/api/deviceproxy.go
@@ -99,6 +99,13 @@ type ProxyListenChoicesResponse struct {
 	Data    ProxyListenChoicesData `json:"data"`
 }
 
+// DeviceProxyInstanceIPCheckResponse is the envelope for
+// GET /proxy/instance/check-ip.
+type DeviceProxyInstanceIPCheckResponse struct {
+	Success bool                              `json:"success" example:"true"`
+	Data    deviceproxy.InstanceIPCheckResult `json:"data"`
+}
+
 // DeviceProxyHandler handles /api/proxy/* endpoints.
 type DeviceProxyHandler struct {
 	svc *deviceproxy.Service
@@ -581,4 +588,47 @@ func (h *DeviceProxyHandler) ApplyInstances(w http.ResponseWriter, r *http.Reque
 	}
 
 	response.Success(w, map[string]bool{"applied": true})
+}
+
+// CheckInstanceExternalIP handles GET /api/proxy/instance/check-ip?id=...
+//
+//	@Summary		Check external IP through one device proxy instance
+//	@Tags			device-proxy
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id		query		string	true	"Instance ID"
+//	@Param			service	query		string	false	"Specific IP service URL"
+//	@Success		200		{object}	DeviceProxyInstanceIPCheckResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/proxy/instance/check-ip [get]
+func (h *DeviceProxyHandler) CheckInstanceExternalIP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id", "MISSING_ID")
+		return
+	}
+	service := r.URL.Query().Get("service")
+
+	result, err := h.svc.CheckInstanceExternalIP(r.Context(), id, service)
+	if err != nil {
+		if errors.Is(err, deviceproxy.ErrInstanceNotFound) {
+			response.ErrorWithStatus(w, http.StatusNotFound, "instance not found", "INSTANCE_NOT_FOUND")
+			return
+		}
+		if errors.Is(err, singbox.ErrSingboxNotRunning) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "SINGBOX_DOWN")
+			return
+		}
+		response.Error(w, err.Error(), "INSTANCE_IP_CHECK_FAILED")
+		return
+	}
+
+	response.Success(w, result)
 }

--- a/internal/deviceproxy/service.go
+++ b/internal/deviceproxy/service.go
@@ -62,6 +62,7 @@ type SubscriptionOutboundInfo struct {
 type SingboxOperator interface {
 	ApplyDeviceProxy(ctx context.Context, spec ExternalSpec) error
 	ApplyDeviceProxyNoReload(ctx context.Context, spec ExternalSpec) error
+	ApplyDeviceProxyInstances(ctx context.Context, specs []ExternalInstanceSpec) error
 	SetSelectorDefault(ctx context.Context, selectorTag, memberTag string) error
 	GetSelectorActive(ctx context.Context, selectorTag string) (string, error)
 	TunnelTags() []string
@@ -78,6 +79,18 @@ type NDMSInterfaceQuery interface {
 // package to keep deviceproxy independent of singbox at the type
 // level. The adapter translates.
 type ExternalSpec struct {
+	Enabled     bool
+	ListenAddr  string
+	Port        int
+	Auth        AuthSpec
+	SelectedTag string
+	AWGTags     []string
+	SBTags      []string
+}
+
+// ExternalInstanceSpec mirrors singbox.DeviceProxyInstanceSpec.
+type ExternalInstanceSpec struct {
+	ID          string
 	Enabled     bool
 	ListenAddr  string
 	Port        int
@@ -106,6 +119,16 @@ type Service struct {
 // requests a tag that is not in the current list of available outbounds.
 var ErrOutboundUnavailable = errors.New("outbound is not available")
 
+// deviceProxyInstanceSelectorTag returns the selector tag for a given instance.
+// The default instance uses the shared "device-proxy-selector" tag;
+// named instances get their own isolated selector: "device-proxy-<id>-selector".
+func deviceProxyInstanceSelectorTag(id string) string {
+	if id == "" || id == "default" {
+		return "device-proxy-selector"
+	}
+	return "device-proxy-" + id + "-selector"
+}
+
 func NewService(d Deps) *Service {
 	return &Service{
 		d:      d,
@@ -116,6 +139,168 @@ func NewService(d Deps) *Service {
 // GetConfig returns the current persisted Config. Defensive copy via Store.
 func (s *Service) GetConfig() Config {
 	return s.d.Store.Get()
+}
+
+// GetSnapshot returns all configured proxy instances.
+func (s *Service) GetSnapshot() Snapshot {
+	return s.d.Store.Snapshot()
+}
+
+// GetInstance returns one configured proxy instance.
+func (s *Service) GetInstance(id string) (Instance, bool) {
+	return s.d.Store.GetInstance(id)
+}
+
+// SaveInstance validates and persists one proxy instance.
+// It now applies the full snapshot after saving.
+func (s *Service) SaveInstance(ctx context.Context, in Instance) error {
+	if in.ID == "" {
+		return fmt.Errorf("instance id is empty")
+	}
+	if in.Name == "" {
+		in.Name = in.ID
+	}
+
+	s.mu.Lock()
+	portFn := s.tunnelPorts
+	s.mu.Unlock()
+
+	cfg := instanceToConfig(in)
+	if err := validateConfigRaw(cfg, portFn); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prev := s.d.Store.Snapshot()
+
+	if err := s.d.Store.SaveInstance(in); err != nil {
+		return err
+	}
+	if err := s.applyInstancesLocked(ctx); err != nil {
+		_ = s.restoreSnapshot(prev)
+		return err
+	}
+	return nil
+}
+
+// DeleteInstance removes one configured proxy instance.
+// The default instance is preserved by Store.DeleteInstance.
+func (s *Service) DeleteInstance(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("instance id is empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prev := s.d.Store.Snapshot()
+
+	if err := s.d.Store.DeleteInstance(id); err != nil {
+		return err
+	}
+	if err := s.applyInstancesLocked(ctx); err != nil {
+		_ = s.restoreSnapshot(prev)
+		return err
+	}
+	return nil
+}
+
+// buildInstanceSpec builds an ExternalInstanceSpec from a stored Instance.
+func (s *Service) buildInstanceSpec(ctx context.Context, in Instance) (ExternalInstanceSpec, error) {
+	cfg := instanceToConfig(in)
+
+	base, err := s.buildSpec(ctx, cfg)
+	if err != nil {
+		return ExternalInstanceSpec{}, err
+	}
+
+	return ExternalInstanceSpec{
+		ID:          in.ID,
+		Enabled:     base.Enabled,
+		ListenAddr:  base.ListenAddr,
+		Port:        base.Port,
+		Auth:        base.Auth,
+		SelectedTag: base.SelectedTag,
+		AWGTags:     append([]string(nil), base.AWGTags...),
+		SBTags:      append([]string(nil), base.SBTags...),
+	}, nil
+}
+
+// buildSnapshotSpecs converts a Snapshot into a slice of ExternalInstanceSpec.
+func (s *Service) buildSnapshotSpecs(ctx context.Context, snap Snapshot) ([]ExternalInstanceSpec, error) {
+	specs := make([]ExternalInstanceSpec, 0, len(snap.Instances))
+	for _, in := range snap.Instances {
+		spec, err := s.buildInstanceSpec(ctx, in)
+		if err != nil {
+			return nil, fmt.Errorf("build instance %q: %w", in.ID, err)
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+// ApplyInstances rebuilds and applies all configured proxy instances.
+func (s *Service) ApplyInstances(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.applyInstancesLocked(ctx)
+}
+
+func (s *Service) applyInstancesLocked(ctx context.Context) error {
+	snap := s.d.Store.Snapshot()
+
+	specs, err := s.buildSnapshotSpecs(ctx, snap)
+	if err != nil {
+		return err
+	}
+
+	if s.d.Singbox != nil {
+		if err := s.d.Singbox.ApplyDeviceProxyInstances(ctx, specs); err != nil {
+			return fmt.Errorf("apply device proxy instances: %w", err)
+		}
+	}
+
+	if s.d.Bus != nil {
+		s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.config"})
+		s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.runtime"})
+	}
+	return nil
+}
+
+// restoreSnapshot attempts to roll the Store back to a previous snapshot.
+// It deletes any extra instances and restores missing ones. Best-effort:
+// errors during rollback are logged via appLog but not returned.
+func (s *Service) restoreSnapshot(snap Snapshot) error {
+	current := s.d.Store.Snapshot()
+
+	// Delete instances present in current but missing in previous.
+	for _, cur := range current.Instances {
+		found := false
+		for _, prev := range snap.Instances {
+			if prev.ID == cur.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := s.d.Store.DeleteInstance(cur.ID); err != nil {
+				s.appLog.Warn("rollback", "delete", fmt.Sprintf("failed to delete instance %s: %v", cur.ID, err))
+				return err
+			}
+		}
+	}
+
+	// Restore (upsert) all instances from the previous snapshot.
+	for _, prev := range snap.Instances {
+		if err := s.d.Store.SaveInstance(prev); err != nil {
+			s.appLog.Warn("rollback", "restore", fmt.Sprintf("failed to restore instance %s: %v", prev.ID, err))
+			return err
+		}
+	}
+
+	return nil
 }
 
 // SetTunnelInboundPorts wires a lookup that ValidateConfig uses to
@@ -386,6 +571,35 @@ func (s *Service) GetRuntimeState(ctx context.Context) RuntimeState {
 	return state
 }
 
+// GetInstanceRuntimeState returns the current selector.now for a specific
+// instance (empty if sing-box is down) plus the persisted default for
+// that instance.
+func (s *Service) GetInstanceRuntimeState(ctx context.Context, id string) (RuntimeState, error) {
+	if id == "" {
+		return RuntimeState{}, fmt.Errorf("instance id is empty")
+	}
+
+	s.mu.Lock()
+	in, ok := s.d.Store.GetInstance(id)
+	sb := s.d.Singbox
+	s.mu.Unlock()
+
+	if !ok {
+		return RuntimeState{}, fmt.Errorf("instance %q not found", id)
+	}
+
+	state := RuntimeState{DefaultTag: in.SelectedOutbound}
+	if sb == nil || !sb.IsRunning() {
+		return state, nil
+	}
+
+	state.Alive = true
+	if active, err := sb.GetSelectorActive(ctx, deviceProxyInstanceSelectorTag(id)); err == nil {
+		state.ActiveTag = active
+	}
+	return state, nil
+}
+
 // Outbound describes one selectable proxy target exposed to the UI.
 type Outbound struct {
 	Tag    string `json:"tag"`
@@ -490,55 +704,118 @@ func (s *Service) SelectRuntimeOutbound(ctx context.Context, tag string) error {
 	return nil
 }
 
-// Reconcile is the single idempotent rebuild path. It verifies the
-// currently-selected outbound still exists in the available list
-// (disables the proxy + publishes deviceproxy:missing-target if not)
-// and re-applies the resulting spec to sing-box.
+// SelectInstanceRuntimeOutbound switches the live selector.now for a
+// specific instance via Clash API. No storage write. No config.json
+// write. The choice is ephemeral — sing-box reload/restart reverts to
+// the instance's persisted default.
+//
+// Errors:
+//   - ErrOutboundUnavailable — tag is not in the currently-available list.
+//   - singbox.ErrSingboxNotRunning — bubbled up from the operator when
+//     the daemon is down.
+func (s *Service) SelectInstanceRuntimeOutbound(ctx context.Context, id, tag string) error {
+	if id == "" {
+		return fmt.Errorf("instance id is empty")
+	}
+
+	s.mu.Lock()
+	_, ok := s.d.Store.GetInstance(id)
+	available := s.listOutboundsLocked(ctx)
+	sb := s.d.Singbox
+	bus := s.d.Bus
+	s.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("instance %q not found", id)
+	}
+
+	found := false
+	for _, ob := range available {
+		if ob.Tag == tag {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: %q", ErrOutboundUnavailable, tag)
+	}
+
+	if sb == nil {
+		return fmt.Errorf("singbox operator unavailable")
+	}
+
+	selectorTag := deviceProxyInstanceSelectorTag(id)
+	if err := sb.SetSelectorDefault(ctx, selectorTag, tag); err != nil {
+		s.appLog.Warn("select-runtime", tag, fmt.Sprintf("hot-switch failed for instance %s: %v", id, err))
+		return err
+	}
+	s.appLog.Info("select-runtime", tag, fmt.Sprintf("Device proxy instance %s hot-switched outbound", id))
+
+	if bus != nil {
+		bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.runtime"})
+	}
+	return nil
+}
+
+// Reconcile is the idempotent rebuild that verifies every enabled instance's
+// selected outbound is still available. Instances with missing targets are
+// disabled, then the full snapshot is applied to sing-box.
 func (s *Service) Reconcile(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cfg := s.d.Store.Get()
-	if cfg.Enabled && cfg.SelectedOutbound != "" {
-		available := s.listOutboundsLocked(ctx)
-		found := false
-		for _, ob := range available {
-			if ob.Tag == cfg.SelectedOutbound {
-				found = true
-				break
-			}
+	snap := s.d.Store.Snapshot()
+	available := s.listOutboundsLocked(ctx)
+
+	availableByTag := make(map[string]struct{}, len(available))
+	for _, ob := range available {
+		availableByTag[ob.Tag] = struct{}{}
+	}
+
+	changed := false
+	missingTags := make([]string, 0)
+
+	for i := range snap.Instances {
+		in := &snap.Instances[i]
+		if !in.Enabled || in.SelectedOutbound == "" {
+			continue
 		}
-		if !found {
-			wasTag := cfg.SelectedOutbound
-			cfg.Enabled = false
-			cfg.SelectedOutbound = ""
-			if err := s.d.Store.Save(cfg); err != nil {
-				return fmt.Errorf("persist after missing target: %w", err)
-			}
-			if s.d.Bus != nil {
-				s.d.Bus.Publish("deviceproxy:missing-target", map[string]string{"wasTag": wasTag})
-				s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.config"})
-				s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.runtime"})
-			}
+		if _, ok := availableByTag[in.SelectedOutbound]; ok {
+			continue
+		}
+
+		missingTags = append(missingTags, in.SelectedOutbound)
+		in.Enabled = false
+		in.SelectedOutbound = ""
+		changed = true
+
+		// Persist the changed instance immediately.
+		if err := s.d.Store.SaveInstance(*in); err != nil {
+			return fmt.Errorf("persist after missing target: %w", err)
 		}
 	}
 
-	// Rebuild sing-box config from whatever cfg is now.
-	spec, err := s.buildSpec(ctx, cfg)
+	if changed && s.d.Bus != nil {
+		for _, wasTag := range missingTags {
+			s.d.Bus.Publish("deviceproxy:missing-target", map[string]string{"wasTag": wasTag})
+		}
+		s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.config"})
+		s.d.Bus.Publish("resource:invalidated", events.ResourceInvalidatedEvent{Resource: "deviceproxy.runtime"})
+	}
+
+	snap = s.d.Store.Snapshot()
+
+	specs, err := s.buildSnapshotSpecs(ctx, snap)
 	if err != nil {
 		return err
 	}
+
 	if s.d.Singbox != nil {
-		// Skip the apply if there is nothing meaningful to do — no proxy,
-		// no sing-box tunnels, no AWG tunnels. Applying in this case would
-		// just write an empty config.json + start sing-box for nothing.
-		if !spec.Enabled && len(spec.SBTags) == 0 && len(spec.AWGTags) == 0 {
-			return nil
-		}
-		if err := s.d.Singbox.ApplyDeviceProxy(ctx, spec); err != nil {
-			return fmt.Errorf("apply spec: %w", err)
+		if err := s.d.Singbox.ApplyDeviceProxyInstances(ctx, specs); err != nil {
+			return fmt.Errorf("apply specs: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -633,20 +910,23 @@ func (s *Service) SubscribeBus(ctx context.Context) func() {
 	return unsub
 }
 
-// HasSelectorReference reports whether the persisted Config references
-// the given outbound tag as the user-chosen SelectedOutbound default.
-// Used by tunnel.Service.Delete to refuse deletions that would orphan
-// the user's explicit choice.
-//
-// Selector membership (the dynamic awg-* member list rebuilt every
-// buildSpec call) is NOT consulted: every existing AWG tunnel is in
-// that list by construction, so consulting it would refuse every
-// delete. Membership disappears naturally on the next Reconcile after
-// the tunnel is gone, and the awgoutbounds + deviceproxy reload chain
-// is debounce-coalesced so sing-box never sees an inconsistent state.
+// HasSelectorReference reports whether any persisted proxy instance references
+// the given outbound tag as its user-chosen SelectedOutbound default.
+// Used by tunnel/subscription delete flows to refuse deletions that would
+// orphan an explicit proxy choice.
 func (s *Service) HasSelectorReference(tag string) bool {
+	if tag == "" {
+		return false
+	}
+
 	s.mu.Lock()
-	cfg := s.d.Store.Get()
+	snap := s.d.Store.Snapshot()
 	s.mu.Unlock()
-	return cfg.SelectedOutbound == tag
+
+	for _, in := range snap.Instances {
+		if in.SelectedOutbound == tag {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/deviceproxy/service.go
+++ b/internal/deviceproxy/service.go
@@ -15,12 +15,13 @@ import (
 // startup in main.go. Nil fields are tolerated — Service degrades and
 // logs where applicable.
 type Deps struct {
-	Store        *Store
-	Singbox      SingboxOperator     // nil → treated as "no sb tunnels, no apply"
-	NDMSQuery    NDMSInterfaceQuery  // nil → ListenInterface resolution fails explicitly
-	Bus          *events.Bus         // nil → no event subscriptions or publishes
-	AWGOutbounds AWGOutboundsCatalog // nil → AWG-related selector members empty
-	AppLogger    logging.AppLogger   // nil → silent in UI logs
+	Store                 *Store
+	Singbox               SingboxOperator              // nil → treated as "no sb tunnels, no apply"
+	SubscriptionOutbounds SubscriptionOutboundsCatalog // nil → no subscription selector/urltest outbounds
+	NDMSQuery             NDMSInterfaceQuery           // nil → ListenInterface resolution fails explicitly
+	Bus                   *events.Bus                  // nil → no event subscriptions or publishes
+	AWGOutbounds          AWGOutboundsCatalog          // nil → AWG-related selector members empty
+	AppLogger             logging.AppLogger            // nil → silent in UI logs
 }
 
 // AWGOutboundsCatalog is the narrow contract Service needs from the
@@ -38,6 +39,21 @@ type AWGTagInfo struct {
 	Label string
 	Kind  string
 	Iface string
+}
+
+// SubscriptionOutboundsCatalog is the narrow contract Service needs from
+// the sing-box subscription service. It exposes subscription selector/urltest
+// outbounds that can be used as device-proxy targets.
+type SubscriptionOutboundsCatalog interface {
+	ListDeviceProxyOutbounds() []SubscriptionOutboundInfo
+}
+
+// SubscriptionOutboundInfo describes a subscription selector/urltest outbound
+// that can be selected by device-proxy.
+type SubscriptionOutboundInfo struct {
+	Tag    string
+	Label  string
+	Detail string
 }
 
 // SingboxOperator is the narrow contract Service needs from
@@ -239,6 +255,19 @@ func (s *Service) ForceApply(ctx context.Context) error {
 
 	cfg := s.d.Store.Get()
 
+	if cfg.Enabled && s.d.Singbox != nil {
+		active, err := s.d.Singbox.GetSelectorActive(ctx, "device-proxy-selector")
+		if err != nil {
+			return fmt.Errorf("force apply read active selector: %w", err)
+		}
+		if active != "" && active != cfg.SelectedOutbound {
+			cfg.SelectedOutbound = active
+			if err := s.d.Store.Save(cfg); err != nil {
+				return fmt.Errorf("force apply persist active selector: %w", err)
+			}
+		}
+	}
+
 	spec, err := s.buildSpec(ctx, cfg)
 	if err != nil {
 		return err
@@ -247,6 +276,12 @@ func (s *Service) ForceApply(ctx context.Context) error {
 	if s.d.Singbox != nil {
 		if err := s.d.Singbox.ApplyDeviceProxy(ctx, spec); err != nil {
 			return fmt.Errorf("force apply: %w", err)
+		}
+
+		if cfg.Enabled && cfg.SelectedOutbound != "" {
+			if err := s.d.Singbox.SetSelectorDefault(ctx, "device-proxy-selector", cfg.SelectedOutbound); err != nil {
+				return fmt.Errorf("force apply selector: %w", err)
+			}
 		}
 	}
 
@@ -313,6 +348,13 @@ func (s *Service) buildSpec(ctx context.Context, cfg Config) (ExternalSpec, erro
 	if s.d.Singbox != nil {
 		spec.SBTags = s.d.Singbox.TunnelTags()
 	}
+
+	// Sing-box subscription selector/urltest tags
+	if s.d.SubscriptionOutbounds != nil {
+		for _, t := range s.d.SubscriptionOutbounds.ListDeviceProxyOutbounds() {
+			spec.SBTags = append(spec.SBTags, t.Tag)
+		}
+	}
 	return spec, nil
 }
 
@@ -347,7 +389,7 @@ func (s *Service) GetRuntimeState(ctx context.Context) RuntimeState {
 // Outbound describes one selectable proxy target exposed to the UI.
 type Outbound struct {
 	Tag    string `json:"tag"`
-	Kind   string `json:"kind"`   // "direct" | "singbox" | "awg"
+	Kind   string `json:"kind"` // "direct" | "singbox" | "awg"
 	Label  string `json:"label"`
 	Detail string `json:"detail"` // extra info for UI (kernel iface, protocol, etc)
 }
@@ -370,6 +412,21 @@ func (s *Service) listOutboundsLocked(ctx context.Context) []Outbound {
 		sort.Strings(tags)
 		for _, tag := range tags {
 			out = append(out, Outbound{Tag: tag, Kind: "singbox", Label: tag})
+		}
+	}
+
+	if s.d.SubscriptionOutbounds != nil {
+		subs := append([]SubscriptionOutboundInfo(nil), s.d.SubscriptionOutbounds.ListDeviceProxyOutbounds()...)
+		sort.Slice(subs, func(i, j int) bool {
+			return subs[i].Label < subs[j].Label
+		})
+		for _, sub := range subs {
+			out = append(out, Outbound{
+				Tag:    sub.Tag,
+				Kind:   "singbox",
+				Label:  sub.Label,
+				Detail: sub.Detail,
+			})
 		}
 	}
 
@@ -557,7 +614,9 @@ func (s *Service) SubscribeBus(ctx context.Context) func() {
 				if !ok {
 					continue
 				}
-				if payload.Resource != "tunnels" && payload.Resource != "singbox.tunnels" {
+				if payload.Resource != "tunnels" &&
+					payload.Resource != "singbox.tunnels" &&
+					payload.Resource != "singbox.subscriptions" {
 					continue
 				}
 			}

--- a/internal/deviceproxy/service.go
+++ b/internal/deviceproxy/service.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"sort"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/sys/exec"
 )
 
 // Deps groups the external collaborators Service needs. Wired once at
@@ -118,6 +123,7 @@ type Service struct {
 // ErrOutboundUnavailable is returned by SelectRuntimeOutbound when the caller
 // requests a tag that is not in the current list of available outbounds.
 var ErrOutboundUnavailable = errors.New("outbound is not available")
+var ErrInstanceNotFound = errors.New("instance not found")
 
 // deviceProxyInstanceSelectorTag returns the selector tag for a given instance.
 // The default instance uses the shared "device-proxy-selector" tag;
@@ -551,6 +557,15 @@ type RuntimeState struct {
 	DefaultTag string `json:"defaultTag"`
 }
 
+// InstanceIPCheckResult contains the direct WAN IP and IP observed through
+// a concrete device-proxy instance.
+type InstanceIPCheckResult struct {
+	DirectIP  string `json:"directIp"`
+	ProxyIP   string `json:"proxyIp"`
+	IPChanged bool   `json:"ipChanged"`
+	Service   string `json:"service"`
+}
+
 // GetRuntimeState returns the current selector.now from Clash API
 // (empty if sing-box is down) plus the persisted default for
 // convenient client-side diffing.
@@ -608,6 +623,19 @@ type Outbound struct {
 	Detail string `json:"detail"` // extra info for UI (kernel iface, protocol, etc)
 }
 
+// TunnelOutboundInfo describes one standalone sing-box tunnel outbound
+// for device-proxy selector UI metadata.
+type TunnelOutboundInfo struct {
+	Tag      string
+	Protocol string
+	Server   string
+	Port     int
+}
+
+type singboxTunnelOutboundsProvider interface {
+	TunnelOutbounds() []TunnelOutboundInfo
+}
+
 // ListOutbounds returns all members that can be assigned as the
 // selector's active outbound — direct + every sb-tunnel tag + every
 // AWG tunnel's awg-<id> tag. Order is deterministic: direct first,
@@ -624,8 +652,27 @@ func (s *Service) listOutboundsLocked(ctx context.Context) []Outbound {
 	if s.d.Singbox != nil {
 		tags := append([]string(nil), s.d.Singbox.TunnelTags()...)
 		sort.Strings(tags)
+
+		byTag := map[string]TunnelOutboundInfo{}
+		if p, ok := s.d.Singbox.(singboxTunnelOutboundsProvider); ok {
+			for _, ti := range p.TunnelOutbounds() {
+				byTag[ti.Tag] = ti
+			}
+		}
+
 		for _, tag := range tags {
-			out = append(out, Outbound{Tag: tag, Kind: "singbox", Label: tag})
+			detail := ""
+			if ti, ok := byTag[tag]; ok {
+				switch {
+				case ti.Protocol != "" && ti.Server != "" && ti.Port > 0:
+					detail = strings.ToUpper(ti.Protocol) + " · " + ti.Server + ":" + fmt.Sprintf("%d", ti.Port)
+				case ti.Server != "" && ti.Port > 0:
+					detail = ti.Server + ":" + fmt.Sprintf("%d", ti.Port)
+				case ti.Protocol != "":
+					detail = strings.ToUpper(ti.Protocol)
+				}
+			}
+			out = append(out, Outbound{Tag: tag, Kind: "singbox", Label: tag, Detail: detail})
 		}
 	}
 
@@ -929,4 +976,110 @@ func (s *Service) HasSelectorReference(tag string) bool {
 		}
 	}
 	return false
+}
+
+const (
+	instanceIPDirectTimeout = 10 * time.Second
+	instanceIPProxyTimeout  = 20 * time.Second
+	instanceIPMaxTimeSec    = 4
+)
+
+var instanceIPCheckServices = []string{
+	"https://api.ipify.org",
+	"https://wtfismyip.com/text",
+	"https://ipinfo.io/ip",
+}
+
+func parseIPResult(stdout string) (string, bool) {
+	ip := strings.TrimSpace(stdout)
+	return ip, net.ParseIP(ip) != nil
+}
+
+func fetchIPViaCurl(ctx context.Context, serviceURL string, extraArgs []string) (string, string, error) {
+	if serviceURL != "" {
+		args := []string{"-s", "--max-time", fmt.Sprintf("%d", instanceIPMaxTimeSec)}
+		args = append(args, extraArgs...)
+		args = append(args, serviceURL)
+		res, err := exec.Run(ctx, "/opt/bin/curl", args...)
+		if err != nil {
+			return "", "", fmt.Errorf("%s: %w", serviceURL, exec.FormatError(res, err))
+		}
+		if ip, ok := parseIPResult(res.Stdout); ok {
+			return ip, serviceURL, nil
+		}
+		return "", "", fmt.Errorf("%s: invalid response %q", serviceURL, strings.TrimSpace(res.Stdout))
+	}
+
+	var lastErr error
+	for _, svcURL := range instanceIPCheckServices {
+		ip, usedService, err := fetchIPViaCurl(ctx, svcURL, extraArgs)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return ip, usedService, nil
+	}
+	if lastErr != nil {
+		return "", "", lastErr
+	}
+	return "", "", fmt.Errorf("all IP services failed")
+}
+
+// CheckInstanceExternalIP resolves external IP through the selected proxy
+// instance and compares it to direct WAN IP.
+func (s *Service) CheckInstanceExternalIP(ctx context.Context, id, serviceURL string) (InstanceIPCheckResult, error) {
+	if id == "" {
+		return InstanceIPCheckResult{}, fmt.Errorf("instance id is empty")
+	}
+
+	s.mu.Lock()
+	in, ok := s.d.Store.GetInstance(id)
+	s.mu.Unlock()
+	if !ok {
+		return InstanceIPCheckResult{}, fmt.Errorf("%w: %q", ErrInstanceNotFound, id)
+	}
+	if !in.Enabled {
+		return InstanceIPCheckResult{}, fmt.Errorf("instance %q is disabled", id)
+	}
+
+	proxyHost := "127.0.0.1"
+	if !in.ListenAll {
+		if s.d.NDMSQuery == nil {
+			return InstanceIPCheckResult{}, fmt.Errorf("cannot resolve listen interface: NDMS query unavailable")
+		}
+		addr, err := s.d.NDMSQuery.GetInterfaceAddress(ctx, in.ListenInterface)
+		if err != nil || addr == "" {
+			return InstanceIPCheckResult{}, fmt.Errorf("resolve listen interface %q: %w", in.ListenInterface, err)
+		}
+		proxyHost = addr
+	}
+
+	proxyURL := &url.URL{
+		Scheme: "socks5h",
+		Host:   fmt.Sprintf("%s:%d", proxyHost, in.Port),
+	}
+	if in.Auth.Enabled {
+		proxyURL.User = url.UserPassword(in.Auth.Username, in.Auth.Password)
+	}
+
+	directCtx, directCancel := context.WithTimeout(ctx, instanceIPDirectTimeout)
+	defer directCancel()
+	directIP, _, err := fetchIPViaCurl(directCtx, serviceURL, nil)
+	if err != nil {
+		return InstanceIPCheckResult{}, fmt.Errorf("failed to get WAN IP: %w", err)
+	}
+
+	proxyCtx, proxyCancel := context.WithTimeout(ctx, instanceIPProxyTimeout)
+	defer proxyCancel()
+	proxyIP, usedService, err := fetchIPViaCurl(proxyCtx, serviceURL, []string{"--proxy", proxyURL.String()})
+	if err != nil {
+		return InstanceIPCheckResult{}, fmt.Errorf("failed to get IP through proxy instance %q: %w", id, err)
+	}
+
+	return InstanceIPCheckResult{
+		DirectIP:  directIP,
+		ProxyIP:   proxyIP,
+		IPChanged: directIP != proxyIP,
+		Service:   usedService,
+	}, nil
 }

--- a/internal/deviceproxy/service_test.go
+++ b/internal/deviceproxy/service_test.go
@@ -113,6 +113,12 @@ func (f *fakeSingboxOperator) GetSelectorActive(_ context.Context, _ string) (st
 	return f.runtimeActive, nil
 }
 
+func (f *fakeSingboxOperator) ApplyDeviceProxyInstances(_ context.Context, specs []ExternalInstanceSpec) error {
+	// For tests, we don't need to do anything. Just return nil.
+	// Optionally store specs for assertions if needed.
+	return nil
+}
+
 type fakeNDMSQuery struct{ addr string }
 
 func (f *fakeNDMSQuery) GetInterfaceAddress(_ context.Context, _ string) (string, error) {

--- a/internal/deviceproxy/service_test.go
+++ b/internal/deviceproxy/service_test.go
@@ -85,6 +85,7 @@ func TestService_SaveConfig_AppliesToSingbox(t *testing.T) {
 type fakeSingboxOperator struct {
 	running       bool
 	tags          []string
+	tunnelInfos   []TunnelOutboundInfo
 	lastSpec      *ExternalSpec
 	lastSpecNR    *ExternalSpec // ApplyDeviceProxyNoReload call
 	lastSelector  string
@@ -101,6 +102,9 @@ func (f *fakeSingboxOperator) ApplyDeviceProxyNoReload(_ context.Context, spec E
 	return nil
 }
 func (f *fakeSingboxOperator) TunnelTags() []string { return f.tags }
+func (f *fakeSingboxOperator) TunnelOutbounds() []TunnelOutboundInfo {
+	return f.tunnelInfos
+}
 func (f *fakeSingboxOperator) IsRunning() bool      { return f.running }
 func (f *fakeSingboxOperator) SetSelectorDefault(_ context.Context, selector, member string) error {
 	f.lastSelector, f.lastMember = selector, member
@@ -203,6 +207,29 @@ func TestService_ListOutbounds_IncludesSystemTunnels(t *testing.T) {
 	if !found {
 		t.Fatalf("awg-sys-Wireguard0 not found in outbounds: %+v", out)
 	}
+}
+
+func TestService_ListOutbounds_IncludesSingboxTunnelDetail(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "deviceproxy.json"))
+	sb := &fakeSingboxOperator{
+		tags: []string{"vless-1"},
+		tunnelInfos: []TunnelOutboundInfo{
+			{Tag: "vless-1", Protocol: "vless", Server: "example.com", Port: 443},
+		},
+	}
+	s := NewService(Deps{Store: store, Singbox: sb})
+
+	out := s.ListOutbounds(context.Background())
+	for _, ob := range out {
+		if ob.Tag != "vless-1" {
+			continue
+		}
+		if ob.Detail != "VLESS · example.com:443" {
+			t.Fatalf("unexpected detail: %q", ob.Detail)
+		}
+		return
+	}
+	t.Fatalf("vless-1 not found in outbounds: %+v", out)
 }
 
 func TestService_SaveConfig_AppliesToSingbox_SystemTunnels(t *testing.T) {

--- a/internal/deviceproxy/singbox_adapter.go
+++ b/internal/deviceproxy/singbox_adapter.go
@@ -101,6 +101,62 @@ func (a *SingboxAdapter) ApplyDeviceProxyNoReload(ctx context.Context, spec Exte
 	return a.op.ApplyConfigNoReload(ctx, cfg)
 }
 
+// ApplyDeviceProxyInstances persists multiple device-proxy instances via
+// the orchestrator (production) or falls back to the legacy embedded-in-tunnels path.
+func (a *SingboxAdapter) ApplyDeviceProxyInstances(ctx context.Context, specs []ExternalInstanceSpec) error {
+	if a.orch != nil {
+		sbSpecs := make([]singbox.DeviceProxyInstanceSpec, 0, len(specs))
+		for _, spec := range specs {
+			sbSpecs = append(sbSpecs, toSingboxInstanceSpec(spec))
+		}
+
+		data, err := singbox.BuildDeviceProxyInstancesConfig(sbSpecs)
+		if err != nil {
+			return fmt.Errorf("build deviceproxy instances config: %w", err)
+		}
+
+		if err := a.orch.Save(orchestrator.SlotDeviceProxy, data); err != nil {
+			return err
+		}
+
+		enabled := false
+		for _, spec := range specs {
+			if spec.Enabled {
+				enabled = true
+				break
+			}
+		}
+
+		if err := a.orch.SetEnabled(orchestrator.SlotDeviceProxy, enabled); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if len(specs) == 0 {
+		cfg, err := a.op.LoadCurrentConfig()
+		if err != nil {
+			return err
+		}
+		cfg.RemoveAllDeviceProxyInstances()
+		return a.op.ApplyConfig(ctx, cfg)
+	}
+
+	cfg, err := a.op.LoadCurrentConfig()
+	if err != nil {
+		return err
+	}
+	cfg.RemoveAllDeviceProxyInstances()
+
+	for _, spec := range specs {
+		if err := cfg.EnsureDeviceProxyInstance(toSingboxInstanceSpec(spec)); err != nil {
+			return err
+		}
+	}
+
+	return a.op.ApplyConfig(ctx, cfg)
+}
+
 // GetSelectorActive returns the currently-active member of the named
 // selector. Thin pass-through — see singbox.Operator for the contract.
 func (a *SingboxAdapter) GetSelectorActive(ctx context.Context, selectorTag string) (string, error) {
@@ -130,6 +186,26 @@ func (a *SingboxAdapter) IsRunning() bool {
 
 func toSingboxSpec(s ExternalSpec) singbox.DeviceProxySpec {
 	out := singbox.DeviceProxySpec{
+		Enabled:     s.Enabled,
+		ListenAddr:  s.ListenAddr,
+		Port:        s.Port,
+		SelectedTag: s.SelectedTag,
+		SBTags:      s.SBTags,
+	}
+	if s.Auth.Enabled {
+		out.Auth = singbox.DeviceProxyAuth{
+			Enabled:  true,
+			Username: s.Auth.Username,
+			Password: s.Auth.Password,
+		}
+	}
+	out.AWGTags = append([]string(nil), s.AWGTags...)
+	return out
+}
+
+func toSingboxInstanceSpec(s ExternalInstanceSpec) singbox.DeviceProxyInstanceSpec {
+	out := singbox.DeviceProxyInstanceSpec{
+		ID:          s.ID,
 		Enabled:     s.Enabled,
 		ListenAddr:  s.ListenAddr,
 		Port:        s.Port,

--- a/internal/deviceproxy/singbox_adapter.go
+++ b/internal/deviceproxy/singbox_adapter.go
@@ -179,6 +179,25 @@ func (a *SingboxAdapter) TunnelTags() []string {
 	return tags
 }
 
+// TunnelOutbounds returns standalone sing-box tunnel metadata used by
+// device-proxy outbound list (second detail line in UI).
+func (a *SingboxAdapter) TunnelOutbounds() []TunnelOutboundInfo {
+	tunnels, err := a.op.ListTunnels(context.Background())
+	if err != nil {
+		return nil
+	}
+	out := make([]TunnelOutboundInfo, 0, len(tunnels))
+	for _, t := range tunnels {
+		out = append(out, TunnelOutboundInfo{
+			Tag:      t.Tag,
+			Protocol: t.Protocol,
+			Server:   t.Server,
+			Port:     t.Port,
+		})
+	}
+	return out
+}
+
 func (a *SingboxAdapter) IsRunning() bool {
 	running, _ := a.op.IsRunningPublic()
 	return running

--- a/internal/deviceproxy/storage.go
+++ b/internal/deviceproxy/storage.go
@@ -8,12 +8,12 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
-// Store persists a single Config to disk as JSON. Thread-safe: all
-// access goes through the embedded mutex; callers see a defensive copy.
+// Store persists a Snapshot of Instances to disk as JSON. Thread-safe: all
+// access goes through the embedded mutex; callers see a defensive copy via Get().
 type Store struct {
-	path string
-	mu   sync.RWMutex
-	cfg  Config
+	path     string
+	mu       sync.RWMutex
+	snapshot Snapshot
 }
 
 // NewStore returns a Store backed by path. The file is loaded eagerly;
@@ -24,45 +24,139 @@ func NewStore(path string) *Store {
 	return s
 }
 
-// Get returns a copy of the current config.
+// Get returns a copy of the "default" instance as legacy Config.
 func (s *Store) Get() Config {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.cfg
+	for _, in := range s.snapshot.Instances {
+		if in.ID == "default" {
+			return instanceToConfig(in)
+		}
+	}
+	return defaultConfig()
 }
 
-// Save writes cfg to disk atomically and updates the in-memory copy.
-// Holds the write lock for the full operation so disk and in-memory
-// state stay in lock-step across concurrent callers.
+// Save writes cfg to disk atomically by updating the "default" instance
+// in the snapshot and persisting the full snapshot.
 func (s *Store) Save(cfg Config) error {
-	raw, err := json.MarshalIndent(cfg, "", "  ")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	found := false
+	for i, in := range s.snapshot.Instances {
+		if in.ID == "default" {
+			next := configToDefaultInstance(cfg)
+			if in.Name != "" {
+				next.Name = in.Name
+			}
+			s.snapshot.Instances[i] = next
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.snapshot.Instances = append(s.snapshot.Instances, configToDefaultInstance(cfg))
+	}
+
+	return s.saveLocked()
+}
+
+// Snapshot returns a defensive copy of all proxy instances.
+func (s *Store) Snapshot() Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := Snapshot{
+		Instances: append([]Instance(nil), s.snapshot.Instances...),
+	}
+	return out
+}
+
+// GetInstance returns one proxy instance by id.
+func (s *Store) GetInstance(id string) (Instance, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, in := range s.snapshot.Instances {
+		if in.ID == id {
+			return in, true
+		}
+	}
+	return Instance{}, false
+}
+
+// SaveInstance inserts or replaces one proxy instance by id.
+func (s *Store) SaveInstance(in Instance) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, existing := range s.snapshot.Instances {
+		if existing.ID == in.ID {
+			s.snapshot.Instances[i] = in
+			return s.saveLocked()
+		}
+	}
+
+	s.snapshot.Instances = append(s.snapshot.Instances, in)
+	return s.saveLocked()
+}
+
+// DeleteInstance removes one proxy instance by id.
+// The default instance cannot be deleted.
+func (s *Store) DeleteInstance(id string) error {
+	if id == "default" {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]Instance, 0, len(s.snapshot.Instances))
+	for _, in := range s.snapshot.Instances {
+		if in.ID == id {
+			continue
+		}
+		out = append(out, in)
+	}
+	s.snapshot.Instances = out
+	return s.saveLocked()
+}
+
+// saveLocked marshals the current snapshot and writes it atomically.
+// Caller must hold s.mu.
+func (s *Store) saveLocked() error {
+	raw, err := json.MarshalIndent(s.snapshot, "", "  ")
 	if err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := storage.AtomicWrite(s.path, raw); err != nil {
-		return err
-	}
-	s.cfg = cfg
-	return nil
+	return storage.AtomicWrite(s.path, raw)
 }
 
 // load reads data from disk. On missing or corrupt file, initializes
-// default config. No error is returned — caller sees defaultConfig().
+// a default snapshot with one "default" instance. Supports both the
+// legacy single-Config format and the new Snapshot format.
 // Caller must NOT hold the lock.
 func (s *Store) load() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	raw, err := os.ReadFile(s.path)
 	if err != nil {
-		s.cfg = defaultConfig()
+		s.snapshot = Snapshot{Instances: []Instance{defaultInstance()}}
 		return
 	}
+
+	var snap Snapshot
+	if err := json.Unmarshal(raw, &snap); err == nil && len(snap.Instances) > 0 {
+		s.snapshot = snap
+		return
+	}
+
 	var cfg Config
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		s.cfg = defaultConfig()
+	if err := json.Unmarshal(raw, &cfg); err == nil {
+		s.snapshot = Snapshot{Instances: []Instance{configToDefaultInstance(cfg)}}
 		return
 	}
-	s.cfg = cfg
+
+	s.snapshot = Snapshot{Instances: []Instance{defaultInstance()}}
 }

--- a/internal/deviceproxy/types.go
+++ b/internal/deviceproxy/types.go
@@ -10,8 +10,8 @@ package deviceproxy
 // storage file is treated as a disabled zero-value Config.
 type Config struct {
 	Enabled          bool     `json:"enabled"`
-	ListenAll        bool     `json:"listenAll"`        // true → bind 0.0.0.0
-	ListenInterface  string   `json:"listenInterface"`  // NDMS interface id when ListenAll=false, e.g. "Bridge0"
+	ListenAll        bool     `json:"listenAll"`       // true → bind 0.0.0.0
+	ListenInterface  string   `json:"listenInterface"` // NDMS interface id when ListenAll=false, e.g. "Bridge0"
 	Port             int      `json:"port"`
 	Auth             AuthSpec `json:"auth"`
 	SelectedOutbound string   `json:"selectedOutbound"` // sing-box tag of the active member
@@ -22,6 +22,64 @@ type AuthSpec struct {
 	Enabled  bool   `json:"enabled"`
 	Username string `json:"username"`
 	Password string `json:"password"`
+}
+
+// Instance represents one logical proxy instance with independent proxy settings.
+type Instance struct {
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	Enabled          bool     `json:"enabled"`
+	ListenAll        bool     `json:"listenAll"`
+	ListenInterface  string   `json:"listenInterface"`
+	Port             int      `json:"port"`
+	Auth             AuthSpec `json:"auth"`
+	SelectedOutbound string   `json:"selectedOutbound"`
+}
+
+// Snapshot holds the current set of proxy instances.
+type Snapshot struct {
+	Instances []Instance `json:"instances"`
+}
+
+// defaultInstance returns a default proxy instance populated from defaultConfig.
+func defaultInstance() Instance {
+	cfg := defaultConfig()
+	return Instance{
+		ID:               "default",
+		Name:             "Прокси",
+		Enabled:          cfg.Enabled,
+		ListenAll:        cfg.ListenAll,
+		ListenInterface:  cfg.ListenInterface,
+		Port:             cfg.Port,
+		Auth:             cfg.Auth,
+		SelectedOutbound: cfg.SelectedOutbound,
+	}
+}
+
+// instanceToConfig converts an Instance to a legacy Config structure.
+func instanceToConfig(in Instance) Config {
+	return Config{
+		Enabled:          in.Enabled,
+		ListenAll:        in.ListenAll,
+		ListenInterface:  in.ListenInterface,
+		Port:             in.Port,
+		Auth:             in.Auth,
+		SelectedOutbound: in.SelectedOutbound,
+	}
+}
+
+// configToDefaultInstance converts a Config into the default-named Instance.
+func configToDefaultInstance(cfg Config) Instance {
+	return Instance{
+		ID:               "default",
+		Name:             "Прокси",
+		Enabled:          cfg.Enabled,
+		ListenAll:        cfg.ListenAll,
+		ListenInterface:  cfg.ListenInterface,
+		Port:             cfg.Port,
+		Auth:             cfg.Auth,
+		SelectedOutbound: cfg.SelectedOutbound,
+	}
 }
 
 // defaultConfig is used when deviceproxy.json does not exist yet.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -719,6 +719,24 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/proxy/outbounds", guarded(deviceProxyHandler.ListOutbounds))
 	mux.HandleFunc("/api/proxy/listen-choices", guarded(deviceProxyHandler.ListenChoices))
 
+	// Multi-instance device proxy endpoints
+	mux.HandleFunc("/api/proxy/instances", guarded(deviceProxyHandler.ListInstances))
+	mux.HandleFunc("/api/proxy/instance", guarded(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			deviceProxyHandler.GetInstance(w, r)
+		case http.MethodPut:
+			deviceProxyHandler.SaveInstance(w, r)
+		case http.MethodDelete:
+			deviceProxyHandler.DeleteInstance(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+	mux.HandleFunc("/api/proxy/instances/apply", guarded(deviceProxyHandler.ApplyInstances))
+	mux.HandleFunc("/api/proxy/instance/runtime", guarded(deviceProxyHandler.GetInstanceRuntime))
+	mux.HandleFunc("/api/proxy/instance/runtime/select", guarded(deviceProxyHandler.SelectInstanceRuntime))
+
 	// Logging (protected + boot guarded)
 	mux.HandleFunc("/api/logs", guarded(loggingHandler.GetLogs))
 	mux.HandleFunc("/api/logs/clear", guarded(loggingHandler.ClearLogs))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -736,6 +736,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/proxy/instances/apply", guarded(deviceProxyHandler.ApplyInstances))
 	mux.HandleFunc("/api/proxy/instance/runtime", guarded(deviceProxyHandler.GetInstanceRuntime))
 	mux.HandleFunc("/api/proxy/instance/runtime/select", guarded(deviceProxyHandler.SelectInstanceRuntime))
+	mux.HandleFunc("/api/proxy/instance/check-ip", guarded(deviceProxyHandler.CheckInstanceExternalIP))
 
 	// Logging (protected + boot guarded)
 	mux.HandleFunc("/api/logs", guarded(loggingHandler.GetLogs))

--- a/internal/singbox/config.go
+++ b/internal/singbox/config.go
@@ -463,6 +463,20 @@ type DeviceProxySpec struct {
 	SBTags      []string // sing-box tunnel tags (user outbounds)
 }
 
+// DeviceProxyInstanceSpec describes one user-facing proxy instance.
+// ID controls generated inbound/selector tags. ID "default" keeps the
+// legacy tags device-proxy-in / device-proxy-selector for compatibility.
+type DeviceProxyInstanceSpec struct {
+	ID          string
+	Enabled     bool
+	ListenAddr  string
+	Port        int
+	Auth        DeviceProxyAuth
+	SelectedTag string
+	AWGTags     []string
+	SBTags      []string
+}
+
 type DeviceProxyAuth struct {
 	Enabled  bool
 	Username string
@@ -475,6 +489,23 @@ const (
 	deviceProxyAWGPrefix   = "awg-"
 )
 
+func deviceProxyInstanceTags(id string) (inboundTag, selectorTag string) {
+	if id == "" || id == "default" {
+		return deviceProxyInboundTag, deviceProxySelectorTag
+	}
+	return "device-proxy-" + id + "-in", "device-proxy-" + id + "-selector"
+}
+
+func isDeviceProxyInboundTag(tag string) bool {
+	return tag == deviceProxyInboundTag ||
+		(strings.HasPrefix(tag, "device-proxy-") && strings.HasSuffix(tag, "-in"))
+}
+
+func isDeviceProxySelectorTag(tag string) bool {
+	return tag == deviceProxySelectorTag ||
+		(strings.HasPrefix(tag, "device-proxy-") && strings.HasSuffix(tag, "-selector"))
+}
+
 // EnsureDeviceProxy writes (or overwrites) the inbound + selector
 // outbound + route rule described by spec. Idempotent. Callers that
 // toggle Enabled=false should use RemoveDeviceProxy.
@@ -484,15 +515,32 @@ const (
 // resolve to outbounds already declared there. Legacy awg-* outbounds
 // from pre-refactor builds are stripped on every call (idempotent).
 func (c *Config) EnsureDeviceProxy(spec DeviceProxySpec) error {
+	return c.EnsureDeviceProxyInstance(DeviceProxyInstanceSpec{
+		ID:          "default",
+		Enabled:     spec.Enabled,
+		ListenAddr:  spec.ListenAddr,
+		Port:        spec.Port,
+		Auth:        spec.Auth,
+		SelectedTag: spec.SelectedTag,
+		AWGTags:     spec.AWGTags,
+		SBTags:      spec.SBTags,
+	})
+}
+
+// EnsureDeviceProxyInstance writes or overwrites one device-proxy instance.
+// Non-default instances use unique tags derived from spec.ID.
+func (c *Config) EnsureDeviceProxyInstance(spec DeviceProxyInstanceSpec) error {
 	if !spec.Enabled {
-		c.RemoveDeviceProxy()
+		c.RemoveDeviceProxyInstance(spec.ID)
 		return nil
 	}
 
 	// Inbound
+	inboundTag, selectorTag := deviceProxyInstanceTags(spec.ID)
+
 	inbound := map[string]any{
 		"type":        "mixed",
-		"tag":         deviceProxyInboundTag,
+		"tag":         inboundTag,
 		"listen":      spec.ListenAddr,
 		"listen_port": spec.Port,
 	}
@@ -504,15 +552,12 @@ func (c *Config) EnsureDeviceProxy(spec DeviceProxySpec) error {
 			},
 		}
 	}
-	c.upsertInbound(deviceProxyInboundTag, inbound)
+	c.upsertInbound(inboundTag, inbound)
 
 	// Strip any legacy awg-* outbounds left over from the pre-15-awg.json
-	// era (one-shot cleanup; idempotent, no-op once the file is clean).
+	// era. AWG outbounds now live in 15-awg.json.
 	c.pruneAWGOutbounds(nil)
 
-	// Selector outbound — members in deterministic order: direct, sb tags,
-	// sorted awg tags from spec. AWG outbounds themselves live in
-	// 15-awg.json; the selector just references them by tag.
 	members := []any{"direct"}
 	for _, tag := range spec.SBTags {
 		members = append(members, tag)
@@ -522,28 +567,88 @@ func (c *Config) EnsureDeviceProxy(spec DeviceProxySpec) error {
 	for _, tag := range awgTagsCopy {
 		members = append(members, tag)
 	}
+
 	selector := map[string]any{
 		"type":      "selector",
-		"tag":       deviceProxySelectorTag,
+		"tag":       selectorTag,
 		"outbounds": members,
 	}
 	if spec.SelectedTag != "" {
 		selector["default"] = spec.SelectedTag
 	}
-	c.upsertOutbound(deviceProxySelectorTag, selector)
+	c.upsertOutbound(selectorTag, selector)
 
-	// Route rule at front of rules list.
-	c.ensureDeviceProxyRouteRule()
+	c.ensureDeviceProxyInstanceRouteRule(inboundTag, selectorTag)
 	return nil
 }
 
 // RemoveDeviceProxy strips every artefact EnsureDeviceProxy adds.
 // Idempotent — safe on a config that never had the proxy.
 func (c *Config) RemoveDeviceProxy() {
-	c.removeInbound(deviceProxyInboundTag)
-	c.removeOutbound(deviceProxySelectorTag)
+	c.RemoveDeviceProxyInstance("default")
+}
+
+// RemoveDeviceProxyInstance strips every artefact created for one instance.
+func (c *Config) RemoveDeviceProxyInstance(id string) {
+	inboundTag, selectorTag := deviceProxyInstanceTags(id)
+	c.removeInbound(inboundTag)
+	c.removeOutbound(selectorTag)
 	c.pruneAWGOutbounds(nil)
-	c.removeDeviceProxyRouteRule()
+	c.removeDeviceProxyInstanceRouteRule(inboundTag)
+}
+
+// RemoveAllDeviceProxyInstances strips every device-proxy inbound/selector/rule
+// (default and named instances). Idempotent.
+func (c *Config) RemoveAllDeviceProxyInstances() {
+	inbounds := c.inbounds()
+	nextInbounds := make([]any, 0, len(inbounds))
+	for _, v := range inbounds {
+		ib, ok := v.(map[string]any)
+		if !ok {
+			nextInbounds = append(nextInbounds, v)
+			continue
+		}
+		tag, _ := ib["tag"].(string)
+		if isDeviceProxyInboundTag(tag) {
+			continue
+		}
+		nextInbounds = append(nextInbounds, v)
+	}
+	c.setInbounds(nextInbounds)
+
+	outbounds := c.outbounds()
+	nextOutbounds := make([]any, 0, len(outbounds))
+	for _, v := range outbounds {
+		ob, ok := v.(map[string]any)
+		if !ok {
+			nextOutbounds = append(nextOutbounds, v)
+			continue
+		}
+		tag, _ := ob["tag"].(string)
+		if isDeviceProxySelectorTag(tag) {
+			continue
+		}
+		nextOutbounds = append(nextOutbounds, v)
+	}
+	c.setOutbounds(nextOutbounds)
+
+	rules := c.routeRules()
+	nextRules := make([]any, 0, len(rules))
+	for _, v := range rules {
+		r, ok := v.(map[string]any)
+		if !ok {
+			nextRules = append(nextRules, v)
+			continue
+		}
+		inbound, _ := r["inbound"].(string)
+		if isDeviceProxyInboundTag(inbound) {
+			continue
+		}
+		nextRules = append(nextRules, v)
+	}
+	c.setRouteRules(nextRules)
+
+	c.pruneAWGOutbounds(nil)
 }
 
 // HasDeviceProxy reports whether the config contains the device-proxy
@@ -583,8 +688,8 @@ func (c *Config) ExtractDeviceProxy() *Config {
 		if !ok {
 			continue
 		}
-		if t, _ := ib["tag"].(string); t == deviceProxyInboundTag {
-			out.upsertInbound(deviceProxyInboundTag, ib)
+		if t, _ := ib["tag"].(string); isDeviceProxyInboundTag(t) {
+			out.upsertInbound(t, ib)
 		}
 	}
 	for _, v := range c.outbounds() {
@@ -592,8 +697,8 @@ func (c *Config) ExtractDeviceProxy() *Config {
 		if !ok {
 			continue
 		}
-		if t, _ := ob["tag"].(string); t == deviceProxySelectorTag {
-			out.upsertOutbound(deviceProxySelectorTag, ob)
+		if t, _ := ob["tag"].(string); isDeviceProxySelectorTag(t) {
+			out.upsertOutbound(t, ob)
 		}
 	}
 	for _, v := range c.routeRules() {
@@ -601,7 +706,7 @@ func (c *Config) ExtractDeviceProxy() *Config {
 		if !ok {
 			continue
 		}
-		if inbound, _ := r["inbound"].(string); inbound == deviceProxyInboundTag {
+		if inbound, _ := r["inbound"].(string); isDeviceProxyInboundTag(inbound) {
 			out.setRouteRules(append(out.routeRules(), r))
 		}
 	}
@@ -713,9 +818,13 @@ func (c *Config) pruneAWGOutbounds(keep map[string]string) {
 }
 
 func (c *Config) ensureDeviceProxyRouteRule() {
+	c.ensureDeviceProxyInstanceRouteRule(deviceProxyInboundTag, deviceProxySelectorTag)
+}
+
+func (c *Config) ensureDeviceProxyInstanceRouteRule(inboundTag, selectorTag string) {
 	rule := map[string]any{
-		"inbound":  deviceProxyInboundTag,
-		"outbound": deviceProxySelectorTag,
+		"inbound":  inboundTag,
+		"outbound": selectorTag,
 	}
 	rules := c.routeRules()
 	filtered := make([]any, 0, len(rules))
@@ -725,7 +834,7 @@ func (c *Config) ensureDeviceProxyRouteRule() {
 			filtered = append(filtered, v)
 			continue
 		}
-		if r["inbound"] == deviceProxyInboundTag {
+		if r["inbound"] == inboundTag {
 			continue
 		}
 		filtered = append(filtered, v)
@@ -734,6 +843,10 @@ func (c *Config) ensureDeviceProxyRouteRule() {
 }
 
 func (c *Config) removeDeviceProxyRouteRule() {
+	c.removeDeviceProxyInstanceRouteRule(deviceProxyInboundTag)
+}
+
+func (c *Config) removeDeviceProxyInstanceRouteRule(inboundTag string) {
 	rules := c.routeRules()
 	out := make([]any, 0, len(rules))
 	for _, v := range rules {
@@ -742,7 +855,7 @@ func (c *Config) removeDeviceProxyRouteRule() {
 			out = append(out, v)
 			continue
 		}
-		if r["inbound"] == deviceProxyInboundTag {
+		if r["inbound"] == inboundTag {
 			continue
 		}
 		out = append(out, v)

--- a/internal/singbox/deviceproxy_config.go
+++ b/internal/singbox/deviceproxy_config.go
@@ -23,12 +23,31 @@ import (
 // The result intentionally omits log/dns/experimental keys: those are
 // owned by 00-base.json and must not collide across config.d slots.
 func BuildDeviceProxyConfig(spec DeviceProxySpec) ([]byte, error) {
+	return BuildDeviceProxyInstancesConfig([]DeviceProxyInstanceSpec{
+		{
+			ID:          "default",
+			Enabled:     spec.Enabled,
+			ListenAddr:  spec.ListenAddr,
+			Port:        spec.Port,
+			Auth:        spec.Auth,
+			SelectedTag: spec.SelectedTag,
+			AWGTags:     spec.AWGTags,
+			SBTags:      spec.SBTags,
+		},
+	})
+}
+
+// BuildDeviceProxyInstancesConfig produces a standalone JSON document
+// containing all enabled device-proxy instances.
+func BuildDeviceProxyInstancesConfig(specs []DeviceProxyInstanceSpec) ([]byte, error) {
 	scratch := NewConfig()
-	if spec.Enabled {
-		if err := scratch.EnsureDeviceProxy(spec); err != nil {
-			return nil, fmt.Errorf("ensure device proxy: %w", err)
+
+	for _, spec := range specs {
+		if err := scratch.EnsureDeviceProxyInstance(spec); err != nil {
+			return nil, fmt.Errorf("ensure device proxy instance %q: %w", spec.ID, err)
 		}
 	}
+
 	cfg := scratch.ExtractDeviceProxy()
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {


### PR DESCRIPTION
[(fix) sing-router: proxy sing-sub usage](https://github.com/hoaxisr/awg-manager/pull/104/commits/ef9c2ffd4b481f4ac9ad782fa705698fa3ffab13)

## Что изменено в рамках правок доступности туннелей в Прокси режиме:

Добавлена поддержка sing-box подписок в настройках Device Proxy.

Теперь в списке outbound-целей для прокси отображаются не только AWG и standalone sing-box туннели, но и включённые sing-box подписки. Для подписок используется их `selector/urltest` outbound tag, поэтому трафик идёт через активный member подписки и сохраняет логику selector/urltest.

## Основные изменения

- Добавлен `SubscriptionOutboundsCatalog` в `deviceproxy.Service`.
- Добавлен adapter в `main.go`, который прокидывает enabled sing-box subscriptions в device-proxy.
- Подписочные selector/urltest tags добавляются в `SBTags` при сборке device-proxy config.
- Подписки отображаются в `/api/proxy/outbounds`.
- Device Proxy теперь реагирует на invalidation `singbox.subscriptions`.
- Исправлено поведение кнопки **«Применить сейчас»**:
  - текущий live outbound сохраняется как новый default;
  - конфиг пересобирается уже с новым selected outbound;
  - после apply live selector синхронизируется с persisted default.

## Проверка

- В настройках Device Proxy появились sing-box подписки.
- Выбор подписки сохраняется и применяется.
- После **«Применить сейчас»** выбранный runtime outbound становится постоянным.
- После перезапуска sing-box используется сохранённый outbound, а не старый default.

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/03c47790-f536-4037-98c8-8c8370830554" />

---

[(add) device-proxy-multi-instance-runtime-and-ui-polish](https://github.com/hoaxisr/awg-manager/pull/104/commits/35afeaf9a6e99efd886e763d571237645144186c)

## Что сделано в рамках введения инстансинга в прокси режиме:

### Backend
- Добавлена полноценная **multi-instance модель Device Proxy** вместо логики одного proxy по умолчанию.
- Расширено хранилище: теперь сохраняется snapshot инстансов (с backward-совместимостью с legacy форматом).
- Добавлены операции по инстансам в сервисе:
  - сохранение/удаление инстанса,
  - массовое применение всех инстансов в sing-box,
  - rollback snapshot при ошибке apply.
- Обновлён reconcile:
  - проверяет `selectedOutbound` у всех enabled-инстансов,
  - при исчезновении outbound отключает только проблемный инстанс,
  - публикует `deviceproxy:missing-target`,
  - инвалидирует `deviceproxy.config`/`deviceproxy.runtime`,
  - применяет актуальный набор инстансов в sing-box.
- `HasSelectorReference` переведён на проверку **всех** инстансов.
- Добавлена поддержка **subscription outbounds** (selector/urltest) для выбора в Device Proxy.
- Добавлены новые API:
  - `GET /api/proxy/instances`
  - `GET /api/proxy/instance?id=...`
  - `PUT /api/proxy/instance`
  - `DELETE /api/proxy/instance?id=...`
  - `POST /api/proxy/instances/apply`
  - `GET /api/proxy/instance/runtime?id=...`
  - `POST /api/proxy/instance/runtime/select?id=...`
- Удаление `default` инстанса запрещено (backend guard).
- Обновлён sing-box config builder:
  - instance-aware теги (`default` сохраняет legacy теги),
  - массовая сборка конфигурации для набора инстансов.

### Frontend
- Добавлены типы и API-клиент для multi-instance операций и per-instance runtime.
- Добавлен polling store инстансов Device Proxy.
- Переработан `storeRegistry`: один resource key теперь может инвалидировать несколько stores.
- `SettingsCard` и `ActiveTunnelCard` отвязаны от legacy-only API через callback-props, чтобы переиспользовать их для любого инстанса.
- `DeviceProxySubTab` переведён на карточки инстансов:
  - создание,
  - редактирование,
  - включение/выключение,
  - runtime-переключение outbound,
  - apply всех инстансов,
  - удаление non-default.
- Добавлена маскировка чувствительного endpoint у subscription outbounds с кнопкой “глаз”:
  - маскируется только host/ip endpoint,
  - direct/AWG не маскируются,
  - клик по “глазу” не переключает outbound.
- Добавлено сворачивание/разворачивание карточек прокси с сохранением состояния (localStorage).
- Убрано дублирование данных в collapsed-виде.
- Во второй строке карточки вместо повторного порта теперь выводится признак авторизации:
  - `с паролем` / `без пароля`.

## Совместимость и поведение
- Legacy API для default-инстанса сохранены.
- Поведение default-инстанса и его теги совместимы с предыдущей схемой.
- При удалении активного non-default инстанса применяется актуальный snapshot, его inbound/selector исчезают, порт закрывается.
- При ошибке применения после Save/Delete выполняется откат storage snapshot.

## Проверки
- Backend smoke/live сценарии по API и реальному proxy-порту пройдены.
- Frontend `npm run check` и `npm run build` проходят.

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/bed07111-b16c-48fb-bf6c-1e2ff6fd1840" />

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/42c890c7-5530-4190-bdf5-c815088bc27c" />

---

[( fix ) mobile view proxy tab](https://github.com/hoaxisr/awg-manager/pull/104/commits/8f03c116f5175e7d018cb5f87c8331b7c41202a8)

- Добавили свернуть/развернуть для проксей, но внутрянку "активный прокси" в мобильной виде разбарабанивало

<img width="522" height="1130" alt="image" src="https://github.com/user-attachments/assets/7bb9d815-c17c-473b-866b-92c53118b2e1" />

---

[feat(deviceproxy): improve instance UX and add per-instance external …](https://github.com/hoaxisr/awg-manager/pull/104/commits/b2e9fcc505c0333c7abbc673aa2a749aeba13e33)

## Что сделано в рамках улучшения UI/UX sing-proxy

В рамках этой сессии доработан Device Proxy (multi-instance) в backend и frontend, с фокусом на стабильность runtime-переключения, диагностируемость и удобство UI.

### Backend

- Добавлен endpoint проверки внешнего IP для конкретного proxy instance:
  - `GET /api/proxy/instance/check-ip?id=...`
- Реализована проверка IP:
  - прямой WAN IP,
  - IP через конкретный SOCKS5 instance,
  - признак изменения IP (`ipChanged`),
  - источник ответа (`service`).
- Добавлена корректная обработка `instance not found` через sentinel-ошибку и стабильный `404` в API.
- Расширен каталог outbound для standalone sing-box туннелей:
  - теперь в `detail` передаются метаданные (протокол, сервер, порт),
  - формат для UI: `PROTOCOL · host:port`.
- Добавлены/обновлены тесты на deviceproxy-сервис (включая detail для standalone sing-box outbound).

### Frontend

- В API-клиент добавлен метод проверки внешнего IP instance.
- В типы добавлен `DeviceProxyInstanceIPCheckResult`.
- Вкладка прокси (`DeviceProxySubTab`) дополнена логикой per-instance IP-check:
  - авто-проверка при открытии вкладки для enabled instances,
  - авто-проверка после runtime переключения outbound,
  - авто-проверка после `Применить сейчас` (с мягким повтором при временной ошибке).
- Исправлено поведение `Применить сейчас` для runtime-смены:
  - активный runtime outbound сохраняется в persisted `selectedOutbound` перед apply,
  - убран кейс, когда UI продолжал показывать «временно» после применения.
- Карточка подключения клиента (`DeviceProxyClientInfoCard`):
  - добавена строка внешнего IP,
  - добавены время последней проверки и источник ответа,
  - добавлено маскирование IP с глазиком,
  - локальный `SOCKS5` адрес тоже маскируется,
  - локальный и внешний адрес используют общий reveal-тоггл,
  - обновлён порядок строк:
    1. `СЛУШАТЬ`
    2. `SOCKS5`
    3. `Внешний IP`.
- `ActiveTunnelCard`:
  - глазик/маскирование detail теперь работают не только для `sub-*`,
  - а для любого `singbox` outbound, если в detail есть endpoint.
- В заголовке instance добавлена более наглядная индикация `с паролем/без пароля` (иконки lock/unlock).

### Поведение источников IP

- Из цепочки источников для proxy IP-check исключён `2ip.ru`.
- Текущая последовательность fallback-источников:
  1. `https://api.ipify.org`
  2. `https://wtfismyip.com/text`
  3. `https://ipinfo.io/ip`

## Результат

- Multi-instance proxy получил рабочую встроенную проверку внешнего IP по запросу и автоматически в ключевых точках жизненного цикла.
- Устранены повторные регрессии в runtime/apply сценарии.
- Улучшена информативность карточек и приватность отображения адресов.
- Для standalone sing-box туннелей добавлена недостающая вторая строка detail.

- Изменения сделаны небольшими логическими блоками, без широкого рефакторинга.
- Для ручной проверки рекомендуется пройти сценарии:
  - переключение outbound в active runtime,
  - `Применить сейчас`,
  - обновление страницы,
  - проверка внешнего IP,
  - проверка глазика для `SOCKS5` и внешнего IP,
  - проверка detail+глазика для standalone/subscription sing-box туннелей.

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/d2baf89a-21a6-4e8b-bb5a-4fa95d4c9e2e" />

