### PR TITLE
fix(singbox-routing): unify DNS rule_set picker with rule editor and …

### DIFF
--- a/frontend/src/lib/components/routing/singboxRouter/DNSRuleEditModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSRuleEditModal.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
 	import Modal from '$lib/components/ui/Modal.svelte';
-	import { Dropdown, type DropdownOption } from '$lib/components/ui';
-	import type { SingboxRouterDNSRule, SingboxRouterDNSServer } from '$lib/types';
+	import { Dropdown, ChipMultiSelect, type DropdownOption, type ChipOption } from '$lib/components/ui';
+	import type { SingboxRouterDNSRule, SingboxRouterDNSServer, SingboxRouterRuleSet } from '$lib/types';
 
 	interface Props {
 		rule?: SingboxRouterDNSRule;
 		servers: SingboxRouterDNSServer[];
+		availableRuleSets: SingboxRouterRuleSet[];
 		onClose: () => void;
 		onSave: (rule: SingboxRouterDNSRule) => Promise<void> | void;
 	}
-	let { rule, servers, onClose, onSave }: Props = $props();
+	let { rule, servers, availableRuleSets, onClose, onSave }: Props = $props();
+
+	function normalizeTags(tags: string[]): string[] {
+		return [...new Set(tags.map((s) => s.trim()).filter(Boolean))];
+	}
 
 	const serverOptions = $derived<DropdownOption[]>([
 		{ value: '', label: '— выберите —' },
@@ -21,7 +26,10 @@
 	]);
 
 	// svelte-ignore state_referenced_locally
-	let ruleSetStr = $state((rule?.rule_set ?? []).join(', '));
+	let ruleSetTags = $state<string[]>(rule?.rule_set ?? []);
+	const ruleSetOptions = $derived<ChipOption[]>(
+		availableRuleSets.map((rs) => ({ value: rs.tag, label: rs.tag })),
+	);
 	// svelte-ignore state_referenced_locally
 	let domainSuffixStr = $state((rule?.domain_suffix ?? []).join('\n'));
 	// svelte-ignore state_referenced_locally
@@ -39,7 +47,7 @@
 	let error = $state('');
 
 	// Snapshot initial state for isDirty detection
-	let initialRuleSetStr = $state('');
+	let initialRuleSetTagsSnapshot = $state<string[]>([]);
 	let initialDomainSuffixStr = $state('');
 	let initialDomainStr = $state('');
 	let initialDomainKeywordStr = $state('');
