### PR TITLE
fix(kmod/awg-proxy): fill S4 transport prefix with random bytes

### DIFF
--- a/kmod/awg-proxy/src/transform.c
+++ b/kmod/awg-proxy/src/transform.c
@@ -130,8 +130,9 @@ u8 *transform_outbound(u8 *buf, int dataoff, int n,
 		else
 			write32_le(data, hrange_pick(&cfg->h4, rand_val));
 		if (cfg->s4 > 0 && dataoff >= cfg->s4) {
+			get_random_bytes(data - cfg->s4, cfg->s4);
 			*out_len = cfg->s4 + n;
-			return buf + dataoff - cfg->s4;
+			return data - cfg->s4;
 		}
 		*out_len = n;
 		return data;

--- a/kmod/awg-proxy/tests/.gitignore
+++ b/kmod/awg-proxy/tests/.gitignore
@@ -1,0 +1,3 @@
+test_cps
+test_transform
+*.dSYM

--- a/kmod/awg-proxy/tests/Makefile
+++ b/kmod/awg-proxy/tests/Makefile
@@ -1,18 +1,18 @@
-# Host-only unit tests for kmod/awg-proxy/src/cps.c.
+# Host-only unit tests for kmod/awg-proxy/src/.
 #
 # Build/run on a regular dev machine — NO Linux kernel headers required.
 # We provide minimal stubs (in stubs/) for the few <linux/*> and <asm/*>
-# includes that cps.c pulls in, and shim.h supplies the integer types,
-# byte-order macros, and deterministic get_random_bytes / ktime_*.
+# includes that the source files pull in, and shim.h supplies the integer
+# types, byte-order macros, and deterministic get_random_bytes / ktime_*.
 #
 # Targets:
-#   make           run tests (default)
-#   make test      run tests
+#   make           run all tests (default)
+#   make test      run all tests
 #   make clean     remove built artifacts
 #
 # To keep determinism, every test seeds the PRNG via shim_set_random_seed()
 # and pins the clock via shim_set_fixed_time(). Byte-exact assertions are
-# reproducible across machines / Go versions / compiler revisions.
+# reproducible across machines / compiler revisions.
 
 CC      ?= gcc
 CFLAGS  := -O0 -g3 -std=c11 -Wall -Wextra -Werror \
@@ -20,18 +20,21 @@ CFLAGS  := -O0 -g3 -std=c11 -Wall -Wextra -Werror \
            -I . -I stubs -include shim.h
 LDFLAGS :=
 
-TARGET  := test_cps
-SOURCES := test_cps.c shim.c ../src/cps.c
+SRC     := ../src
 
 .PHONY: all test clean
 
 all: test
 
-test: $(TARGET)
-	./$(TARGET)
+test: test_cps test_transform
+	./test_cps
+	./test_transform
 
-$(TARGET): $(SOURCES) shim.h
-	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)
+test_cps: test_cps.c shim.c shim.h $(SRC)/cps.c
+	$(CC) $(CFLAGS) -o $@ test_cps.c shim.c $(SRC)/cps.c $(LDFLAGS)
+
+test_transform: test_transform.c shim.c shim.h $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c
+	$(CC) $(CFLAGS) -o $@ test_transform.c shim.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(LDFLAGS)
 
 clean:
-	rm -f $(TARGET) *.o
+	rm -f test_cps test_transform *.o

--- a/kmod/awg-proxy/tests/shim.h
+++ b/kmod/awg-proxy/tests/shim.h
@@ -19,7 +19,15 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#else
 #include <endian.h>
+#endif
 
 /* ---- Linux integer aliases ---- */
 typedef uint8_t  u8;

--- a/kmod/awg-proxy/tests/stubs/asm/unaligned.h
+++ b/kmod/awg-proxy/tests/stubs/asm/unaligned.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Stub for <asm/unaligned.h> — used by blake2s.c in host tests. */
+#ifndef _ASM_UNALIGNED_STUB_H
+#define _ASM_UNALIGNED_STUB_H
+
+#include <string.h>
+#include <stdint.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#else
+#include <endian.h>
+#endif
+
+static inline uint32_t get_unaligned_le32(const void *p)
+{
+	uint32_t v;
+	memcpy(&v, p, 4);
+	return le32toh(v);
+}
+
+static inline void put_unaligned_le32(uint32_t v, void *p)
+{
+	v = htole32(v);
+	memcpy(p, &v, 4);
+}
+
+#endif /* _ASM_UNALIGNED_STUB_H */

