### PR TITLE
Singbox ux improvenents

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -220,6 +220,37 @@ const MOCK_SINGBOX_TUNNELS = [
 		connectivity: { connected: false, latency: null },
 		running: true,
 	},
+	// Process up + TUN present, but outbound unreachable (Clash delay = timeout).
+	{
+		tag: 'vless-blackhole',
+		protocol: 'vless',
+		server: 'blackhole.demo.example',
+		port: 443,
+		security: 'reality',
+		transport: 'tcp',
+		listenPort: 11014,
+		proxyInterface: 't2s3',
+		kernelInterface: 'sb3',
+		sni: 'cdn.cloudflare.com',
+		fingerprint: 'chrome',
+		connectivity: { connected: false, latency: null },
+		running: true,
+	},
+	// sing-box / kernel iface down — card shows "stopped", not a latency timeout.
+	{
+		tag: 'hysteria-stopped',
+		protocol: 'hysteria2',
+		server: 'jp-stale.demo.example',
+		port: 8443,
+		security: 'tls',
+		transport: 'tcp',
+		listenPort: 11015,
+		proxyInterface: 't2s4',
+		kernelInterface: 'sb4',
+		sni: 'jp-stale.demo.example',
+		connectivity: { connected: false, latency: null },
+		running: false,
+	},
 ];
 
 const TRAFFIC_PROFILES = {
@@ -312,6 +343,36 @@ const TRAFFIC_PROFILES = {
 		burstEvery: 8,
 		burstRx: 260_000,
 		burstTx: 90_000,
+	},
+	'vless-blackhole': {
+		baseRx: 8_000,
+		baseTx: 2_000,
+		waveRx: 4_000,
+		waveTx: 1_000,
+		driftRx: 2_000,
+		driftTx: 500,
+		rxStep: 6_000,
+		txStep: 2_000,
+		jitterRx: 1_000,
+		jitterTx: 400,
+		burstEvery: 0,
+		burstRx: 0,
+		burstTx: 0,
+	},
+	'hysteria-stopped': {
+		baseRx: 0,
+		baseTx: 0,
+		waveRx: 0,
+		waveTx: 0,
+		driftRx: 0,
+		driftTx: 0,
+		rxStep: 0,
+		txStep: 0,
+		jitterRx: 0,
+		jitterTx: 0,
+		burstEvery: 0,
+		burstRx: 0,
+		burstTx: 0,
 	},
 };
 
@@ -514,11 +575,37 @@ function tickSingboxTraffic() {
 	});
 }
 
