### PR TITLE
feat(singbox): use compiled ruleset instead of inline

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -1019,6 +1019,7 @@ func main() {
 
 	routerSvc := router.NewService(router.Deps{
 		Log:                    log,
+		AppLog:                 loggingService,
 		Settings:               settingsStore,
 		Singbox:                singboxOp,
 		Policies:               &routerAccessPolicyAdapter{svc: accessPolicySvc, wan: wanModel},

--- a/frontend/src/lib/components/routing/singboxRouter/RuleSetAddModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/RuleSetAddModal.svelte
@@ -12,6 +12,7 @@
 		isInlineRuleListEmpty,
 		parseInlineRuleList,
 		stringifyInlineRuleList,
+		validateRuleSetTag,
 	} from '$lib/utils/singboxInlineRules';
 	import { expandGeoLinesInInput } from '$lib/utils/singboxInlineGeoExpand';
 
@@ -361,8 +362,9 @@ geosite:xai`;
 		error = '';
 		try {
 			const cleanTag = isEditing ? (ruleSet?.tag ?? '') : tag.trim();
-			if (!cleanTag) {
-				error = 'Tag обязателен';
+			const tagErr = validateRuleSetTag(cleanTag);
+			if (tagErr) {
+				error = tagErr;
 				busy = false;
 				return;
 			}
@@ -456,7 +458,11 @@ geosite:xai`;
 		<label class="field">
 			<div class="lbl">Tag (имя)</div>
 			<input bind:value={tag} placeholder="geosite-example" disabled={isEditing} />
-			{#if isEditing}<div class="hint">Tag нельзя менять у существующего набора.</div>{/if}
+			{#if isEditing}
+				<div class="hint">Tag нельзя менять у существующего набора.</div>
+			{:else}
+				<div class="hint">Не используйте суффикс -srs — он добавляется автоматически для скомпилированного набора.</div>
+			{/if}
 		</label>
 
 		{#if type !== 'inline'}
@@ -490,7 +496,7 @@ geosite:xai`;
 		{:else if type === 'local'}
 			<label class="field">
 				<div class="lbl">Путь к файлу</div>
-				<input bind:value={path} placeholder="/opt/etc/awg-manager/singbox/rulesets/my-custom.srs" />
+				<input bind:value={path} placeholder="/opt/etc/awg-manager/singbox/config.d/rule-sets/my.srs" />
 				<div class="hint">Абсолютный путь. Файл должен существовать на роутере.</div>
 			</label>
 		{:else}

--- a/frontend/src/lib/components/singbox-routing/RuleSetsSubTab.svelte
+++ b/frontend/src/lib/components/singbox-routing/RuleSetsSubTab.svelte
@@ -37,16 +37,22 @@
 	const localCount = $derived(ruleSets.filter((r) => r.type === 'local').length);
 	const inlineCount = $derived(ruleSets.filter((r) => r.type === 'inline').length);
 
+	/** Backend hides compiled -srs companions; filter defensively for older configs. */
+	function isVisibleRuleSet(rs: SingboxRouterRuleSet): boolean {
+		return !rs.tag.endsWith('-srs');
+	}
+
 	const visibleRuleSets = $derived(
-		sourceFilter === 'all'
+		(sourceFilter === 'all'
 			? ruleSets
-			: ruleSets.filter((r) => r.type === sourceFilter),
+			: ruleSets.filter((r) => r.type === sourceFilter)
+		).filter(isVisibleRuleSet),
 	);
 
 	const statTiles = $derived<StatTile[]>([
-		{ label: 'Наборов', value: ruleSets.length },
-		{ label: 'Удалённых', value: remoteCount },
-		{ label: 'Локальных', value: localCount },
+		{ label: 'Всего наборов', value: ruleSets.length },
+		{ label: 'Remote', value: remoteCount },
+		{ label: 'Local', value: localCount },
 		{ label: 'Inline', value: inlineCount },
 	]);
 
@@ -210,14 +216,19 @@
 			<div class="card">
 				<div class="card-head">
 					<div class="tag mono" title={rs.tag}>{rs.tag}</div>
-					<Badge
-						variant={rs.type === 'remote' ? 'accent' : 'info'}
-						size="sm"
-						uppercase
-						mono
-					>
-						{rs.type}
-					</Badge>
+					<div class="badges">
+						<Badge
+							variant={rs.type === 'remote' ? 'accent' : 'info'}
+							size="sm"
+							uppercase
+							mono
+						>
+							{rs.type}
+						</Badge>
+						{#if rs.type === 'inline' && rs.materialized_srs}
+							<Badge variant="muted" size="sm" uppercase mono>srs</Badge>
+						{/if}
+					</div>
 				</div>
 
 				{#if rs.type !== 'inline' && rs.format}
@@ -448,6 +459,12 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 0.5rem;
+	}
+	.badges {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		flex-shrink: 0;
 	}
 	.tag {
 		font-size: 0.875rem;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1345,6 +1345,8 @@ export interface SingboxRouterRuleSet {
 	download_detour?: string;
 	path?: string;
 	rules?: Record<string, unknown>[];
+	/** True when a compiled .srs sibling exists (inline only). */
+	materialized_srs?: boolean;
 }
 
 export interface SingboxRouterOutbound {

--- a/frontend/src/lib/utils/singboxInlineRules.test.ts
+++ b/frontend/src/lib/utils/singboxInlineRules.test.ts
@@ -5,6 +5,7 @@ import {
 	parseInlineRuleList,
 	stringifyInlineRuleList,
 	toAsciiHostname,
+	validateRuleSetTag,
 } from '$lib/utils/singboxInlineRules';
 
 describe('toAsciiHostname', () => {
@@ -378,5 +379,19 @@ describe('analyzeInlineRuleListLossy', () => {
 		const r = analyzeInlineRuleListLossy([{ domain: ['z.com'], inverted: [true] } as Record<string, unknown>]);
 		expect(r.lossy).toBe(true);
 		expect(r.issues.some((i) => i.includes('inverted'))).toBe(true);
+	});
+});
+
+describe('validateRuleSetTag', () => {
+	it('rejects empty tag', () => {
+		expect(validateRuleSetTag('')).toMatch(/обязателен/i);
+	});
+
+	it('rejects reserved -srs suffix', () => {
+		expect(validateRuleSetTag('geosite-samsung-srs')).toMatch(/-srs/);
+	});
+
+	it('allows base tag', () => {
+		expect(validateRuleSetTag('geosite-samsung')).toBeNull();
 	});
 });

--- a/frontend/src/lib/utils/singboxInlineRules.ts
+++ b/frontend/src/lib/utils/singboxInlineRules.ts
@@ -548,3 +548,16 @@ function isValidSimpleIpv6(addr: string): boolean {
 	if (hextets.length < 3 || hextets.length > 8) return false;
 	return hextets.every((h) => h === '' || /^[0-9a-f]{0,4}$/i.test(h));
 }
+
+/** Reserved for AWG-compiled inline → local .srs companion (see ruleset_materializer). */
+export const INLINE_RULE_SET_SRS_SUFFIX = '-srs';
+
+/** Returns a user-facing error, or null when the tag is allowed. */
+export function validateRuleSetTag(tag: string): string | null {
+	const t = tag.trim();
+	if (!t) return 'Tag обязателен';
+	if (t.endsWith(INLINE_RULE_SET_SRS_SUFFIX)) {
+		return `Суффикс «${INLINE_RULE_SET_SRS_SUFFIX}» зарезервирован для скомпилированного набора — укажите имя без него (например geosite-samsung, не geosite-samsung-srs)`;
+	}
+	return null;
+}

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -103,6 +103,7 @@ type SingboxRouterRuleSetDTO struct {
 	DownloadDetour string           `json:"download_detour,omitempty" example:"direct"`
 	Path           string           `json:"path,omitempty" example:"/opt/etc/singbox/rulesets/geosite-cn.srs"`
 	Rules          []map[string]any `json:"rules,omitempty"`
+	MaterializedSRS bool            `json:"materialized_srs,omitempty" example:"true"`
 }
 
 // SingboxRouterRuleSetUpdateRequest is the body for POST /singbox/router/rulesets/update.

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -104,31 +104,61 @@ func (c *RouterConfig) UpdateRuleSet(tag string, next RuleSet) error {
 }
 
 func (c *RouterConfig) DeleteRuleSet(tag string, force bool) error {
-	refs := c.rulesReferencingRuleSet(tag)
-	if len(refs) > 0 && !force {
-		return fmt.Errorf("%w: %q referenced by rules %v", ErrRuleSetReferenced, tag, refs)
+	tags := ruleSetTagsWithCompanion(tag)
+	refs := c.rulesReferencingRuleSets(tags)
+	if len(refs.route) > 0 && !force {
+		return fmt.Errorf("%w: %q referenced by route rules %v", ErrRuleSetReferenced, tag, refs.route)
+	}
+	if len(refs.dns) > 0 && !force {
+		return fmt.Errorf("%w: %q referenced by dns rules %v", ErrRuleSetReferenced, tag, refs.dns)
+	}
+	remove := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		remove[t] = struct{}{}
 	}
 	filtered := make([]RuleSet, 0, len(c.Route.RuleSet))
 	for _, rs := range c.Route.RuleSet {
-		if rs.Tag != tag {
-			filtered = append(filtered, rs)
+		if _, drop := remove[rs.Tag]; drop {
+			continue
 		}
+		filtered = append(filtered, rs)
 	}
 	c.Route.RuleSet = filtered
 	return nil
 }
 
-func (c *RouterConfig) rulesReferencingRuleSet(tag string) []int {
-	var refs []int
+type ruleSetRefIndices struct {
+	route []int
+	dns   []int
+}
+
+func (c *RouterConfig) rulesReferencingRuleSets(tags []string) ruleSetRefIndices {
+	want := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		want[t] = struct{}{}
+	}
+	var out ruleSetRefIndices
 	for i, r := range c.Route.Rules {
 		for _, rsTag := range r.RuleSet {
-			if rsTag == tag {
-				refs = append(refs, i)
+			if _, ok := want[rsTag]; ok {
+				out.route = append(out.route, i)
 				break
 			}
 		}
 	}
-	return refs
+	for i, r := range c.DNS.Rules {
+		for _, rsTag := range r.RuleSet {
+			if _, ok := want[rsTag]; ok {
+				out.dns = append(out.dns, i)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func (c *RouterConfig) rulesReferencingRuleSet(tag string) []int {
+	return c.rulesReferencingRuleSets(ruleSetTagsWithCompanion(tag)).route
 }
 
 func (c *RouterConfig) AddRule(r Rule) error {
@@ -447,6 +477,9 @@ func validateRule(r Rule) error {
 func validateRuleSet(rs RuleSet) error {
 	if rs.Tag == "" {
 		return fmt.Errorf("rule_set tag is required")
+	}
+	if strings.HasSuffix(rs.Tag, inlineSRSSuffix) {
+		return fmt.Errorf("rule_set %q: tag suffix %q is reserved for compiled inline rulesets", rs.Tag, inlineSRSSuffix)
 	}
 	switch rs.Type {
 	case "inline":

--- a/internal/singbox/router/config_patch_test.go
+++ b/internal/singbox/router/config_patch_test.go
@@ -82,6 +82,16 @@ func TestRuleSetRemoteURLValidation(t *testing.T) {
 	}
 }
 
+func TestRuleSetTagReservedSRSSuffix(t *testing.T) {
+	cfg := NewEmptyConfig()
+	err := cfg.AddRuleSet(RuleSet{Tag: "geosite-samsung-srs", Type: "inline", Rules: []map[string]any{
+		{"domain_suffix": []any{".samsung.com"}},
+	}})
+	if err == nil || !contains(err.Error(), "-srs") {
+		t.Fatalf("expected reserved -srs suffix error, got %v", err)
+	}
+}
+
 func TestRuleSetInlineValidation(t *testing.T) {
 	cfg := NewEmptyConfig()
 

--- a/internal/singbox/router/ruleset_materializer.go
+++ b/internal/singbox/router/ruleset_materializer.go
@@ -2,8 +2,6 @@ package router
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,9 +9,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
 )
 
-const inlineRuleSetSourceVersion = 5
+const (
+	inlineRuleSetSourceVersion = 5
+	inlineSRSSuffix            = "-srs"
+)
 
 var safeRuleSetTagRe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
@@ -25,6 +28,7 @@ type inlineRuleSetSource struct {
 type ruleSetMaterializer struct {
 	configDir string
 	binary    string
+	log       *logging.ScopedLogger
 }
 
 var inlineRuleSetCompileExec = func(binary string, args []string) (stdout, stderr string, err error) {
@@ -36,25 +40,73 @@ var inlineRuleSetCompileExec = func(binary string, args []string) (stdout, stder
 	return so.String(), se.String(), err
 }
 
+func inlineSRSTag(inlineTag string) string {
+	return inlineTag + inlineSRSSuffix
+}
+
+func inlineTagFromSRSTag(tag string) (string, bool) {
+	if !strings.HasSuffix(tag, inlineSRSSuffix) {
+		return "", false
+	}
+	base := strings.TrimSuffix(tag, inlineSRSSuffix)
+	if base == "" {
+		return "", false
+	}
+	return base, true
+}
+
+func ruleSetTagsWithCompanion(tag string) []string {
+	if _, ok := inlineTagFromSRSTag(tag); ok {
+		return []string{tag}
+	}
+	return []string{tag, inlineSRSTag(tag)}
+}
+
 func (m ruleSetMaterializer) materializeConfig(cfg *RouterConfig) (*RouterConfig, error) {
 	if cfg == nil {
 		return nil, nil
 	}
-	out := *cfg
-	out.Route = cfg.Route
-	out.Route.RuleSet = make([]RuleSet, 0, len(cfg.Route.RuleSet))
-	for _, rs := range cfg.Route.RuleSet {
-		if rs.Type != "inline" {
-			out.Route.RuleSet = append(out.Route.RuleSet, rs)
+	working := m.expandManagedToInline(cfg)
+	out := *working
+	out.Route = working.Route
+	out.Route.RuleSet = make([]RuleSet, 0, len(working.Route.RuleSet))
+
+	var inlineSets []RuleSet
+	for _, rs := range working.Route.RuleSet {
+		if rs.Type == "inline" {
+			inlineSets = append(inlineSets, rs)
 			continue
 		}
+		if m.isManagedLocalRuleSet(rs) {
+			continue
+		}
+		out.Route.RuleSet = append(out.Route.RuleSet, rs)
+	}
+	for _, rs := range inlineSets {
 		local, err := m.materializeRuleSet(rs)
 		if err != nil {
 			return nil, err
 		}
+		m.rewriteRuleSetRefs(&out, rs.Tag, local.Tag)
 		out.Route.RuleSet = append(out.Route.RuleSet, local)
 	}
 	return &out, nil
+}
+
+func (m ruleSetMaterializer) expandManagedToInline(cfg *RouterConfig) *RouterConfig {
+	if cfg == nil {
+		return nil
+	}
+	out := *cfg
+	out.Route = cfg.Route
+	out.Route.RuleSet = make([]RuleSet, len(cfg.Route.RuleSet))
+	copy(out.Route.RuleSet, cfg.Route.RuleSet)
+	for i, rs := range out.Route.RuleSet {
+		if m.isManagedLocalRuleSet(rs) {
+			out.Route.RuleSet[i] = m.restoreRuleSet(rs)
+		}
+	}
+	return &out
 }
 
 func (m ruleSetMaterializer) restoreConfig(cfg *RouterConfig) *RouterConfig {
@@ -64,10 +116,128 @@ func (m ruleSetMaterializer) restoreConfig(cfg *RouterConfig) *RouterConfig {
 	out := *cfg
 	out.Route = cfg.Route
 	out.Route.RuleSet = make([]RuleSet, 0, len(cfg.Route.RuleSet))
+	inlineSeen := make(map[string]struct{}, len(cfg.Route.RuleSet))
+
 	for _, rs := range cfg.Route.RuleSet {
-		out.Route.RuleSet = append(out.Route.RuleSet, m.restoreRuleSet(rs))
+		if m.isManagedLocalRuleSet(rs) {
+			inline := m.restoreRuleSet(rs)
+			inline.MaterializedSRS = true
+			if _, ok := inlineSeen[inline.Tag]; ok {
+				continue
+			}
+			inlineSeen[inline.Tag] = struct{}{}
+			out.Route.RuleSet = append(out.Route.RuleSet, inline)
+			continue
+		}
+		if base, ok := inlineTagFromSRSTag(rs.Tag); ok {
+			if _, seen := inlineSeen[base]; seen {
+				continue
+			}
+			if rs.Type == "inline" {
+				rs.MaterializedSRS = m.hasManagedSRSCompanion(cfg, base)
+				inlineSeen[base] = struct{}{}
+				out.Route.RuleSet = append(out.Route.RuleSet, rs)
+				continue
+			}
+			continue
+		}
+		if rs.Type == "inline" {
+			rs.MaterializedSRS = m.hasManagedSRSCompanion(cfg, rs.Tag)
+			inlineSeen[rs.Tag] = struct{}{}
+		}
+		out.Route.RuleSet = append(out.Route.RuleSet, rs)
 	}
+	// Rewrite rule_set refs using the on-disk rule_set slice: out.Route.RuleSet
+	// no longer contains managed local entries (they were projected to inline).
+	m.rewritePersistedSRSRefsToInline(cfg, &out)
+	m.rewriteSRSSuffixRuleSetRefs(&out)
 	return &out
+}
+
+func (m ruleSetMaterializer) rewritePersistedSRSRefsToInline(src, dst *RouterConfig) {
+	for _, rs := range src.Route.RuleSet {
+		if !m.isManagedLocalRuleSet(rs) {
+			continue
+		}
+		inlineTag, ok := inlineTagFromSRSTag(rs.Tag)
+		if !ok {
+			inlineTag = rs.Tag
+		}
+		m.rewriteRuleSetRefs(dst, rs.Tag, inlineTag)
+	}
+}
+
+// rewriteSRSSuffixRuleSetRefs strips reserved -srs suffixes from rule_set tags
+// in route/DNS rules so the UI always shows the inline tag (defense in depth).
+func (m ruleSetMaterializer) rewriteSRSSuffixRuleSetRefs(cfg *RouterConfig) {
+	for i := range cfg.Route.Rules {
+		cfg.Route.Rules[i].RuleSet = rewriteRuleSetTagsStripSRSSuffix(cfg.Route.Rules[i].RuleSet)
+	}
+	for i := range cfg.DNS.Rules {
+		cfg.DNS.Rules[i].RuleSet = rewriteRuleSetTagsStripSRSSuffix(cfg.DNS.Rules[i].RuleSet)
+	}
+}
+
+func rewriteRuleSetTagsStripSRSSuffix(tags []string) []string {
+	if len(tags) == 0 {
+		return tags
+	}
+	out := make([]string, len(tags))
+	changed := false
+	for i, tag := range tags {
+		if base, ok := inlineTagFromSRSTag(tag); ok {
+			out[i] = base
+			changed = true
+		} else {
+			out[i] = tag
+		}
+	}
+	if !changed {
+		return tags
+	}
+	return out
+}
+
+func (m ruleSetMaterializer) rewriteRuleSetRefs(cfg *RouterConfig, from, to string) {
+	if cfg == nil || from == "" || to == "" || from == to {
+		return
+	}
+	for i := range cfg.Route.Rules {
+		cfg.Route.Rules[i].RuleSet = rewriteRuleSetSlice(cfg.Route.Rules[i].RuleSet, from, to)
+	}
+	for i := range cfg.DNS.Rules {
+		cfg.DNS.Rules[i].RuleSet = rewriteRuleSetSlice(cfg.DNS.Rules[i].RuleSet, from, to)
+	}
+}
+
+func rewriteRuleSetSlice(tags []string, from, to string) []string {
+	if len(tags) == 0 {
+		return tags
+	}
+	out := make([]string, len(tags))
+	changed := false
+	for i, tag := range tags {
+		if tag == from {
+			out[i] = to
+			changed = true
+		} else {
+			out[i] = tag
+		}
+	}
+	if !changed {
+		return tags
+	}
+	return out
+}
+
+func (m ruleSetMaterializer) hasManagedSRSCompanion(cfg *RouterConfig, inlineTag string) bool {
+	want := inlineSRSTag(inlineTag)
+	for _, rs := range cfg.Route.RuleSet {
+		if rs.Tag == want && m.isManagedLocalRuleSet(rs) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m ruleSetMaterializer) materializeRuleSet(rs RuleSet) (RuleSet, error) {
@@ -81,16 +251,11 @@ func (m ruleSetMaterializer) materializeRuleSet(rs RuleSet) (RuleSet, error) {
 	if err != nil {
 		return RuleSet{}, fmt.Errorf("rule_set %q: %w", rs.Tag, err)
 	}
-	hash := sha256.Sum256(sourceJSON)
-	hashText := hex.EncodeToString(hash[:])[:16]
-	base := safeRuleSetFilename(rs.Tag) + "-" + hashText
+	base := safeRuleSetFilename(rs.Tag)
 	dir := filepath.Join(m.configDir, "rule-sets", "inline")
-	srsPath := filepath.Join(dir, base+".srs")
 	jsonPath := filepath.Join(dir, base+".json")
+	srsPath := filepath.Join(dir, base+".srs")
 
-	if regularFileExists(srsPath) && regularFileExists(jsonPath) {
-		return managedLocalRuleSet(rs.Tag, srsPath), nil
-	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return RuleSet{}, fmt.Errorf("mkdir inline rule-set dir: %w", err)
 	}
@@ -117,7 +282,6 @@ func (m ruleSetMaterializer) materializeRuleSet(rs RuleSet) (RuleSet, error) {
 	}
 	tmpOutPath := tmpOut.Name()
 	_ = tmpOut.Close()
-	_ = os.Remove(tmpOutPath)
 
 	args := []string{"rule-set", "compile", "--output", tmpOutPath, tmpSourcePath}
 	_, stderr, err := inlineRuleSetCompileExec(m.binary, args)
@@ -144,25 +308,56 @@ func (m ruleSetMaterializer) materializeRuleSet(rs RuleSet) (RuleSet, error) {
 		return RuleSet{}, fmt.Errorf("publish binary: %w", err)
 	}
 
-	return managedLocalRuleSet(rs.Tag, srsPath), nil
+	if m.log != nil {
+		m.log.Info(
+			"materialize",
+			rs.Tag,
+			fmt.Sprintf("compiled inline rule-set %q to %s (%s)", rs.Tag, srsPath, inlineSRSTag(rs.Tag)),
+		)
+	}
+
+	return managedLocalRuleSet(inlineSRSTag(rs.Tag), srsPath), nil
+}
+
+func (m ruleSetMaterializer) removeInlineArtifacts(tag string) {
+	if m.configDir == "" || tag == "" {
+		return
+	}
+	base := safeRuleSetFilename(tag)
+	dir := filepath.Join(m.configDir, "rule-sets", "inline")
+	for _, name := range []string{base + ".json", base + ".srs"} {
+		path := filepath.Join(dir, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) && m.log != nil {
+			m.log.Warn("cleanup", tag, fmt.Sprintf("remove %s: %v", path, err))
+		}
+	}
 }
 
 func (m ruleSetMaterializer) restoreRuleSet(rs RuleSet) RuleSet {
 	if !m.isManagedLocalRuleSet(rs) {
 		return rs
 	}
+	inlineTag := rs.Tag
+	if base, ok := inlineTagFromSRSTag(rs.Tag); ok {
+		inlineTag = base
+	}
 	raw, err := os.ReadFile(strings.TrimSuffix(rs.Path, ".srs") + ".json")
 	if err != nil {
-		return rs
+		return RuleSet{Tag: inlineTag, Type: "inline", MaterializedSRS: true}
 	}
 	var source inlineRuleSetSource
 	if err := json.Unmarshal(raw, &source); err != nil {
-		return rs
+		return RuleSet{Tag: inlineTag, Type: "inline", MaterializedSRS: true}
 	}
 	if len(source.Rules) == 0 {
-		return rs
+		return RuleSet{Tag: inlineTag, Type: "inline", MaterializedSRS: true}
 	}
-	return RuleSet{Tag: rs.Tag, Type: "inline", Rules: source.Rules}
+	return RuleSet{
+		Tag:             inlineTag,
+		Type:            "inline",
+		Rules:           source.Rules,
+		MaterializedSRS: true,
+	}
 }
 
 func (m ruleSetMaterializer) isManagedLocalRuleSet(rs RuleSet) bool {

--- a/internal/singbox/router/ruleset_materializer_test.go
+++ b/internal/singbox/router/ruleset_materializer_test.go
@@ -59,11 +59,13 @@ func TestInlineRuleSetMaterializer_CompilesLocalBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("materializeRuleSet: %v", err)
 	}
-	if got.Tag != rs.Tag || got.Type != "local" || got.Format != "binary" {
+	wantTag := inlineSRSTag(rs.Tag)
+	if got.Tag != wantTag || got.Type != "local" || got.Format != "binary" {
 		t.Fatalf("unexpected materialized ruleset: %+v", got)
 	}
-	if !strings.HasPrefix(got.Path, filepath.Join(dir, "rule-sets", "inline")) {
-		t.Fatalf("path outside managed dir: %q", got.Path)
+	wantPath := filepath.Join(dir, "rule-sets", "inline", "geosite-example.srs")
+	if got.Path != wantPath {
+		t.Fatalf("path = %q, want %q", got.Path, wantPath)
 	}
 	if _, err := os.Stat(got.Path); err != nil {
 		t.Fatalf("compiled .srs missing: %v", err)
@@ -89,10 +91,10 @@ func TestInlineRuleSetMaterializer_CompilesLocalBinary(t *testing.T) {
 		t.Fatalf("second materializeRuleSet: %v", err)
 	}
 	if again.Path != got.Path {
-		t.Fatalf("content-addressed path changed: %q -> %q", got.Path, again.Path)
+		t.Fatalf("stable path changed: %q -> %q", got.Path, again.Path)
 	}
-	if calls != 1 {
-		t.Fatalf("expected compile once with cached artifact, got %d", calls)
+	if calls != 2 {
+		t.Fatalf("expected compile on each save (overwrite), got %d", calls)
 	}
 }
 
@@ -139,5 +141,164 @@ func TestInlineRuleSetMaterializer_RestoresManagedLocalAsInline(t *testing.T) {
 	restored := m.restoreRuleSet(local)
 	if restored.Type != "inline" || restored.Tag != inline.Tag || len(restored.Rules) != 1 {
 		t.Fatalf("unexpected restored ruleset: %+v", restored)
+	}
+	if !restored.MaterializedSRS {
+		t.Fatal("expected materialized_srs on restore")
+	}
+}
+
+func TestInlineRuleSetMaterializer_RestoreConfigHidesSRSCompanion(t *testing.T) {
+	dir := t.TempDir()
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	m := ruleSetMaterializer{configDir: dir, binary: "/opt/bin/sing-box"}
+	inline := RuleSet{
+		Tag:   "pair",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{"example.com"}}},
+	}
+	local, err := m.materializeRuleSet(inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{inline, local}
+	out := m.restoreConfig(cfg)
+	if len(out.Route.RuleSet) != 1 {
+		t.Fatalf("want one visible ruleset, got %d: %+v", len(out.Route.RuleSet), out.Route.RuleSet)
+	}
+	if out.Route.RuleSet[0].Tag != "pair" || out.Route.RuleSet[0].Type != "inline" || !out.Route.RuleSet[0].MaterializedSRS {
+		t.Fatalf("unexpected list projection: %+v", out.Route.RuleSet[0])
+	}
+}
+
+func TestInlineRuleSetMaterializer_MaterializeConfigWritesSRSCompanion(t *testing.T) {
+	dir := t.TempDir()
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	m := ruleSetMaterializer{configDir: dir, binary: "/opt/bin/sing-box"}
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{{
+		Tag:   "foo",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".example.com"}}},
+	}}
+	out, err := m.materializeConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Route.RuleSet) != 1 {
+		t.Fatalf("rule_set len = %d", len(out.Route.RuleSet))
+	}
+	if out.Route.RuleSet[0].Tag != "foo-srs" || out.Route.RuleSet[0].Type != "local" {
+		t.Fatalf("unexpected persisted ruleset: %+v", out.Route.RuleSet[0])
+	}
+}
+
+func TestInlineRuleSetMaterializer_RemoveInlineArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	m := ruleSetMaterializer{configDir: dir, binary: "/opt/bin/sing-box"}
+	_, err := m.materializeRuleSet(RuleSet{
+		Tag:   "gone",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".x"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.removeInlineArtifacts("gone")
+	for _, ext := range []string{".json", ".srs"} {
+		if _, err := os.Stat(filepath.Join(dir, "rule-sets", "inline", "gone"+ext)); !os.IsNotExist(err) {
+			t.Fatalf("expected gone%s removed, stat err=%v", ext, err)
+		}
+	}
+}
+
+func TestInlineRuleSetMaterializer_RewritesRuleRefsOnMaterialize(t *testing.T) {
+	dir := t.TempDir()
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	m := ruleSetMaterializer{configDir: dir, binary: "/opt/bin/sing-box"}
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{{
+		Tag:   "foo",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".example.com"}}},
+	}}
+	cfg.Route.Rules = []Rule{{RuleSet: []string{"foo"}, Action: "route", Outbound: "direct"}}
+	out, err := m.materializeConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Route.Rules) != 1 || len(out.Route.Rules[0].RuleSet) != 1 || out.Route.Rules[0].RuleSet[0] != "foo-srs" {
+		t.Fatalf("route rule_set refs = %+v", out.Route.Rules[0].RuleSet)
+	}
+}
+
+func TestInlineRuleSetMaterializer_RestoreRewritesSRSRefsToInline(t *testing.T) {
+	dir := t.TempDir()
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	m := ruleSetMaterializer{configDir: dir, binary: "/opt/bin/sing-box"}
+	local, err := m.materializeRuleSet(RuleSet{
+		Tag:   "foo",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".example.com"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{local}
+	cfg.Route.Rules = []Rule{{RuleSet: []string{"foo-srs"}, Action: "route", Outbound: "direct"}}
+	out := m.restoreConfig(cfg)
+	if len(out.Route.Rules) != 1 || out.Route.Rules[0].RuleSet[0] != "foo" {
+		t.Fatalf("restored route rule_set refs = %+v", out.Route.Rules[0].RuleSet)
+	}
+}
+
+func TestInlineRuleSetMaterializer_RestoreRewritesSRSRefsWithoutManagedEntryInOutput(t *testing.T) {
+	// Simulates persisted config: only foo-srs in rule_set[], refs still foo-srs.
+	m := ruleSetMaterializer{configDir: t.TempDir(), binary: "/opt/bin/sing-box"}
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{{
+		Tag:    "geosite-samsung-srs",
+		Type:   "local",
+		Format: "binary",
+		Path:   filepath.Join(m.configDir, "rule-sets", "inline", "geosite-samsung.srs"),
+	}}
+	cfg.Route.Rules = []Rule{{RuleSet: []string{"geosite-samsung-srs"}, Action: "route", Outbound: "direct"}}
+	out := m.restoreConfig(cfg)
+	if len(out.Route.RuleSet) != 1 || out.Route.RuleSet[0].Tag != "geosite-samsung" {
+		t.Fatalf("rule_set projection = %+v", out.Route.RuleSet)
+	}
+	if len(out.Route.Rules) != 1 || out.Route.Rules[0].RuleSet[0] != "geosite-samsung" {
+		t.Fatalf("rule refs = %+v", out.Route.Rules[0].RuleSet)
+	}
+}
+
+func TestDeleteRuleSet_RemovesCompanionTag(t *testing.T) {
+	cfg := NewEmptyConfig()
+	cfg.Route.RuleSet = []RuleSet{
+		{Tag: "foo", Type: "inline", Rules: []map[string]any{{"domain_suffix": []any{".x"}}}},
+		{Tag: "foo-srs", Type: "local", Format: "binary", Path: "/tmp/foo.srs"},
+	}
+	if err := cfg.DeleteRuleSet("foo", false); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Route.RuleSet) != 0 {
+		t.Fatalf("expected empty rule sets, got %+v", cfg.Route.RuleSet)
 	}
 }

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logger"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
@@ -177,6 +178,7 @@ type StagingEventBus interface {
 
 type Deps struct {
 	Log            *logger.Logger
+	AppLog         logging.AppLogger
 	Settings       *storage.SettingsStore
 	Singbox        SingboxController
 	Policies       AccessPolicyProvider
@@ -294,7 +296,11 @@ func (s *ServiceImpl) ruleSetMaterializer() ruleSetMaterializer {
 	if s.deps.Singbox != nil {
 		binary = s.deps.Singbox.Binary()
 	}
-	return ruleSetMaterializer{configDir: configDir, binary: binary}
+	return ruleSetMaterializer{
+		configDir: configDir,
+		binary:    binary,
+		log:       logging.NewScopedLogger(s.deps.AppLog, logging.GroupRouting, logging.SubSingboxRouter),
+	}
 }
 
 // loadRouterConfig returns the router config the user is currently editing.
@@ -976,6 +982,7 @@ func (s *ServiceImpl) withConfig(ctx context.Context, event string, fn func(*Rou
 	if err != nil {
 		return err
 	}
+	cfg = s.ruleSetMaterializer().restoreConfig(cfg)
 	if err := fn(cfg); err != nil {
 		return err
 	}
@@ -1016,7 +1023,7 @@ func (s *ServiceImpl) ListRules(ctx context.Context) ([]Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cfg.Route.Rules, nil
+	return s.ruleSetMaterializer().restoreConfig(cfg).Route.Rules, nil
 }
 
 func (s *ServiceImpl) AddRule(ctx context.Context, r Rule) error {
@@ -1115,7 +1122,17 @@ func (s *ServiceImpl) UpdateRuleSet(ctx context.Context, tag string, rs RuleSet)
 }
 
 func (s *ServiceImpl) DeleteRuleSet(ctx context.Context, tag string, force bool) error {
-	return s.withConfig(ctx, "rulesets", func(c *RouterConfig) error { return c.DeleteRuleSet(tag, force) })
+	inlineTag := tag
+	if base, ok := inlineTagFromSRSTag(tag); ok {
+		inlineTag = base
+	}
+	return s.withConfig(ctx, "rulesets", func(c *RouterConfig) error {
+		if err := c.DeleteRuleSet(inlineTag, force); err != nil {
+			return err
+		}
+		s.ruleSetMaterializer().removeInlineArtifacts(inlineTag)
+		return nil
+	})
 }
 
 func (s *ServiceImpl) ListCompositeOutbounds(ctx context.Context) ([]CompositeOutboundView, error) {

--- a/internal/singbox/router/service_dns.go
+++ b/internal/singbox/router/service_dns.go
@@ -27,7 +27,7 @@ func (s *ServiceImpl) ListDNSRules(ctx context.Context) ([]DNSRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cfg.DNS.Rules, nil
+	return s.ruleSetMaterializer().restoreConfig(cfg).DNS.Rules, nil
 }
 
 func (s *ServiceImpl) AddDNSRule(ctx context.Context, r DNSRule) error {

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -655,7 +655,7 @@ func TestAddRuleSet_InlineWritesLocalBinaryToPendingAndListsInline(t *testing.T)
 		t.Fatalf("rule_set len = %d", len(cfg.Route.RuleSet))
 	}
 	stored := cfg.Route.RuleSet[0]
-	if stored.Tag != "custom-inline" || stored.Type != "local" || stored.Format != "binary" {
+	if stored.Tag != "custom-inline-srs" || stored.Type != "local" || stored.Format != "binary" {
 		t.Fatalf("stored rule_set not materialized local binary: %+v", stored)
 	}
 	if _, err := os.Stat(stored.Path); err != nil {
@@ -669,9 +669,47 @@ func TestAddRuleSet_InlineWritesLocalBinaryToPendingAndListsInline(t *testing.T)
 	if len(listed) != 1 || listed[0].Type != "inline" || len(listed[0].Rules) != 1 {
 		t.Fatalf("expected inline projection, got %+v", listed)
 	}
+	if !listed[0].MaterializedSRS {
+		t.Fatal("expected materialized_srs in list projection")
+	}
 }
 
-func TestUpdateRuleSet_InlineUsesNewContentAddressedFileWithoutChangingOld(t *testing.T) {
+func TestListRules_RewritesSRSCompanionRefToInlineTag(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+
+	if err := svc.AddRuleSet(context.Background(), RuleSet{
+		Tag:   "geosite-samsung",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".samsung.com"}}},
+	}); err != nil {
+		t.Fatalf("AddRuleSet: %v", err)
+	}
+	if err := svc.AddRule(context.Background(), Rule{
+		RuleSet:  []string{"geosite-samsung"},
+		Action:   "route",
+		Outbound: "direct",
+	}); err != nil {
+		t.Fatalf("AddRule: %v", err)
+	}
+
+	rules, err := svc.ListRules(context.Background())
+	if err != nil {
+		t.Fatalf("ListRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("rules len = %d", len(rules))
+	}
+	if len(rules[0].RuleSet) != 1 || rules[0].RuleSet[0] != "geosite-samsung" {
+		t.Fatalf("ListRules rule_set = %v, want [geosite-samsung]", rules[0].RuleSet)
+	}
+}
+
+func TestUpdateRuleSet_InlineOverwritesSameSRSFile(t *testing.T) {
 	svc, dir := newOrchedTestService(t)
 	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"
 	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
@@ -715,13 +753,47 @@ func TestUpdateRuleSet_InlineUsesNewContentAddressedFileWithoutChangingOld(t *te
 		t.Fatal(err)
 	}
 	secondPath := secondCfg.Route.RuleSet[0].Path
-	if firstPath == secondPath {
-		t.Fatalf("updated inline content reused old path: %q", firstPath)
-	}
-	if _, err := os.Stat(firstPath); err != nil {
-		t.Fatalf("old .srs should remain for live safety: %v", err)
+	if firstPath != secondPath {
+		t.Fatalf("expected stable srs path, got %q -> %q", firstPath, secondPath)
 	}
 	if _, err := os.Stat(secondPath); err != nil {
-		t.Fatalf("new .srs missing: %v", err)
+		t.Fatalf("updated .srs missing: %v", err)
+	}
+}
+
+func TestDeleteRuleSet_InlineRemovesSRSCompanionAndFiles(t *testing.T) {
+	svc, dir := newOrchedTestService(t)
+	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+
+	if err := svc.AddRuleSet(context.Background(), RuleSet{
+		Tag:   "to-delete",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".gone.example"}}},
+	}); err != nil {
+		t.Fatalf("AddRuleSet: %v", err)
+	}
+	if err := svc.DeleteRuleSet(context.Background(), "to-delete", false); err != nil {
+		t.Fatalf("DeleteRuleSet: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "pending", "20-router.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg RouterConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Route.RuleSet) != 0 {
+		t.Fatalf("expected no rule sets after delete, got %+v", cfg.Route.RuleSet)
+	}
+	for _, ext := range []string{".json", ".srs"} {
+		p := filepath.Join(dir, "rule-sets", "inline", "to-delete"+ext)
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed, stat err=%v", p, err)
+		}
 	}
 }

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -105,6 +105,9 @@ type RuleSet struct {
 	DownloadDetour string           `json:"download_detour,omitempty"`
 	Path           string           `json:"path,omitempty"`
 	Rules          []map[string]any `json:"rules,omitempty"`
+	// MaterializedSRS is set by ListRuleSets when a compiled .srs sibling
+	// exists for an inline ruleset. Not persisted in router JSON.
+	MaterializedSRS bool `json:"materialized_srs,omitempty"`
 }
 
 type Outbound struct {


### PR DESCRIPTION
## Summary

Улучшена материализация inline rule set в sing-box router: стабильные `.srs` на диске, отдельный compiled-тег `*-srs` в live-конфиге и единая UI-модель «редактируем inline `foo`, sing-box видит `foo-srs`». Исправлены сироты и отображение `set: …-srs` в списке правил.

Опирается на #150 (базовый materializer + `sing-box rule-set compile`).

---

## Проблема

После #150 inline при сохранении превращался в local binary, но:

- имена файлов были content-addressed (hash) и копились при правках;
- в `route.rules` оставались ссылки `tag-srs`, а API отдавал их без нормализации → в UI `set: geosite-samsung-srs` и **сирота** в редакторе (наборы — `geosite-samsung`);
- пользователь мог вручную задать тег с суффиксом `-srs`.

---

## Решение

### Backend (`ruleset_materializer`)

| Аспект | Поведение |
|--------|-----------|
| Файлы | `config.d/rule-sets/inline/{safe-tag}.json` + `.srs`, **перезапись** при каждом save |
| Live-конфиг | `type: local`, tag **`{inline-tag}-srs`**, `format: binary`, `path` → `.srs` |
| Исходник inline | JSON sidecar рядом с `.srs` для restore в UI |
| Ссылки | При persist: `foo` → `foo-srs` в route/DNS rules; при read API: обратно `foo-srs` → `foo` |
| Удаление | `DeleteRuleSet("foo")` снимает `foo-srs` из конфига и удаляет `.json`/`.srs` |
| Логи | `routing/singbox-router`, action `materialize` — видно в диагностике |
| Валидация | Теги с суффиксом `-srs` запрещены (зарезервированы под compiled companion) |

### API / service

- `withConfig` перед правками вызывает `restoreConfig` (редактирование всегда в терминах inline).
- `ListRuleSets`, `ListRules`, `ListDNSRules` отдают **UI-проекцию** (inline + `materialized_srs`, без дублей `*-srs`).
- Исправлен `restoreConfig`: перепись `rule_set` в правилах идёт по **исходному** on-disk `cfg`, а не по уже спроецированному `out` (+ защитная нормализация суффикса `-srs` в refs).

### Frontend

- Список наборов: один inline-элемент + бейдж **srs** при `materialized_srs`; скрытие `*-srs` companions.
- Модалка набора: hint и `validateRuleSetTag()` — нельзя вводить `-srs` вручную.
- Placeholder пути local: `config.d/rule-sets/...`.

---

## Модель для пользователя

```
UI (черновик):     inline "geosite-samsung"  +  rule_set: ["geosite-samsung"]
                         ↓ persist / Apply
Live (20-router):  local  "geosite-samsung-srs"  +  rule_set: ["geosite-samsung-srs"]
Файлы:             geosite-samsung.json, geosite-samsung.srs
```

---

## Тесты

- Materializer: compile, overwrite, restore, refs, delete companion, restore refs без managed entry в output.
- Service: add inline → pending с `*-srs`, list inline + `materialized_srs`, `ListRules` без `-srs`, delete + cleanup файлов.
- Config: reserved `-srs` suffix.
- Frontend: `validateRuleSetTag`.

---

## Test plan

- [ ] Создать inline-набор `geosite-samsung`, сохранить → в pending/active только `geosite-samsung-srs`, файлы в `rule-sets/inline/`.
- [ ] «+ Правило» с этим набором → в таблице `set: geosite-samsung`, в редакторе без сироты.
- [ ] Apply → sing-box стартует без `rule-set not found`.
- [ ] Изменить inline-правила → те же пути файлов, перекомпиляция.
- [ ] Удалить набор → записи и `.json`/`.srs` с диска уходят.
- [ ] Попытка тега `foo-srs` в модалке → ошибка.
- [ ] Диагностика → лог `materialize` для набора.

---

## Ограничения / follow-up

- Старые hash-имена и local без `-srs` **не мигрируются** автоматически (пересохранение набора или ручная чистка).
- GC старых `.srs` нет — только delete / uninstall.
- `GetStatus().ruleSetCount` может завышать счётчик (считает сырой конфиг с `*-srs`).

---

**Ветка:** `srs-test` → `develop`  
**Коммит:** `feat(singbox): use compiled ruleset instead of inline`