@@ -50,7 +58,7 @@
 	// Initialize snapshot when modal opens
 	$effect(() => {
 		if (rule) {
-			initialRuleSetStr = (rule.rule_set ?? []).join(', ');
+			initialRuleSetTagsSnapshot = [...(rule.rule_set ?? [])];
 			initialDomainSuffixStr = (rule.domain_suffix ?? []).join('\n');
 			initialDomainStr = (rule.domain ?? []).join('\n');
 			initialDomainKeywordStr = (rule.domain_keyword ?? []).join(', ');
@@ -58,7 +66,7 @@
 			initialAction = rule.action === 'reject' ? 'reject' : 'route';
 			initialServer = rule.server ?? '';
 		} else {
-			initialRuleSetStr = '';
+			initialRuleSetTagsSnapshot = [];
 			initialDomainSuffixStr = '';
 			initialDomainStr = '';
 			initialDomainKeywordStr = '';
@@ -70,7 +78,7 @@
 
 	const isDirty = $derived.by(() => {
 		return (
-			ruleSetStr !== initialRuleSetStr ||
+			normalizeTags(ruleSetTags).join(',') !== normalizeTags(initialRuleSetTagsSnapshot).join(',') ||
 			domainSuffixStr !== initialDomainSuffixStr ||
 			domainStr !== initialDomainStr ||
 			domainKeywordStr !== initialDomainKeywordStr ||
@@ -84,7 +92,7 @@
 		busy = true;
 		error = '';
 		try {
-			const rule_set = ruleSetStr.split(',').map((s) => s.trim()).filter(Boolean);
+			const rule_set = normalizeTags(ruleSetTags);
 			const domain_suffix = domainSuffixStr.split('\n').map((s) => s.trim()).filter(Boolean);
 			const domain = domainStr.split('\n').map((s) => s.trim()).filter(Boolean);
 			const domain_keyword = domainKeywordStr.split(',').map((s) => s.trim()).filter(Boolean);
@@ -131,8 +139,14 @@
 		<div class="section-label">Matchers (минимум один)</div>
 
 		<label class="field">
-			<div class="lbl">Rule sets (через запятую)</div>
-			<input bind:value={ruleSetStr} placeholder="geosite-youtube, geoip-ru" />
+			<div class="lbl">Rule sets</div>
+			<ChipMultiSelect
+				values={ruleSetTags}
+				options={ruleSetOptions}
+				onchange={(next) => (ruleSetTags = next)}
+				placeholder="не выбрано"
+				allowOrphans
+			/>
 		</label>
 
 		<label class="field">

--- a/frontend/src/lib/components/routing/singboxRouter/DNSRulesList.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSRulesList.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
-	import type { SingboxRouterDNSRule, SingboxRouterDNSServer } from '$lib/types';
+	import type { SingboxRouterDNSRule, SingboxRouterDNSServer, SingboxRouterRuleSet } from '$lib/types';
 	import DNSRuleEditModal from './DNSRuleEditModal.svelte';
 	import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte';
 
 	interface Props {
 		rules: SingboxRouterDNSRule[];
 		servers: SingboxRouterDNSServer[];
+		availableRuleSets: SingboxRouterRuleSet[];
 		finalLabel: string;
 		onChange: () => Promise<void> | void;
 	}
-	let { rules, servers, finalLabel, onChange }: Props = $props();
+	let { rules, servers, availableRuleSets, finalLabel, onChange }: Props = $props();
 
 	let editIndex = $state<number | null>(null);
 	let addMode = $state(false);
@@ -114,6 +115,7 @@
 {#if addMode}
 	<DNSRuleEditModal
 		{servers}
+		{availableRuleSets}
 		onClose={() => (addMode = false)}
 		onSave={async (rule) => {
 			await api.singboxRouterAddDNSRule(rule);
@@ -128,6 +130,7 @@
 	<DNSRuleEditModal
 		rule={rules[idx]}
 		{servers}
+		{availableRuleSets}
 		onClose={() => (editIndex = null)}
 		onSave={async (rule) => {
 			await api.singboxRouterUpdateDNSRule(idx, rule);

--- a/frontend/src/lib/components/routing/singboxRouter/DNSTab.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSTab.svelte
@@ -3,6 +3,7 @@
 		SingboxRouterDNSServer,
 		SingboxRouterDNSRule,
 		SingboxRouterDNSGlobals,
+		SingboxRouterRuleSet,
 	} from '$lib/types';
 	import type { OutboundGroup } from './outboundOptions';
 	import DNSGlobals from './DNSGlobals.svelte';
@@ -13,10 +14,11 @@
 		servers: SingboxRouterDNSServer[];
 		rules: SingboxRouterDNSRule[];
 		globals: SingboxRouterDNSGlobals;
+		ruleSets: SingboxRouterRuleSet[];
 		outboundOptions: OutboundGroup[];
 		onChange: () => Promise<void> | void;
 	}
-	let { servers, rules, globals, outboundOptions, onChange }: Props = $props();
+	let { servers, rules, globals, ruleSets, outboundOptions, onChange }: Props = $props();
 
 	type DNSSection = 'servers' | 'rules';
 	let section = $state<DNSSection>('servers');
@@ -37,7 +39,7 @@
 	{#if section === 'servers'}
 		<DNSServersList {servers} {outboundOptions} {onChange} />
 	{:else}
-		<DNSRulesList {rules} {servers} finalLabel={globals.final} {onChange} />
+		<DNSRulesList {rules} {servers} availableRuleSets={ruleSets} finalLabel={globals.final} {onChange} />
 	{/if}
 </div>
 

--- a/frontend/src/lib/components/singbox-routing/DnsSubTab.svelte
+++ b/frontend/src/lib/components/singbox-routing/DnsSubTab.svelte
@@ -16,6 +16,7 @@
 		SingboxRouterDNSRule,
 		SingboxRouterDNSServer,
 		SingboxRouterDNSStrategy,
+		SingboxRouterRuleSet,
 	} from '$lib/types';
 	import {
 		DNSServerEditModal,
@@ -26,11 +27,13 @@
 	const dnsRulesStore = singboxRouter.dnsRules;
 	const dnsGlobalsStore = singboxRouter.dnsGlobals;
 	const optionsStore = singboxRouter.options;
+	const ruleSetsStore = singboxRouter.ruleSets;
 
 	const servers = $derived($dnsServersStore);
 	const rules = $derived($dnsRulesStore);
 	const globals = $derived($dnsGlobalsStore);
 	const outboundOptions = $derived($optionsStore);
+	const ruleSets = $derived<SingboxRouterRuleSet[]>($ruleSetsStore);
 
 	async function refresh(): Promise<void> {
 		await singboxRouter.loadAll();
@@ -537,6 +540,7 @@
 {#if ruleAddMode}
 	<DNSRuleEditModal
 		{servers}
+		availableRuleSets={ruleSets}
 		onClose={() => (ruleAddMode = false)}
 		onSave={async (rule) => {
 			await api.singboxRouterAddDNSRule(rule);
@@ -551,6 +555,7 @@
 	<DNSRuleEditModal
 		rule={rules[idx]}
 		{servers}
+		availableRuleSets={ruleSets}
 		onClose={() => (ruleEditIndex = null)}
 		onSave={async (rule) => {
 			await api.singboxRouterUpdateDNSRule(idx, rule);


### PR DESCRIPTION
# Описание правки: выбор `rule-set` в DNS-модалке

## Что изменено

- В модалке редактирования DNS-правила поле `rule_set` переведено с ручного ввода строкой на селектор чипов (`ChipMultiSelect`), как в обычных правилах роутера.
- Список доступных `rule-set` теперь передаётся по цепочке компонентов до DNS-модалки из `singboxRouter.ruleSets`.
- Сохранена поддержка orphan-значений (`allowOrphans`): уже существующие теги, отсутствующие в текущем списке, не теряются.

## Надёжность и совместимость

- Добавлена нормализация тегов `rule_set` перед сохранением:
  - `trim` значений;
  - удаление пустых;
  - удаление дублей.
- Проверка `isDirty` для `rule_set` переведена на ту же нормализацию, чтобы не было ложных срабатываний из-за пробелов и дублей.
- Формат payload не менялся: в API по-прежнему уходит `rule_set?: string[]`.

## Результат

- UX DNS-правил унифицирован с обычными правилами.
- Ручные ошибки ввода снижены.
- Обратная совместимость со старыми конфигами сохранена.

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/0480e201-bd1e-42f5-b00b-051e9b86a8e7" />

DNS rule-set в модалке переведён на chip-select, добавлена нормализация тегов.