### PR TITLE
fix(kmod/awg-proxy): add missing MAC1 recompute for 2 of 4 handshake types

### DIFF
--- a/kmod/awg-proxy/src/transform.c
+++ b/kmod/awg-proxy/src/transform.c
@@ -160,6 +160,9 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 
 		if (hrange_contains(&cfg->h1, h)) {
 			write32_le(buf + cfg->s1, WG_HANDSHAKE_INIT);
+			if (cfg->has_client_pub)
+				recompute_mac1(buf + cfg->s1,
+					       cfg->mac1key_client);
 			*out_len = n - cfg->s1;
 			return buf + cfg->s1;
 		}

--- a/kmod/awg-proxy/src/transform.c
+++ b/kmod/awg-proxy/src/transform.c
@@ -88,6 +88,8 @@ u8 *transform_outbound(u8 *buf, int dataoff, int n,
 
 	if (msgType == WG_HANDSHAKE_RESPONSE && n == WG_RESP_SIZE) {
 		write32_le(data, hrange_pick(&cfg->h2, rand_val));
+		if (cfg->has_server_pub)
+			recompute_mac1_response(data, cfg->mac1key_server);
 		if (cfg->s2 > 0) {
 			if (WARN_ON_ONCE(dataoff < cfg->s2)) {
 				*out_len = n;


### PR DESCRIPTION
## Summary

awg_proxy.ko only recomputes MAC1 for 2 of the 4 handshake message types after header substitution. The two missing cases produce packets with bad MAC1 that the remote peer silently drops.

### What's broken

MAC1 covers bytes `[0..mac1_offset]` of every WireGuard handshake packet, including the first 4 bytes (the message type). When awg_proxy swaps in the H1/H2 header value, those bytes change and the MAC1 no longer matches. The kmod port recomputes it for outbound init and inbound response but skips the other two:

| Direction | Message | Before fix | After fix |
|-----------|---------|-----------|-----------|
| Outbound | Init | recompute with `mac1key_server` | (no change) |
| Outbound | Response | not recomputed | recompute with `mac1key_server` |
| Inbound | Init | not recomputed | recompute with `mac1key_client` |
| Inbound | Response | recompute with `mac1key_client` | (no change) |

### How it fails

Outbound response: WG kernel sends a handshake response, proxy swaps in H2, MAC1 is now wrong. Remote server drops it. Handshake never finishes.

Inbound init: Remote AWG server sends a rekey init (~2 min into the session). Proxy restores the header back to type 1, MAC1 becomes invalid. Local WG kernel drops it. Tunnel dies after key rotation.

### Checked against other AWG implementations

- [timbrs/amneziawg-mikrotik-c](https://github.com/timbrs/amneziawg-mikrotik-c) (C reference): both `transform_outbound_with_mac1` and `transform_inbound` recompute MAC1 for all handshake types
- [amnezia-vpn/amneziawg-go](https://github.com/amnezia-vpn/amneziawg-go) (Go): MAC1 is recomputed in `CreateMessageInitiation` / `CreateMessageResponse` after header substitution
- boringtun fork (Rust): `append_mac1_and_mac2()` runs for both init and response outbound; `rate_limiter.verify_packet()` validates both inbound

All three recompute MAC1 on every handshake packet after header substitution, both directions.

## Test plan

- [ ] Build awg_proxy.ko for target arch, verify it loads
- [ ] Start a tunnel, confirm initial handshake completes (outbound response fix)
- [ ] Wait >2 min for rekey, confirm tunnel stays up (inbound init fix)
- [ ] Test with non-default H1/H2 ranges and public keys set

---
Generated with [Claude Code](https://claude.ai/claude-code)