--- a/kmod/awg-proxy/tests/test_transform.c
+++ b/kmod/awg-proxy/tests/test_transform.c
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Userspace unit tests for kmod/awg-proxy/src/transform.c.
+ *
+ * Covers:
+ *   1. S4 transport prefix filled with random bytes (not stale heap)
+ *   2. S4 fill is deterministic given a seeded PRNG
+ *   3. S1 handshake-init prefix filled with random bytes
+ *   4. H4-noop identity passthrough (no prefix, no copy)
+ *   5. MAC1 recomputed on outbound handshake init after H1 substitution
+ *   6. MAC1 recomputed on inbound handshake init after header restore
+ *
+ * Run via `make test`.
+ */
+
+#include "shim.h"
+#include "../src/transform.h"
+#include "../src/blake2s.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+/* ---- Tiny test harness (matches test_cps.c style) ---- */
+
+static int tests_run, tests_failed;
+
+static void test_fail(const char *test, const char *fmt, ...)
+{
+	va_list ap;
+
+	fprintf(stderr, "FAIL %s: ", test);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+	tests_failed++;
+}
+
+#define ASSERT_TRUE(test, cond, msg) do { \
+	if (!(cond)) test_fail((test), "%s", (msg)); \
+} while (0)
+
+#define ASSERT_EQ(test, got, want, msg) do { \
+	if ((got) != (want)) \
+		test_fail((test), "%s: got %d, want %d", (msg), (int)(got), (int)(want)); \
+} while (0)
+
+#define ASSERT_PTR_EQ(test, got, want, msg) do { \
+	if ((got) != (want)) \
+		test_fail((test), "%s: got %p, want %p", (msg), (void *)(got), (void *)(want)); \
+} while (0)
+
+static int all_byte(const u8 *buf, int len, u8 val)
+{
+	int i;
+	for (i = 0; i < len; i++)
+		if (buf[i] != val)
+			return 0;
+	return 1;
+}
+
+static void write32_le_host(u8 *p, u32 v)
+{
+	__le32 le = cpu_to_le32(v);
+	memcpy(p, &le, 4);
+}
+
+/* Build a minimal awg_config_t for tests.  Zero everything first. */
+static void cfg_init(awg_config_t *cfg)
+{
+	memset(cfg, 0, sizeof(*cfg));
+	/* Identity defaults — no transform */
+	cfg->h1.min = WG_HANDSHAKE_INIT;    cfg->h1.max = WG_HANDSHAKE_INIT;
+	cfg->h2.min = WG_HANDSHAKE_RESPONSE; cfg->h2.max = WG_HANDSHAKE_RESPONSE;
+	cfg->h3.min = WG_COOKIE_REPLY;      cfg->h3.max = WG_COOKIE_REPLY;
+	cfg->h4.min = WG_TRANSPORT_DATA;    cfg->h4.max = WG_TRANSPORT_DATA;
+}
+
+/* ---------- Tests ---------- */
+
+/*
+ * Test 1: S4 transport prefix is filled with random bytes.
+ *
+ * Fill the entire buffer with 0xAA sentinel, build a transport packet,
+ * call transform_outbound. The S4 region must no longer be 0xAA.
+ */
+static void test_s4_random_fill(void)
+{
+	awg_config_t cfg;
+	u8 buf[512];
+	int dataoff = 256;
+	int out_len, sendJunk;
+	u32 msgType;
+	u8 *out;
+
+	tests_run++;
+	cfg_init(&cfg);
+	cfg.s4 = 64;
+	cfg.h4.min = 100; cfg.h4.max = 200;
+	config_compute(&cfg);
+
+	memset(buf, 0xAA, sizeof(buf));
+	/* Write a minimal WG transport packet at buf + dataoff */
+	write32_le_host(buf + dataoff, WG_TRANSPORT_DATA);
+	memset(buf + dataoff + 4, 0xBB, WG_TRANSPORT_MIN - 4);
+
+	shim_set_random_seed(0xCAFE);
+	out = transform_outbound(buf, dataoff, WG_TRANSPORT_MIN,
+				 &cfg, 0x42ULL,
+				 &out_len, &sendJunk, &msgType);
+
+	ASSERT_PTR_EQ("s4_random_fill", out, buf + dataoff - 64, "returned pointer");
+	ASSERT_EQ("s4_random_fill", out_len, 64 + WG_TRANSPORT_MIN, "out_len");
+	ASSERT_TRUE("s4_random_fill",
+		    !all_byte(buf + dataoff - 64, 64, 0xAA),
+		    "S4 region should not be all-sentinel (was overwritten by random)");
+	ASSERT_EQ("s4_random_fill", sendJunk, 0, "transport should not trigger junk");
+}
+
+/*
+ * Test 2: S4 fill is deterministic with seeded PRNG.
+ *
+ * Same seed → same S4 bytes.
+ */
+static void test_s4_deterministic(void)
+{
+	awg_config_t cfg;
+	u8 buf1[512], buf2[512];
+	int dataoff = 256;
+	int out_len, sendJunk;
+	u32 msgType;
+
+	tests_run++;
+	cfg_init(&cfg);
+	cfg.s4 = 64;
+	cfg.h4.min = 100; cfg.h4.max = 100; /* fixed H4 for reproducibility */
+	config_compute(&cfg);
+
+	/* First call */
+	memset(buf1, 0, sizeof(buf1));
+	write32_le_host(buf1 + dataoff, WG_TRANSPORT_DATA);
+	memset(buf1 + dataoff + 4, 0xBB, WG_TRANSPORT_MIN - 4);
+	shim_set_random_seed(0x12345);
+	transform_outbound(buf1, dataoff, WG_TRANSPORT_MIN,
+			   &cfg, 0x42ULL, &out_len, &sendJunk, &msgType);
+
+	/* Second call, same seed */
+	memset(buf2, 0, sizeof(buf2));
+	write32_le_host(buf2 + dataoff, WG_TRANSPORT_DATA);
+	memset(buf2 + dataoff + 4, 0xBB, WG_TRANSPORT_MIN - 4);
+	shim_set_random_seed(0x12345);
+	transform_outbound(buf2, dataoff, WG_TRANSPORT_MIN,
+			   &cfg, 0x42ULL, &out_len, &sendJunk, &msgType);
+
+	ASSERT_TRUE("s4_deterministic",
+		    memcmp(buf1 + dataoff - 64, buf2 + dataoff - 64, 64) == 0,
+		    "same seed should produce identical S4 prefix bytes");
+}
+
+/*
+ * Test 3: S1 handshake-init prefix filled with random bytes.
+ */
+static void test_s1_random_fill(void)
+{
+	awg_config_t cfg;
+	u8 buf[512];
+	int dataoff = 256;
+	int out_len, sendJunk;
+	u32 msgType;
+	u8 *out;
+
+	tests_run++;
+	cfg_init(&cfg);
+	cfg.s1 = 32;
+	cfg.h1.min = 1000; cfg.h1.max = 2000;
+	config_compute(&cfg);
+
+	memset(buf, 0xAA, sizeof(buf));
+	/* Write a 148-byte WG handshake init at buf + dataoff */
+	write32_le_host(buf + dataoff, WG_HANDSHAKE_INIT);
+	memset(buf + dataoff + 4, 0xCC, WG_INIT_SIZE - 4);
+
+	shim_set_random_seed(0xBEEF);
+	out = transform_outbound(buf, dataoff, WG_INIT_SIZE,
+				 &cfg, 0x99ULL,
+				 &out_len, &sendJunk, &msgType);
+
+	ASSERT_PTR_EQ("s1_random_fill", out, buf + dataoff - 32, "returned pointer");
+	ASSERT_EQ("s1_random_fill", out_len, 32 + WG_INIT_SIZE, "out_len");
+	ASSERT_TRUE("s1_random_fill",
+		    !all_byte(buf + dataoff - 32, 32, 0xAA),
+		    "S1 region should not be all-sentinel");
+	ASSERT_EQ("s1_random_fill", sendJunk, 0,
+		  "sendJunk=0 because jc=0");
+}
+
+/*
+ * Test 4: H4-noop identity passthrough — no prefix, pointer unchanged.
+ */
+static void test_s4_noop_passthrough(void)
+{
+	awg_config_t cfg;
+	u8 buf[256];
+	int dataoff = 64;
+	int out_len, sendJunk;
+	u32 msgType;
+	u8 *out;
+
+	tests_run++;
+	cfg_init(&cfg);
+	/* identity: H4={4,4}, S4=0 → h4_noop */
+	config_compute(&cfg);
+
+	ASSERT_TRUE("s4_noop_passthrough", cfg.h4_noop,
+		    "config_compute should set h4_noop for identity H4");
+
+	write32_le_host(buf + dataoff, WG_TRANSPORT_DATA);
+	memset(buf + dataoff + 4, 0xDD, WG_TRANSPORT_MIN - 4);
+
+	out = transform_outbound(buf, dataoff, WG_TRANSPORT_MIN,
+				 &cfg, 0ULL,
+				 &out_len, &sendJunk, &msgType);
+
+	ASSERT_PTR_EQ("s4_noop_passthrough", out, buf + dataoff, "pointer unchanged");
+	ASSERT_EQ("s4_noop_passthrough", out_len, WG_TRANSPORT_MIN, "length unchanged");
+}
+
+/*
+ * Test 5: MAC1 is recomputed on outbound handshake init after H1 substitution.
+ * Guards the fix from PR #138.
+ */
+static void test_mac1_recompute_outbound_init(void)
+{
+	awg_config_t cfg;
+	u8 buf[512];
+	int dataoff = 256;
+	int out_len, sendJunk;
+	u32 msgType;
+	u8 mac1_before[16];
+
+	tests_run++;
+	cfg_init(&cfg);
+	cfg.h1.min = 999; cfg.h1.max = 999;
+	/* Set a non-zero server public key so MAC1 recompute triggers */
+	memset(cfg.server_pub, 0x42, 32);
+	config_compute(&cfg);
+
+	ASSERT_TRUE("mac1_outbound_init", cfg.has_server_pub,
+		    "server_pub should be detected as non-zero");
+
+	/* Build a 148-byte init packet with known MAC1 area */
+	memset(buf + dataoff, 0xEE, WG_INIT_SIZE);
+	write32_le_host(buf + dataoff, WG_HANDSHAKE_INIT);
+
+	/* Save the MAC1 region before transform (bytes 116..132) */
+	memcpy(mac1_before, buf + dataoff + 116, 16);
+
+	transform_outbound(buf, dataoff, WG_INIT_SIZE,
+			   &cfg, 0x55ULL,
+			   &out_len, &sendJunk, &msgType);
+
+	ASSERT_TRUE("mac1_outbound_init",
+		    memcmp(mac1_before, buf + dataoff + 116, 16) != 0,
+		    "MAC1 should differ after H1 substitution + recompute");
+}
+
+/*
+ * Test 6: MAC1 is recomputed on inbound handshake init after header restore.
+ * Guards the fix from PR #138.
+ */
+static void test_mac1_recompute_inbound_init(void)
+{
+	awg_config_t cfg;
+	u8 buf[512];
+	int s1 = 16;
+	int out_len;
+	u8 mac1_before[16];
+	u8 *out;
+
+	tests_run++;
+	cfg_init(&cfg);
+	cfg.s1 = s1;
+	cfg.h1.min = 999; cfg.h1.max = 999;
+	/* Set a non-zero client public key so inbound MAC1 recompute triggers */
+	memset(cfg.client_pub, 0x37, 32);
+	config_compute(&cfg);
+
+	ASSERT_TRUE("mac1_inbound_init", cfg.has_client_pub,
+		    "client_pub should be detected as non-zero");
+
+	/* Build a packet that looks like it came from AWG server:
+	 * [S1 random prefix][H1-substituted header][148-byte body] */
+	memset(buf, 0, sizeof(buf));
+	memset(buf, 0x11, s1);  /* S1 prefix (random in reality) */
+	write32_le_host(buf + s1, 999);  /* H1-substituted header */
+	memset(buf + s1 + 4, 0x77, WG_INIT_SIZE - 4);  /* body */
+
+	/* Save MAC1 before (bytes 116..132 within the init portion) */
+	memcpy(mac1_before, buf + s1 + 116, 16);
+
+	out = transform_inbound(buf, s1 + WG_INIT_SIZE, &cfg, &out_len);
+
+	ASSERT_TRUE("mac1_inbound_init", out != NULL, "should not be NULL (valid packet)");
+	ASSERT_EQ("mac1_inbound_init", out_len, WG_INIT_SIZE, "stripped size");
+	ASSERT_TRUE("mac1_inbound_init",
+		    memcmp(mac1_before, out + 116, 16) != 0,
+		    "MAC1 should differ after header restore + recompute");
+}
+
+/* ---------- Main ---------- */
+
+int main(void)
+{
+	test_s4_random_fill();
+	test_s4_deterministic();
+	test_s1_random_fill();
+	test_s4_noop_passthrough();
+	test_mac1_recompute_outbound_init();
+	test_mac1_recompute_inbound_init();
+
+	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
+	return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`transform_outbound` never fills the S4 headroom region with random bytes before returning a pointer into it. Transport packets with S4 > 0 go out with stale `kmalloc` heap data as the prefix instead of random bytes.

### The bug

When `transform_outbound` handles transport data (type 4) with S4 padding, it shifts the output pointer back by S4 bytes into the buffer headroom and returns it. But it never writes anything there:

```c
if (cfg->s4 > 0 && dataoff >= cfg->s4) {
    *out_len = cfg->s4 + n;
    return buf + dataoff - cfg->s4;  // headroom is uninitialized
}
```

Compare with S1/S2/S3 in the same file, which all call `get_random_bytes()` before returning:

```c
// S1 (handshake init)
get_random_bytes(data - cfg->s1, cfg->s1);
*out_len = cfg->s1 + n;
return data - cfg->s1;
```

S4 was the only one skipped.

### Impact

The buffer is a single `kmalloc(headroom + bufsize, GFP_KERNEL)` in `c2s_thread_fn`. `kmalloc` doesn't zero memory, so the headroom region contains whatever was in that kernel slab before. It never gets overwritten between packets.

Every transport packet ends up with the same static byte prefix where the reference has random data. That's a trivial fingerprint. It also leaks kernel heap contents to the network, which is just wrong regardless of exploitability.

### How the reference handles it

[amnezia-vpn/amneziawg-linux-kernel-module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) (authoritative kernel module) fills transport S4 per-packet in `encrypt_packet` (`src/send.c:261`): `get_random_bytes(skb_push(skb, junk_size), junk_size)`.

[timbrs/amneziawg-mikrotik-c](https://github.com/timbrs/amneziawg-mikrotik-c) pre-fills the S4 headroom at init time (`proxy_init`, line 374-377: `fastrand_fill(&p->rng, p->recv_c2s.bufs[i], c2s_headroom)`). The comment in `transform_outbound` says "Caller fills random into headroom."

[amnezia-vpn/amneziawg-go](https://github.com/amnezia-vpn/amneziawg-go) fills transport padding per-packet with `rand.Read(elem.buffer[:padding])` in `RoutineSequentialSender` (`device/send.go:583`).

All three fill S4 with random bytes. Our kmod was the only one that didn't.

### Fix

One line: `get_random_bytes(data - cfg->s4, cfg->s4)` before returning, same pattern as S1/S2/S3 in the same file.

### Host tests

Added 6 userspace unit tests in `kmod/awg-proxy/tests/test_transform.c` that compile and run on a dev machine (no kernel headers needed):

- S4 transport prefix is filled with random bytes (verifies this fix)
- S4 fill is deterministic with seeded PRNG
- S1 handshake init prefix is filled with random bytes
- H4-noop identity passthrough (no prefix, pointer unchanged)
- MAC1 recomputed on outbound init after H1 substitution (guards PR #138)
- MAC1 recomputed on inbound init after header restore (guards PR #138)

Run with `cd kmod/awg-proxy/tests && make test`.

## Test plan

- [x] Host unit tests pass (`make test` — 6 CPS + 6 transform, all green)
- [ ] Build awg_proxy.ko, load on target device
- [ ] Start a tunnel with S4 > 0, confirm transport data flows
- [ ] Capture packets, verify the S4 prefix bytes differ across packets (not static)
- [ ] Confirm no regression on S4 = 0 configs (fast-path untouched)

---
Generated with [Claude Code](https://claude.ai/claude-code)