### PR TITLE
fix(monitoring): show subscription label for runtime sing-box members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ docs/
 debug.md
 tree.md
 pub.md
+diff.md
+build.log
+frontend/package-lock.json
 
 # Windows-only helper scripts (personal tooling — never commit)
 *.bat

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ tree.md
 pub.md
 diff.md
 build.log
-frontend/package-lock.json
 
 # Windows-only helper scripts (personal tooling — never commit)
 *.bat

--- a/cmd/awg-manager/awg_outbounds_adapters.go
+++ b/cmd/awg-manager/awg_outbounds_adapters.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/deviceproxy"
 	"github.com/hoaxisr/awg-manager/internal/monitoring"
@@ -221,6 +222,7 @@ func (a *monitoringSingboxTunnelAdapter) List(ctx context.Context) ([]monitoring
 	}
 	out := make([]monitoring.SingboxTunnelInfo, 0, len(tunnels))
 	seen := make(map[string]bool, len(tunnels))
+	subLabelByActiveTag := make(map[string]string)
 	for _, t := range tunnels {
 		// Keep config-backed sing-box rows probeable by interface.
 		// Runtime-only subscription member tags are appended separately below.
@@ -234,6 +236,41 @@ func (a *monitoringSingboxTunnelAdapter) List(ctx context.Context) ([]monitoring
 			InterfaceName: t.KernelInterface,
 		})
 	}
+	if a.sub != nil {
+		for _, sub := range a.sub.List() {
+			if !sub.Enabled {
+				continue
+			}
+			label := strings.TrimSpace(sub.Label)
+			if label == "" {
+				label = strings.TrimSpace(sub.SelectorTag)
+			}
+			if label == "" {
+				label = strings.TrimSpace(sub.ActiveMember)
+			}
+			if sub.ActiveMember != "" {
+				subLabelByActiveTag[sub.ActiveMember] = label
+			}
+			for _, tag := range sub.MemberTags {
+				tag = strings.TrimSpace(tag)
+				if tag == "" {
+					continue
+				}
+				if _, exists := subLabelByActiveTag[tag]; !exists {
+					subLabelByActiveTag[tag] = label
+				}
+			}
+			for _, member := range sub.Members {
+				tag := strings.TrimSpace(member.Tag)
+				if tag == "" {
+					continue
+				}
+				if _, exists := subLabelByActiveTag[tag]; !exists {
+					subLabelByActiveTag[tag] = label
+				}
+			}
+		}
+	}
 	// Add active member tags from enabled subscriptions. These outbounds are
 	// often "runtime-only" (no dedicated inbound/listen_port), so they may not
 	// have a kernel interface in config-derived TunnelInfo, but they are still
@@ -244,9 +281,13 @@ func (a *monitoringSingboxTunnelAdapter) List(ctx context.Context) ([]monitoring
 				continue
 			}
 			seen[tag] = true
+			name := tag
+			if label := subLabelByActiveTag[tag]; label != "" {
+				name = label
+			}
 			out = append(out, monitoring.SingboxTunnelInfo{
 				Tag:           tag,
-				Name:          tag,
+				Name:          name,
 				InterfaceName: "",
 			})
 		}


### PR DESCRIPTION
Мониторинг теперь показывает человекочитаемый label подписки вместо технического tag для runtime-строк.

---

В мониторинге исправлено отображение имён для runtime-only sing-box строк, связанных с подписками: вместо технического member tag теперь выводится человекочитаемое имя подписки.

Что сделано:

В monitoringSingboxTunnelAdapter добавлен маппинг tag -> display name на основе данных подписок.
Для display name используется безопасная цепочка:
subscription.label
fallback: subscription.selectorTag
fallback: subscription.activeMember
Маппинг строится не только по activeMember, но и по всем memberTags и members[].tag, чтобы корректно покрывать runtime/live-active сценарии.
Добавлена нормализация через TrimSpace для label и тегов, чтобы исключить визуально пустые или “грязные” значения.
Для runtime строки сохраняется технический Tag (идентификатор), меняется только отображаемое Name.
При отсутствии подходящего label остаётся безопасный fallback на технический tag (без деградации интерфейса).

<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/845992d6-4e18-4bf5-bdef-19b38e26d7f4" />
<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/918d21d2-606b-43b5-997a-3da840af01d2" />