-function currentSingboxDelays() {
-	return MOCK_SINGBOX_TUNNELS.map((t, i) => ({
-		tag: t.tag,
-		delay: 70 + i * 35 + Math.floor(Math.random() * 45),
-	}));
+/** Member tags that always report delay timeout in mocks (matches proxies.test + SSE). */
+const MOCK_SUB_DEAD_MEMBER_TAGS = new Set([
+	'sub-demo0001-deadrelay',
+	'sub-bigprov-rudead01',
+]);
+
+function delayMsForSubscriptionMemberTag(tag) {
+	if (MOCK_SUB_DEAD_MEMBER_TAGS.has(tag)) return 0;
+	let h = 0;
+	for (let i = 0; i < tag.length; i++) h = ((h << 5) - h + tag.charCodeAt(i)) | 0;
+	const base = Math.abs(h) % 370 + 30;
+	const jitter = Math.floor(Math.random() * 40) - 20;
+	return Math.max(1, base + jitter);
+}
+
+/** Samples for SSE `singbox:delay`: managed tunnels + every subscription member tag. */
+function buildSingboxDelayEventBatch() {
+	const out = [];
+	MOCK_SINGBOX_TUNNELS.forEach((t, i) => {
+		let delay;
+		if (t.running === false) delay = 0;
+		else if (!t.connectivity?.connected) delay = 0;
+		else delay = 70 + i * 35 + Math.floor(Math.random() * 45);
+		out.push({ tag: t.tag, delay });
+	});
+	for (const sub of mockSubscriptions) {
+		for (const tag of sub.memberTags) {
+			out.push({ tag, delay: delayMsForSubscriptionMemberTag(tag) });
+		}
+	}
+	return out;
 }
 
 // ── Subscriptions mock state ───────────────────────────────────
@@ -543,11 +630,13 @@ let mockSubscriptions = [
 			'sub-demo0001-aabbccdd',
 			'sub-demo0001-eeff0011',
 			'sub-demo0001-22334455',
+			'sub-demo0001-deadrelay',
 		],
 		members: [
 			{ tag: 'sub-demo0001-aabbccdd', protocol: 'vless', server: 'de01.demo.example', port: 443, transport: 'tcp', security: 'reality' },
 			{ tag: 'sub-demo0001-eeff0011', protocol: 'vless', server: 'nl02.demo.example', port: 443, transport: 'ws', security: 'tls' },
 			{ tag: 'sub-demo0001-22334455', protocol: 'trojan', server: 'fi03.demo.example', port: 443, transport: 'tcp', security: 'tls' },
+			{ tag: 'sub-demo0001-deadrelay', label: 'DE — мёртвый relay', protocol: 'vless', server: '0.0.0.1', port: 443, transport: 'tcp', security: 'reality' },
 		],
 		orphanTags: [],
 		activeMember: 'sub-demo0001-aabbccdd',
@@ -578,7 +667,7 @@ let mockSubscriptions = [
 		// - urltest mode header (Issue 1)
 		// - per-member labels from #fragment (Issue 2): country names, mixed languages
 		// - SNI row visibility (Issue from previous PR)
-		// - 11 members (above the "10+ feels slow" threshold)
+		// - 12 members (above the "10+ feels slow" threshold)
 		id: 'sub-bigprov',
 		label: 'Big Provider Pro',
 		url: 'https://bigprovider.example/sub/xyz',
@@ -610,6 +699,7 @@ let mockSubscriptions = [
 			'sub-bigprov-hk09q7r8',
 			'sub-bigprov-ca10s9t0',
 			'sub-bigprov-au11u1v2',
+			'sub-bigprov-rudead01',
 		],
 		members: [
 			{ tag: 'sub-bigprov-de01a1b2', label: '🇩🇪 Germany — Frankfurt', protocol: 'vless',       server: 'de01.bigprov.example',  port: 443,   sni: 'cdn.example.com',     transport: 'tcp', security: 'reality' },
@@ -623,10 +713,52 @@ let mockSubscriptions = [
 			{ tag: 'sub-bigprov-hk09q7r8', label: '🇭🇰 Hong Kong',            protocol: 'trojan',     server: 'hk09.bigprov.example',  port: 443,                                transport: 'ws',  security: 'tls' },
 			{ tag: 'sub-bigprov-ca10s9t0', label: '🇨🇦 Canada — Toronto',     protocol: 'vless',      server: 'ca10.bigprov.example',  port: 21123, sni: 'ca.example.cloud',    transport: 'tcp', security: 'tls' },
 			{ tag: 'sub-bigprov-au11u1v2',                                    protocol: 'naive',      server: 'au11.bigprov.example',  port: 443,   sni: 'au.example.app',      transport: 'tcp', security: 'tls' },
+			{ tag: 'sub-bigprov-rudead01', label: '🇷🇺 RU — offline',          protocol: 'vless',      server: '10.255.255.1',        port: 443,   sni: 'dead.bigprov.example', transport: 'tcp', security: 'tls' },
 		],
 		orphanTags: [],
 		activeMember: 'sub-bigprov-de01a1b2',
 		enabled: true,
+	},
+	{
+		id: 'sub-off-legacy',
+		label: 'Legacy EU (выключена)',
+		url: 'https://legacy.example/sub/old',
+		headers: [],
+		refreshHours: 0,
+		lastFetched: new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString(),
+		lastError: '',
+		selectorTag: 'sub-off-legacy',
+		inboundTag: 'sub-off-legacy-in',
+		listenPort: 11004,
+		proxyIndex: 14,
+		memberTags: ['sub-off-legacy-m01'],
+		members: [
+			{ tag: 'sub-off-legacy-m01', protocol: 'vless', server: 'legacy.example', port: 443, transport: 'tcp', security: 'tls' },
+		],
+		orphanTags: [],
+		activeMember: 'sub-off-legacy-m01',
+		enabled: false,
+	},
+	{
+		id: 'sub-off-trial',
+		label: 'Пробный период (выключена)',
+		url: 'https://trial.example/sub/expired',
+		headers: [],
+		refreshHours: 12,
+		lastFetched: new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString(),
+		lastError: 'subscription expired',
+		selectorTag: 'sub-off-trial',
+		inboundTag: 'sub-off-trial-in',
+		listenPort: 11005,
+		proxyIndex: 15,
+		memberTags: ['sub-off-trial-m01', 'sub-off-trial-m02'],
+		members: [
+			{ tag: 'sub-off-trial-m01', label: 'Node A', protocol: 'trojan', server: 'trial.example', port: 443, transport: 'ws', security: 'tls' },
+			{ tag: 'sub-off-trial-m02', label: 'Node B', protocol: 'vless', server: 'trial2.example', port: 443, transport: 'tcp', security: 'reality' },
+		],
+		orphanTags: [],
+		activeMember: 'sub-off-trial-m01',
+		enabled: false,
 	},
 ];
 let mockSubID = 2;
@@ -911,7 +1043,7 @@ const mockProxies = {
 	'veesp-fast': {
 		type: 'selector',
 		now: 'vless-1',
-		all: ['vless-1', 'vless-2', 'vless-3'],
+		all: ['vless-1', 'vless-dead', 'vless-2', 'vless-3'],
 	},
 	'auto': {
 		type: 'urltest',
@@ -921,12 +1053,18 @@ const mockProxies = {
 };
 const mockProxyDelays = {
 	'vless-1': 45,
+	'vless-dead': 0,
 	'vless-2': 78,
 	'vless-3': 180,
 	'vless-4': 320,
 };
+const PROXY_DELAY_ALWAYS_DEAD = new Set(['vless-dead']);
 function randomizeDelays() {
 	for (const k of Object.keys(mockProxyDelays)) {
+		if (PROXY_DELAY_ALWAYS_DEAD.has(k)) {
+			mockProxyDelays[k] = 0;
+			continue;
+		}
 		const base = mockProxyDelays[k];
 		if (Math.random() < 0.05) {
 			mockProxyDelays[k] = 0; // 5% timeout
@@ -1034,7 +1172,7 @@ const server = http.createServer(async (req, res) => {
 			sendEvent('tunnel:traffic', event);
 		}
 		sendEvent('singbox:traffic', tickSingboxTraffic());
-		for (const delay of currentSingboxDelays()) {
+		for (const delay of buildSingboxDelayEventBatch()) {
 			sendEvent('singbox:delay', delay);
 		}
 
@@ -1043,7 +1181,7 @@ const server = http.createServer(async (req, res) => {
 				sendEvent('tunnel:traffic', event);
 			}
 			sendEvent('singbox:traffic', tickSingboxTraffic());
-			for (const delay of currentSingboxDelays()) {
+			for (const delay of buildSingboxDelayEventBatch()) {
 				sendEvent('singbox:delay', delay);
 			}
 		}, 1500);
@@ -1244,12 +1382,7 @@ const server = http.createServer(async (req, res) => {
 				}
 				const delays = {};
 				for (const tag of sub.memberTags) {
-					// Stable hash of the tag → base latency 30..400 ms, plus jitter.
-					let h = 0;
-					for (let i = 0; i < tag.length; i++) h = ((h << 5) - h + tag.charCodeAt(i)) | 0;
-					const base = Math.abs(h) % 370 + 30;
-					const jitter = Math.floor(Math.random() * 40) - 20;
-					delays[tag] = Math.max(1, base + jitter);
+					delays[tag] = delayMsForSubscriptionMemberTag(tag);
 				}
 				send(res, 200, { success: true, data: { delays } });
 				console.log(`[mock-proxy] proxies.test sub ${group} → ${JSON.stringify(delays)}`);
@@ -1357,6 +1490,33 @@ const server = http.createServer(async (req, res) => {
 			success: true,
 			data: MOCK_SINGBOX_TUNNELS.map((t) => ({ ...t })),
 		});
+		return;
+	}
+
+	if (req.method === 'POST' && path === '/singbox/tunnels/delay-check') {
+		const tag = new URL(req.url, 'http://x').searchParams.get('tag') ?? '';
+		if (!tag) {
+			send(res, 400, { success: false, error: 'tag required' });
+			return;
+		}
+		const tunnel = MOCK_SINGBOX_TUNNELS.find((t) => t.tag === tag);
+		let delay = 0;
+		if (tunnel) {
+			if (tunnel.running === false) delay = 0;
+			else if (!tunnel.connectivity?.connected) delay = 0;
+			else {
+				const i = MOCK_SINGBOX_TUNNELS.indexOf(tunnel);
+				delay = 70 + i * 35 + Math.floor(Math.random() * 45);
+			}
+		} else {
+			const knownMember = mockSubscriptions.some((s) => s.memberTags.includes(tag));
+			if (!knownMember) {
+				send(res, 404, { success: false, error: { code: 'NOT_FOUND', message: `unknown tag ${tag}` } });
+				return;
+			}
+			delay = delayMsForSubscriptionMemberTag(tag);
+		}
+		send(res, 200, { success: true, data: { tag, delay } });
 		return;
 	}
 

--- a/frontend/src/lib/components/LoginForm.svelte
+++ b/frontend/src/lib/components/LoginForm.svelte
@@ -82,10 +82,14 @@
 			</div>
 		</form>
 
-		<p class="login-hint">
-			Используйте логин и пароль администратора роутера
-		</p>
-	</div>
+	<p class="login-hint">
+		Используйте логин и пароль администратора роутера
+	</p>
+
+	<p class="login-hint" style="margin-top: 0.2rem;">
+		Продолжая использование, вы соглашаетесь с <a href="/terms">пользовательским соглашением</a>
+	</p>
+</div>
 </div>
 
 <style>
@@ -161,5 +165,15 @@
 		text-align: center;
 		font-size: 0.75rem;
 		color: var(--text-muted);
+	}
+
+	.login-terms a {
+		color: var(--color-accent, var(--text-muted));
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.login-terms a:hover {
+		opacity: 0.8;
 	}
 </style>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { LegacyTabs, LegacyTab, IconButton, SaveStatusIndicator } from '$lib/components/ui';
+	import { LegacyTabs, LegacyTab, IconButton } from '$lib/components/ui';
 	import BrandLogoMark from './BrandLogoMark.svelte';
 	import { usageLevel } from '$lib/stores/settings';
 	import type { ThemeState } from '$lib/stores/theme';
@@ -180,10 +180,6 @@
 						</span>
 					{/if}
 				</span>
-			{/if}
-
-			{#if authenticated}
-				<SaveStatusIndicator />
 			{/if}
 		</div>
 
@@ -368,12 +364,12 @@
 	.header-inner {
 		max-width: 1120px;
 		margin: 0 auto;
-		padding: 0 1rem;
+		padding: 0 1.25rem;
 		height: 56px;
 		display: grid;
 		grid-template-columns: auto 1fr auto;
 		align-items: center;
-		gap: 1.5rem;
+		gap: 1rem;
 	}
 
 	.brand-group {
@@ -401,10 +397,11 @@
 
 	.nav {
 		min-width: 0;
+		display: flex;
 		overflow-x: auto;
 		scrollbar-width: none;
-		justify-self: center;
 	}
+
 	.nav::-webkit-scrollbar {
 		display: none;
 	}
@@ -413,6 +410,13 @@
 	.nav :global(.tabs.variant-underline) {
 		border-bottom: none;
 		gap: 1.25rem;
+		flex-shrink: 0;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.nav :global(.tab) {
+		white-space: nowrap;
 	}
 
 	.nav-spacer {
@@ -559,13 +563,17 @@
 		display: none;
 	}
 
-	@media (max-width: 900px) {
+	@media (max-width: 1050px) {
 		.nav {
 			display: none;
 		}
 
 		.hamburger {
 			display: inline-flex;
+		}
+
+		.header-inner {
+			grid-template-columns: 1fr auto;
 		}
 
 		.mobile-backdrop {
@@ -615,10 +623,6 @@
 	@media (max-width: 640px) {
 		.app-header.unauthenticated .user-tools {
 			display: none;
-		}
-
-		.header-inner {
-			grid-template-columns: 1fr auto;
 		}
 
 		.wordmark {

--- a/frontend/src/lib/components/settings/SettingsFooter.svelte
+++ b/frontend/src/lib/components/settings/SettingsFooter.svelte
@@ -30,6 +30,8 @@
 	<div class="settings-footer-bar">
 		<span class="footer-link-group">
 			Документация: <a href="https://awgm.hoaxisr.ru" target="_blank" rel="noopener noreferrer">awgm.hoaxisr.ru</a>
+			<span class="footer-sep">·</span>
+			<a href="/terms">Пользовательское соглашение</a>
 		</span>
 		<button
 			type="button"
@@ -82,6 +84,11 @@
 
 	.footer-link-group a:hover {
 		text-decoration: underline;
+	}
+
+	.footer-sep {
+		margin: 0 0.375rem;
+		opacity: 0.4;
 	}
 
 	.footer-collapse {

--- a/frontend/src/lib/components/singbox/SingboxTunnelCard.svelte
+++ b/frontend/src/lib/components/singbox/SingboxTunnelCard.svelte
@@ -9,18 +9,21 @@
 		triggerDelayCheck,
 	} from '$lib/stores/singbox';
 	import { untrack } from 'svelte';
-	import { Modal, Button, TrafficChart } from '$lib/components/ui';
+	import { Modal, Button, TrafficChart, TrafficSparkline } from '$lib/components/ui';
 	import { getTrafficRates, subscribeTraffic, loadHistory } from '$lib/stores/traffic';
 	import SingboxSpeedTestModal from './SingboxSpeedTestModal.svelte';
+	import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
 
 	interface Props {
 		tunnel: SingboxTunnel;
+		layout?: SingboxLayoutMode;
 		autoDelayCheckNonce?: number;
 		autoDelayCheckDelayMs?: number;
 	}
 
 	let {
 		tunnel,
+		layout = 'grid',
 		autoDelayCheckNonce = 0,
 		autoDelayCheckDelayMs = 0,
 	}: Props = $props();
@@ -47,6 +50,17 @@
 			: 0,
 	);
 	const traffic = $derived($singboxTraffic.get(tunnel.tag));
+
+	const trafficSparkData = $derived.by(() => {
+		const n = Math.min(rxRates.length, txRates.length);
+		if (n === 0) return [];
+		const take = Math.min(36, n);
+		const out: number[] = [];
+		for (let i = n - take; i < n; i++) {
+			out.push(Math.max(0, rxRates[i] ?? 0) + Math.max(0, txRates[i] ?? 0));
+		}
+		return out;
+	});
 
 	type State = 'ok' | 'slow' | 'fail' | 'unknown' | 'stopped';
 	const cardState: State = $derived.by(() => {
@@ -155,6 +169,116 @@
 	});
 </script>
 
+{#if layout === 'list'}
+	<div
+		class="sbx-tunnel-list-row"
+		class:ok={cardState === 'ok'}
+		class:slow={cardState === 'slow'}
+		class:fail={cardState === 'fail'}
+		class:unknown={cardState === 'unknown'}
+		class:stopped={cardState === 'stopped'}
+	>
+		<div class="list-cell list-cell-delay" data-label="Delay">
+			<span class="dot {cardState}" aria-hidden="true"></span>
+			<button
+				type="button"
+				class="lat-btn {cardState}"
+				class:checking
+				onclick={triggerCheck}
+				title="Обновить delay"
+				disabled={checking}
+			>
+				{checking ? '...' : latText}
+			</button>
+		</div>
+		<div class="list-cell list-cell-name" data-label="Туннель">
+			<button type="button" class="name-btn" onclick={edit}>{tunnel.tag}</button>
+			<div class="list-sub mono">
+				{tunnel.proxyInterface}
+				{#if tunnel.kernelInterface}<span> · {tunnel.kernelInterface}</span>{/if}
+			</div>
+		</div>
+		<div class="list-cell list-cell-badges" data-label="Протокол">
+			<div class="badges-inline">
+				<span class="badge b-{tunnel.protocol}">{protocolLabel}</span>
+				{#if tunnel.security === 'reality'}
+					<span class="badge b-reality">Reality</span>
+				{:else if tunnel.security === 'tls'}
+					<span class="badge b-tls">TLS</span>
+				{/if}
+				<span class="badge b-transport">{tunnel.transport.toUpperCase()}</span>
+			</div>
+		</div>
+		<div class="list-cell list-cell-server" data-label="Сервер">
+			<div class="server-line">
+				{#if showServer}
+					<span class="mono">{tunnel.server}</span>
+				{:else}
+					<span class="muted">••••••••</span>
+				{/if}
+				<button
+					type="button"
+					class="eye-inline"
+					onclick={() => (showServer = !showServer)}
+					aria-label={showServer ? 'Скрыть' : 'Показать'}
+				>
+					{#if showServer}
+						<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+					{:else}
+						<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+					{/if}
+				</button>
+				<span class="mono">:{tunnel.port}</span>
+			</div>
+		</div>
+		<div class="list-cell list-cell-run" data-label="Процесс">
+			<span class="run-pill" class:run-on={tunnel.running === true}>{tunnel.running === true ? 'running' : 'stopped'}</span>
+		</div>
+		<div class="list-cell list-cell-traffic" data-label="Трафик">
+			<div class="traffic-row-list">
+				<TrafficSparkline
+					data={trafficSparkData}
+					width={84}
+					height={22}
+					color={tunnel.running === true ? 'var(--color-accent)' : 'var(--color-border-hover)'}
+				/>
+				<div class="traffic-mini-col mono">
+					<span>↓ {formatBytes(traffic?.download ?? 0)}</span>
+					<span>↑ {formatBytes(traffic?.upload ?? 0)}</span>
+				</div>
+			</div>
+		</div>
+		<div class="list-cell list-cell-ping-mini" data-label="Ping">
+			<div
+				class="spark-mini spark {cardState}"
+				onclick={triggerCheck}
+				onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && triggerCheck()}
+				role="button"
+				tabindex="0"
+				title="Клик — обновить delay"
+			>
+				{#if history.length === 0}
+					{#each Array(10) as _, i (i)}
+						<div class="bar empty"></div>
+					{/each}
+				{:else}
+					{@const max = Math.max(...history.map((v) => (v <= 0 ? 100 : v)), 100)}
+					{#each history.slice(-14) as d, i (i)}
+						<div class="bar" style="height: {Math.max((d <= 0 ? max : d) / max, 0.08) * 100}%;"></div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+		<div class="list-cell list-cell-actions" data-label="Действия">
+			<div class="list-actions">
+				<Button variant="ghost" size="sm" onclick={edit}>Изменить</Button>
+				<Button variant="danger" size="sm" onclick={() => (confirmDeleteOpen = true)} loading={deleting}>
+					Удалить
+				</Button>
+			</div>
+		</div>
+	</div>
+{:else}
 <div class="card" class:ok={cardState === 'ok'} class:slow={cardState === 'slow'} class:fail={cardState === 'fail'} class:unknown={cardState === 'unknown'} class:stopped={cardState === 'stopped'}>
 	<div class="led-wrap">
 		<span class="dot {cardState}" aria-hidden="true"></span>
@@ -294,6 +418,7 @@
 		</Button>
 	</div>
 </div>
+{/if}
 
 <SingboxSpeedTestModal
 	open={speedtestOpen}
@@ -506,6 +631,35 @@
 		height: 30% !important;
 	}
 
+	.spark-mini {
+		height: 22px;
+		max-width: 100%;
+		gap: 1px;
+		padding: 1px 0;
+	}
+	.spark-mini .bar {
+		min-width: 0;
+		min-height: 2px;
+	}
+	.list-cell-ping-mini {
+		justify-content: flex-start;
+	}
+	.traffic-row-list {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+	.traffic-mini-col {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+		font-size: 0.7rem;
+		line-height: 1.15;
+		color: var(--text-muted);
+		flex-shrink: 0;
+	}
+
 	.actions {
 		display: flex;
 		gap: 6px;
@@ -513,5 +667,88 @@
 		margin-top: 12px;
 		padding-top: 10px;
 		border-top: 1px solid var(--border);
+	}
+
+	/* List row (grid columns set on parent .singbox-tunnel-list-table) */
+	.sbx-tunnel-list-row {
+		align-items: center;
+		min-width: 0;
+	}
+	.sbx-tunnel-list-row .list-cell {
+		min-width: 0;
+	}
+	.sbx-tunnel-list-row .list-cell-delay {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+	.sbx-tunnel-list-row .name-btn {
+		font: inherit;
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: var(--text);
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		text-align: left;
+	}
+	.sbx-tunnel-list-row .name-btn:hover {
+		color: var(--color-accent, #58a6ff);
+	}
+	.sbx-tunnel-list-row .list-sub {
+		margin-top: 0.2rem;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.badges-inline {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+	}
+	.server-line {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 0.8125rem;
+		overflow: hidden;
+	}
+	.muted {
+		color: var(--text-muted);
+	}
+	.eye-inline {
+		display: inline-flex;
+		padding: 0.1rem;
+		border: none;
+		background: none;
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+	.run-pill {
+		font-size: 0.68rem;
+		font-weight: 600;
+		padding: 0.15rem 0.45rem;
+		border-radius: 999px;
+		background: var(--bg-tertiary, rgba(100, 100, 100, 0.25));
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.run-pill.run-on {
+		background: rgba(16, 185, 129, 0.2);
+		color: #10b981;
+	}
+	.traffic-mini {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+	.list-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		justify-content: flex-end;
 	}
 </style>

--- a/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
+++ b/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
@@ -337,7 +337,7 @@
 					<span class="lbl">Ссылки на серверы (по одной на строку)</span>
 					<ShareLinksTextarea
 						bind:value={inlineText}
-						placeholder={`vless://...\ntrojan://...\nhysteria2://...`}
+						placeholder={`vless://...\ntrojan://...\nhysteria2://...\nnaive+https://\nss://...`}
 						rows={6}
 						onpaste={(e) => onShareListPaste(e, () => inlineText, (v) => (inlineText = v))}
 					/>

--- a/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
+++ b/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
@@ -9,6 +9,10 @@
 	} from '$lib/types';
 	import HeadersTextarea from './HeadersTextarea.svelte';
 	import { DEFAULT_PRESET, parseHeadersText } from './headersParser';
+	import {
+		mergePastedShareList,
+		normalizeSpaceSeparatedShareLinks,
+	} from '$lib/utils/shareLinkListInput';
 
 	type WizardKind = 'single' | 'inline' | 'url';
 
@@ -119,6 +123,29 @@
 		error = '';
 	}
 
+	function onShareListPaste(
+		e: ClipboardEvent & { currentTarget: HTMLTextAreaElement },
+		get: () => string,
+		set: (v: string) => void,
+	): void {
+		const data = e.clipboardData?.getData('text/plain');
+		if (data == null) return;
+		const normalized = normalizeSpaceSeparatedShareLinks(data);
+		if (normalized === data) return;
+		e.preventDefault();
+		const ta = e.currentTarget;
+		const { next, caret } = mergePastedShareList(
+			get(),
+			ta.selectionStart ?? 0,
+			ta.selectionEnd ?? 0,
+			data,
+		);
+		set(next);
+		queueMicrotask(() => {
+			ta.selectionStart = ta.selectionEnd = caret;
+		});
+	}
+
 	const titleByKind: Record<WizardKind | 'choose', string> = {
 		choose: 'Добавить',
 		single: 'Один сервер',
@@ -127,6 +154,7 @@
 	};
 
 	async function submitSingle(): Promise<void> {
+		singleLinks = normalizeSpaceSeparatedShareLinks(singleLinks);
 		if (!singleLinks.trim() || submitting) return;
 		submitting = true;
 		error = '';
@@ -153,6 +181,9 @@
 	async function submitSubscription(): Promise<void> {
 		if (submitting) return;
 		const isInline = kind === 'inline';
+		if (isInline) {
+			inlineText = normalizeSpaceSeparatedShareLinks(inlineText);
+		}
 		if (isInline && !inlineText.trim()) {
 			error = 'Вставьте хотя бы одну ссылку';
 			return;
@@ -239,9 +270,10 @@
 		>
 			<p class="lead">
 				Каждая строка — отдельный sing-box туннель со своим Proxy NDMS.
-				Поддерживаются <code>vless://</code>, <code>trojan://</code>,
-				<code>ss://</code>, <code>hysteria2://</code>,
-				<code>naive+https://</code>.
+				Поддерживаются <code>vless://</code>, <code>hy2://</code>,
+				<code>trojan://</code>, <code>ss://</code>, <code>hysteria2://</code>,
+				<code>naive+http://</code>, <code>naive+https://</code>.
+				Список через пробел при вставке разбивается на строки автоматически.
 			</p>
 			{#if !singboxInstalled}
 				<div class="warn">
@@ -254,6 +286,7 @@
 				placeholder={`vless://uuid@host:443?...#Germany\nhysteria2://pass@host:8443#Finland`}
 				rows="6"
 				disabled={!singboxInstalled || submitting}
+				onpaste={(e) => onShareListPaste(e, () => singleLinks, (v) => (singleLinks = v))}
 			></textarea>
 			{#if error}<div class="err">{error}</div>{/if}
 			{#if singleResult && singleResult.errors.length > 0}
@@ -307,9 +340,11 @@
 						bind:value={inlineText}
 						placeholder={`vless://...\ntrojan://...\nhysteria2://...`}
 						rows="6"
+						onpaste={(e) => onShareListPaste(e, () => inlineText, (v) => (inlineText = v))}
 					></textarea>
 					<span class="hint">
 						Поддерживаются share-link'и, Clash YAML и sing-box JSON.
+						Список ссылок через пробел при вставке разбивается на строки.
 						Авто-обновления нет — список замораживается на момент создания,
 						редактируется во вкладке «Серверы».
 					</span>

--- a/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
+++ b/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
@@ -8,6 +8,7 @@
 		type SubscriptionMode,
 	} from '$lib/types';
 	import HeadersTextarea from './HeadersTextarea.svelte';
+	import ShareLinksTextarea from './ShareLinksTextarea.svelte';
 	import { DEFAULT_PRESET, parseHeadersText } from './headersParser';
 	import {
 		mergePastedShareList,
@@ -280,14 +281,13 @@
 					Sing-box не установлен — установи в настройках перед добавлением туннелей.
 				</div>
 			{/if}
-			<textarea
-				class="inp links-area"
+			<ShareLinksTextarea
 				bind:value={singleLinks}
 				placeholder={`vless://uuid@host:443?...#Germany\nhysteria2://pass@host:8443#Finland`}
-				rows="6"
+				rows={6}
 				disabled={!singboxInstalled || submitting}
 				onpaste={(e) => onShareListPaste(e, () => singleLinks, (v) => (singleLinks = v))}
-			></textarea>
+			/>
 			{#if error}<div class="err">{error}</div>{/if}
 			{#if singleResult && singleResult.errors.length > 0}
 				<div class="err">
@@ -335,13 +335,12 @@
 			{:else}
 				<label class="row">
 					<span class="lbl">Ссылки на серверы (по одной на строку)</span>
-					<textarea
-						class="inp inline-area"
+					<ShareLinksTextarea
 						bind:value={inlineText}
 						placeholder={`vless://...\ntrojan://...\nhysteria2://...`}
-						rows="6"
+						rows={6}
 						onpaste={(e) => onShareListPaste(e, () => inlineText, (v) => (inlineText = v))}
-					></textarea>
+					/>
 					<span class="hint">
 						Поддерживаются share-link'и, Clash YAML и sing-box JSON.
 						Список ссылок через пробел при вставке разбивается на строки.
@@ -509,12 +508,6 @@
 		border: 1px solid var(--color-border);
 		border-radius: 4px;
 		color: var(--color-text-primary);
-	}
-	.inline-area, .links-area {
-		font-family: var(--font-mono, ui-monospace, monospace);
-		font-size: 0.78rem;
-		min-height: 140px;
-		resize: vertical;
 	}
 	.hint {
 		font-size: 0.74rem;

--- a/frontend/src/lib/components/subscriptions/ShareLinksTextarea.svelte
+++ b/frontend/src/lib/components/subscriptions/ShareLinksTextarea.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { escapeAndHighlightShareProtocols } from '$lib/utils/shareLinkListInput';
+	import { highlightShareEditorContent } from '$lib/utils/shareEditorHighlight';
 	import { tick } from 'svelte';
 
 	interface Props {
@@ -21,7 +21,7 @@
 	let ta = $state<HTMLTextAreaElement | null>(null);
 	let back = $state<HTMLPreElement | null>(null);
 
-	let highlightHtml = $derived(escapeAndHighlightShareProtocols(value));
+	let highlightHtml = $derived(highlightShareEditorContent(value));
 
 	$effect(() => {
 		value;
@@ -35,37 +35,44 @@
 	}
 </script>
 
-<!-- Underlay shows highlighted protocols; textarea text is transparent (IDE-style). -->
-<div class="share-links-editor" class:disabled>
-	<pre
-		class="share-links-back"
-		aria-hidden="true"
-		bind:this={back}
-	>{@html highlightHtml}</pre>
-	<textarea
-		class="share-links-ta"
-		bind:this={ta}
-		bind:value={value}
-		{rows}
-		{disabled}
-		{placeholder}
-		spellcheck="false"
-		autocomplete="off"
-		autocapitalize="off"
-		onscroll={syncScroll}
-		onpaste={onpaste}
-	></textarea>
+<!-- Resize lives on the outer box so height can shrink below text; inner textarea scrolls. -->
+<div
+	class="share-links-editor"
+	class:disabled
+	style="--sl-rows: {rows}"
+>
+	<div class="share-links-stack">
+		<pre
+			class="share-links-back"
+			aria-hidden="true"
+			bind:this={back}
+		>{@html highlightHtml}</pre>
+		<textarea
+			class="share-links-ta"
+			bind:this={ta}
+			bind:value={value}
+			rows={1}
+			{disabled}
+			{placeholder}
+			spellcheck="false"
+			autocomplete="off"
+			autocapitalize="off"
+			onscroll={syncScroll}
+			onpaste={onpaste}
+		></textarea>
+	</div>
 </div>
 
 <style>
 	.share-links-editor {
 		position: relative;
-		display: grid;
-		grid-template: 1fr / 1fr;
-		align-items: stretch;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
 		width: 100%;
 		min-width: 0;
 		min-height: 140px;
+		height: calc(var(--sl-rows, 6) * 1.45em + 1rem);
 		padding: 0.5rem 0.7rem;
 		background: var(--color-bg-primary);
 		border: 1px solid var(--color-border);
@@ -74,8 +81,19 @@
 		font-size: 0.78rem;
 		color: var(--color-text-primary);
 		transition: border-color 120ms;
+		resize: vertical;
+		overflow: hidden;
 	}
-	.share-links-editor > * {
+	.share-links-stack {
+		position: relative;
+		flex: 1 1 auto;
+		min-height: 0;
+		width: 100%;
+		display: grid;
+		grid-template: 1fr / 1fr;
+		align-items: stretch;
+	}
+	.share-links-stack > * {
 		grid-area: 1 / 1;
 		min-height: 0;
 		width: 100%;
@@ -95,7 +113,9 @@
 		letter-spacing: inherit;
 		white-space: pre-wrap;
 		word-break: break-word;
-		overflow: auto;
+		overflow: hidden;
+		height: 100%;
+		z-index: 0;
 		pointer-events: none;
 		color: var(--color-text-primary);
 		background: transparent;
@@ -108,10 +128,40 @@
 		font-weight: 600;
 		color: var(--color-primary, #2563eb);
 	}
+	.share-links-back :global(.hl-json-str) {
+		color: var(--hl-json-str, #16a34a);
+	}
+	.share-links-back :global(.hl-json-num) {
+		color: var(--hl-json-num, #ea580c);
+	}
+	.share-links-back :global(.hl-json-lit) {
+		color: var(--hl-json-lit, #9333ea);
+	}
+	.share-links-back :global(.hl-json-punct) {
+		color: var(--hl-json-punct, var(--color-text-muted));
+		opacity: 0.9;
+	}
+	.share-links-back :global(.hl-yaml-key) {
+		color: var(--hl-yaml-key, #0284c7);
+		font-weight: 600;
+	}
+	.share-links-back :global(.hl-yaml-comment) {
+		color: var(--hl-yaml-comment, var(--color-text-muted));
+		font-style: italic;
+	}
+	.share-links-back :global(.hl-yaml-str) {
+		color: var(--hl-yaml-str, #15803d);
+	}
+	.share-links-back :global(.hl-yaml-punct) {
+		color: var(--hl-yaml-punct, var(--color-text-muted));
+	}
 	.share-links-ta {
 		margin: 0;
 		padding: 0;
-		resize: vertical;
+		position: relative;
+		z-index: 1;
+		height: 100%;
+		resize: none;
 		overflow: auto;
 		font: inherit;
 		line-height: 1.45;

--- a/frontend/src/lib/components/subscriptions/ShareLinksTextarea.svelte
+++ b/frontend/src/lib/components/subscriptions/ShareLinksTextarea.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { escapeAndHighlightShareProtocols } from '$lib/utils/shareLinkListInput';
+	import { tick } from 'svelte';
+
+	interface Props {
+		value?: string;
+		rows?: number;
+		disabled?: boolean;
+		placeholder?: string;
+		onpaste?: (e: ClipboardEvent & { currentTarget: HTMLTextAreaElement }) => void;
+	}
+
+	let {
+		value = $bindable(''),
+		rows = 6,
+		disabled = false,
+		placeholder = '',
+		onpaste,
+	}: Props = $props();
+
+	let ta = $state<HTMLTextAreaElement | null>(null);
+	let back = $state<HTMLPreElement | null>(null);
+
+	let highlightHtml = $derived(escapeAndHighlightShareProtocols(value));
+
+	$effect(() => {
+		value;
+		void tick().then(syncScroll);
+	});
+
+	function syncScroll(): void {
+		if (!ta || !back) return;
+		back.scrollTop = ta.scrollTop;
+		back.scrollLeft = ta.scrollLeft;
+	}
+</script>
+
+<!-- Underlay shows highlighted protocols; textarea text is transparent (IDE-style). -->
+<div class="share-links-editor" class:disabled>
+	<pre
+		class="share-links-back"
+		aria-hidden="true"
+		bind:this={back}
+	>{@html highlightHtml}</pre>
+	<textarea
+		class="share-links-ta"
+		bind:this={ta}
+		bind:value={value}
+		{rows}
+		{disabled}
+		{placeholder}
+		spellcheck="false"
+		autocomplete="off"
+		autocapitalize="off"
+		onscroll={syncScroll}
+		onpaste={onpaste}
+	></textarea>
+</div>
+
+<style>
+	.share-links-editor {
+		position: relative;
+		display: grid;
+		grid-template: 1fr / 1fr;
+		align-items: stretch;
+		width: 100%;
+		min-width: 0;
+		min-height: 140px;
+		padding: 0.5rem 0.7rem;
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: 4px;
+		font-family: var(--font-mono, ui-monospace, monospace);
+		font-size: 0.78rem;
+		color: var(--color-text-primary);
+		transition: border-color 120ms;
+	}
+	.share-links-editor > * {
+		grid-area: 1 / 1;
+		min-height: 0;
+		width: 100%;
+		box-sizing: border-box;
+	}
+	.share-links-editor.disabled {
+		opacity: 0.65;
+		pointer-events: none;
+	}
+	.share-links-back {
+		margin: 0;
+		padding: 0;
+		border: none;
+		border-radius: inherit;
+		font: inherit;
+		line-height: 1.45;
+		letter-spacing: inherit;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow: auto;
+		pointer-events: none;
+		color: var(--color-text-primary);
+		background: transparent;
+		scrollbar-width: none;
+	}
+	.share-links-back::-webkit-scrollbar {
+		display: none;
+	}
+	.share-links-back :global(.share-link-proto) {
+		font-weight: 600;
+		color: var(--color-primary, #2563eb);
+	}
+	.share-links-ta {
+		margin: 0;
+		padding: 0;
+		resize: vertical;
+		overflow: auto;
+		font: inherit;
+		line-height: 1.45;
+		letter-spacing: inherit;
+		border: none;
+		border-radius: inherit;
+		outline: none;
+		background: transparent;
+		color: transparent;
+		-webkit-text-fill-color: transparent;
+		caret-color: var(--color-text-primary);
+	}
+	.share-links-ta::placeholder {
+		opacity: 1;
+		color: var(--color-text-muted);
+		-webkit-text-fill-color: var(--color-text-muted);
+	}
+	.share-links-ta:focus-visible {
+		outline: none;
+	}
+	.share-links-ta::selection {
+		background: color-mix(in srgb, var(--color-primary, #2563eb) 38%, transparent);
+	}
+	.share-links-editor:focus-within {
+		border-color: var(--color-primary, #3b82f6);
+	}
+</style>

--- a/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
@@ -438,8 +438,14 @@
     .server-text {
         font-size: 0.82rem;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+        min-width: 0;
     }
     .server-text.mono {
         font-family: var(--font-mono, ui-monospace, monospace);

--- a/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
@@ -10,6 +10,7 @@
         triggerDelayCheck,
     } from '$lib/stores/singbox';
     import { subscriptionsStore } from '$lib/stores/subscriptions';
+    import { notifications } from '$lib/stores/notifications';
     import type { Subscription, SubscriptionMember } from '$lib/types';
     import { formatRelativeTime } from '$lib/utils/format';
     import SubscriptionMemberPicker from './SubscriptionMemberPicker.svelte';
@@ -394,7 +395,13 @@
                     class:server-btn-readonly={isURLTest}
                     onclick={(e) => {
                         e.stopPropagation();
-                        if (isURLTest) return;
+                        if (isURLTest) {
+                            notifications.info(
+                                'Включён автовыбор (URLTest). Чтобы выбирать сервер вручную, откройте подписку → вкладка «Настройки» → режим «Вручную».',
+                                { duration: 9000 },
+                            );
+                            return;
+                        }
                         pickerOpen = !pickerOpen;
                     }}
                     aria-haspopup={isURLTest ? undefined : 'listbox'}

--- a/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
@@ -2,7 +2,8 @@
     import { untrack } from 'svelte';
     import { goto } from '$app/navigation';
     import { api } from '$lib/api/client';
-    import { Button } from '$lib/components/ui';
+    import { Button, TrafficSparkline } from '$lib/components/ui';
+    import { getTrafficRates, subscribeTraffic, loadHistory } from '$lib/stores/traffic';
     import {
         singboxDelayHistory,
         singboxTraffic,
@@ -13,18 +14,21 @@
     import { formatRelativeTime } from '$lib/utils/format';
     import SubscriptionMemberPicker from './SubscriptionMemberPicker.svelte';
     import SingboxSpeedTestModal from '$lib/components/singbox/SingboxSpeedTestModal.svelte';
+    import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
 
     interface Props {
         subscription: Subscription;
         activeMember: SubscriptionMember;
         autoDelayCheckNonce?: number;
         autoDelayCheckDelayMs?: number;
+        layout?: SingboxLayoutMode;
     }
     let {
         subscription,
         activeMember,
         autoDelayCheckNonce = 0,
         autoDelayCheckDelayMs = 0,
+        layout = 'grid',
     }: Props = $props();
 
     let pickerOpen = $state(false);
@@ -55,6 +59,37 @@
             history[history.length - 2] <= 0,
     );
     const traffic = $derived($singboxTraffic.get(activeMember.tag));
+
+    const trafficSparkData = $derived.by(() => {
+        const n = Math.min(rxRates.length, txRates.length);
+        if (n === 0) return [];
+        const take = Math.min(36, n);
+        const out: number[] = [];
+        for (let i = n - take; i < n; i++) {
+            out.push(Math.max(0, rxRates[i] ?? 0) + Math.max(0, txRates[i] ?? 0));
+        }
+        return out;
+    });
+
+    let rxRates = $state<number[]>([]);
+    let txRates = $state<number[]>([]);
+    let trafficMemberTag = $derived(activeMember.tag);
+
+    $effect(() => {
+        const tag = trafficMemberTag;
+        const update = () => {
+            const t = getTrafficRates(tag);
+            rxRates = t.rx;
+            txRates = t.tx;
+        };
+        update();
+        return subscribeTraffic(update);
+    });
+
+    $effect(() => {
+        const tag = trafficMemberTag;
+        untrack(() => loadHistory(tag));
+    });
     const endpointText = $derived(`${activeMember.server}:${activeMember.port}`);
     const isURLTest = $derived(subscription.mode === 'urltest');
     const lastFetchedHuman = $derived(
@@ -132,6 +167,158 @@
 
 </script>
 
+{#if layout === 'list'}
+    <div
+        class="sub-active-list-group"
+        class:ok={cardState === 'ok'}
+        class:slow={cardState === 'slow'}
+        class:fail={cardState === 'fail'}
+        class:unknown={cardState === 'unknown'}
+    >
+        <div
+            class="sbx-sub-active-row"
+            onclick={openDetail}
+            onkeydown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openDetail();
+                }
+            }}
+            role="button"
+            tabindex="0"
+        >
+            <div class="lc lc-delay" data-label="Delay">
+                {#if subscription.lastError}
+                    <span class="dot fail" aria-hidden="true"></span>
+                    <span class="delay-inline-err mono" title={subscription.lastError}>
+                        {subscription.lastError}
+                    </span>
+                {:else}
+                    <span class="dot {cardState}" aria-hidden="true"></span>
+                    <button
+                        type="button"
+                        class="lat-btn {cardState}"
+                        class:checking
+                        onclick={(e) => {
+                            e.stopPropagation();
+                            void triggerCheck(e);
+                        }}
+                        title="Обновить delay"
+                        disabled={checking}
+                    >
+                        {checking ? '...' : latText}
+                    </button>
+                {/if}
+            </div>
+            <div class="lc lc-name" data-label="Подписка">
+                <div class="t1">{subscription.label}</div>
+                <div class="t2 mono">{proxyIface}{#if kernelIface} · {kernelIface}{/if}</div>
+            </div>
+            <div class="lc lc-mode" data-label="Режим">
+                {isURLTest ? 'URLTest' : 'Selector'}
+            </div>
+            <div class="lc lc-endpoint mono" data-label="Активный сервер">
+                {#if showEndpoint}{endpointText}{:else}••••••••{/if}
+                <button
+                    type="button"
+                    class="eye-mini"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        showEndpoint = !showEndpoint;
+                    }}
+                    aria-label={showEndpoint ? 'Скрыть' : 'Показать'}
+                >
+                    {#if showEndpoint}
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                    {:else}
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                    {/if}
+                </button>
+            </div>
+            <div class="lc lc-members" data-label="Серверов">
+                {subscription.memberTags.length}
+            </div>
+            <div class="lc lc-updated mono" data-label="Обновлено">
+                {lastFetchedHuman}
+            </div>
+            <div class="lc lc-traffic" data-label="Трафик">
+                {#if subscription.lastError}
+                    <span class="delay-dash">—</span>
+                {:else}
+                    <div class="traffic-row-list">
+                        <TrafficSparkline
+                            data={trafficSparkData}
+                            width={84}
+                            height={22}
+                            color="var(--color-accent)"
+                        />
+                        <div class="traffic-mini-col mono">
+                            <span>↓ {formatBytes(traffic?.download ?? 0)}</span>
+                            <span>↑ {formatBytes(traffic?.upload ?? 0)}</span>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+            <div class="lc lc-ping-mini" data-label="Ping">
+                {#if subscription.lastError}
+                    <span class="delay-dash">—</span>
+                {:else}
+                    <div
+                        class="spark-mini {cardState}"
+                        role="button"
+                        tabindex="0"
+                        onclick={(e) => {
+                            e.stopPropagation();
+                            void triggerCheck(e);
+                        }}
+                        onkeydown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                void triggerCheck(e);
+                            }
+                        }}
+                        title="Клик — обновить delay"
+                    >
+                        {#if history.length === 0}
+                            {#each Array(10) as _, i (i)}
+                                <div class="bar empty"></div>
+                            {/each}
+                        {:else}
+                            {@const max = Math.max(...history.map((v) => (v <= 0 ? 100 : v)), 100)}
+                            {#each history.slice(-14) as d, i (i)}
+                                <div class="bar" style="height: {Math.max((d <= 0 ? max : d) / max, 0.08) * 100}%;"></div>
+                            {/each}
+                        {/if}
+                    </div>
+                {/if}
+            </div>
+            <div class="lc lc-actions" data-label="">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={!kernelIface}
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        if (kernelIface) speedtestOpen = true;
+                    }}
+                >
+                    Скорость
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        openDetail();
+                    }}
+                >
+                    Открыть
+                </Button>
+            </div>
+        </div>
+    </div>
+{:else}
 <div
     class="card"
     class:ok={cardState === 'ok'}
@@ -310,6 +497,7 @@
         <Button variant="ghost" size="sm" onclick={openDetail}>Открыть подписку</Button>
     </div>
 </div>
+{/if}
 
 <SingboxSpeedTestModal
     open={speedtestOpen}
@@ -505,5 +693,146 @@
     }
     .mono {
         font-family: var(--font-mono, ui-monospace, monospace);
+    }
+
+    .sub-active-list-group {
+        border-bottom: 1px solid var(--color-border);
+    }
+    .sub-active-list-group:last-child {
+        border-bottom: none;
+    }
+    .sbx-sub-active-row {
+        display: grid;
+        grid-template-columns:
+            minmax(92px, 1fr)
+            minmax(132px, 1.1fr)
+            minmax(72px, 0.9fr)
+            minmax(112px, 1fr)
+            minmax(52px, 0.75fr)
+            minmax(88px, 0.95fr)
+            minmax(148px, 1.1fr)
+            minmax(72px, 0.88fr)
+            minmax(150px, 1fr);
+        gap: 0.75rem 1rem;
+        align-items: center;
+        padding: 0.75rem 1rem;
+        cursor: pointer;
+        min-width: 1040px;
+    }
+    .sbx-sub-active-row:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: -2px;
+    }
+    .lc {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        font-size: 0.8125rem;
+        color: var(--color-text-secondary);
+    }
+    .lc-delay {
+        gap: 0.35rem;
+        min-width: 0;
+    }
+    .delay-inline-err {
+        font-size: 0.68rem;
+        line-height: 1.25;
+        color: #f85149;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+        flex: 1;
+    }
+    .delay-dash {
+        font-size: 0.8125rem;
+        color: var(--color-text-muted);
+    }
+    .lc-ping-mini {
+        justify-content: flex-start;
+    }
+    .spark-mini {
+        height: 22px;
+        max-width: 100%;
+        display: flex;
+        align-items: flex-end;
+        gap: 1px;
+        padding: 1px 0;
+        cursor: pointer;
+    }
+    .spark-mini:focus {
+        outline: 1px dashed var(--color-text-muted);
+        outline-offset: 2px;
+    }
+    .spark-mini .bar {
+        flex: 1;
+        min-width: 0;
+        min-height: 2px;
+        border-radius: 1px;
+        background: var(--color-bg-tertiary);
+    }
+    .spark-mini.ok .bar {
+        background: #3fb950;
+    }
+    .spark-mini.slow .bar {
+        background: #d29922;
+    }
+    .spark-mini.fail .bar {
+        background: #f85149;
+    }
+    .spark-mini.unknown .bar,
+    .spark-mini .bar.empty {
+        opacity: 0.35;
+        height: 30% !important;
+    }
+    .traffic-row-list {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+        width: 100%;
+    }
+    .traffic-mini-col {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1rem;
+        font-size: 0.7rem;
+        line-height: 1.15;
+        color: var(--color-text-muted);
+        flex-shrink: 0;
+    }
+    .lc-name {
+        flex-direction: column;
+        align-items: flex-start !important;
+        gap: 0.15rem;
+    }
+    .lc-name .t1 {
+        font-weight: 600;
+        font-size: 0.9375rem;
+        color: var(--color-text-primary);
+    }
+    .lc-name .t2 {
+        font-size: 0.72rem;
+        color: var(--color-text-muted);
+    }
+    .lc-endpoint {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        overflow: hidden;
+    }
+    .eye-mini {
+        display: inline-flex;
+        padding: 0.15rem;
+        border: none;
+        background: none;
+        color: var(--color-text-muted);
+        cursor: pointer;
+        flex-shrink: 0;
+    }
+    .lc-actions {
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        justify-content: flex-end;
     }
 </style>

--- a/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
@@ -1,12 +1,113 @@
 <script lang="ts">
 	import type { Subscription } from '$lib/types';
+	import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
 	import { goto } from '$app/navigation';
+	import { untrack } from 'svelte';
+	import { singboxDelayHistory, singboxTraffic, triggerDelayCheck } from '$lib/stores/singbox';
+	import { getTrafficRates, subscribeTraffic, loadHistory } from '$lib/stores/traffic';
+	import { TrafficSparkline } from '$lib/components/ui';
+	import { formatBytes } from '$lib/utils/format';
 
 	interface Props {
 		subscription: Subscription;
+		layout?: SingboxLayoutMode;
 		ondelete?: (id: string) => void;
 	}
-	let { subscription, ondelete }: Props = $props();
+	let { subscription, layout = 'grid', ondelete }: Props = $props();
+
+	const latencyTag = $derived.by(() => {
+		if (subscription.activeMember && subscription.memberTags.includes(subscription.activeMember)) {
+			return subscription.activeMember;
+		}
+		return subscription.memberTags[0] ?? '';
+	});
+
+	const history = $derived($singboxDelayHistory.get(latencyTag) ?? []);
+	const latest = $derived(history.length > 0 ? history[history.length - 1] : -1);
+	const hasConsecutiveTimeout = $derived(
+		history.length >= 2 &&
+			history[history.length - 1] <= 0 &&
+			history[history.length - 2] <= 0,
+	);
+
+	const DELAY_OK = 200;
+	const DELAY_SLOW = 500;
+
+	const delayState = $derived.by((): 'ok' | 'slow' | 'fail' | 'unknown' => {
+		if (!latencyTag) return 'unknown';
+		if (latest < 0) return 'unknown';
+		if (latest <= 0) return hasConsecutiveTimeout ? 'fail' : 'slow';
+		if (latest < DELAY_OK) return 'ok';
+		if (latest < DELAY_SLOW) return 'slow';
+		return 'slow';
+	});
+	const delayText = $derived.by(() => {
+		if (!latencyTag) return '—';
+		if (delayState === 'unknown') return '—';
+		if (delayState === 'fail') return 'timeout';
+		if (latest <= 0) return '…';
+		return `${latest}ms`;
+	});
+
+	const traffic = $derived(latencyTag ? $singboxTraffic.get(latencyTag) : undefined);
+
+	const trafficSparkData = $derived.by(() => {
+		const n = Math.min(rxRates.length, txRates.length);
+		if (n === 0) return [];
+		const take = Math.min(36, n);
+		const out: number[] = [];
+		for (let i = n - take; i < n; i++) {
+			out.push(Math.max(0, rxRates[i] ?? 0) + Math.max(0, txRates[i] ?? 0));
+		}
+		return out;
+	});
+
+	let rxRates = $state<number[]>([]);
+	let txRates = $state<number[]>([]);
+	let trafficTag = $derived(latencyTag);
+
+	$effect(() => {
+		const tag = trafficTag;
+		const update = () => {
+			if (!tag) {
+				rxRates = [];
+				txRates = [];
+				return;
+			}
+			const t = getTrafficRates(tag);
+			rxRates = t.rx;
+			txRates = t.tx;
+		};
+		update();
+		if (!tag) return () => {};
+		return subscribeTraffic(update);
+	});
+
+	$effect(() => {
+		const tag = trafficTag;
+		if (!tag) return;
+		untrack(() => loadHistory(tag));
+	});
+
+	let testingDelay = $state(false);
+
+	async function runDelayCheck(e?: MouseEvent | KeyboardEvent): Promise<void> {
+		e?.stopPropagation();
+		if (!latencyTag || testingDelay) return;
+		testingDelay = true;
+		try {
+			await triggerDelayCheck(latencyTag);
+		} finally {
+			testingDelay = false;
+		}
+	}
+	function onDelayKeydown(e: KeyboardEvent): void {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			e.stopPropagation();
+			void runDelayCheck(e);
+		}
+	}
 
 	function open(): void {
 		goto(`/subscriptions/${subscription.id}`);
@@ -34,10 +135,132 @@
 	}
 </script>
 
+{#if layout === 'list'}
+	<div class="sub-list-group" class:err={status === 'error'}>
+		<div
+			role="button"
+			tabindex="0"
+			class="sub-list-click"
+			onclick={open}
+			onkeydown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					open();
+				}
+			}}
+		>
+			<div class="sbx-sub-inactive-row">
+				<div class="list-cell" data-label="Статус">
+					<div class="badge {status}">
+						{#if status === 'ok'}OK{:else if status === 'error'}Ошибка{:else}—{/if}
+					</div>
+				</div>
+				<div class="list-cell list-cell-delay" data-label="Delay">
+					{#if subscription.lastError}
+						<span class="delay-inline-err mono" title={subscription.lastError}>
+							{subscription.lastError}
+						</span>
+					{:else if latencyTag}
+						<button
+							type="button"
+							class="lat-btn {delayState}"
+							class:is-checking={testingDelay}
+							disabled={testingDelay}
+							onclick={runDelayCheck}
+							onkeydown={onDelayKeydown}
+							title="Обновить delay"
+						>
+							{testingDelay ? '...' : delayText}
+						</button>
+					{:else}
+						<span class="delay-dash">—</span>
+					{/if}
+				</div>
+				<div class="list-cell list-name" data-label="Подписка">
+					<div class="label-strong">{subscription.label || subscription.url}</div>
+					<div class="meta mono">{subscription.inboundTag} · :{subscription.listenPort}</div>
+				</div>
+				<div class="list-cell" data-label="Серверов">
+					{subscription.memberTags.length}
+				</div>
+				<div class="list-cell mono" data-label="Активен">
+					{subscription.activeMember || '—'}
+				</div>
+				<div class="list-cell list-cell-traffic" data-label="Трафик">
+					{#if subscription.lastError}
+						<span class="delay-dash">—</span>
+					{:else if latencyTag}
+						<div class="traffic-row-list">
+							<TrafficSparkline
+								data={trafficSparkData}
+								width={84}
+								height={22}
+								color="var(--color-accent)"
+							/>
+							<div class="traffic-mini-col mono">
+								<span>↓ {formatBytes(traffic?.download ?? 0)}</span>
+								<span>↑ {formatBytes(traffic?.upload ?? 0)}</span>
+							</div>
+						</div>
+					{:else}
+						<span class="delay-dash">—</span>
+					{/if}
+				</div>
+				<div class="list-cell list-cell-ping" data-label="Ping">
+					{#if subscription.lastError}
+						<span class="delay-dash">—</span>
+					{:else if latencyTag}
+						<div
+							class="spark-mini {delayState}"
+							role="button"
+							tabindex="0"
+							onclick={(e) => runDelayCheck(e)}
+							onkeydown={onDelayKeydown}
+							title="Клик — обновить delay"
+						>
+							{#if history.length === 0}
+								{#each Array(10) as _, i (i)}
+									<div class="bar empty"></div>
+								{/each}
+							{:else}
+								{@const max = Math.max(...history.map((v) => (v <= 0 ? 100 : v)), 100)}
+								{#each history.slice(-14) as d, i (i)}
+									<div class="bar" style="height: {Math.max((d <= 0 ? max : d) / max, 0.08) * 100}%;"></div>
+								{/each}
+							{/if}
+						</div>
+					{:else}
+						<span class="delay-dash">—</span>
+					{/if}
+				</div>
+				<div class="list-cell" data-label="Обновлено">
+					{lastFetchedHuman}
+				</div>
+				<div class="list-cell list-actions" data-label="">
+					{#if ondelete}
+						<button
+							type="button"
+							class="card-remove"
+							title="Удалить подписку"
+							aria-label="Удалить подписку {subscription.label || subscription.url}"
+							onclick={requestDelete}
+						>
+							<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{:else}
 <div
 	role="button"
 	tabindex="0"
 	class="card"
+	class:panel={layout === 'grid'}
 	class:err={status === 'error'}
 	onclick={open}
 	onkeydown={(e) => {
@@ -80,6 +303,7 @@
 		<div class="err-msg mono">{subscription.lastError}</div>
 	{/if}
 </div>
+{/if}
 
 <style>
 	.card {
@@ -94,6 +318,145 @@
 		text-align: left;
 		color: var(--color-text-primary);
 		cursor: pointer;
+	}
+	.card.panel {
+		padding: 16px;
+		border-radius: 10px;
+	}
+	.sub-list-group {
+		border-bottom: 1px solid var(--color-border);
+	}
+	.sub-list-group:last-child {
+		border-bottom: none;
+	}
+	.sub-list-click {
+		cursor: pointer;
+	}
+	.sub-list-click:focus-visible {
+		outline: 2px solid var(--color-primary, #3b82f6);
+		outline-offset: 2px;
+	}
+	.sbx-sub-inactive-row {
+		display: grid;
+		grid-template-columns:
+			minmax(64px, 0.9fr)
+			minmax(84px, 1fr)
+			minmax(140px, 1.25fr)
+			minmax(56px, 0.85fr)
+			minmax(88px, 1fr)
+			minmax(150px, 1.15fr)
+			minmax(56px, 0.85fr)
+			minmax(88px, 1fr)
+			minmax(44px, 0.75fr);
+		gap: 0.75rem 1rem;
+		align-items: center;
+		padding: 0.75rem 1rem;
+		min-width: 960px;
+	}
+	.sub-list-group.err .sbx-sub-inactive-row {
+		background: rgba(248, 81, 73, 0.04);
+	}
+	.sbx-sub-inactive-row .list-cell {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+	.list-name {
+		flex-direction: column;
+		align-items: flex-start !important;
+		gap: 0.15rem;
+	}
+	.label-strong {
+		font-weight: 600;
+		font-size: 0.9375rem;
+		color: var(--color-text-primary);
+	}
+	.sbx-sub-inactive-row .list-cell-delay {
+		min-width: 0;
+	}
+	.delay-inline-err {
+		font-size: 0.68rem;
+		line-height: 1.25;
+		color: #f85149;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 100%;
+	}
+	.delay-dash {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+	.lat-btn {
+		padding: 0.15rem 0.45rem;
+		border-radius: 4px;
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-muted);
+		border: 1px solid var(--color-border);
+		font: inherit;
+		font-size: 0.72rem;
+		font-family: var(--font-mono, ui-monospace, monospace);
+		cursor: pointer;
+	}
+	.lat-btn.is-checking {
+		opacity: 0.55;
+		cursor: wait;
+	}
+	.lat-btn.ok {
+		color: #3fb950;
+	}
+	.lat-btn.slow {
+		color: #d29922;
+	}
+	.lat-btn.fail {
+		color: #f85149;
+	}
+	.spark-mini {
+		display: flex;
+		align-items: flex-end;
+		gap: 1px;
+		height: 20px;
+		width: 100%;
+		max-width: 82px;
+		cursor: pointer;
+	}
+	.spark-mini .bar {
+		flex: 1;
+		min-width: 0;
+		min-height: 2px;
+		border-radius: 1px;
+		background: var(--color-bg-tertiary);
+	}
+	.spark-mini.ok .bar {
+		background: #3fb950;
+	}
+	.spark-mini.slow .bar {
+		background: #d29922;
+	}
+	.spark-mini.fail .bar {
+		background: #f85149;
+	}
+	.spark-mini.unknown .bar,
+	.spark-mini .bar.empty {
+		opacity: 0.35;
+		height: 30% !important;
+	}
+	.traffic-row-list {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		min-width: 0;
+	}
+	.traffic-mini-col {
+		display: flex;
+		flex-direction: column;
+		gap: 0.08rem;
+		font-size: 0.68rem;
+		line-height: 1.15;
+		color: var(--color-text-muted);
+		flex-shrink: 0;
 	}
 	.card:focus-visible {
 		outline: 2px solid var(--color-primary, #3b82f6);

--- a/frontend/src/lib/components/subscriptions/SubscriptionMemberCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionMemberCard.svelte
@@ -65,6 +65,8 @@
 			default: return member.protocol;
 		}
 	});
+
+	const heading = $derived(member.label || member.server);
 </script>
 
 <button
@@ -78,7 +80,7 @@
 >
 	<div class="header">
 		<span class="led" class:on={active} aria-hidden="true"></span>
-		<span class="title" title={member.tag}>{member.label || member.server}</span>
+		<span class="title" title={heading}>{heading}</span>
 		<span class="port mono">:{member.port}</span>
 	</div>
 	<div class="badges">
@@ -176,9 +178,15 @@
 		font-size: 0.92rem;
 		font-weight: 600;
 		flex: 1;
+		min-width: 0;
 		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		white-space: normal;
+		word-break: break-word;
+		overflow-wrap: anywhere;
 	}
 	.port { font-size: 0.78rem; color: var(--color-text-muted); }
 	.badges { display: flex; gap: 0.4rem; flex-wrap: wrap; }

--- a/frontend/src/lib/components/subscriptions/SubscriptionMemberCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionMemberCard.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import type { SubscriptionMember } from '$lib/types';
-	import { singboxDelayHistory, triggerDelayCheck } from '$lib/stores/singbox';
+	import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
+	import { untrack } from 'svelte';
+	import { singboxDelayHistory, singboxTraffic, triggerDelayCheck } from '$lib/stores/singbox';
+	import { getTrafficRates, subscribeTraffic, loadHistory } from '$lib/stores/traffic';
+	import { TrafficSparkline } from '$lib/components/ui';
+	import { formatBytes } from '$lib/utils/format';
 
 	interface Props {
 		member: SubscriptionMember;
@@ -8,8 +13,9 @@
 		switching: boolean;
 		disabled: boolean;
 		onclick: () => void;
+		layout?: SingboxLayoutMode;
 	}
-	let { member, active, switching, disabled, onclick }: Props = $props();
+	let { member, active, switching, disabled, onclick, layout = 'grid' }: Props = $props();
 
 	const history = $derived($singboxDelayHistory.get(member.tag) ?? []);
 	const latest = $derived(history.length > 0 ? history[history.length - 1] : -1);
@@ -21,8 +27,8 @@
 
 	let testing = $state(false);
 
-	async function runTest(e: MouseEvent | KeyboardEvent): Promise<void> {
-		e.stopPropagation(); // don't trigger card-as-radio click
+	async function runTest(e?: MouseEvent | KeyboardEvent): Promise<void> {
+		e?.stopPropagation(); // don't trigger card-as-radio click
 		if (testing) return;
 		testing = true;
 		try {
@@ -67,8 +73,113 @@
 	});
 
 	const heading = $derived(member.label || member.server);
+
+	const traffic = $derived($singboxTraffic.get(member.tag));
+
+	const trafficSparkData = $derived.by(() => {
+		const n = Math.min(rxRates.length, txRates.length);
+		if (n === 0) return [];
+		const take = Math.min(36, n);
+		const out: number[] = [];
+		for (let i = n - take; i < n; i++) {
+			out.push(Math.max(0, rxRates[i] ?? 0) + Math.max(0, txRates[i] ?? 0));
+		}
+		return out;
+	});
+
+	let rxRates = $state<number[]>([]);
+	let txRates = $state<number[]>([]);
+	let memberTag = $derived(member.tag);
+
+	$effect(() => {
+		const tag = memberTag;
+		const update = () => {
+			const t = getTrafficRates(tag);
+			rxRates = t.rx;
+			txRates = t.tx;
+		};
+		update();
+		return subscribeTraffic(update);
+	});
+
+	let trafficHistoryLoaded = false;
+	$effect(() => {
+		const tag = memberTag;
+		if (trafficHistoryLoaded) return;
+		trafficHistoryLoaded = true;
+		untrack(() => loadHistory(tag));
+	});
 </script>
 
+{#if layout === 'list'}
+	<div class="mbr-flatten">
+		<div class="c c-delay" data-label="Delay">
+			<span
+				role="button"
+				tabindex="0"
+				class="delay-btn {delayState}"
+				class:is-disabled={testing}
+				onclick={runTest}
+				onkeydown={onTestKeydown}
+			>
+				{testing ? '...' : delayText}
+			</span>
+		</div>
+		<div class="c c-name" data-label="Сервер">
+			<span class="n1" title={heading}>{heading}</span>
+			<span class="n2 mono" title={member.tag}>{member.server}:{member.port}</span>
+		</div>
+		<div class="c c-badges" data-label="Протокол">
+			<span class="badge proto">{protocolLabel}</span>
+			{#if member.transport && member.transport !== 'tcp'}
+				<span class="badge transport">{member.transport.toUpperCase()}</span>
+			{/if}
+		</div>
+		<div class="c c-traffic-mini" data-label="Трафик">
+			<div class="traffic-row-list">
+				<TrafficSparkline
+					data={trafficSparkData}
+					width={84}
+					height={22}
+					color={active ? 'var(--color-accent)' : 'var(--color-border-hover)'}
+				/>
+				<div class="traffic-mini-col mono">
+					<span>↓ {formatBytes(traffic?.download ?? 0)}</span>
+					<span>↑ {formatBytes(traffic?.upload ?? 0)}</span>
+				</div>
+			</div>
+		</div>
+		<div class="c c-ping-mini" data-label="Ping">
+			<div
+				class="spark-mini {delayState}"
+				role="button"
+				tabindex="0"
+				onclick={(e) => runTest(e)}
+				onkeydown={onTestKeydown}
+				title="Клик — обновить delay"
+			>
+				{#if history.length === 0}
+					{#each Array(10) as _, i (i)}
+						<div class="bar empty"></div>
+					{/each}
+				{:else}
+					{@const max = Math.max(...history.map((v) => (v <= 0 ? 100 : v)), 100)}
+					{#each history.slice(-14) as d, i (i)}
+						<div class="bar" style="height: {Math.max((d <= 0 ? max : d) / max, 0.08) * 100}%;"></div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+		<div class="c mono c-tag" data-label="Тег">{member.tag}</div>
+		<div class="c c-state" data-label="">
+			{#if active}
+				<span class="state-badge active-badge">активен</span>
+			{:else if switching}
+				<span class="state-badge switching-badge">…</span>
+			{/if}
+		</div>
+	</div>
+{:else}
 <button
 	type="button"
 	class="card"
@@ -136,6 +247,7 @@
 		{/if}
 	</div>
 </button>
+{/if}
 
 <style>
 	.card {
@@ -295,5 +407,98 @@
 			padding: 13px 14px;
 			min-height: 0;
 		}
+	}
+
+	.c {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		padding: 0.65rem 0;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+	.c-name {
+		flex-direction: column;
+		align-items: flex-start !important;
+		gap: 0.12rem;
+	}
+	.n1 {
+		font-weight: 600;
+		color: var(--color-text-primary);
+		font-size: 0.9rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+	.n2 {
+		font-size: 0.72rem;
+		color: var(--color-text-muted);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+	.c-badges {
+		gap: 0.3rem;
+		flex-wrap: wrap;
+	}
+	.c-tag {
+		font-size: 0.72rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.c-ping-mini {
+		padding-left: 0;
+		padding-right: 0;
+	}
+	.spark-mini {
+		display: flex;
+		align-items: flex-end;
+		gap: 1px;
+		height: 20px;
+		width: 100%;
+		max-width: 82px;
+		cursor: pointer;
+	}
+	.spark-mini .bar {
+		flex: 1;
+		min-width: 0;
+		min-height: 2px;
+		border-radius: 1px;
+		background: var(--color-bg-tertiary);
+	}
+	.spark-mini.ok .bar {
+		background: #3fb950;
+	}
+	.spark-mini.slow .bar {
+		background: #d29922;
+	}
+	.spark-mini.fail .bar {
+		background: #f85149;
+	}
+	.spark-mini.unknown .bar,
+	.spark-mini .bar.empty {
+		opacity: 0.35;
+		height: 30% !important;
+	}
+	.c-traffic-mini {
+		min-width: 0;
+	}
+	.traffic-row-list {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		min-width: 0;
+		width: 100%;
+	}
+	.traffic-mini-col {
+		display: flex;
+		flex-direction: column;
+		gap: 0.08rem;
+		font-size: 0.68rem;
+		line-height: 1.15;
+		color: var(--color-text-muted);
+		flex-shrink: 0;
 	}
 </style>

--- a/frontend/src/lib/components/subscriptions/SubscriptionMembersTab.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionMembersTab.svelte
@@ -162,8 +162,14 @@
 
 	async function pickActive(memberTag: string): Promise<void> {
 		// Urltest auto-selects fastest member; manual pick is rejected by backend
-		// with 409. Surface no error, just no-op the click.
-		if (subscription.mode === 'urltest') return;
+		// with 409. Tell the user how to switch to selector mode.
+		if (subscription.mode === 'urltest') {
+			notifications.info(
+				'Включён автовыбор (URLTest). Чтобы переключать сервер вручную, откройте вкладку «Настройки» этой подписки и выберите режим «Вручную».',
+				{ duration: 9000 },
+			);
+			return;
+		}
 		if (memberTag === subscription.activeMember) return;
 		switching = memberTag;
 		lastError = '';

--- a/frontend/src/lib/components/subscriptions/SubscriptionMembersTab.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionMembersTab.svelte
@@ -3,18 +3,22 @@
 	import { goto } from '$app/navigation';
 	import type { Subscription, SubscriptionMember } from '$lib/types';
 	import { api } from '$lib/api/client';
-	import { Button, Modal } from '$lib/components/ui';
-	import { triggerDelayCheck } from '$lib/stores/singbox';
+	import { Button, Modal, Stat, StatStrip } from '$lib/components/ui';
+	import { singboxDelayHistory, singboxTraffic, triggerDelayCheck } from '$lib/stores/singbox';
+	import { subscribeTraffic } from '$lib/stores/traffic';
+	import { formatBytes } from '$lib/utils/format';
 	import { notifications } from '$lib/stores/notifications';
 	import SubscriptionMemberCard from './SubscriptionMemberCard.svelte';
+	import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
 
 	interface Props {
 		subscription: Subscription;
 		onUpdated: () => void;
 		autoDelayCheckNonce?: number;
 		liveActiveMember?: string | null;
+		layout?: SingboxLayoutMode;
 	}
-	let { subscription, onUpdated, autoDelayCheckNonce = 0, liveActiveMember = null }: Props = $props();
+	let { subscription, onUpdated, autoDelayCheckNonce = 0, liveActiveMember = null, layout = 'grid' }: Props = $props();
 
 	let refreshing = $state(false);
 	let switching = $state<string | null>(null);
@@ -84,6 +88,45 @@
 					port: 0,
 			  })),
 	);
+
+	let memberTrafficTick = $state(0);
+	$effect(() => {
+		return subscribeTraffic(() => {
+			memberTrafficTick++;
+		});
+	});
+
+	const membersListStats = $derived.by(() => {
+		void memberTrafficTick;
+		let down = 0;
+		let up = 0;
+		let delaySum = 0;
+		let delayN = 0;
+		let minLatest = Infinity;
+		const trMap = $singboxTraffic;
+		const histMap = $singboxDelayHistory;
+		for (const m of memberList) {
+			const tr = trMap.get(m.tag);
+			if (tr) {
+				down += tr.download ?? 0;
+				up += tr.upload ?? 0;
+			}
+			const h = histMap.get(m.tag) ?? [];
+			const last = h.length > 0 ? h[h.length - 1] : 0;
+			if (typeof last === 'number' && last > 0) {
+				delaySum += last;
+				delayN++;
+				if (last < minLatest) minLatest = last;
+			}
+		}
+		return {
+			count: memberList.length,
+			down,
+			up,
+			avgDelayMs: delayN > 0 ? Math.round(delaySum / delayN) : null,
+			minDelayMs: minLatest === Infinity ? null : Math.round(minLatest),
+		};
+	});
 
 	const modeLabel = $derived(subscription.mode === 'urltest' ? 'URLTest' : 'Selector');
 	const modeHint = $derived(
@@ -220,6 +263,99 @@
 	<div class="empty">Подписка ещё не загружена. Нажмите «Обновить сейчас».</div>
 {:else}
 	<div class="hint">{modeHint}</div>
+	{#if layout === 'list'}
+		<div class="awg-summary-row">
+			<StatStrip>
+				<Stat value={`${membersListStats.count}`} label="Серверов" sub="в подписке" />
+				<Stat
+					value={formatBytes(membersListStats.down + membersListStats.up)}
+					label="Суммарный трафик"
+					sub={`↓ ${formatBytes(membersListStats.down)} · ↑ ${formatBytes(membersListStats.up)}`}
+				/>
+				<Stat
+					value={membersListStats.avgDelayMs !== null ? `${membersListStats.avgDelayMs} ms` : '—'}
+					label="Средний delay"
+					sub="по последним проверкам"
+				/>
+				<Stat
+					value={membersListStats.minDelayMs !== null ? `${membersListStats.minDelayMs} ms` : '—'}
+					label="Мин. delay"
+					sub="лучший из последних по серверам"
+				/>
+			</StatStrip>
+		</div>
+		<div class="awg-list-table member-list-table" class:with-inline-remove={subscription.isInline}>
+			<div
+				class="sbx-member-list-row sbx-member-list-row--head">
+				<span>Delay</span>
+				<span>Сервер</span>
+				<span>Протокол</span>
+				<span>Трафик</span>
+				<span>Ping</span>
+				<span>Тег</span>
+				<span>Статус</span>
+				{#if subscription.isInline}<span class="h-rm" aria-hidden="true"></span>{/if}
+			</div>
+			<div class="member-list-meta-row mono">
+				<span class="meta-lbl">Мин. delay</span>
+				{#if membersListStats.minDelayMs !== null}
+					<span class="meta-val"><strong>{membersListStats.minDelayMs} ms</strong></span>
+					<span class="meta-hint">по последним проверкам среди серверов</span>
+				{:else}
+					<span class="meta-empty">—</span>
+				{/if}
+			</div>
+			{#each memberList as member (member.tag)}
+				<div
+					class="member-list-line"
+					class:active-line={member.tag === effectiveActiveMember}
+					class:switching-line={switching === member.tag}
+					class:is-disabled={switching !== null}
+					role="button"
+					tabindex="0"
+					aria-pressed={member.tag === effectiveActiveMember}
+					onclick={() => {
+						if (switching !== null) return;
+						pickActive(member.tag);
+					}}
+					onkeydown={(e) => {
+						if (switching !== null) return;
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							pickActive(member.tag);
+						}
+					}}
+				>
+					<SubscriptionMemberCard
+						{member}
+						active={member.tag === effectiveActiveMember}
+						switching={switching === member.tag}
+						disabled={switching !== null}
+						onclick={() => pickActive(member.tag)}
+						layout="list"
+					/>
+					{#if subscription.isInline}
+						<button
+							type="button"
+							class="member-remove-list"
+							title="Удалить сервер"
+							aria-label="Удалить сервер {member.label || member.tag}"
+							disabled={removingTag !== null}
+							onclick={(e) => {
+								e.stopPropagation();
+								requestRemove(member);
+							}}
+						>
+							<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{:else}
 	<div class="grid">
 		{#each memberList as member (member.tag)}
 			<div class="member-slot">
@@ -251,6 +387,7 @@
 			</div>
 		{/each}
 	</div>
+	{/if}
 {/if}
 
 <Modal
@@ -509,5 +646,153 @@
 		.grid {
 			grid-template-columns: 1fr;
 		}
+	}
+
+	.member-list-table {
+		border: 1px solid var(--color-border);
+		border-radius: 12px;
+		background: var(--color-bg-secondary);
+		overflow-x: auto;
+		overflow-y: hidden;
+		margin-top: 0.25rem;
+	}
+	.awg-summary-row {
+		margin-bottom: 0.75rem;
+	}
+	.sbx-member-list-row {
+		display: grid;
+		grid-template-columns:
+			minmax(80px, 1fr)
+			minmax(0, 1.35fr)
+			minmax(0, 1fr)
+			minmax(140px, 1.1fr)
+			minmax(56px, 0.9fr)
+			minmax(0, 0.95fr)
+			minmax(88px, 1fr);
+		gap: 0 1rem;
+		align-items: center;
+		padding: 0.65rem 1rem;
+		min-width: 940px;
+		border-bottom: 1px solid var(--color-border);
+	}
+	.member-list-table.with-inline-remove .sbx-member-list-row {
+		grid-template-columns:
+			minmax(80px, 1fr)
+			minmax(0, 1.35fr)
+			minmax(0, 1fr)
+			minmax(140px, 1.1fr)
+			minmax(56px, 0.9fr)
+			minmax(0, 0.95fr)
+			minmax(88px, 1fr)
+			42px;
+		min-width: 980px;
+	}
+	.sbx-member-list-row--head {
+		background: var(--color-bg-tertiary);
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--color-text-muted);
+	}
+	.sbx-member-list-row--head .h-rm {
+		display: block;
+	}
+	.member-list-meta-row {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.25rem 0.4rem;
+		padding: 0.45rem 1rem;
+		border-bottom: 1px solid var(--color-border);
+		background: var(--color-bg-primary);
+		font-size: 0.78rem;
+		color: var(--color-text-muted);
+		min-width: 940px;
+	}
+	.member-list-table.with-inline-remove .member-list-meta-row {
+		min-width: 980px;
+	}
+	.member-list-meta-row .meta-lbl {
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		font-size: 0.65rem;
+		font-weight: 700;
+	}
+	.member-list-meta-row .meta-val {
+		color: var(--color-text-primary);
+	}
+	.member-list-meta-row .meta-val strong {
+		color: #3fb950;
+		font-weight: 600;
+	}
+	.member-list-meta-row .meta-empty {
+		color: var(--color-text-muted);
+	}
+	.member-list-meta-row .meta-hint {
+		font-size: 0.7rem;
+		opacity: 0.85;
+		margin-left: 0.25rem;
+	}
+	.member-list-line {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.15rem 1rem;
+		border-bottom: 1px solid var(--color-border);
+		cursor: pointer;
+		min-width: 940px;
+	}
+	.member-list-table.with-inline-remove .member-list-line {
+		min-width: 980px;
+	}
+	.member-list-line:last-child {
+		border-bottom: none;
+	}
+	.member-list-line.active-line {
+		background: rgba(63, 185, 80, 0.06);
+	}
+	.member-list-line.switching-line {
+		opacity: 0.65;
+		cursor: wait;
+	}
+	.member-list-line.is-disabled {
+		cursor: not-allowed;
+	}
+	.member-list-line :global(.mbr-flatten) {
+		flex: 1;
+		min-width: 0;
+		display: grid;
+		grid-template-columns:
+			minmax(80px, 1fr)
+			minmax(0, 1.35fr)
+			minmax(0, 1fr)
+			minmax(0, 1.1fr)
+			minmax(56px, 0.9fr)
+			minmax(0, 0.95fr)
+			minmax(88px, 1fr);
+		gap: 0 0.75rem;
+		align-items: center;
+	}
+	.member-remove-list {
+		flex: 0 0 38px;
+		width: 32px;
+		height: 32px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: 50%;
+		color: var(--color-text-muted);
+		cursor: pointer;
+	}
+	.member-remove-list:hover {
+		color: var(--color-error, #ef4444);
+		border-color: var(--color-error, #ef4444);
+	}
+	.member-remove-list:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontend/src/lib/components/ui/GridListToggle.svelte
+++ b/frontend/src/lib/components/ui/GridListToggle.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
+
+	interface Props {
+		value: SingboxLayoutMode;
+		/** When false (e.g. basic tier), list mode is unavailable — toggle hidden. */
+		showListOption?: boolean;
+		onchange: (next: SingboxLayoutMode) => void;
+	}
+	let { value, showListOption = true, onchange }: Props = $props();
+</script>
+
+{#if showListOption}
+	<div class="view-mode-switch" role="group" aria-label="Вид списка">
+		<button
+			type="button"
+			class="view-mode-btn"
+			class:active={value === 'grid'}
+			aria-pressed={value === 'grid'}
+			aria-label="Сетка"
+			title="Сетка"
+			onclick={() => onchange('grid')}
+		>
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+				<rect x="4" y="5" width="7" height="6" rx="1.5" />
+				<rect x="13" y="5" width="7" height="6" rx="1.5" />
+				<rect x="4" y="13" width="7" height="6" rx="1.5" />
+				<rect x="13" y="13" width="7" height="6" rx="1.5" />
+			</svg>
+		</button>
+		<button
+			type="button"
+			class="view-mode-btn"
+			class:active={value === 'list'}
+			aria-pressed={value === 'list'}
+			aria-label="Список"
+			title="Список"
+			onclick={() => onchange('list')}
+		>
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+				<path d="M9 7h11" />
+				<path d="M9 12h11" />
+				<path d="M9 17h11" />
+				<circle cx="5" cy="7" r="1.2" fill="currentColor" stroke="none" />
+				<circle cx="5" cy="12" r="1.2" fill="currentColor" stroke="none" />
+				<circle cx="5" cy="17" r="1.2" fill="currentColor" stroke="none" />
+			</svg>
+		</button>
+	</div>
+{/if}
+
+<style>
+	.view-mode-switch {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.1875rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-secondary);
+	}
+
+	.view-mode-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border: none;
+		border-radius: calc(var(--radius-sm) - 2px);
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		transition:
+			background var(--t-fast) ease,
+			color var(--t-fast) ease;
+	}
+
+	.view-mode-btn:hover {
+		background: var(--color-bg-hover);
+		color: var(--color-text-primary);
+	}
+
+	.view-mode-btn.active {
+		background: var(--color-accent-tint);
+		color: var(--color-accent);
+	}
+
+	.view-mode-btn:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+
+	.view-mode-btn svg {
+		width: 1rem;
+		height: 1rem;
+	}
+</style>

--- a/frontend/src/lib/components/ui/SaveStatusIndicator.svelte
+++ b/frontend/src/lib/components/ui/SaveStatusIndicator.svelte
@@ -119,16 +119,8 @@
 		align-items: center;
 		justify-content: flex-start;
 		flex-shrink: 0;
-		width: 8rem;
-        text-align: center;
 		min-height: 1.375rem;
 		box-sizing: border-box;
-	}
-
-	@media (max-width: 640px) {
-		.save-status-slot {
-			width: 4rem;
-		}
 	}
 
 	.save-status-placeholder {

--- a/frontend/src/lib/components/ui/index.ts
+++ b/frontend/src/lib/components/ui/index.ts
@@ -35,3 +35,4 @@ export { default as StatRow } from './StatRow.svelte';
 export type { StatTile, StatTileAccent } from './StatRow.svelte';
 export { default as LatencySparkline } from './LatencySparkline.svelte';
 export { default as BackLink } from './BackLink.svelte';
+export { default as GridListToggle } from './GridListToggle.svelte';

--- a/frontend/src/lib/constants/singboxLayout.ts
+++ b/frontend/src/lib/constants/singboxLayout.ts
@@ -1,0 +1,9 @@
+/** Sing-box surfaces: main tunnels tab, subscriptions tab, subscription detail members. */
+export type SingboxLayoutMode = 'grid' | 'list';
+
+export const SINGBOX_LAYOUT_STORAGE_KEY = 'singbox_layout_mode';
+
+export function parseSingboxLayoutMode(value: string | null): SingboxLayoutMode | null {
+	if (value === 'grid' || value === 'list') return value;
+	return null;
+}

--- a/frontend/src/lib/stores/auth.ts
+++ b/frontend/src/lib/stores/auth.ts
@@ -47,7 +47,7 @@ function createAuthStore() {
 			if (import.meta.env.DEV) {
 				set({
 					authenticated: true,
-					authDisabled: true,
+					authDisabled: false,
 					login: 'dev',
 					loading: false,
 					error: null

--- a/frontend/src/lib/utils/shareEditorHighlight.ts
+++ b/frontend/src/lib/utils/shareEditorHighlight.ts
@@ -1,0 +1,205 @@
+/**
+ * IDE-style HTML underlay for ShareLinksTextarea: share schemes, JSON, YAML (incl. Clash).
+ */
+
+function escapeHtml(text: string): string {
+	return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+const PROTO_CORE =
+	'naive\\+https://|naive\\+http://|hysteria2://|vless://|hy2://|trojan://|ss://';
+
+/** Match scheme at line start / after indent / after whitespace (not inside HTML). */
+const PROTO_IN_ESCAPED = new RegExp(
+	`(?:^|(?<=[\\n\\r])|(?<=[ \\t\\u00a0]))(${PROTO_CORE})`,
+	'gi',
+);
+
+function wrapShareProtocolsInEscaped(escaped: string): string {
+	return escaped.replace(
+		PROTO_IN_ESCAPED,
+		(_m, p1: string) => `<span class="share-link-proto">${p1}</span>`,
+	);
+}
+
+function isShareLinkLine(line: string): boolean {
+	const t = line.trimStart();
+	return new RegExp(`^(?:${PROTO_CORE})`, 'i').test(t);
+}
+
+function highlightShareLinkLine(rawLine: string): string {
+	const esc = escapeHtml(rawLine);
+	return esc.replace(
+		new RegExp(`(^[\\t ]*)(${PROTO_CORE})`, 'i'),
+		(_, indent: string, proto: string) => `${indent}<span class="share-link-proto">${proto}</span>`,
+	);
+}
+
+function firstNonEmptyTrimmedLine(raw: string): string {
+	for (const line of raw.split('\n')) {
+		const t = line.trim();
+		if (t) return t;
+	}
+	return '';
+}
+
+/** First non-empty line starts with `{` or `[` — JSON-style coloring (works for invalid / partial JSON). */
+function looksJsonStructure(raw: string): boolean {
+	const t = firstNonEmptyTrimmedLine(raw);
+	return t.startsWith('{') || t.startsWith('[');
+}
+
+function highlightJson(src: string): string {
+	let i = 0;
+	const n = src.length;
+	let out = '';
+
+	const punct = new Set('{}[],:');
+
+	while (i < n) {
+		const c = src[i];
+		if (c === ' ' || c === '\n' || c === '\r' || c === '\t') {
+			out += escapeHtml(c);
+			i++;
+			continue;
+		}
+		if (c === '"') {
+			out += '<span class="hl-json-str">';
+			out += '"';
+			i++;
+			let closed = false;
+			while (i < n) {
+				const d = src[i];
+				if (d === '\\' && i + 1 < n) {
+					out += escapeHtml(d) + escapeHtml(src[i + 1]);
+					i += 2;
+					continue;
+				}
+				if (d === '"') {
+					out += '"</span>';
+					i++;
+					closed = true;
+					break;
+				}
+				out += escapeHtml(d);
+				i++;
+			}
+			if (!closed) {
+				out += '</span>';
+			}
+			continue;
+		}
+		if (punct.has(c)) {
+			out += `<span class="hl-json-punct">${escapeHtml(c)}</span>`;
+			i++;
+			continue;
+		}
+		if (c === '-' || (c >= '0' && c <= '9')) {
+			let j = i;
+			if (src[j] === '-') j++;
+			while (j < n && /[0-9.eE+-]/.test(src[j] ?? '')) j++;
+			if (j > i) {
+				out += `<span class="hl-json-num">${escapeHtml(src.slice(i, j))}</span>`;
+				i = j;
+				continue;
+			}
+		}
+		const rest = src.slice(i);
+		if (/^null\b/.test(rest)) {
+			out += '<span class="hl-json-lit">null</span>';
+			i += 4;
+			continue;
+		}
+		if (/^true\b/.test(rest)) {
+			out += '<span class="hl-json-lit">true</span>';
+			i += 4;
+			continue;
+		}
+		if (/^false\b/.test(rest)) {
+			out += '<span class="hl-json-lit">false</span>';
+			i += 5;
+			continue;
+		}
+		out += escapeHtml(c);
+		i++;
+	}
+	return out;
+}
+
+/** YAML key:value with mandatory whitespace after ':' — avoids matching `vless://`. */
+const YAML_KV = /^(\s*)([\w.-]+)(\s*:\s*)(.*)$/;
+
+function highlightYamlTail(tail: string): string {
+	const t = tail.trimStart();
+	if (t.startsWith('"') || t.startsWith("'")) {
+		const esc = escapeHtml(tail);
+		return `<span class="hl-yaml-str">${esc}</span>`;
+	}
+	const esc = escapeHtml(tail);
+	return wrapShareProtocolsInEscaped(esc);
+}
+
+function highlightYamlOrPlainLine(line: string): string {
+	const trimmed = line.trimStart();
+	if (trimmed.startsWith('#')) {
+		return `<span class="hl-yaml-comment">${escapeHtml(line)}</span>`;
+	}
+	if (isShareLinkLine(line)) {
+		return highlightShareLinkLine(line);
+	}
+	const kv = YAML_KV.exec(line);
+	if (kv) {
+		const [, indent, key, sep, tail] = kv;
+		return `${escapeHtml(indent)}<span class="hl-yaml-key">${escapeHtml(key)}</span>${escapeHtml(sep)}${highlightYamlTail(tail)}`;
+	}
+	if (/^\s*-\s/.test(line)) {
+		const m = /^(\s*-\s)(.*)$/.exec(line);
+		if (m) {
+			const [, dashPart, rest] = m;
+			return `<span class="hl-yaml-punct">${escapeHtml(dashPart)}</span>${highlightYamlOrPlainLine(rest)}`;
+		}
+	}
+	return wrapShareProtocolsInEscaped(escapeHtml(line));
+}
+
+function looksYamlishDocument(raw: string): boolean {
+	const nonEmpty = raw
+		.split('\n')
+		.map((l) => l.trim())
+		.filter(Boolean);
+	if (nonEmpty.length === 0) return false;
+	if (nonEmpty.every((l) => isShareLinkLine(l))) return false;
+	const yamlish = nonEmpty.some(
+		(l) =>
+			l.startsWith('#') ||
+			l.startsWith('-') ||
+			l.startsWith('---') ||
+			(YAML_KV.test(l) && !isShareLinkLine(l)),
+	);
+	return yamlish;
+}
+
+function highlightMixedYamlAndLinks(raw: string): string {
+	const lines = raw.split('\n');
+	const parts: string[] = [];
+	for (let li = 0; li < lines.length; li++) {
+		parts.push(highlightYamlOrPlainLine(lines[li]!));
+		if (li < lines.length - 1) parts.push('\n');
+	}
+	return parts.join('');
+}
+
+/**
+ * Produce HTML for the underlay: JSON, YAML/Clash, share links, or mixed YAML+links.
+ */
+export function highlightShareEditorContent(raw: string): string {
+	if (!raw) return '';
+	if (looksJsonStructure(raw)) {
+		return highlightJson(raw);
+	}
+	if (looksYamlishDocument(raw)) {
+		return highlightMixedYamlAndLinks(raw);
+	}
+	const esc = escapeHtml(raw);
+	return wrapShareProtocolsInEscaped(esc);
+}

--- a/frontend/src/lib/utils/shareLinkListInput.ts
+++ b/frontend/src/lib/utils/shareLinkListInput.ts
@@ -24,22 +24,3 @@ export function mergePastedShareList(
 	return { next, caret: selectionStart + normalized.length };
 }
 
-/** Share schemes for IDE-style highlighting (longest first inside alternation). */
-const HIGHLIGHT_PROTO =
-	'(naive\\+https://|naive\\+http://|hysteria2://|vless://|hy2://|trojan://|ss://)';
-
-/**
- * Escape HTML, then wrap known share schemes in <span class="share-link-proto">…</span>
- * for use under a transparent textarea. Boundaries: line start, after newline/CR, or after space/tab/NBSP.
- */
-export function escapeAndHighlightShareProtocols(raw: string): string {
-	const esc = raw
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;');
-	const re = new RegExp(
-		`(?:^|(?<=[\\n\\r])|(?<=[ \\t\\u00a0]))(${HIGHLIGHT_PROTO})`,
-		'gi',
-	);
-	return esc.replace(re, '<span class="share-link-proto">$1</span>');
-}

--- a/frontend/src/lib/utils/shareLinkListInput.ts
+++ b/frontend/src/lib/utils/shareLinkListInput.ts
@@ -1,0 +1,25 @@
+/**
+ * Share-link schemes often pasted as a single space-separated line (e.g. from messengers).
+ * Longest prefixes first so `naive+https://` wins over `naive+http://`.
+ * Space/tab only before a scheme — not full `\\s`, so multiline YAML/JSON indents are not touched.
+ */
+const SPACE_BEFORE_SCHEME_PATTERN =
+	'[ \\t]+(naive\\+https://|naive\\+http://|hysteria2://|vless://|hy2://|trojan://|ss://)';
+
+const spaceBeforeShareSchemeRe = new RegExp(SPACE_BEFORE_SCHEME_PATTERN, 'g');
+
+/** Space(s) before a known share scheme → newline so each link is on its own line. */
+export function normalizeSpaceSeparatedShareLinks(text: string): string {
+	return text.replace(spaceBeforeShareSchemeRe, '\n$1');
+}
+
+export function mergePastedShareList(
+	current: string,
+	selectionStart: number,
+	selectionEnd: number,
+	pasted: string,
+): { next: string; caret: number } {
+	const normalized = normalizeSpaceSeparatedShareLinks(pasted);
+	const next = current.slice(0, selectionStart) + normalized + current.slice(selectionEnd);
+	return { next, caret: selectionStart + normalized.length };
+}

--- a/frontend/src/lib/utils/shareLinkListInput.ts
+++ b/frontend/src/lib/utils/shareLinkListInput.ts
@@ -23,3 +23,23 @@ export function mergePastedShareList(
 	const next = current.slice(0, selectionStart) + normalized + current.slice(selectionEnd);
 	return { next, caret: selectionStart + normalized.length };
 }
+
+/** Share schemes for IDE-style highlighting (longest first inside alternation). */
+const HIGHLIGHT_PROTO =
+	'(naive\\+https://|naive\\+http://|hysteria2://|vless://|hy2://|trojan://|ss://)';
+
+/**
+ * Escape HTML, then wrap known share schemes in <span class="share-link-proto">…</span>
+ * for use under a transparent textarea. Boundaries: line start, after newline/CR, or after space/tab/NBSP.
+ */
+export function escapeAndHighlightShareProtocols(raw: string): string {
+	const esc = raw
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+	const re = new RegExp(
+		`(?:^|(?<=[\\n\\r])|(?<=[ \\t\\u00a0]))(${HIGHLIGHT_PROTO})`,
+		'gi',
+	);
+	return esc.replace(re, '<span class="share-link-proto">$1</span>');
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -358,7 +358,7 @@
 		onOpenDonate={() => (donateModalOpen = true)}
 	/>
 
-	{#if !$isAuthenticated}
+	{#if !$isAuthenticated && $page.url.pathname !== '/terms'}
 		<LoginForm />
 	{:else}
 		<main class="main">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -20,18 +20,23 @@
 		StatusDot,
 		Stat,
 		StatStrip,
+		GridListToggle,
 	} from '$lib/components/ui';
-	import { singboxStatus, singboxTunnels } from '$lib/stores/singbox';
+	import { singboxDelayHistory, singboxStatus, singboxTraffic, singboxTunnels } from '$lib/stores/singbox';
 	import { SingboxInstallBanner, SingboxTunnelCard } from '$lib/components/singbox';
 	import { feedTraffic, getTrafficRates, subscribeTraffic } from '$lib/stores/traffic';
 	import { usageLevel } from '$lib/stores/settings';
 	import { isSectionVisible } from '$lib/types/usageLevel';
 	import { subscriptionsStore } from '$lib/stores/subscriptions';
-	import SubscriptionList from '$lib/components/subscriptions/SubscriptionList.svelte';
+	import SubscriptionCard from '$lib/components/subscriptions/SubscriptionCard.svelte';
 	import AddTunnelWizard from '$lib/components/subscriptions/AddTunnelWizard.svelte';
 	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
+	import {
+		SINGBOX_LAYOUT_STORAGE_KEY,
+		type SingboxLayoutMode,
+	} from '$lib/constants/singboxLayout';
 
 	type TunnelTab = 'awg' | 'singbox' | 'subscriptions';
 	type AwgTunnelViewMode = 'cards' | 'compact' | 'list';
@@ -241,6 +246,40 @@
 
 	let singboxTunnelsList = $derived($singboxTunnels.data ?? []);
 
+	const singboxTunnelListStats = $derived.by(() => {
+		void trafficTick;
+		const list = singboxTunnelsList;
+		let running = 0;
+		let down = 0;
+		let up = 0;
+		let delaySum = 0;
+		let delayN = 0;
+		const trMap = $singboxTraffic;
+		const histMap = $singboxDelayHistory;
+		for (const t of list) {
+			if (t.running === true) running++;
+			const tr = trMap.get(t.tag);
+			if (tr) {
+				down += tr.download ?? 0;
+				up += tr.upload ?? 0;
+			}
+			const h = histMap.get(t.tag) ?? [];
+			const last = h.length > 0 ? h[h.length - 1] : 0;
+			if (typeof last === 'number' && last > 0) {
+				delaySum += last;
+				delayN++;
+			}
+		}
+		return {
+			count: list.length,
+			running,
+			stopped: list.length - running,
+			down,
+			up,
+			avgDelayMs: delayN > 0 ? Math.round(delaySum / delayN) : null,
+		};
+	});
+
 	let unsubSubs: (() => void) | undefined;
 	onMount(() => { unsubSubs = subscriptionsStore.subscribe(() => {}); });
 	onDestroy(() => unsubSubs?.());
@@ -344,18 +383,61 @@
 		subscriptionsList.filter((subscription) => !subscriptionActiveIds.has(subscription.id)),
 	);
 
+	const singboxSubscriptionsTrafficStats = $derived.by(() => {
+		void trafficTick;
+		let down = 0;
+		let up = 0;
+		const map = $singboxTraffic;
+		for (const card of subscriptionsActiveCards) {
+			const tr = map.get(card.activeMember.tag);
+			if (tr) {
+				down += tr.download ?? 0;
+				up += tr.upload ?? 0;
+			}
+		}
+		for (const sub of subscriptionsListRows) {
+			const tag =
+				sub.activeMember && sub.memberTags.includes(sub.activeMember)
+					? sub.activeMember
+					: sub.memberTags[0] ?? '';
+			if (!tag) continue;
+			const tr = map.get(tag);
+			if (tr) {
+				down += tr.download ?? 0;
+				up += tr.upload ?? 0;
+			}
+		}
+		return {
+			count: subscriptionsList.length,
+			activeCount: subscriptionsActiveCards.length,
+			inactiveCount: subscriptionsListRows.length,
+			down,
+			up,
+		};
+	});
+
 	// Tabs
 	let activeTab = $state<TunnelTab>('awg');
 	let awgViewMode = $state<AwgTunnelViewMode>('compact');
 	let awgViewModeReady = false;
 	let isAwgMobile = $state(false);
 	let showAwgListViewOption = $derived($usageLevel !== 'basic');
+	let singboxLayoutMode = $state<SingboxLayoutMode>('grid');
+	let singboxLayoutReady = false;
+	let showSingboxListOption = $derived($usageLevel !== 'basic');
+	let singboxEffectiveLayout = $derived<SingboxLayoutMode>(
+		!showSingboxListOption && singboxLayoutMode === 'list' ? 'grid' : singboxLayoutMode,
+	);
 	let awgEffectiveViewMode = $derived<AwgTunnelViewMode>(
 		isAwgMobile || (!showAwgListViewOption && awgViewMode === 'list') ? 'compact' : awgViewMode
 	);
 
 	function isAwgTunnelViewMode(value: string | null): value is AwgTunnelViewMode {
 		return value === 'cards' || value === 'compact' || value === 'list';
+	}
+
+	function isSingboxLayoutMode(value: string | null): value is SingboxLayoutMode {
+		return value === 'grid' || value === 'list';
 	}
 
 	const tunnelTabs = $derived(
@@ -383,6 +465,11 @@
 			awgViewMode = stored;
 		}
 		awgViewModeReady = true;
+		const sb = localStorage.getItem(SINGBOX_LAYOUT_STORAGE_KEY);
+		if (isSingboxLayoutMode(sb)) {
+			singboxLayoutMode = sb;
+		}
+		singboxLayoutReady = true;
 	});
 
 	onMount(() => {
@@ -399,6 +486,11 @@
 	$effect(() => {
 		if (!awgViewModeReady) return;
 		localStorage.setItem(AWG_TUNNEL_VIEW_STORAGE_KEY, awgViewMode);
+	});
+
+	$effect(() => {
+		if (!singboxLayoutReady) return;
+		localStorage.setItem(SINGBOX_LAYOUT_STORAGE_KEY, singboxLayoutMode);
 	});
 
 
@@ -1488,27 +1580,116 @@
 							{subscriptionsList.length === 1 ? 'подписка' : subscriptionsList.length < 5 ? 'подписки' : 'подписок'}
 						</span>
 						<div class="toolbar-actions">
+							{#if subscriptionsList.length > 0}
+								<GridListToggle
+									value={singboxEffectiveLayout}
+									showListOption={showSingboxListOption}
+									onchange={(v) => (singboxLayoutMode = v)}
+								/>
+							{/if}
 							<Button variant="primary" size="md" onclick={() => openWizard('url')}>+ Добавить</Button>
 						</div>
 					</div>
-					{#if subscriptionsActiveCards.length > 0}
-						<div class="subscription-active-grid">
-							{#each subscriptionsActiveCards as card, i (card.subscription.id)}
-								<SubscriptionActiveCard
-									subscription={card.subscription}
-									activeMember={card.activeMember}
-									autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-									autoDelayCheckDelayMs={i * 180}
-								/>
-							{/each}
+					{#if subscriptionsList.length === 0}
+						<div class="subscription-empty">
+							<div class="subscription-empty-title">Нет подписок</div>
+							<p class="subscription-empty-desc">
+								Добавьте подписку — мастер скачает список серверов и создаст selector-туннель.
+							</p>
+							<Button variant="primary" size="md" onclick={() => openWizard('url')}>+ Добавить подписку</Button>
 						</div>
-					{/if}
-					{#if subscriptionsListRows.length > 0}
-						<SubscriptionList
-							subscriptions={subscriptionsListRows}
-							onAdd={() => openWizard('url')}
-							ondelete={requestSubscriptionDelete}
-						/>
+					{:else if singboxEffectiveLayout === 'list'}
+						<div class="awg-summary-row">
+							<StatStrip>
+								<Stat
+									value={`${singboxSubscriptionsTrafficStats.count}`}
+									label="Подписок"
+									sub={`в работе ${singboxSubscriptionsTrafficStats.activeCount} · не активные ${singboxSubscriptionsTrafficStats.inactiveCount}`}
+								/>
+								<Stat
+									value={formatBytes(
+										singboxSubscriptionsTrafficStats.down + singboxSubscriptionsTrafficStats.up,
+									)}
+									label="Суммарный трафик"
+									sub={`↓ ${formatBytes(singboxSubscriptionsTrafficStats.down)} · ↑ ${formatBytes(singboxSubscriptionsTrafficStats.up)}`}
+								/>
+							</StatStrip>
+						</div>
+						{#if subscriptionsActiveCards.length > 0}
+							<h2 class="section-title">В работе</h2>
+							<div class="awg-list-table singbox-sub-list-table singbox-sub-list-table--active">
+								<div class="sbx-sub-list-row sbx-sub-list-row--head">
+									<span>Delay</span>
+									<span>Подписка</span>
+									<span>Режим</span>
+									<span>Активный сервер</span>
+									<span>Серверов</span>
+									<span>Обновлено</span>
+									<span>Трафик</span>
+									<span>Ping</span>
+									<span class="sbx-sub-list-head-actions">Действия</span>
+								</div>
+								{#each subscriptionsActiveCards as card, i (card.subscription.id)}
+									<SubscriptionActiveCard
+										subscription={card.subscription}
+										activeMember={card.activeMember}
+										autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+										autoDelayCheckDelayMs={i * 180}
+										layout="list"
+									/>
+								{/each}
+							</div>
+						{/if}
+						{#if subscriptionsListRows.length > 0}
+							<h2 class="section-title">Не активные</h2>
+							<div class="awg-list-table singbox-sub-list-table singbox-sub-list-table--inactive">
+								<div class="sbx-sub-list-row sbx-sub-list-row--head sbx-sub-inactive-head">
+									<span>Статус</span>
+									<span>Delay</span>
+									<span>Подписка</span>
+									<span>Серверов</span>
+									<span>Активен</span>
+									<span>Трафик</span>
+									<span>Ping</span>
+									<span>Обновлено</span>
+									<span class="sbx-sub-list-head-actions"></span>
+								</div>
+								{#each subscriptionsListRows as sub (sub.id)}
+									<SubscriptionCard
+										subscription={sub}
+										layout="list"
+										ondelete={requestSubscriptionDelete}
+									/>
+								{/each}
+							</div>
+						{/if}
+					{:else}
+						{#if subscriptionsActiveCards.length > 0}
+							<h2 class="section-title">В работе</h2>
+							<div class="subscription-active-grid">
+								{#each subscriptionsActiveCards as card, i (card.subscription.id)}
+									<SubscriptionActiveCard
+										subscription={card.subscription}
+										activeMember={card.activeMember}
+										autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+										autoDelayCheckDelayMs={i * 180}
+										layout="grid"
+									/>
+								{/each}
+							</div>
+						{/if}
+						{#if subscriptionsListRows.length > 0}
+							<h2 class="section-title">Не активные</h2>
+							<div class="subscription-active-grid">
+								{#each subscriptionsListRows as sub (sub.id)}
+									<SubscriptionCard
+										subscription={sub}
+										layout="grid"
+										ondelete={requestSubscriptionDelete}
+									/>
+								{/each}
+							</div>
+						{/if}
 					{/if}
 				{/if}
 			{/if}
@@ -1521,6 +1702,13 @@
 						{singboxTunnelsList.length === 1 ? 'туннель' : singboxTunnelsList.length < 5 ? 'туннеля' : 'туннелей'}
 					</span>
 					<div class="toolbar-actions">
+						{#if singboxTunnelsList.length > 0}
+							<GridListToggle
+								value={singboxEffectiveLayout}
+								showListOption={showSingboxListOption}
+								onchange={(v) => (singboxLayoutMode = v)}
+							/>
+						{/if}
 						<Button variant="primary" size="md" onclick={() => openWizard('choose')}>+ Добавить</Button>
 					</div>
 				</div>
@@ -1582,15 +1770,60 @@
 					</div>
 				</div>
 			{:else if singboxTunnelsList.length > 0}
-				<div class="tunnel-grid">
-					{#each singboxTunnelsList as tunnel, i (tunnel.tag)}
-						<SingboxTunnelCard
-							{tunnel}
-							autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-							autoDelayCheckDelayMs={i * 180}
-						/>
-					{/each}
-				</div>
+				{#if singboxEffectiveLayout === 'list'}
+					<div class="awg-summary-row">
+						<StatStrip>
+							<Stat
+								value={`${singboxTunnelListStats.running}/${singboxTunnelListStats.count}`}
+								label="Процессы"
+								sub={`${singboxTunnelListStats.running} running · ${singboxTunnelListStats.stopped} stopped`}
+							/>
+							<Stat
+								value={formatBytes(singboxTunnelListStats.down + singboxTunnelListStats.up)}
+								label="Суммарный трафик"
+								sub={`↓ ${formatBytes(singboxTunnelListStats.down)} · ↑ ${formatBytes(singboxTunnelListStats.up)}`}
+							/>
+							<Stat
+								value={singboxTunnelListStats.avgDelayMs !== null
+									? `${singboxTunnelListStats.avgDelayMs} ms`
+									: '—'}
+								label="Средний delay"
+								sub="по последним проверкам"
+							/>
+						</StatStrip>
+					</div>
+					<div class="awg-list-table singbox-tunnel-list-table">
+						<div class="sbx-tunnel-list-row sbx-tunnel-list-row--head">
+							<span>Delay</span>
+							<span>Туннель</span>
+							<span>Протокол</span>
+							<span>Сервер</span>
+							<span>Процесс</span>
+							<span>Трафик</span>
+							<span>Ping</span>
+							<span class="sbx-tunnel-list-head-actions">Действия</span>
+						</div>
+						{#each singboxTunnelsList as tunnel, i (tunnel.tag)}
+							<SingboxTunnelCard
+								{tunnel}
+								layout="list"
+								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+								autoDelayCheckDelayMs={i * 180}
+							/>
+						{/each}
+					</div>
+				{:else}
+					<div class="tunnel-grid">
+						{#each singboxTunnelsList as tunnel, i (tunnel.tag)}
+							<SingboxTunnelCard
+								{tunnel}
+								layout="grid"
+								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+								autoDelayCheckDelayMs={i * 180}
+							/>
+						{/each}
+					</div>
+				{/if}
 		{/if}
 	{/if}
 	{/if}
@@ -2535,6 +2768,111 @@
 		grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 		gap: 1rem;
 		margin-bottom: 1rem;
+	}
+
+	.subscription-empty {
+		padding: 3rem 1.5rem;
+		text-align: center;
+		border: 1px dashed var(--color-border);
+		border-radius: 6px;
+		margin-top: 0.5rem;
+	}
+	.subscription-empty-title {
+		color: var(--color-text-primary);
+		font-size: 1.1rem;
+		font-weight: 600;
+		margin-bottom: 0.4rem;
+	}
+	.subscription-empty-desc {
+		color: var(--color-text-muted);
+		font-size: 0.88rem;
+		margin-bottom: 1.2rem;
+	}
+
+	.singbox-tunnel-list-table :global(.sbx-tunnel-list-row) {
+		display: grid;
+		grid-template-columns:
+			minmax(88px, 1fr)
+			minmax(0, 1.2fr)
+			minmax(0, 1fr)
+			minmax(0, 1.05fr)
+			minmax(76px, 0.95fr)
+			minmax(150px, 1.1fr)
+			minmax(72px, 0.95fr)
+			minmax(150px, 1fr);
+		gap: 0.75rem 1rem;
+		align-items: center;
+		padding: 0.75rem 1rem;
+		border-bottom: 1px solid var(--color-border);
+		min-width: 960px;
+	}
+	.singbox-tunnel-list-table :global(.sbx-tunnel-list-row:last-child) {
+		border-bottom: none;
+	}
+	.singbox-tunnel-list-table .sbx-tunnel-list-row--head {
+		background: var(--color-bg-tertiary);
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--color-text-muted);
+		padding-top: 0.65rem;
+		padding-bottom: 0.65rem;
+	}
+	.sbx-tunnel-list-head-actions {
+		text-align: right;
+	}
+
+	.singbox-sub-list-table {
+		margin-bottom: 1.25rem;
+	}
+	.singbox-sub-list-table :global(.sbx-sub-active-row) {
+		min-width: 1040px;
+	}
+	.singbox-sub-list-table--inactive :global(.sbx-sub-inactive-row) {
+		min-width: 960px;
+	}
+	.singbox-sub-list-table .sbx-sub-list-row--head {
+		display: grid;
+		gap: 0 1rem;
+		align-items: center;
+		padding: 0.65rem 1rem;
+		background: var(--color-bg-tertiary);
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--color-text-muted);
+		border-bottom: 1px solid var(--color-border);
+	}
+	.singbox-sub-list-table--active .sbx-sub-list-row--head {
+		grid-template-columns:
+			minmax(92px, 1fr)
+			minmax(132px, 1.1fr)
+			minmax(72px, 0.9fr)
+			minmax(112px, 1fr)
+			minmax(52px, 0.75fr)
+			minmax(88px, 0.95fr)
+			minmax(148px, 1.1fr)
+			minmax(72px, 0.88fr)
+			minmax(150px, 1fr);
+		min-width: 1040px;
+	}
+	.singbox-sub-list-table--inactive .sbx-sub-inactive-head {
+		grid-template-columns:
+			minmax(64px, 0.9fr)
+			minmax(84px, 1fr)
+			minmax(140px, 1.25fr)
+			minmax(56px, 0.85fr)
+			minmax(88px, 1fr)
+			minmax(150px, 1.15fr)
+			minmax(56px, 0.85fr)
+			minmax(88px, 1fr)
+			minmax(44px, 0.75fr);
+		min-width: 960px;
+	}
+	.sbx-sub-list-head-actions {
+		text-align: right;
 	}
 
 	@media (max-width: 700px) {

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -33,7 +33,7 @@
 		try {
 			const fresh = await api.singboxUpdateTunnel(tag, outbound);
 			singboxTunnels.applyMutationResponse(fresh);
-			goto('/');
+			goto('/?tab=singbox');
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
 		} finally {
@@ -69,7 +69,7 @@
 <PageContainer>
 	<div class="sticky-header">
 		<div class="header-left">
-			<Button variant="ghost" size="sm" onclick={() => goto('/')} iconBefore={backIcon}>
+			<Button variant="ghost" size="sm" onclick={() => goto('/?tab=singbox')} iconBefore={backIcon}>
 				Назад
 			</Button>
 			<h1 class="page-title">{tag}</h1>
@@ -312,7 +312,7 @@
 			{/if}
 
 			<div class="form-actions">
-				<Button variant="secondary" size="sm" onclick={() => goto('/')}>Отмена</Button>
+				<Button variant="secondary" size="sm" onclick={() => goto('/?tab=singbox')}>Отмена</Button>
 				<Button variant="primary" size="sm" type="submit" loading={saving}>
 					Сохранить
 				</Button>

--- a/frontend/src/routes/singbox/new/+page.svelte
+++ b/frontend/src/routes/singbox/new/+page.svelte
@@ -20,7 +20,7 @@
 <PageContainer>
 	<div class="sticky-header">
 		<div class="header-left">
-			<Button variant="ghost" size="sm" onclick={() => goto('/')} iconBefore={backIcon}>
+			<Button variant="ghost" size="sm" onclick={() => goto('/?tab=singbox')} iconBefore={backIcon}>
 				Назад
 			</Button>
 			<h1 class="page-title">Новый Sing-box туннель</h1>

--- a/frontend/src/routes/subscriptions/[id]/+page.svelte
+++ b/frontend/src/routes/subscriptions/[id]/+page.svelte
@@ -4,9 +4,14 @@
 	import { api } from '$lib/api/client';
 	import type { Subscription } from '$lib/types';
 	import { PageContainer, PageHeader, LoadingSpinner } from '$lib/components/layout';
-	import { Tabs } from '$lib/components/ui';
+	import { Tabs, GridListToggle } from '$lib/components/ui';
 	import SubscriptionMembersTab from '$lib/components/subscriptions/SubscriptionMembersTab.svelte';
 	import SubscriptionSettingsTab from '$lib/components/subscriptions/SubscriptionSettingsTab.svelte';
+	import { usageLevel } from '$lib/stores/settings';
+	import {
+		SINGBOX_LAYOUT_STORAGE_KEY,
+		type SingboxLayoutMode,
+	} from '$lib/constants/singboxLayout';
 
 	// Poll Clash for the live "now" pointer this often when on members tab in urltest
 	// mode. 5s balances responsiveness with Clash API load.
@@ -30,6 +35,17 @@
 	let currentSubscriptionSurface = '';
 	let subscriptionSurfaceEntryNonce = $state(0);
 	let lastAutoDelayCheckKey = '';
+
+	let singboxLayoutMode = $state<SingboxLayoutMode>('grid');
+	let singboxLayoutReady = false;
+	const showSingboxListOption = $derived($usageLevel !== 'basic');
+	const singboxEffectiveLayout = $derived<SingboxLayoutMode>(
+		!showSingboxListOption && singboxLayoutMode === 'list' ? 'grid' : singboxLayoutMode,
+	);
+
+	function isSingboxLayoutMode(value: string | null): value is SingboxLayoutMode {
+		return value === 'grid' || value === 'list';
+	}
 
 	let evtSrc: EventSource | null = null;
 
@@ -95,7 +111,12 @@
 		};
 	}
 
-	onMount(loadStream);
+	onMount(() => {
+		const sb = localStorage.getItem(SINGBOX_LAYOUT_STORAGE_KEY);
+		if (isSingboxLayoutMode(sb)) singboxLayoutMode = sb;
+		singboxLayoutReady = true;
+		loadStream();
+	});
 	onDestroy(() => {
 		evtSrc?.close();
 		evtSrc = null;
@@ -152,6 +173,11 @@
 		lastAutoDelayCheckKey = key;
 		membersAutoDelayCheckNonce += 1;
 	});
+
+	$effect(() => {
+		if (!singboxLayoutReady) return;
+		localStorage.setItem(SINGBOX_LAYOUT_STORAGE_KEY, singboxLayoutMode);
+	});
 </script>
 
 <svelte:head>
@@ -191,11 +217,21 @@
 		{/if}
 		<section class="content">
 			{#if active === 'members'}
+				{#if subscription.memberTags.length > 0}
+					<div class="members-toolbar">
+						<GridListToggle
+							value={singboxEffectiveLayout}
+							showListOption={showSingboxListOption}
+							onchange={(v) => (singboxLayoutMode = v)}
+						/>
+					</div>
+				{/if}
 				<SubscriptionMembersTab
 					{subscription}
 					{liveActiveMember}
 					onUpdated={loadStream}
 					autoDelayCheckNonce={membersAutoDelayCheckNonce}
+					layout={singboxEffectiveLayout}
 				/>
 			{:else}
 				<SubscriptionSettingsTab {subscription} onUpdated={loadStream} />
@@ -207,6 +243,11 @@
 <style>
 	.err { color: #f85149; margin-top: 1rem; }
 	.content { margin-top: 1rem; }
+	.members-toolbar {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 0.75rem;
+	}
 	.loading-progress {
 		margin: 1rem 0;
 		display: flex;

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -1,0 +1,246 @@
+<svelte:head>
+	<title>Пользовательское соглашение - AWG Manager</title>
+</svelte:head>
+
+<div class="terms-page">
+	<div class="terms-card">
+		<h1>Пользовательское соглашение</h1>
+		<p class="intro">
+			<strong>AWG Manager</strong> — независимый open-source инструмент для управления AmneziaWG туннелями
+			на роутерах Keenetic. Используя это ПО, вы принимаете условия ниже.
+		</p>
+
+		<section>
+			<h2>1. Независимость</h2>
+			<p>
+				AWG Manager является независимым программным обеспечением и <strong>не аффилирован</strong> с компанией
+				Keenetic, её партнёрами или лицензиарами. Все права на торговую марку «Keenetic», программное
+				обеспечение и устройства Keenetic принадлежат их законным правообладателям.
+			</p>
+			<p>
+				AWG Manager является независимым open-source проектом и <strong>не аффилирован</strong> с
+				Amnezia.org, не является официальным продуктом или разработкой команды Amnezia.
+			</p>
+		</section>
+
+		<section>
+			<h2>2. Гарантии и ответственность</h2>
+			<p>
+				Программное обеспечение предоставляется <strong>«как есть»</strong> (as is), без каких-либо явных
+				или подразумеваемых гарантий. Разработчики не несут ответственности за:
+			</p>
+			<ul>
+				<li>повреждение устройства или потерю данных;</li>
+				<li>потерю гарантии на оборудование;</li>
+				<li>перебои в работе сети или деградацию сервисов;</li>
+				<li>любые прямые или косвенные убытки, возникшие вследствие использования ПО.</li>
+			</ul>
+			<p>Вы используете программное обеспечение на собственный страх и риск.</p>
+		</section>
+
+		<section>
+			<h2>3. Условия использования</h2>
+			<p>Используя AWG Manager, вы подтверждаете, что:</p>
+			<ul>
+				<li>являетесь законным владельцем или администратором устройства, на котором установлено ПО;</li>
+				<li>принимаете полную ответственность за конфигурацию и эксплуатацию;</li>
+				<li>соблюдаете применимое законодательство вашей страны.</li>
+			</ul>
+		</section>
+
+		<section>
+			<h2>4. Назначение</h2>
+			<p>
+				AWG Manager разработан и используется исключительно в образовательных и исследовательских целях —
+				для изучения сетевых технологий и протокола WireGuard.
+			</p>
+			<p>
+				Данное программное обеспечение <strong>не является</strong> средством обхода блокировок, не
+				предназначено для таких целей и <strong>не призывает</strong> к нарушению законодательства
+				Российской Федерации или любой другой страны. Разработчики не пропагандируют и не рекламируют
+				использование VPN или иных средств обхода ограничений доступа к информации.
+			</p>
+			<p>
+				Пользователь самостоятельно несёт ответственность за соблюдение применимого законодательства
+				при использовании данного ПО.
+			</p>
+		</section>
+
+		<section>
+			<h2>5. Техническая поддержка</h2>
+			<p class="no-support">Техническая поддержка не осуществляется.</p>
+			<p>Для решения всех проблем главная команда:</p>
+			<pre><code>opkg remove awg-manager</code></pre>
+			<p>
+				Для получения сочувствия <span class="muted">(also known as посильная помощь)</span> необходимо
+				предоставить:
+			</p>
+			<ol>
+				<li>Логи уровня debug</li>
+				<li>Подробное описание проблемы</li>
+				<li>Версию ОС Keenetic и модель роутера</li>
+				<li>Скриншот диагностики</li>
+			</ol>
+
+			<div class="faq">
+				<div class="faq-item">
+					<p class="faq-q">«Почему туннель не коннектится?»</p>
+					<p class="faq-a">Решение гарантировано доступно на <a href="https://aviasales.ru" target="_blank" rel="noopener noreferrer">aviasales.ru</a>.</p>
+				</div>
+				<div class="faq-item">
+					<p class="faq-q">«Вчера всё работало, а сегодня нет»</p>
+					<p class="faq-a">
+						Не касаясь политики: нужны технические подробности. Лечить болезнь печени
+						по симптому «соседская собака ушла и не вернулась» не представляется возможным.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<footer class="terms-footer">
+			<a href="/" class="back-link">← Вернуться</a>
+		</footer>
+	</div>
+</div>
+
+<style>
+	.terms-page {
+		min-height: 100vh;
+		display: flex;
+		justify-content: center;
+		padding: 2rem 1rem;
+		background: var(--color-bg-primary);
+	}
+
+	.terms-card {
+		width: 100%;
+		max-width: 680px;
+		padding: 2rem 2.5rem;
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius);
+		align-self: flex-start;
+	}
+
+	h1 {
+		font-size: 1.5rem;
+		font-weight: 700;
+		margin: 0 0 0.75rem;
+	}
+
+	.intro {
+		color: var(--color-text-secondary);
+		font-size: 0.9375rem;
+		margin-bottom: 2rem;
+		line-height: 1.6;
+	}
+
+	section {
+		margin-bottom: 1.75rem;
+	}
+
+	h2 {
+		font-size: 1rem;
+		font-weight: 600;
+		margin: 0 0 0.625rem;
+		color: var(--color-text);
+	}
+
+	p {
+		font-size: 0.9rem;
+		color: var(--color-text-secondary);
+		line-height: 1.65;
+		margin: 0 0 0.625rem;
+	}
+
+	ul, ol {
+		margin: 0 0 0.625rem;
+		padding-left: 1.5rem;
+	}
+
+	li {
+		font-size: 0.9rem;
+		color: var(--color-text-secondary);
+		line-height: 1.65;
+		margin-bottom: 0.25rem;
+	}
+
+	pre {
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		padding: 0.625rem 0.875rem;
+		margin: 0.5rem 0 0.75rem;
+		overflow-x: auto;
+	}
+
+	code {
+		font-family: var(--font-mono, ui-monospace, monospace);
+		font-size: 0.85rem;
+		color: var(--color-text);
+	}
+
+	.no-support {
+		font-weight: 600;
+		color: var(--color-text) !important;
+	}
+
+	.muted {
+		color: var(--color-text-muted);
+		font-size: 0.85em;
+	}
+
+	.faq {
+		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.875rem;
+	}
+
+	.faq-item {
+		border-left: 2px solid var(--color-border);
+		padding-left: 0.875rem;
+	}
+
+	.faq-q {
+		font-style: italic;
+		font-weight: 500;
+		color: var(--color-text) !important;
+		margin-bottom: 0.25rem !important;
+	}
+
+	.faq-a {
+		margin: 0 !important;
+	}
+
+	.faq-a a {
+		color: var(--color-accent);
+		text-decoration: none;
+	}
+
+	.faq-a a:hover {
+		text-decoration: underline;
+	}
+
+	.terms-footer {
+		margin-top: 2rem;
+		padding-top: 1.25rem;
+		border-top: 1px solid var(--color-border);
+	}
+
+	.back-link {
+		font-size: 0.875rem;
+		color: var(--color-accent);
+		text-decoration: none;
+	}
+
+	.back-link:hover {
+		text-decoration: underline;
+	}
+
+	@media (max-width: 640px) {
+		.terms-card {
+			padding: 1.5rem 1.25rem;
+		}
+	}
+</style>

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1745,6 +1745,67 @@ definitions:
           type: string
         type: array
     type: object
+  api.RouterDetails:
+    properties:
+      architecture:
+        type: string
+      bootSlot:
+        type: string
+      cpuModel:
+        type: string
+      cpuTempC:
+        type: integer
+      featureComponents:
+        items:
+          type: string
+        type: array
+      firmwareBuildDate:
+        type: string
+      firmwareRelease:
+        type: string
+      firmwareSandbox:
+        type: string
+      firmwareTitle:
+        type: string
+      hardwareId:
+        type: string
+      loadAverage:
+        type: string
+      memoryTotalMB:
+        type: integer
+      memoryUsedMB:
+        type: integer
+      memoryUsedPercent:
+        type: integer
+      meshMembers:
+        items:
+          type: string
+        type: array
+      model:
+        type: string
+      modelDisplay:
+        type: string
+      opkgStorage:
+        type: string
+      portedBuild:
+        type: boolean
+      region:
+        type: string
+      storageComponents:
+        items:
+          type: string
+        type: array
+      uptimeHuman:
+        type: string
+      vpnComponents:
+        items:
+          type: string
+        type: array
+      wifi5TempC:
+        type: integer
+      wifi24TempC:
+        type: integer
+    type: object
   api.RouterInterfaceDTO:
     properties:
       label:
@@ -3161,6 +3222,8 @@ definitions:
       kernelModuleVersion:
         example: ""
         type: string
+      routerDetails:
+        $ref: '#/definitions/api.RouterDetails'
       routerIP:
         example: 192.168.1.1
         type: string

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -1141,6 +1141,47 @@ func (o *Operator) GetTunnel(ctx context.Context, tag string) (json.RawMessage, 
 	return cfg.GetOutbound(tag)
 }
 
+// tunnelTagsInUse returns outbound tags already present in cfg.
+func tunnelTagsInUse(cfg *Config) map[string]bool {
+	used := make(map[string]bool)
+	for _, t := range cfg.Tunnels() {
+		used[t.Tag] = true
+	}
+	return used
+}
+
+// allocUniqueTunnelTag returns base if unused; otherwise base-2, base-3, …
+// (Share links often reuse the same URI fragment for different nodes — sing-box
+// tags must stay unique.)
+func allocUniqueTunnelTag(used map[string]bool, base string) string {
+	if base == "" {
+		base = "tunnel"
+	}
+	candidate := base
+	if !used[candidate] {
+		return candidate
+	}
+	for n := 2; ; n++ {
+		candidate = fmt.Sprintf("%s-%d", base, n)
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}
+
+func outboundJSONWithTag(raw json.RawMessage, tag string) (json.RawMessage, error) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("outbound json: %w", err)
+	}
+	m["tag"] = tag
+	out, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(out), nil
+}
+
 // AddTunnels parses one or more links and atomically adds them.
 // Returns successfully-added tunnels and parse errors.
 func (o *Operator) AddTunnels(ctx context.Context, linksText string) ([]TunnelInfo, []BatchError, error) {
@@ -1157,6 +1198,7 @@ func (o *Operator) AddTunnels(ctx context.Context, linksText string) ([]TunnelIn
 	if err != nil {
 		return nil, parseErrs, err
 	}
+	tagOccupied := tunnelTagsInUse(cfg)
 	// reserved tracks ProxyN indices we've handed out in this batch so
 	// NextFreeIndex doesn't reuse the same slot twice before the batch
 	// is committed to NDMS.
@@ -1169,12 +1211,19 @@ func (o *Operator) AddTunnels(ctx context.Context, linksText string) ([]TunnelIn
 			continue
 		}
 		listenPort := firstPort + freeIdx
-		if err := cfg.AddTunnelWithListenPort(p.Tag, p.Protocol, p.Server, int(p.Port), listenPort, p.Outbound); err != nil {
+		tag := allocUniqueTunnelTag(tagOccupied, p.Tag)
+		outbound, jerr := outboundJSONWithTag(p.Outbound, tag)
+		if jerr != nil {
+			parseErrs = append(parseErrs, BatchError{Input: p.Tag, Err: jerr})
+			continue
+		}
+		if err := cfg.AddTunnelWithListenPort(tag, p.Protocol, p.Server, int(p.Port), listenPort, outbound); err != nil {
 			parseErrs = append(parseErrs, BatchError{Input: p.Tag, Err: err})
 			continue
 		}
+		tagOccupied[tag] = true
 		reserved[freeIdx] = true
-		addedTags = append(addedTags, p.Tag)
+		addedTags = append(addedTags, tag)
 	}
 	if len(addedTags) == 0 {
 		return nil, parseErrs, nil

--- a/internal/singbox/operator_tagalloc_test.go
+++ b/internal/singbox/operator_tagalloc_test.go
@@ -1,0 +1,41 @@
+package singbox
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAllocUniqueTunnelTag(t *testing.T) {
+	used := map[string]bool{"a": true, "a-2": true}
+	if got := allocUniqueTunnelTag(used, "a"); got != "a-3" {
+		t.Fatalf("got %q want a-3", got)
+	}
+	used["b"] = true
+	if got := allocUniqueTunnelTag(used, "b"); got != "b-2" {
+		t.Fatalf("got %q want b-2", got)
+	}
+	if got := allocUniqueTunnelTag(used, "fresh"); got != "fresh" {
+		t.Fatalf("got %q want fresh", got)
+	}
+	if got := allocUniqueTunnelTag(map[string]bool{}, ""); got != "tunnel" {
+		t.Fatalf("empty base: got %q", got)
+	}
+}
+
+func TestOutboundJSONWithTag(t *testing.T) {
+	raw := json.RawMessage(`{"type":"vless","tag":"old","server":"x"}`)
+	out, err := outboundJSONWithTag(raw, "new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["tag"] != "new" {
+		t.Fatalf("tag=%v", m["tag"])
+	}
+	if m["type"] != "vless" {
+		t.Fatalf("type=%v", m["type"])
+	}
+}

--- a/internal/singbox/subscription/normalize.go
+++ b/internal/singbox/subscription/normalize.go
@@ -7,11 +7,62 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/singbox/vlink"
 )
 
-// schemeLineRegex matches share-link URLs we're interested in extracting from
-// HTML / mixed text. Order: well-known schemes only.
-var schemeLineRegex = regexp.MustCompile(
-	`(vless|trojan|ss|hysteria2|hy2|naive\+\w+|vpn)://[^\s"<>']+`,
-)
+// shareSchemeCore matches supported share-link scheme names (no ://).
+const shareSchemeCore = `(?:vless|trojan|ss|hysteria2|hy2|naive\+\w+|vpn)`
+
+// shareURLStartPlain finds share URLs in plain text: after line start or ASCII whitespace.
+// Used so fragments may contain spaces (e.g. "#📆 Осталось: 28 дней") and space-separated
+// links on one line still split correctly (old [^\s]+ truncated at the first space anywhere).
+var shareURLStartPlain = regexp.MustCompile(`(?i)(?:^|\s+)(` + shareSchemeCore + `://)`)
+
+// shareURLStartHTML is like plain but allows common HTML/JSON delimiters before the scheme.
+var shareURLStartHTML = regexp.MustCompile(`(?i)(?:^|[\s"'<>=]+)(` + shareSchemeCore + `://)`)
+
+// trimShareURLSuffix removes trailing delimiters often glued after a URL in HTML/JSON
+// (quotes, commas, angle brackets, whitespace).
+func trimShareURLSuffix(u string) string {
+	u = strings.TrimSpace(u)
+	// React/JSON payloads: URL value often followed by "} after the fragment.
+	if j := strings.LastIndex(u, "\"}"); j > 0 && strings.Contains(u, "://") {
+		u = u[:j]
+	}
+	for u != "" {
+		switch u[len(u)-1] {
+		case '"', '\'', ',', '>', '}', ']', ' ', '\t', '\n', '\r':
+			u = u[:len(u)-1]
+		default:
+			return u
+		}
+	}
+	return u
+}
+
+// splitShareURLs slices s into individual share-link strings using startRe match positions.
+func splitShareURLs(s string, startRe *regexp.Regexp) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	loc := startRe.FindAllStringSubmatchIndex(s, -1)
+	if len(loc) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(loc))
+	for k := range loc {
+		start := loc[k][2]
+		var end int
+		if k+1 < len(loc) {
+			end = loc[k+1][2]
+		} else {
+			end = len(s)
+		}
+		seg := strings.TrimSpace(s[start:end])
+		if seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
 
 // NormalizeBody decodes a subscription body via the standard cascade:
 //  1. Try base64 (urlsafe-aware) once. If the decoded text looks like
@@ -44,7 +95,13 @@ func splitLines(b []byte) []string {
 		if p == "" || strings.HasPrefix(p, "#") {
 			continue
 		}
-		out = append(out, p)
+		links := splitShareURLs(p, shareURLStartPlain)
+		if len(links) == 0 {
+			continue
+		}
+		for _, link := range links {
+			out = append(out, trimShareURLSuffix(link))
+		}
 	}
 	return out
 }
@@ -65,21 +122,24 @@ func isHTML(body []byte, contentType string) bool {
 // motivating case is GitHub's blob view: it serialises the file body
 // as a JSON string inside a script tag, so a real `&` separator in a
 // share-link surfaces in the HTML as the six-character literal `&`.
-// The schemeLineRegex character class accepts that sequence as part of
-// the URL, and downstream `url.Parse` then treats `\` and `u0026` as
-// part of a single query parameter value — yielding the classic
-// "everything after the first `=` is one giant `flow=` value" failure.
+// The legacy schemeLineRegex used [^\s]+ which truncated URLs at the first space
+// (common in URI fragments: "#📆 Осталось: 28 дней"). We now slice from each scheme://
+// to the next scheme boundary.
 //
 // Other JSON escapes worth unwrapping (`<` / `>` / `'` /
 // `\/` / `\"` / `\\`) appear in the same envelope for similar reasons.
 // The order of replacements is significant — backslash must be last so
 // we don't mangle the front of the other escapes mid-pass.
 func extractFromHTML(body []byte) []string {
-	matches := schemeLineRegex.FindAll(body, -1)
-	out := make([]string, 0, len(matches))
+	raw := string(body)
+	segments := splitShareURLs(raw, shareURLStartHTML)
+	if len(segments) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(segments))
 	seen := make(map[string]bool)
-	for _, m := range matches {
-		s := jsonUnescapeURL(string(m))
+	for _, seg := range segments {
+		s := trimShareURLSuffix(jsonUnescapeURL(seg))
 		if seen[s] {
 			continue
 		}

--- a/internal/singbox/subscription/normalize_test.go
+++ b/internal/singbox/subscription/normalize_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+func TestNormalize_SpaceInFragmentAndConcatenated(t *testing.T) {
+	a := "vless://u@localhost:80?x=1#📆 Осталось: 28 дней"
+	b := "vless://u2@localhost:444#➡️t.me/bot"
+	body := []byte(a + " " + b)
+	lines := NormalizeBody(body, "text/plain")
+	if len(lines) != 2 {
+		t.Fatalf("lines=%d %v want 2", len(lines), lines)
+	}
+	if lines[0] != a || lines[1] != b {
+		t.Errorf("got\n%q\n%q\nwant\n%q\n%q", lines[0], lines[1], a, b)
+	}
+}
+
 func TestNormalize_PlainText(t *testing.T) {
 	body := []byte("vless://a@b:1\ntrojan://c@d:2\n#comment\n\n")
 	lines := NormalizeBody(body, "text/plain")


### PR DESCRIPTION
1. Исправлено добавление share-link списка, когда он разделен не переносами, а пробелами, для "Группы серверов" в singbox

2. Добавлена подсветка синтаксиса в том же разделе для всех 3 типов: share-link, clash YAML и sing-box JSON
<img width="1458" height="715" alt="image" src="https://github.com/user-attachments/assets/62771328-7e62-41c9-8e58-0eb4f9d42d46" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/de53eddf-4766-40f9-a791-8e8831875370" />
<img width="49%"  alt="image" src="https://github.com/user-attachments/assets/dc7ec62f-acde-4fc0-a11a-8f04c50008b7" />

3. Исправлено поведение карточек/строк как неочевидного индикатора включенности подписки

4. Добавлен режим список/сетка в sing-box туннели, sing-box подписки, а так же во внутрь подписок
<img width="1461" height="706" alt="Снимок экрана 2026-05-14 в 22 50 20" src="https://github.com/user-attachments/assets/f18aede7-8b5f-4fc2-ab7e-10241c778e4a" />

5. Исправлено отображение прокси, когда подписка содержит отладочную информацию на русском с пробелами после #, например остаток гигабайт или дней, у некоторых провайдеров

6. Добавлено уведомление при попытке переключения основного прокси в подписке при включенном автоматическом режиме, что необходимо включить ручной.
<img width="376" height="95" alt="image" src="https://github.com/user-attachments/assets/9e96af19-d6ad-4e84-a910-a6e8182b5459" />

7. Добавлено пользовательское соглашение в меню настройки в самом низу, а так же на экран авторизации
<img width="49%"  alt="image" src="https://github.com/user-attachments/assets/10bff280-7647-49d9-bbeb-fd1702f6f66e" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/18f96fae-e15d-4177-9a4c-c75fe67844fb" />

<img width="386" height="505" alt="image" src="https://github.com/user-attachments/assets/c0518b48-1f89-4420-aaa0-00413fff253e" />

8. Исправлен header, удалена плашка сохранения за ненадобностью


