### PR TITLE
Fix awg_proxy obfuscation correctness gaps

### DIFF
--- a/internal/tunnel/config/classify.go
+++ b/internal/tunnel/config/classify.go
@@ -18,8 +18,8 @@ func ClassifyAWGVersion(iface *storage.AWGInterface) string {
 	if isRange(iface.H1) || isRange(iface.H2) || isRange(iface.H3) || isRange(iface.H4) {
 		return "awg2.0"
 	}
-	// AWG 1.5: has signature packet I1
-	if iface.I1 != "" {
+	// AWG 1.5: has any signature packet slot I1-I5
+	if hasAnySignaturePacket(iface) {
 		return "awg1.5"
 	}
 	// AWG 1.0: all four H-values set
@@ -37,4 +37,12 @@ func IsAWGObfuscated(iface *storage.AWGInterface) bool {
 
 func isRange(s string) bool {
 	return s != "" && rangePattern.MatchString(s)
+}
+
+func hasAnySignaturePacket(iface *storage.AWGInterface) bool {
+	if iface == nil {
+		return false
+	}
+	return iface.I1 != "" || iface.I2 != "" || iface.I3 != "" ||
+		iface.I4 != "" || iface.I5 != ""
 }

--- a/internal/tunnel/config/config.go
+++ b/internal/tunnel/config/config.go
@@ -47,8 +47,8 @@ func writeAWGParams(b *strings.Builder, iface *storage.AWGInterface) {
 	b.WriteString(fmt.Sprintf("H2 = %s\n", iface.H2))
 	b.WriteString(fmt.Sprintf("H3 = %s\n", iface.H3))
 	b.WriteString(fmt.Sprintf("H4 = %s\n", iface.H4))
-	// Extended params (S3, S4, I1-I5) — only if any extended param is set
-	if iface.S3 > 0 || iface.S4 > 0 || iface.I1 != "" {
+	// Extended params (S3, S4, I1-I5) - only if any extended param is set
+	if iface.S3 > 0 || iface.S4 > 0 || hasAnySignaturePacket(iface) {
 		b.WriteString(fmt.Sprintf("S3 = %d\n", iface.S3))
 		b.WriteString(fmt.Sprintf("S4 = %d\n", iface.S4))
 		if iface.I1 != "" {

--- a/internal/tunnel/config/config_test.go
+++ b/internal/tunnel/config/config_test.go
@@ -553,6 +553,39 @@ func TestGenerate_WithSignaturePackets(t *testing.T) {
 	assertContains(t, result, "I5 = 2233")
 }
 
+func TestGenerate_WithSignaturePacketsWithoutI1(t *testing.T) {
+	tunnel := &storage.AWGTunnel{
+		Interface: storage.AWGInterface{
+			PrivateKey: "privkey=",
+			AWGObfuscation: storage.AWGObfuscation{
+				Jc:   4,
+				Jmin: 50,
+				Jmax: 1000,
+				S1:   56,
+				S2:   78,
+				H1:   "111",
+				H2:   "222",
+				H3:   "333",
+				H4:   "444",
+				I2:   "CCDD",
+				I5:   "2233",
+			},
+		},
+		Peer: storage.AWGPeer{
+			PublicKey:           "pubkey=",
+			Endpoint:            "server:51820",
+			AllowedIPs:          []string{"0.0.0.0/0"},
+			PersistentKeepalive: 25,
+		},
+	}
+
+	result := Generate(tunnel)
+
+	assertNotContains(t, result, "I1 =")
+	assertContains(t, result, "I2 = CCDD")
+	assertContains(t, result, "I5 = 2233")
+}
+
 func TestGenerate_PresharedKey(t *testing.T) {
 	tunnel := &storage.AWGTunnel{
 		Interface: storage.AWGInterface{
@@ -853,6 +886,15 @@ func TestClassifyAWGVersion_AWG10_PartialH_IsWG(t *testing.T) {
 func TestClassifyAWGVersion_AWG15(t *testing.T) {
 	iface := &storage.AWGInterface{
 		AWGObfuscation: storage.AWGObfuscation{H1: "111", H2: "222", H3: "333", H4: "444", I1: "AABB"},
+	}
+	if v := ClassifyAWGVersion(iface); v != "awg1.5" {
+		t.Errorf("ClassifyAWGVersion = %q, want %q", v, "awg1.5")
+	}
+}
+
+func TestClassifyAWGVersion_AWG15_AnySignaturePacket(t *testing.T) {
+	iface := &storage.AWGInterface{
+		AWGObfuscation: storage.AWGObfuscation{I3: "AABB"},
 	}
 	if v := ClassifyAWGVersion(iface); v != "awg1.5" {
 		t.Errorf("ClassifyAWGVersion = %q, want %q", v, "awg1.5")

--- a/kmod/awg-proxy/package/Makefile
+++ b/kmod/awg-proxy/package/Makefile
@@ -57,6 +57,7 @@ define KernelPackage/awg-proxy
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
   TITLE:=AWG Proxy netfilter module
+  DEPENDS:=+kmod-crypto-aead +kmod-crypto-chacha20poly1305
   FILES:=$(PKG_BUILD_DIR)/src/awg_proxy.ko
 endef
 

--- a/kmod/awg-proxy/package/Makefile
+++ b/kmod/awg-proxy/package/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=awg-proxy
-PKG_VERSION:=1.1.6
+PKG_VERSION:=1.1.7
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/kmod/awg-proxy/src/Kbuild
+++ b/kmod/awg-proxy/src/Kbuild
@@ -1,5 +1,5 @@
 # AWG Proxy - Kernel UDP proxy for WG<->AWG packet transformation
 obj-m := awg_proxy.o
-awg_proxy-objs := main.o proxy.o transform.o tunnel.o cps.o blake2s.o
+awg_proxy-objs := main.o proxy.o transform.o tunnel.o cps.o blake2s.o cookie.o
 
 ccflags-y := -DAWG_PROXY_VERSION=\"$(AWG_PROXY_VERSION)\"

--- a/kmod/awg-proxy/src/Makefile
+++ b/kmod/awg-proxy/src/Makefile
@@ -1,7 +1,7 @@
 # Standalone out-of-tree build (for development/testing on host)
 # For cross-compilation, use the SDK package or build.sh
 
-AWG_PROXY_VERSION ?= 1.1.6
+AWG_PROXY_VERSION ?= 1.1.7
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 

--- a/kmod/awg-proxy/src/blake2s.c
+++ b/kmod/awg-proxy/src/blake2s.c
@@ -198,6 +198,15 @@ void compute_mac1_key(const u8 pubkey[32], u8 mac1key[32])
 	blake2s_256(input, 40, mac1key);
 }
 
+void compute_cookie_key(const u8 pubkey[32], u8 cookie_key[32])
+{
+	u8 input[40];
+
+	memcpy(input, "cookie--", 8);
+	memcpy(input + 8, pubkey, 32);
+	blake2s_256(input, 40, cookie_key);
+}
+
 void recompute_mac1(u8 *buf, const u8 mac1key[32])
 {
 	u8 mac1[16];

--- a/kmod/awg-proxy/src/blake2s.h
+++ b/kmod/awg-proxy/src/blake2s.h
@@ -13,6 +13,9 @@ void blake2s_128mac(const u8 key[32], const void *data, size_t len, u8 out[16]);
 /* Derive MAC1 key: BLAKE2s-256("mac1----" || pubkey) */
 void compute_mac1_key(const u8 pubkey[32], u8 mac1key[32]);
 
+/* Derive cookie key: BLAKE2s-256("cookie--" || pubkey) */
+void compute_cookie_key(const u8 pubkey[32], u8 cookie_key[32]);
+
 /* Recompute MAC1 in handshake init (148 bytes). MAC1 at [116:132], covers [0:116]. */
 void recompute_mac1(u8 *buf, const u8 mac1key[32]);
 

--- a/kmod/awg-proxy/src/cookie.c
+++ b/kmod/awg-proxy/src/cookie.c
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * XChaCha20-Poly1305 helpers for cookie_reply AAD translation.
+ *
+ * WireGuard cookie replies are encrypted with AAD = MAC1 from the denied
+ * handshake. awg_proxy rewrites handshake headers and recomputes MAC1 for the
+ * remote AWG peer, so the returned cookie must be re-encrypted with the local
+ * vanilla-WG client's original MAC1 before forwarding it back.
+ */
+
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/crypto.h>
+#include <linux/scatterlist.h>
+#include <crypto/aead.h>
+#include <crypto/chacha.h>
+#include <asm/unaligned.h>
+
+#include "cookie.h"
+
+static void hchacha20_subkey(u8 subkey[32], const u8 key[32],
+			     const u8 nonce_16[16])
+{
+	u32 state[16];
+	u32 out_words[8];
+	int i;
+
+	chacha_init_consts(state);
+	for (i = 0; i < 8; i++)
+		state[4 + i] = get_unaligned_le32(key + i * 4);
+	for (i = 0; i < 4; i++)
+		state[12 + i] = get_unaligned_le32(nonce_16 + i * 4);
+
+	hchacha_block(state, out_words, 20);
+
+	for (i = 0; i < 8; i++)
+		put_unaligned_le32(out_words[i], subkey + i * 4);
+
+	memzero_explicit(state, sizeof(state));
+	memzero_explicit(out_words, sizeof(out_words));
+}
+
+int awg_cookie_aead_create(struct crypto_aead **out)
+{
+	struct crypto_aead *aead;
+	int ret;
+
+	aead = crypto_alloc_aead("rfc7539(chacha20,poly1305)", 0,
+				 CRYPTO_ALG_ASYNC);
+	if (IS_ERR(aead))
+		return PTR_ERR(aead);
+
+	ret = crypto_aead_setauthsize(aead, 16);
+	if (ret) {
+		crypto_free_aead(aead);
+		return ret;
+	}
+
+	*out = aead;
+	return 0;
+}
+
+void awg_cookie_aead_destroy(struct crypto_aead *aead)
+{
+	if (aead && !IS_ERR(aead))
+		crypto_free_aead(aead);
+}
+
+static int xchacha20p1305_op(bool encrypt, struct crypto_aead *aead,
+			     const u8 key[32], const u8 nonce_24[24],
+			     const u8 *aad, size_t aad_len,
+			     u8 *payload, size_t payload_len)
+{
+	u8 subkey[32];
+	u8 iv[12];
+	struct aead_request *req;
+	struct scatterlist sg;
+	u8 *combined;
+	size_t total;
+	int ret;
+
+	if (!aead || !key || !nonce_24 || !aad || !payload)
+		return -EINVAL;
+
+	hchacha20_subkey(subkey, key, nonce_24);
+
+	memset(iv, 0, 4);
+	memcpy(iv + 4, nonce_24 + 16, 8);
+
+	total = aad_len + payload_len + (encrypt ? 16 : 0);
+	combined = kmalloc(total, GFP_KERNEL);
+	if (!combined) {
+		ret = -ENOMEM;
+		goto out_zeroize;
+	}
+	memcpy(combined, aad, aad_len);
+	memcpy(combined + aad_len, payload, payload_len);
+
+	ret = crypto_aead_setkey(aead, subkey, 32);
+	if (ret)
+		goto out_free;
+
+	req = aead_request_alloc(aead, GFP_KERNEL);
+	if (!req) {
+		ret = -ENOMEM;
+		goto out_free;
+	}
+
+	sg_init_one(&sg, combined, total);
+	aead_request_set_callback(req, 0, NULL, NULL);
+	aead_request_set_crypt(req, &sg, &sg, payload_len, iv);
+	aead_request_set_ad(req, aad_len);
+
+	if (encrypt)
+		ret = crypto_aead_encrypt(req);
+	else
+		ret = crypto_aead_decrypt(req);
+
+	aead_request_free(req);
+
+	if (!ret) {
+		size_t out_len = encrypt ? payload_len + 16 : payload_len - 16;
+
+		memcpy(payload, combined + aad_len, out_len);
+	}
+
+out_free:
+	memzero_explicit(combined, total);
+	kfree(combined);
+out_zeroize:
+	memzero_explicit(subkey, sizeof(subkey));
+	memzero_explicit(iv, sizeof(iv));
+	return ret;
+}
+
+int awg_xchacha20p1305_decrypt(struct crypto_aead *aead, const u8 key[32],
+			       const u8 nonce_24[24],
+			       const u8 *aad, size_t aad_len,
+			       u8 *ct_with_tag, size_t ct_with_tag_len)
+{
+	if (ct_with_tag_len < 16)
+		return -EINVAL;
+
+	return xchacha20p1305_op(false, aead, key, nonce_24, aad, aad_len,
+				 ct_with_tag, ct_with_tag_len);
+}
+
+int awg_xchacha20p1305_encrypt(struct crypto_aead *aead, const u8 key[32],
+			       const u8 nonce_24[24],
+			       const u8 *aad, size_t aad_len,
+			       u8 *pt_out_buf, size_t pt_len)
+{
+	return xchacha20p1305_op(true, aead, key, nonce_24, aad, aad_len,
+				 pt_out_buf, pt_len);
+}

--- a/kmod/awg-proxy/src/cookie.h
+++ b/kmod/awg-proxy/src/cookie.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _AWG_PROXY_COOKIE_H
+#define _AWG_PROXY_COOKIE_H
+
+#include <linux/types.h>
+
+struct crypto_aead;
+
+int awg_cookie_aead_create(struct crypto_aead **out);
+void awg_cookie_aead_destroy(struct crypto_aead *aead);
+
+int awg_xchacha20p1305_decrypt(struct crypto_aead *aead, const u8 key[32],
+			       const u8 nonce_24[24],
+			       const u8 *aad, size_t aad_len,
+			       u8 *ct_with_tag, size_t ct_with_tag_len);
+
+int awg_xchacha20p1305_encrypt(struct crypto_aead *aead, const u8 key[32],
+			       const u8 nonce_24[24],
+			       const u8 *aad, size_t aad_len,
+			       u8 *pt_out_buf, size_t pt_len);
+
+#endif /* _AWG_PROXY_COOKIE_H */

--- a/kmod/awg-proxy/src/main.c
+++ b/kmod/awg-proxy/src/main.c
@@ -28,6 +28,8 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("hoaxisr");
 MODULE_DESCRIPTION("AWG Proxy - Kernel UDP proxy for WG<->AWG transformation");
 MODULE_VERSION(AWG_PROXY_VERSION);
+/* cookie_reply AEAD translation needs rfc7539(chacha20,poly1305). */
+MODULE_SOFTDEP("pre: chacha20poly1305");
 
 /* ────────────────────────── Procfs ───────────────────────────────── */
 

--- a/kmod/awg-proxy/src/proxy.c
+++ b/kmod/awg-proxy/src/proxy.c
@@ -729,6 +729,8 @@ out_cleanup:
 		awg_cookie_aead_destroy(p->cookie_aead);
 		p->cookie_aead = NULL;
 	}
+	memzero_explicit(p->cookie_decryption_key,
+			 sizeof(p->cookie_decryption_key));
 	p->active = false;
 	awg_config_free(&p->cfg);
 out_free:
@@ -773,6 +775,8 @@ static void proxy_stop(struct awg_proxy *p)
 		awg_cookie_aead_destroy(p->cookie_aead);
 		p->cookie_aead = NULL;
 	}
+	memzero_explicit(p->cookie_decryption_key,
+			 sizeof(p->cookie_decryption_key));
 
 	awg_config_free(&p->cfg);
 }

--- a/kmod/awg-proxy/src/proxy.c
+++ b/kmod/awg-proxy/src/proxy.c
@@ -26,6 +26,8 @@
 #include "proxy.h"
 #include "transform.h"
 #include "cps.h"
+#include "cookie.h"
+#include "blake2s.h"
 
 static struct awg_proxy proxies[AWG_MAX_TUNNELS];
 static DEFINE_MUTEX(proxy_mutex);
@@ -309,6 +311,8 @@ static int c2s_thread_fn(void *data)
 		int n, out_len, sendJunk;
 		u32 msgType;
 		u64 rand_val;
+		u8 captured_mac1_old[16];
+		bool mac1_capture_pending = false;
 
 		/* Receive from listen socket (WG sends here) */
 		payload = raw_buf + headroom;
@@ -346,6 +350,18 @@ static int c2s_thread_fn(void *data)
 			spin_unlock(&proxy->client_lock);
 		}
 
+		if (proxy->cookie_aead) {
+			if (payload[0] == WG_HANDSHAKE_INIT &&
+			    n == WG_INIT_SIZE) {
+				memcpy(captured_mac1_old, payload + 116, 16);
+				mac1_capture_pending = true;
+			} else if (payload[0] == WG_HANDSHAKE_RESPONSE &&
+				   n == WG_RESP_SIZE) {
+				memcpy(captured_mac1_old, payload + 60, 16);
+				mac1_capture_pending = true;
+			}
+		}
+
 		/* Get random value for H range selection */
 		get_random_bytes(&rand_val, sizeof(rand_val));
 
@@ -353,6 +369,30 @@ static int c2s_thread_fn(void *data)
 		out = transform_outbound(raw_buf, headroom, n,
 					 &proxy->cfg, rand_val,
 					 &out_len, &sendJunk, &msgType);
+
+		if (mac1_capture_pending && proxy->cookie_aead) {
+			int s_prefix = -1;
+			int mac1_off = -1;
+
+			if (msgType == WG_HANDSHAKE_INIT) {
+				s_prefix = proxy->cfg.s1;
+				mac1_off = 116;
+			} else if (msgType == WG_HANDSHAKE_RESPONSE) {
+				s_prefix = proxy->cfg.s2;
+				mac1_off = 60;
+			}
+
+			if (s_prefix >= 0 && mac1_off >= 0 &&
+			    out_len >= s_prefix + mac1_off + 16) {
+				spin_lock(&proxy->mac1_lock);
+				memcpy(proxy->last_mac1_old,
+				       captured_mac1_old, 16);
+				memcpy(proxy->last_mac1_new,
+				       out + s_prefix + mac1_off, 16);
+				WRITE_ONCE(proxy->have_last_mac1, true);
+				spin_unlock(&proxy->mac1_lock);
+			}
+		}
 
 		/* Send CPS + junk before handshake init if needed */
 		if (sendJunk) {
@@ -473,6 +513,33 @@ static int s2c_thread_fn(void *data)
 
 		/* Transform inbound AWG -> WG */
 		out = transform_inbound(buf, n, &proxy->cfg, &out_len);
+		if (out && out_len == WG_COOKIE_SIZE &&
+		    out[0] == WG_COOKIE_REPLY &&
+		    proxy->cookie_aead &&
+		    READ_ONCE(proxy->have_last_mac1)) {
+			u8 mac1_old[16], mac1_new[16];
+			u8 cookie_buf[32];
+			int ret;
+
+			spin_lock(&proxy->mac1_lock);
+			memcpy(mac1_old, proxy->last_mac1_old, 16);
+			memcpy(mac1_new, proxy->last_mac1_new, 16);
+			spin_unlock(&proxy->mac1_lock);
+
+			memcpy(cookie_buf, out + 32, 32);
+			ret = awg_xchacha20p1305_decrypt(
+				proxy->cookie_aead,
+				proxy->cookie_decryption_key,
+				out + 8, mac1_new, 16, cookie_buf, 32);
+			if (!ret) {
+				ret = awg_xchacha20p1305_encrypt(
+					proxy->cookie_aead,
+					proxy->cookie_decryption_key,
+					out + 8, mac1_old, 16, cookie_buf, 16);
+				if (!ret)
+					memcpy(out + 32, cookie_buf, 32);
+			}
+		}
 		if (!out)
 			continue; /* junk/CPS — drop silently */
 
@@ -556,8 +623,22 @@ int awg_proxy_add(const char *config_line)
 	memcpy(&p->cfg, &tmp, sizeof(tmp));
 	memset(tmp.cps, 0, sizeof(tmp.cps)); /* prevent double-free */
 	spin_lock_init(&p->client_lock);
+	spin_lock_init(&p->mac1_lock);
 	p->cps_counter = 0;
+	p->have_last_mac1 = false;
+	p->cookie_aead = NULL;
 	p->headroom = compute_headroom(&p->cfg);
+
+	if (p->cfg.has_server_pub) {
+		compute_cookie_key(p->cfg.server_pub, p->cookie_decryption_key);
+		ret = awg_cookie_aead_create(&p->cookie_aead);
+		if (ret) {
+			pr_warn("awg_proxy: cookie AEAD setup failed: %d\n",
+				ret);
+			p->cookie_aead = NULL;
+			ret = 0;
+		}
+	}
 	atomic64_set(&p->rx_bytes, 0);
 	atomic64_set(&p->tx_bytes, 0);
 	atomic_set(&p->rx_packets, 0);
@@ -644,6 +725,10 @@ out_cleanup:
 		sock_release(p->remote_sock);
 		p->remote_sock = NULL;
 	}
+	if (p->cookie_aead) {
+		awg_cookie_aead_destroy(p->cookie_aead);
+		p->cookie_aead = NULL;
+	}
 	p->active = false;
 	awg_config_free(&p->cfg);
 out_free:
@@ -683,6 +768,10 @@ static void proxy_stop(struct awg_proxy *p)
 	if (p->remote_sock) {
 		sock_release(p->remote_sock);
 		p->remote_sock = NULL;
+	}
+	if (p->cookie_aead) {
+		awg_cookie_aead_destroy(p->cookie_aead);
+		p->cookie_aead = NULL;
 	}
 
 	awg_config_free(&p->cfg);

--- a/kmod/awg-proxy/src/proxy.h
+++ b/kmod/awg-proxy/src/proxy.h
@@ -69,6 +69,19 @@ struct awg_proxy {
 
 	/* Active flag */
 	bool active;
+
+	/*
+	 * Cookie-reply AAD translation state. The AWG server encrypts
+	 * cookie_reply with AAD = MAC1_new (after our header substitution and
+	 * MAC1 recompute), while the local vanilla-WG client decrypts with
+	 * AAD = MAC1_old (the MAC1 it originally generated).
+	 */
+	u8 cookie_decryption_key[32];
+	u8 last_mac1_old[16];
+	u8 last_mac1_new[16];
+	bool have_last_mac1;
+	spinlock_t mac1_lock;
+	struct crypto_aead *cookie_aead;
 } __aligned(8);
 
 /*

--- a/kmod/awg-proxy/src/tunnel.c
+++ b/kmod/awg-proxy/src/tunnel.c
@@ -14,24 +14,22 @@
 #include "blake2s.h"
 #include "cps.h"
 
-/*
- * Parse hex string into binary buffer.
- * Returns number of bytes written, or -1 on error.
- */
-static int parse_hex(const char *hex, u8 *out, int maxlen)
+static int parse_hex_exact(const char *hex, u8 *out, int len)
 {
-	int i = 0;
-	int hi, lo;
+	int i, hi, lo;
 
-	while (hex[0] && hex[1] && i < maxlen) {
+	for (i = 0; i < len; i++) {
+		if (!hex[0] || !hex[1])
+			return -EINVAL;
 		hi = hex_to_bin(hex[0]);
 		lo = hex_to_bin(hex[1]);
 		if (hi < 0 || lo < 0)
-			return -1;
-		out[i++] = (hi << 4) | lo;
+			return -EINVAL;
+		out[i] = (hi << 4) | lo;
 		hex += 2;
 	}
-	return i;
+
+	return *hex ? -EINVAL : 0;
 }
 
 static int hrange_overlaps(const hrange_t *a, const hrange_t *b)
@@ -162,9 +160,17 @@ int awg_config_parse(const char *config_line, awg_config_t *cfg)
 		} else if (strcmp(key, "Jmax") == 0) {
 			kstrtoint(val, 10, &cfg->jmax);
 		} else if (strcmp(key, "PUB_SERVER") == 0) {
-			parse_hex(val, cfg->server_pub, 32);
+			if (parse_hex_exact(val, cfg->server_pub, 32)) {
+				pr_warn("awg_proxy: invalid PUB_SERVER\n");
+				kfree(val);
+				goto out_invalid;
+			}
 		} else if (strcmp(key, "PUB_CLIENT") == 0) {
-			parse_hex(val, cfg->client_pub, 32);
+			if (parse_hex_exact(val, cfg->client_pub, 32)) {
+				pr_warn("awg_proxy: invalid PUB_CLIENT\n");
+				kfree(val);
+				goto out_invalid;
+			}
 		} else if (strcmp(key, "BIND") == 0) {
 			strscpy(cfg->bind_iface, val, sizeof(cfg->bind_iface));
 		} else if (key[0] == 'I' && key[1] >= '1' && key[1] <= '5' &&

--- a/kmod/awg-proxy/src/tunnel.c
+++ b/kmod/awg-proxy/src/tunnel.c
@@ -34,6 +34,11 @@ static int parse_hex(const char *hex, u8 *out, int maxlen)
 	return i;
 }
 
+static int hrange_overlaps(const hrange_t *a, const hrange_t *b)
+{
+	return a->min <= b->max && b->min <= a->max;
+}
+
 /*
  * Parse config line format:
  *   IP:PORT H1=min-max H2=min-max H3=min-max H4=min-max
@@ -202,6 +207,15 @@ int awg_config_parse(const char *config_line, awg_config_t *cfg)
 	if (cfg->h1.min > cfg->h1.max || cfg->h2.min > cfg->h2.max ||
 	    cfg->h3.min > cfg->h3.max || cfg->h4.min > cfg->h4.max) {
 		pr_warn("awg_proxy: H range min > max\n");
+		goto out_invalid;
+	}
+	if (hrange_overlaps(&cfg->h1, &cfg->h2) ||
+	    hrange_overlaps(&cfg->h1, &cfg->h3) ||
+	    hrange_overlaps(&cfg->h1, &cfg->h4) ||
+	    hrange_overlaps(&cfg->h2, &cfg->h3) ||
+	    hrange_overlaps(&cfg->h2, &cfg->h4) ||
+	    hrange_overlaps(&cfg->h3, &cfg->h4)) {
+		pr_warn("awg_proxy: H ranges must not overlap\n");
 		goto out_invalid;
 	}
 

--- a/kmod/awg-proxy/tests/Makefile
+++ b/kmod/awg-proxy/tests/Makefile
@@ -26,9 +26,10 @@ SRC     := ../src
 
 all: test
 
-test: test_cps test_transform
+test: test_cps test_transform test_tunnel
 	./test_cps
 	./test_transform
+	./test_tunnel
 
 test_cps: test_cps.c shim.c shim.h $(SRC)/cps.c
 	$(CC) $(CFLAGS) -o $@ test_cps.c shim.c $(SRC)/cps.c $(LDFLAGS)
@@ -36,5 +37,8 @@ test_cps: test_cps.c shim.c shim.h $(SRC)/cps.c
 test_transform: test_transform.c shim.c shim.h $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c
 	$(CC) $(CFLAGS) -o $@ test_transform.c shim.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(LDFLAGS)
 
+test_tunnel: test_tunnel.c shim.c shim.h $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c
+	$(CC) $(CFLAGS) -o $@ test_tunnel.c shim.c $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(LDFLAGS)
+
 clean:
-	rm -f test_cps test_transform *.o
+	rm -f test_cps test_transform test_tunnel *.o

--- a/kmod/awg-proxy/tests/shim.h
+++ b/kmod/awg-proxy/tests/shim.h
@@ -19,6 +19,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #define htole32(x) OSSwapHostToLittleInt32(x)
@@ -54,6 +56,46 @@ static inline void *kmalloc(size_t n, int gfp) { (void)gfp; return malloc(n); }
 static inline void *kzalloc(size_t n, int gfp) { (void)gfp; return calloc(1, n); }
 static inline void  kfree(void *p) { free(p); }
 #define GFP_KERNEL 0
+
+static inline int kstrtoint(const char *s, unsigned int base, int *res)
+{
+	char *end = NULL;
+	long v;
+
+	if (!s || !*s)
+		return -EINVAL;
+	errno = 0;
+	v = strtol(s, &end, base);
+	if (errno || !end || *end)
+		return -EINVAL;
+	*res = (int)v;
+	return 0;
+}
+
+static inline ssize_t strscpy(char *dst, const char *src, size_t size)
+{
+	size_t len;
+
+	if (!size)
+		return -E2BIG;
+	len = strlen(src);
+	if (len >= size)
+		len = size - 1;
+	memcpy(dst, src, len);
+	dst[len] = '\0';
+	return (ssize_t)len;
+}
+
+static inline int hex_to_bin(char ch)
+{
+	if (ch >= '0' && ch <= '9')
+		return ch - '0';
+	if (ch >= 'a' && ch <= 'f')
+		return ch - 'a' + 10;
+	if (ch >= 'A' && ch <= 'F')
+		return ch - 'A' + 10;
+	return -1;
+}
 
 /* ---- Random + time stubs (deterministic for tests) ---- */
 void shim_set_random_seed(uint32_t seed);

--- a/kmod/awg-proxy/tests/stubs/linux/inet.h
+++ b/kmod/awg-proxy/tests/stubs/linux/inet.h
@@ -1,0 +1,12 @@
+/* Host-build stub for <linux/inet.h>. */
+#ifndef _STUB_LINUX_INET_H
+#define _STUB_LINUX_INET_H
+
+#include <arpa/inet.h>
+
+static inline __be32 in_aton(const char *str)
+{
+	return (__be32)inet_addr(str);
+}
+
+#endif

--- a/kmod/awg-proxy/tests/stubs/linux/slab.h
+++ b/kmod/awg-proxy/tests/stubs/linux/slab.h
@@ -1,0 +1,4 @@
+/* Host-build stub. Allocation helpers come from shim.h. */
+#ifndef _STUB_LINUX_SLAB_H
+#define _STUB_LINUX_SLAB_H
+#endif

--- a/kmod/awg-proxy/tests/test_tunnel.c
+++ b/kmod/awg-proxy/tests/test_tunnel.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Userspace unit tests for kmod/awg-proxy/src/tunnel.c.
+ */
+
+#include "shim.h"
+#include "../src/tunnel.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+static int tests_run, tests_failed;
+
+static void test_fail(const char *test, const char *fmt, ...)
+{
+	va_list ap;
+
+	fprintf(stderr, "FAIL %s: ", test);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+	tests_failed++;
+}
+
+#define ASSERT_TRUE(test, cond, msg) do { \
+	if (!(cond)) test_fail((test), "%s", (msg)); \
+} while (0)
+
+static void test_accepts_non_overlapping_h_ranges(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 H1=100-199 H2=200-299 H3=300-399 H4=400-499",
+			       &cfg);
+	ASSERT_TRUE("accepts_non_overlapping_h_ranges", ret == 0,
+		    "non-overlapping H ranges should parse");
+	if (!ret)
+		awg_config_free(&cfg);
+}
+
+static void test_rejects_overlapping_h_ranges(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 H1=100-200 H2=200-300 H3=400 H4=500",
+			       &cfg);
+	ASSERT_TRUE("rejects_overlapping_h_ranges", ret != 0,
+		    "H ranges sharing a boundary must be rejected");
+}
+
+static void test_rejects_range_overlapping_default_header(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 H2=1-20",
+			       &cfg);
+	ASSERT_TRUE("rejects_range_overlapping_default_header", ret != 0,
+		    "configured H2 range must not overlap default H1=1");
+}
+
+int main(void)
+{
+	test_accepts_non_overlapping_h_ranges();
+	test_rejects_overlapping_h_ranges();
+	test_rejects_range_overlapping_default_header();
+
+	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
+	return tests_failed == 0 ? 0 : 1;
+}

--- a/kmod/awg-proxy/tests/test_tunnel.c
+++ b/kmod/awg-proxy/tests/test_tunnel.c
@@ -66,11 +66,75 @@ static void test_rejects_range_overlapping_default_header(void)
 		    "configured H2 range must not overlap default H1=1");
 }
 
+static void test_accepts_exact_public_keys(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 "
+			       "PUB_SERVER=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f "
+			       "PUB_CLIENT=202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+			       &cfg);
+	ASSERT_TRUE("accepts_exact_public_keys", ret == 0,
+		    "64-char hex public keys should parse");
+	if (!ret) {
+		ASSERT_TRUE("accepts_exact_public_keys", cfg.has_server_pub,
+			    "server public key should be marked present");
+		ASSERT_TRUE("accepts_exact_public_keys", cfg.has_client_pub,
+			    "client public key should be marked present");
+		awg_config_free(&cfg);
+	}
+}
+
+static void test_rejects_short_public_key(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 "
+			       "PUB_SERVER=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e",
+			       &cfg);
+	ASSERT_TRUE("rejects_short_public_key", ret != 0,
+		    "short public key hex must be rejected");
+}
+
+static void test_rejects_long_public_key(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 "
+			       "PUB_SERVER=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f00",
+			       &cfg);
+	ASSERT_TRUE("rejects_long_public_key", ret != 0,
+		    "long public key hex must be rejected");
+}
+
+static void test_rejects_invalid_public_key_hex(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	tests_run++;
+	ret = awg_config_parse("203.0.113.1:51820 "
+			       "PUB_CLIENT=zz0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			       &cfg);
+	ASSERT_TRUE("rejects_invalid_public_key_hex", ret != 0,
+		    "non-hex public key data must be rejected");
+}
+
 int main(void)
 {
 	test_accepts_non_overlapping_h_ranges();
 	test_rejects_overlapping_h_ranges();
 	test_rejects_range_overlapping_default_header();
+	test_accepts_exact_public_keys();
+	test_rejects_short_public_key();
+	test_rejects_long_public_key();
+	test_rejects_invalid_public_key_hex();
 
 	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
 	return tests_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Four correctness fixes for awg_proxy and AWG config handling, found by comparing against the official AmneziaWG implementations:

- translate cookie_reply AEAD between the rewritten MAC1 and the original vanilla-WG MAC1
- reject overlapping H1-H4 magic header ranges in the kmod parser
- require exact 32-byte hex for public keys used in MAC/cookie key derivation
- treat I1-I5 signature packet slots independently in config export/classification

Bumps awg_proxy to 1.1.7. Prebuilt `.ko` artifacts in `kmod/awg-proxy/out/` are not rebuilt yet.

## Changes

### Cookie reply MAC1/AAD translation

WG cookie replies encrypt with AAD = MAC1 from the denied handshake. The server uses the MAC1 it received, the client decrypts with its stored `last_mac1_sent`:

- https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/blob/master/src/cookie.c#L180-L219
- https://github.com/amnezia-vpn/amneziawg-go/blob/master/device/cookie.go#L117-L207

Since awg_proxy rewrites H1/H2 and recomputes MAC1 before forwarding to the AWG server, the server encrypts cookie_reply with `MAC1_new` while the local WG client still has `MAC1_old`. The cookie gets rejected, MAC2 stays zero, and handshakes loop while the server is under load.

We derive the cookie key from `BLAKE2s("cookie--" || server_pub)`, capture the old/new MAC1 pair on outbound handshakes, then decrypt inbound cookie replies with `MAC1_new` AAD and re-encrypt with `MAC1_old` AAD before forwarding. HChaCha subkey uses explicit LE loads/stores so big-endian MIPS gets the same XChaCha key as official implementations.

### H1-H4 overlap validation

Official AWG rejects overlapping magic header ranges since packet type detection relies on them:

- https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/blob/master/src/device.c#L606-L612
- https://github.com/amnezia-vpn/amneziawg-go/blob/master/device/uapi.go#L725-L733

awg_proxy only checked `min <= max`, so configs with overlapping ranges would parse fine and then misclassify packets on receive. Now rejects any H1-H4 overlap during `/proc/awg_proxy/add` parsing. Host tests cover non-overlapping accept, boundary overlap reject, and default-value overlap reject.

### Exact public key hex validation

`PUB_SERVER` and `PUB_CLIENT` feed MAC1 and cookie key derivation. The old parser silently accepted short, long, or partly invalid hex, leaving partial key material with zero padding. MAC1/cookie crypto would then fail with no obvious cause.

Now requires exactly 64 hex characters per key and fails the slot otherwise. Host tests for exact, short, long, and invalid hex.

### I1-I5 signature packet slots

Official AWG treats signature packet templates as independent slots and sends every configured one:

- https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/blob/master/src/send.c#L46-L57
- https://github.com/amnezia-vpn/amneziawg-go/blob/master/device/send.go#L131-L137

The Go config path only checked `I1` for AWG 1.5 classification. Configs with `I2`-`I5` but no `I1` would lose those slots on export. Now classifies AWG 1.5 when any I-slot is present and writes the extended block accordingly. Go tests for I2/I5 without I1.

## Validation

- `make -C kmod/awg-proxy/tests test`
- `docker run --rm -v /private/tmp/awg-manager-obfs-fixes:/src -w /src -e GOCACHE=/tmp/go-cache -e GOMODCACHE=/tmp/go-mod-cache golang:1.23 go test ./internal/tunnel/config ./internal/tunnel/nwg ./internal/ndms ./internal/managed`