### PR TITLE
refactor(subscriptions): unify member tag resolution for traffic and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ docs/
 .planning/
 debug.md
 tree.md
+pub.md
 
 # Windows-only helper scripts (personal tooling — never commit)
 *.bat

--- a/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
@@ -7,22 +7,19 @@
 	import { getTrafficRates, subscribeTraffic, loadHistory } from '$lib/stores/traffic';
 	import { TrafficSparkline } from '$lib/components/ui';
 	import { formatBytes } from '$lib/utils/format';
+	import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
 
 	interface Props {
 		subscription: Subscription;
+		liveActiveMember?: string | null;
 		layout?: SingboxLayoutMode;
 		ondelete?: (id: string) => void;
 	}
-	let { subscription, layout = 'grid', ondelete }: Props = $props();
+	let { subscription, liveActiveMember = null, layout = 'grid', ondelete }: Props = $props();
 
-	const latencyTag = $derived.by(() => {
-		if (subscription.activeMember && subscription.memberTags.includes(subscription.activeMember)) {
-			return subscription.activeMember;
-		}
-		return subscription.memberTags[0] ?? '';
-	});
+	const resolvedMemberTag = $derived(resolveSubscriptionMemberTag(subscription, liveActiveMember));
 
-	const history = $derived($singboxDelayHistory.get(latencyTag) ?? []);
+	const history = $derived($singboxDelayHistory.get(resolvedMemberTag) ?? []);
 	const latest = $derived(history.length > 0 ? history[history.length - 1] : -1);
 	const hasConsecutiveTimeout = $derived(
 		history.length >= 2 &&
@@ -34,7 +31,7 @@
 	const DELAY_SLOW = 500;
 
 	const delayState = $derived.by((): 'ok' | 'slow' | 'fail' | 'unknown' => {
-		if (!latencyTag) return 'unknown';
+		if (!resolvedMemberTag) return 'unknown';
 		if (latest < 0) return 'unknown';
 		if (latest <= 0) return hasConsecutiveTimeout ? 'fail' : 'slow';
 		if (latest < DELAY_OK) return 'ok';
@@ -42,14 +39,14 @@
 		return 'slow';
 	});
 	const delayText = $derived.by(() => {
-		if (!latencyTag) return '—';
+		if (!resolvedMemberTag) return '—';
 		if (delayState === 'unknown') return '—';
 		if (delayState === 'fail') return 'timeout';
 		if (latest <= 0) return '…';
 		return `${latest}ms`;
 	});
 
-	const traffic = $derived(latencyTag ? $singboxTraffic.get(latencyTag) : undefined);
+	const traffic = $derived(resolvedMemberTag ? $singboxTraffic.get(resolvedMemberTag) : undefined);
 
 	const trafficSparkData = $derived.by(() => {
 		const n = Math.min(rxRates.length, txRates.length);
@@ -64,7 +61,7 @@
 
 	let rxRates = $state<number[]>([]);
 	let txRates = $state<number[]>([]);
-	let trafficTag = $derived(latencyTag);
+	let trafficTag = $derived(resolvedMemberTag);
 
 	$effect(() => {
 		const tag = trafficTag;
@@ -93,10 +90,10 @@
 
 	async function runDelayCheck(e?: MouseEvent | KeyboardEvent): Promise<void> {
 		e?.stopPropagation();
-		if (!latencyTag || testingDelay) return;
+		if (!resolvedMemberTag || testingDelay) return;
 		testingDelay = true;
 		try {
-			await triggerDelayCheck(latencyTag);
+			await triggerDelayCheck(resolvedMemberTag);
 		} finally {
 			testingDelay = false;
 		}
@@ -160,7 +157,7 @@
 						<span class="delay-inline-err mono" title={subscription.lastError}>
 							{subscription.lastError}
 						</span>
-					{:else if latencyTag}
+					{:else if resolvedMemberTag}
 						<button
 							type="button"
 							class="lat-btn {delayState}"
@@ -189,7 +186,7 @@
 				<div class="list-cell list-cell-traffic" data-label="Трафик">
 					{#if subscription.lastError}
 						<span class="delay-dash">—</span>
-					{:else if latencyTag}
+					{:else if resolvedMemberTag}
 						<div class="traffic-row-list">
 							<TrafficSparkline
 								data={trafficSparkData}
@@ -209,7 +206,7 @@
 				<div class="list-cell list-cell-ping" data-label="Ping">
 					{#if subscription.lastError}
 						<span class="delay-dash">—</span>
-					{:else if latencyTag}
+					{:else if resolvedMemberTag}
 						<div
 							class="spark-mini {delayState}"
 							role="button"

--- a/frontend/src/lib/utils/subscriptionMember.ts
+++ b/frontend/src/lib/utils/subscriptionMember.ts
@@ -1,0 +1,14 @@
+import type { Subscription } from '$lib/types';
+
+export function resolveSubscriptionMemberTag(
+	subscription: Subscription,
+	liveActiveMember?: string | null,
+): string {
+	if (liveActiveMember && subscription.memberTags.includes(liveActiveMember)) {
+		return liveActiveMember;
+	}
+	if (subscription.activeMember && subscription.memberTags.includes(subscription.activeMember)) {
+		return subscription.activeMember;
+	}
+	return subscription.memberTags[0] ?? '';
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -33,6 +33,7 @@
 	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
+	import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
 	import {
 		SINGBOX_LAYOUT_STORAGE_KEY,
 		TUNNEL_MOBILE_LAYOUT_MAX_WIDTH_PX,
@@ -404,10 +405,7 @@
 			}
 		}
 		for (const sub of subscriptionsListRows) {
-			const tag =
-				sub.activeMember && sub.memberTags.includes(sub.activeMember)
-					? sub.activeMember
-					: sub.memberTags[0] ?? '';
+			const tag = resolveSubscriptionMemberTag(sub, liveActives[sub.id] || null);
 			if (!tag) continue;
 			const tr = map.get(tag);
 			if (tr) {
@@ -1666,6 +1664,7 @@
 								{#each subscriptionsListRows as sub (sub.id)}
 									<SubscriptionCard
 										subscription={sub}
+										liveActiveMember={liveActives[sub.id] || null}
 										layout="list"
 										ondelete={requestSubscriptionDelete}
 									/>
@@ -1693,6 +1692,7 @@
 								{#each subscriptionsListRows as sub (sub.id)}
 									<SubscriptionCard
 										subscription={sub}
+										liveActiveMember={liveActives[sub.id] || null}
 										layout="grid"
 										ondelete={requestSubscriptionDelete}
 									/>


### PR DESCRIPTION
…delay

Вынес выбор active member-тега в общий helper без изменения поведения.

Исходное предположение не подтвердилось:
Запрос к Clash “по группе вместо активного члена” для трафика уже исправлен в бэкенде. Вероятнее проблема в UI-выборе тега для карточки (fallback на неактивный member), а не в самом Clash traffic source.

---

# Рефактор выбора активного member-тега для подписок

## Что сделано

В рамках правки устранено дублирование логики выбора тега участника подписки, который используется для отображения задержки и трафика.

- Добавлен общий helper `resolveSubscriptionMemberTag(subscription, liveActiveMember)` в `frontend/src/lib/utils/subscriptionMember.ts`.
- В `SubscriptionCard.svelte` локальная логика выбора тега заменена на вызов helper.
- В `+page.svelte` (расчет суммарной статистики трафика для подписок) использован тот же helper.
- В `SubscriptionCard.svelte` уточнено имя переменной: `latencyTag` → `resolvedMemberTag` (семантически точнее, так как тег используется не только для delay).

## Логика выбора тега

Приоритет выбора оставлен прежним и теперь централизован:

1. `liveActiveMember`, если он есть и входит в `subscription.memberTags`;
2. `subscription.activeMember`, если он валиден для подписки;
3. fallback на `subscription.memberTags[0]`;
4. пустая строка, если тегов нет.

## Зачем это нужно

- Исключить расхождение поведения между карточкой подписки и агрегированной статистикой.
- Снизить риск будущих регрессий при изменении логики выбора активного участника.
- Повысить читаемость и сопровождаемость кода без изменения пользовательского поведения.

## Проверки

- `npm run check` — успешно (0 ошибок, 0 предупреждений).
- `npm run build` — успешно.
