### PR TITLE
fix(ui): shrink save-status slot on mobile to free hamburger

### DIFF
--- a/frontend/src/lib/components/ui/SaveStatusIndicator.svelte
+++ b/frontend/src/lib/components/ui/SaveStatusIndicator.svelte
@@ -125,6 +125,12 @@
 		box-sizing: border-box;
 	}
 
+	@media (max-width: 640px) {
+		.save-status-slot {
+			width: 4rem;
+		}
+	}
+
 	.save-status-placeholder {
 		display: block;
 		width: 100%;


### PR DESCRIPTION
At <=640px the fixed 8rem save-status slot pushed user-tools beyond viewport, hiding the hamburger button. Halve the slot to 4rem on mobile; indicator already truncates with ellipsis, tone+title preserved.