### PR TITLE
Feature/ndms capacity and save settle

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -321,7 +321,8 @@ func main() {
 		eventBus,
 		3*time.Second,
 		10*time.Second,
-		0, nil,
+		env.DurationDefault("AWG_NDMS_SAVE_SETTLE_DELAY", 2*time.Second),
+		ndmsQueries.RunningConfig,
 	)
 	ndmsCommands := ndmscommand.NewCommands(ndmscommand.Deps{
 		Poster:       ndmsTransportClient,
@@ -1701,7 +1702,14 @@ func runCleanup(dataDir string) {
 
 	// Build NDMS Commands early so the Operator can consume them. HookNotifier
 	// is wired below once the orchestrator exists (see SetHookNotifier call).
-	cleanupNDMSSave := ndmscommand.NewSaveCoordinator(cleanupNDMSTransport, cleanupEventBus, 3*time.Second, 10*time.Second, 0, nil)
+	cleanupNDMSSave := ndmscommand.NewSaveCoordinator(
+		cleanupNDMSTransport,
+		cleanupEventBus,
+		3*time.Second,
+		10*time.Second,
+		env.DurationDefault("AWG_NDMS_SAVE_SETTLE_DELAY", 2*time.Second),
+		cleanupNDMSQueries.RunningConfig,
+	)
 	cleanupNDMSCommands := ndmscommand.NewCommands(ndmscommand.Deps{
 		Poster:  cleanupNDMSTransport,
 		Save:    cleanupNDMSSave,

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/singbox/subscription"
 	"github.com/hoaxisr/awg-manager/internal/staticroute"
 	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/sys/env"
 	"github.com/hoaxisr/awg-manager/internal/sys/kmod"
 	"github.com/hoaxisr/awg-manager/internal/sys/ndmsinfo"
 	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
@@ -250,7 +251,7 @@ func main() {
 	// (state.Manager, routing.Catalog, etc.) can depend on them. Commands
 	// + SaveCoordinator are constructed later (they depend on eventBus +
 	// orchestrator).
-	ndmsSem := ndmstransport.NewSemaphore(4)
+	ndmsSem := ndmstransport.NewSemaphore(env.IntDefault("AWG_NDMS_CAP", 30))
 	ndmsTransportClient := ndmstransport.New(ndmsSem)
 	ndmsTransportClient.SetAppLogger(loggingService)
 

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -321,6 +321,7 @@ func main() {
 		eventBus,
 		3*time.Second,
 		10*time.Second,
+		0, nil,
 	)
 	ndmsCommands := ndmscommand.NewCommands(ndmscommand.Deps{
 		Poster:       ndmsTransportClient,
@@ -1700,7 +1701,7 @@ func runCleanup(dataDir string) {
 
 	// Build NDMS Commands early so the Operator can consume them. HookNotifier
 	// is wired below once the orchestrator exists (see SetHookNotifier call).
-	cleanupNDMSSave := ndmscommand.NewSaveCoordinator(cleanupNDMSTransport, cleanupEventBus, 3*time.Second, 10*time.Second)
+	cleanupNDMSSave := ndmscommand.NewSaveCoordinator(cleanupNDMSTransport, cleanupEventBus, 3*time.Second, 10*time.Second, 0, nil)
 	cleanupNDMSCommands := ndmscommand.NewCommands(ndmscommand.Deps{
 		Poster:  cleanupNDMSTransport,
 		Save:    cleanupNDMSSave,

--- a/internal/dnsroute/helpers_test.go
+++ b/internal/dnsroute/helpers_test.go
@@ -58,7 +58,7 @@ func newTestNDMS() (*query.Queries, *command.Commands, *fakePoster, *query.FakeG
 		Logger: query.NopLogger(),
 		IsOS5:  func() bool { return true },
 	})
-	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second)
+	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second, 0, nil)
 	c := command.NewCommands(command.Deps{
 		Poster:  poster,
 		Save:    sc,

--- a/internal/hydraroute/policies_test.go
+++ b/internal/hydraroute/policies_test.go
@@ -54,7 +54,7 @@ func newTestQueries() (*query.Queries, *query.FakeGetter) {
 // newTestPolicyCommands builds a real *command.PolicyCommands wired to a fakePoster.
 func newTestPolicyCommands(q *query.Queries) (*command.PolicyCommands, *fakePoster) {
 	poster := &fakePoster{}
-	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second)
+	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second, 0, nil)
 	return command.NewPolicyCommands(poster, sc, q, nil), poster
 }
 

--- a/internal/ndms/command/dnsroutes_test.go
+++ b/internal/ndms/command/dnsroutes_test.go
@@ -12,7 +12,7 @@ import (
 func newTestDNSRouteCommands(_ *testing.T, isOS5 bool) (*DNSRouteCommands, *fakePoster) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{
 		Getter: query.NewFakeGetter(),
 		Logger: query.NopLogger(),

--- a/internal/ndms/command/interfaces_test.go
+++ b/internal/ndms/command/interfaces_test.go
@@ -31,7 +31,7 @@ func testQueries() *query.Queries {
 func newTestInterfaceCommands(_ *testing.T) (*InterfaceCommands, *fakePoster, *SaveCoordinator, *query.Queries, *spyHookNotifier) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := testQueries()
 	hn := &spyHookNotifier{}
 	return NewInterfaceCommands(poster, sc, q, hn), poster, sc, q, hn
@@ -125,7 +125,7 @@ func TestInterfaceCommands_InterfaceDown_WithHookNotifier(t *testing.T) {
 func TestInterfaceCommands_InterfaceUp_NilHookNotifier(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := testQueries()
 	cmds := NewInterfaceCommands(poster, sc, q, nil)
 	if err := cmds.InterfaceUp(context.Background(), "OpkgTun0"); err != nil {

--- a/internal/ndms/command/objectgroups_test.go
+++ b/internal/ndms/command/objectgroups_test.go
@@ -11,7 +11,7 @@ import (
 func newTestObjectGroupCommands(_ *testing.T) (*ObjectGroupCommands, *fakePoster) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger()})
 	return NewObjectGroupCommands(poster, sc, q), poster
 }

--- a/internal/ndms/command/pingcheck_test.go
+++ b/internal/ndms/command/pingcheck_test.go
@@ -12,7 +12,7 @@ import (
 func newTestPingCheckCommands(_ *testing.T) (*PingCheckCommands, *fakePoster) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger()})
 	return NewPingCheckCommands(poster, sc, q), poster
 }

--- a/internal/ndms/command/policies_test.go
+++ b/internal/ndms/command/policies_test.go
@@ -11,7 +11,7 @@ import (
 func newTestPolicyCommands(_ *testing.T) (*PolicyCommands, *fakePoster, *SaveCoordinator, *spyHookNotifier) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger(), IsOS5: func() bool { return true }})
 	hn := &spyHookNotifier{}
 	return NewPolicyCommands(poster, sc, q, hn), poster, sc, hn

--- a/internal/ndms/command/proxy_test.go
+++ b/internal/ndms/command/proxy_test.go
@@ -11,7 +11,7 @@ import (
 func newTestProxyCommands(_ *testing.T) (*ProxyCommands, *fakePoster, *SaveCoordinator) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger(), IsOS5: func() bool { return true }})
 	return NewProxyCommands(poster, sc, q), poster, sc
 }

--- a/internal/ndms/command/routes_test.go
+++ b/internal/ndms/command/routes_test.go
@@ -11,7 +11,7 @@ import (
 func newTestRouteCommands(_ *testing.T) (*RouteCommands, *fakePoster) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger(), IsOS5: func() bool { return true }})
 	return NewRouteCommands(poster, sc, q), poster
 }

--- a/internal/ndms/command/save.go
+++ b/internal/ndms/command/save.go
@@ -15,6 +15,17 @@ type Poster interface {
 	Post(ctx context.Context, payload any) (json.RawMessage, error)
 }
 
+// PostSaveInvalidator is the minimal cache-invalidation surface
+// SaveCoordinator needs after a successful save. RunningConfigStore
+// from internal/ndms/query satisfies it via the embedded
+// *cache.ListStore[T].InvalidateAll() promoted method.
+//
+// The interface is declared here (not in query/) to keep
+// SaveCoordinator's package free of an import cycle with query/.
+type PostSaveInvalidator interface {
+	InvalidateAll()
+}
+
 // savePayload is the NDMS command for "persist running-config to flash".
 // Matches the exact shape Keenetic's own web UI uses:
 //   {"system":{"configuration":{"save":{}}}}
@@ -41,6 +52,9 @@ type SaveCoordinator struct {
 	retryDelay time.Duration
 	maxRetries int
 
+	settleDelay time.Duration
+	invalidator PostSaveInvalidator
+
 	mu              sync.Mutex
 	timer           *time.Timer
 	firstAt         time.Time // zero if no pending batch
@@ -59,19 +73,43 @@ const (
 )
 
 // NewSaveCoordinator constructs a coordinator with production defaults.
-// debounce — delay before firing Save after the last Request().
-// maxWait  — hard ceiling from first Request() in the current batch.
+// debounce    — delay before firing Save after the last Request().
+// maxWait     — hard ceiling from first Request() in the current batch.
+// settleDelay — pause after a successful save before invalidating the
+//               RunningConfig cache. NDMS publishes running-config
+//               asynchronously after writing flash, so reads issued
+//               immediately after save would still see the old view.
+//               Pass 0 to disable settle entirely (skip both sleep and
+//               invalidate).
+// invalidator — cache surface invalidated after settle. Pass nil to
+//               disable settle (sleep is still skipped). Typically
+//               wired to query.Queries.RunningConfig.
 // Retries: 3 attempts 5 seconds apart after a failed fire.
-func NewSaveCoordinator(poster Poster, pub StatusPublisher, debounce, maxWait time.Duration) *SaveCoordinator {
+func NewSaveCoordinator(
+	poster Poster,
+	pub StatusPublisher,
+	debounce, maxWait, settleDelay time.Duration,
+	invalidator PostSaveInvalidator,
+) *SaveCoordinator {
 	return &SaveCoordinator{
-		poster:     poster,
-		publisher:  pub,
-		debounce:   debounce,
-		maxWait:    maxWait,
-		retryDelay: defaultRetryDelay,
-		maxRetries: defaultMaxRetries,
-		state:      SaveStateIdle,
+		poster:      poster,
+		publisher:   pub,
+		debounce:    debounce,
+		maxWait:     maxWait,
+		retryDelay:  defaultRetryDelay,
+		maxRetries:  defaultMaxRetries,
+		settleDelay: settleDelay,
+		invalidator: invalidator,
+		state:       SaveStateIdle,
 	}
+}
+
+// SetSettleDelay overrides the post-save settle delay — used by tests
+// that need sub-second timings. Mirrors the SetRetryPolicy pattern.
+func (s *SaveCoordinator) SetSettleDelay(d time.Duration) {
+	s.mu.Lock()
+	s.settleDelay = d
+	s.mu.Unlock()
 }
 
 // SetRetryPolicy overrides the retry delay and max retries — used by tests

--- a/internal/ndms/command/save.go
+++ b/internal/ndms/command/save.go
@@ -246,18 +246,27 @@ func (s *SaveCoordinator) Flush(ctx context.Context) error {
 
 	s.mu.Lock()
 	s.flushInProgress = false
-	if err == nil {
+	successful := err == nil
+	if successful {
 		s.pendingCount = 0
 		s.retryCount = 0
 		s.lastSaveAt = time.Now()
 		s.setStateLocked(SaveStateIdle, "")
 	} else {
-		// Flush IS the explicit retry — failure is terminal, go
-		// straight to Failed. Mark retry budget exhausted.
+		// Flush IS the explicit retry — failure is terminal, go straight
+		// to Failed. Mark retry budget exhausted.
 		s.retryCount = s.maxRetries + 1
 		s.setStateLocked(SaveStateFailed, err.Error())
 	}
+	invalidator := s.invalidator
 	s.mu.Unlock()
+
+	// On Flush — invalidate WITHOUT sleep. Flush is a terminal operation
+	// (shutdown or explicit UI retry); callers either don't read after
+	// (shutdown) or are already waiting on a UI spinner (retry button).
+	if successful && invalidator != nil {
+		invalidator.InvalidateAll()
+	}
 	return err
 }
 

--- a/internal/ndms/command/save.go
+++ b/internal/ndms/command/save.go
@@ -186,7 +186,26 @@ func (s *SaveCoordinator) fire() {
 		s.retryCount = 0
 		s.lastSaveAt = time.Now()
 		s.setStateLocked(SaveStateIdle, "")
+		// Snapshot settle deps under the lock so SetSettleDelay races
+		// can't tear our view of (delay, invalidator).
+		settleDelay := s.settleDelay
+		invalidator := s.invalidator
 		s.mu.Unlock()
+
+		// Post-save settle (outside all mutexes — semaphore slot already
+		// released by postJSON's defer above): wait for NDMS to publish
+		// the updated running-config view, then invalidate the cache so
+		// the next reader gets fresh data.
+		if settleDelay > 0 && invalidator != nil {
+			time.Sleep(settleDelay)
+			invalidator.InvalidateAll()
+			if s.publisher != nil {
+				s.publisher.Publish("resource:invalidated", events.ResourceInvalidatedEvent{
+					Resource: "saveStatus",
+					Reason:   "save-settled",
+				})
+			}
+		}
 		return
 	}
 

--- a/internal/ndms/command/save_integration_test.go
+++ b/internal/ndms/command/save_integration_test.go
@@ -1,0 +1,153 @@
+package command
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms/query"
+	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
+)
+
+// fakeNDMS counts hits per category and returns canonical JSON shapes
+// for save + running-config reads. The matchers are deliberately broad
+// — they look for distinctive substrings rather than exact JSON, so
+// minor payload-format drift doesn't break the test.
+type fakeNDMS struct {
+	saveHits int32
+	rcHits   int32
+}
+
+func (f *fakeNDMS) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bs := string(body)
+		path := r.URL.Path
+		switch {
+		// Save command: {"system":{"configuration":{"save":...}}}
+		case strings.Contains(bs, `"save"`) && strings.Contains(bs, `"configuration"`):
+			atomic.AddInt32(&f.saveHits, 1)
+			// emulate slow flash write
+			time.Sleep(100 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+
+		// Running-config read: GET /show/running-config (path-based)
+		// or POST with body containing "running-config" (defensive fallback).
+		case strings.Contains(path, "running-config"),
+			strings.Contains(bs, `"running-config"`):
+			atomic.AddInt32(&f.rcHits, 1)
+			w.WriteHeader(http.StatusOK)
+			// Minimal shape RunningConfigStore.fetch() accepts: {"message":[...]}
+			_, _ = w.Write([]byte(`{"message": []}`))
+
+		default:
+			// Unknown payload — surface as 400 so test author notices wiring drift.
+			http.Error(w, "fakeNDMS: unexpected payload, path="+path+" body="+bs, http.StatusBadRequest)
+		}
+	}
+}
+
+func (f *fakeNDMS) SaveHits() int32 { return atomic.LoadInt32(&f.saveHits) }
+func (f *fakeNDMS) RCHits() int32   { return atomic.LoadInt32(&f.rcHits) }
+
+// intgNopPublisher is a no-op StatusPublisher for integration tests.
+// Naming intg* avoids collision with any other nopPublisher in package.
+type intgNopPublisher struct{}
+
+func (intgNopPublisher) Publish(eventType string, data any) {}
+
+func TestIntegration_SaveSettleInvalidatesRunningConfig(t *testing.T) {
+	fake := &fakeNDMS{}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	sem := transport.NewSemaphore(8)
+	client := transport.NewWithURL(srv.URL, sem)
+	rcStore := query.NewRunningConfigStore(client, query.NopLogger())
+
+	settle := 80 * time.Millisecond
+	sc := NewSaveCoordinator(
+		client,
+		intgNopPublisher{},
+		5*time.Millisecond,  // debounce
+		50*time.Millisecond, // maxWait
+		settle,
+		rcStore,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Step 1: prime the cache via a first read.
+	if _, err := rcStore.Lines(ctx); err != nil {
+		t.Fatalf("first Lines: %v", err)
+	}
+	if got := fake.RCHits(); got != 1 {
+		t.Fatalf("first Lines should hit NDMS once, got %d", got)
+	}
+
+	// Step 2: trigger save. Wait for: debounce + POST save (100ms slow)
+	// + settle + safety margin.
+	sc.Request()
+	time.Sleep(500 * time.Millisecond)
+
+	if got := fake.SaveHits(); got != 1 {
+		t.Errorf("save POST hits: want 1, got %d", got)
+	}
+
+	// Step 3: re-read running-config — should bypass cache (invalidated
+	// during settle).
+	if _, err := rcStore.Lines(ctx); err != nil {
+		t.Fatalf("second Lines: %v", err)
+	}
+	if got := fake.RCHits(); got != 2 {
+		t.Errorf("second Lines should re-fetch (invalidate happened), got total RC hits %d", got)
+	}
+}
+
+func TestIntegration_SaveSettleDisabled_NoInvalidate(t *testing.T) {
+	fake := &fakeNDMS{}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	sem := transport.NewSemaphore(8)
+	client := transport.NewWithURL(srv.URL, sem)
+	rcStore := query.NewRunningConfigStore(client, query.NopLogger())
+
+	// settleDelay = 0 → settle disabled
+	sc := NewSaveCoordinator(
+		client,
+		intgNopPublisher{},
+		5*time.Millisecond,
+		50*time.Millisecond,
+		0, rcStore,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := rcStore.Lines(ctx); err != nil {
+		t.Fatalf("first Lines: %v", err)
+	}
+
+	sc.Request()
+	time.Sleep(400 * time.Millisecond)
+
+	if got := fake.SaveHits(); got != 1 {
+		t.Errorf("save hits: want 1, got %d", got)
+	}
+
+	// Second read — should be cache hit (no invalidate happened).
+	if _, err := rcStore.Lines(ctx); err != nil {
+		t.Fatalf("second Lines: %v", err)
+	}
+	if got := fake.RCHits(); got != 1 {
+		t.Errorf("with settle disabled, second Lines should hit cache; total RC hits=%d (want 1)", got)
+	}
+}

--- a/internal/ndms/command/save_test.go
+++ b/internal/ndms/command/save_test.go
@@ -82,6 +82,30 @@ func (p *fakePublisher) Hints() []events.ResourceInvalidatedEvent {
 	return out
 }
 
+// mockInvalidator counts InvalidateAll calls. Used in post-save settle
+// tests. CalledAt records when invalidate fired so timing assertions
+// can pin "sleep happened before invalidate".
+type mockInvalidator struct {
+	mu       sync.Mutex
+	calls    int32
+	calledAt time.Time
+}
+
+func (m *mockInvalidator) InvalidateAll() {
+	atomic.AddInt32(&m.calls, 1)
+	m.mu.Lock()
+	m.calledAt = time.Now()
+	m.mu.Unlock()
+}
+
+func (m *mockInvalidator) Calls() int32 { return atomic.LoadInt32(&m.calls) }
+
+func (m *mockInvalidator) CalledAt() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calledAt
+}
+
 // --- Tests ---
 
 func TestSaveCoordinator_SingleRequestTriggersSave(t *testing.T) {
@@ -351,5 +375,145 @@ func TestSaveCoordinator_StatusSnapshot(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if st := sc.Status(); st.State != SaveStateIdle {
 		t.Errorf("after fire: want Idle, got %v", st.State)
+	}
+}
+
+// --- Post-save settle tests (fire path) ---
+
+func TestSaveCoordinator_fire_OnSuccess_InvalidatesRunningConfig(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond,
+		20*time.Millisecond, inv)
+
+	sc.Request()
+	// debounce 10ms + post 0ms + settle 20ms = ~30ms. Wait 100ms for safety.
+	time.Sleep(100 * time.Millisecond)
+
+	if got := inv.Calls(); got != 1 {
+		t.Errorf("invalidator calls: want 1, got %d", got)
+	}
+}
+
+func TestSaveCoordinator_fire_OnSuccess_SettlesBeforeInvalidate(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	settle := 50 * time.Millisecond
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		settle, inv)
+
+	t0 := time.Now()
+	sc.Request()
+	time.Sleep(150 * time.Millisecond)
+
+	if inv.Calls() != 1 {
+		t.Fatalf("invalidator should be called once, got %d", inv.Calls())
+	}
+	elapsed := inv.CalledAt().Sub(t0)
+	// debounce 5ms + (instant POST) + settle 50ms = >= 55ms.
+	// Allow lower bound a few ms below to absorb scheduler jitter on slow CI.
+	if elapsed < settle {
+		t.Errorf("invalidate fired too early: elapsed %s, want >= %s", elapsed, settle)
+	}
+}
+
+func TestSaveCoordinator_fire_OnSuccess_PublishesSettledHint(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		10*time.Millisecond, inv)
+
+	sc.Request()
+	time.Sleep(80 * time.Millisecond)
+
+	// Filter for save-settled hint specifically — fire() also publishes
+	// state-change hints via setStateLocked.
+	var settled int
+	for _, h := range pub.Hints() {
+		if h.Resource == "saveStatus" && h.Reason == "save-settled" {
+			settled++
+		}
+	}
+	if settled != 1 {
+		t.Errorf("save-settled hints: want 1, got %d (all hints: %+v)",
+			settled, pub.Hints())
+	}
+}
+
+func TestSaveCoordinator_fire_OnFailure_DoesNotInvalidate(t *testing.T) {
+	poster := &fakePoster{}
+	poster.SetError(errors.New("boom"))
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		10*time.Millisecond, inv)
+	sc.SetRetryPolicy(50*time.Millisecond, 0) // disable retry — single attempt then fail
+
+	sc.Request()
+	time.Sleep(100 * time.Millisecond)
+
+	if got := inv.Calls(); got != 0 {
+		t.Errorf("invalidator should not be called on failure, got %d calls", got)
+	}
+}
+
+func TestSaveCoordinator_fire_ZeroSettleDelay_SkipsSettle(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		0, inv) // settleDelay = 0
+
+	sc.Request()
+	time.Sleep(80 * time.Millisecond)
+
+	if got := inv.Calls(); got != 0 {
+		t.Errorf("settleDelay=0 should skip invalidate, got %d calls", got)
+	}
+	for _, h := range pub.Hints() {
+		if h.Reason == "save-settled" {
+			t.Errorf("settleDelay=0 should not publish save-settled hint, got %+v", h)
+		}
+	}
+}
+
+func TestSaveCoordinator_fire_NilInvalidator_SkipsSettle(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		20*time.Millisecond, nil) // invalidator = nil
+
+	sc.Request()
+	time.Sleep(80 * time.Millisecond)
+
+	// No invalidator, but also no panic — and no save-settled hint either.
+	for _, h := range pub.Hints() {
+		if h.Reason == "save-settled" {
+			t.Errorf("nil invalidator should not publish save-settled hint, got %+v", h)
+		}
+	}
+}
+
+func TestSaveCoordinator_fire_Retry_InvalidatesOnceAfterFinalSuccess(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		10*time.Millisecond, inv)
+	sc.SetRetryPolicy(20*time.Millisecond, 3)
+
+	// First attempt fails, second attempt succeeds.
+	poster.SetError(errors.New("transient"))
+	sc.Request()
+	time.Sleep(30 * time.Millisecond) // first fire fails, retry scheduled
+
+	poster.SetError(nil) // unblock retry
+	time.Sleep(80 * time.Millisecond)
+
+	if got := inv.Calls(); got != 1 {
+		t.Errorf("invalidator should be called once after final success, got %d", got)
 	}
 }

--- a/internal/ndms/command/save_test.go
+++ b/internal/ndms/command/save_test.go
@@ -87,7 +87,7 @@ func (p *fakePublisher) Hints() []events.ResourceInvalidatedEvent {
 func TestSaveCoordinator_SingleRequestTriggersSave(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 20*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 20*time.Millisecond, 100*time.Millisecond, 0, nil)
 
 	sc.Request()
 	time.Sleep(50 * time.Millisecond)
@@ -100,7 +100,7 @@ func TestSaveCoordinator_SingleRequestTriggersSave(t *testing.T) {
 func TestSaveCoordinator_MultipleRequestsCoalesce(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 30*time.Millisecond, 500*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 30*time.Millisecond, 500*time.Millisecond, 0, nil)
 
 	for i := 0; i < 5; i++ {
 		sc.Request()
@@ -117,7 +117,7 @@ func TestSaveCoordinator_MaxWaitCapsDelay(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
 	// Tight maxWait; debounce is larger than the whole test window.
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 80*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 80*time.Millisecond, 0, nil)
 
 	start := time.Now()
 	// Issue Requests faster than debounce so debounce would never fire,
@@ -152,7 +152,7 @@ func TestSaveCoordinator_MaxWaitCapsDelay(t *testing.T) {
 func TestSaveCoordinator_PublishesStatusTransitions(t *testing.T) {
 	poster := &fakePoster{sleep: 20 * time.Millisecond}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 15*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 15*time.Millisecond, 100*time.Millisecond, 0, nil)
 
 	sc.Request()
 	time.Sleep(80 * time.Millisecond)
@@ -181,7 +181,7 @@ func TestSaveCoordinator_RetryOnFailure(t *testing.T) {
 	poster.SetError(boom)
 
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond, 0, nil)
 	sc.SetRetryPolicy(20*time.Millisecond, 3) // 3 retries, 20ms apart
 
 	sc.Request()
@@ -212,7 +212,7 @@ func TestSaveCoordinator_RetrySucceedsClearsError(t *testing.T) {
 	poster.SetError(errors.New("first flake"))
 
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond, 0, nil)
 	sc.SetRetryPolicy(20*time.Millisecond, 3)
 
 	sc.Request()
@@ -232,7 +232,7 @@ func TestSaveCoordinator_RetrySucceedsClearsError(t *testing.T) {
 func TestSaveCoordinator_FlushBypassesDebounce(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 1*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 1*time.Second, 0, nil)
 
 	sc.Request()
 	// Immediately Flush — debounce would otherwise keep Save pending.
@@ -249,7 +249,7 @@ func TestSaveCoordinator_FlushClearsFailedState(t *testing.T) {
 	poster.SetError(errors.New("down"))
 
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 50*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 50*time.Millisecond, 0, nil)
 	sc.SetRetryPolicy(10*time.Millisecond, 1)
 
 	sc.Request()
@@ -269,7 +269,7 @@ func TestSaveCoordinator_FlushFailureGoesToFailed(t *testing.T) {
 	poster := &fakePoster{}
 	poster.SetError(errors.New("flash write failed"))
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 100*time.Millisecond, 500*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 100*time.Millisecond, 500*time.Millisecond, 0, nil)
 
 	err := sc.Flush(context.Background())
 	if err == nil {
@@ -295,7 +295,7 @@ func TestSaveCoordinator_FlushConcurrentWithInFlightFire(t *testing.T) {
 	// would overwrite Flush's state.
 	poster := &fakePoster{sleep: 60 * time.Millisecond}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 10*time.Millisecond, 100*time.Millisecond, 0, nil)
 
 	sc.Request()
 	// Wait long enough that fire() has been dispatched and is inside
@@ -330,7 +330,7 @@ func TestSaveCoordinator_FlushConcurrentWithInFlightFire(t *testing.T) {
 func TestSaveCoordinator_StatusSnapshot(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 20*time.Millisecond, 100*time.Millisecond)
+	sc := NewSaveCoordinator(poster, pub, 20*time.Millisecond, 100*time.Millisecond, 0, nil)
 
 	// Fresh coordinator: Idle, 0 pending.
 	if st := sc.Status(); st.State != SaveStateIdle || st.PendingCount != 0 {

--- a/internal/ndms/command/save_test.go
+++ b/internal/ndms/command/save_test.go
@@ -517,3 +517,57 @@ func TestSaveCoordinator_fire_Retry_InvalidatesOnceAfterFinalSuccess(t *testing.
 		t.Errorf("invalidator should be called once after final success, got %d", got)
 	}
 }
+
+// --- Post-save settle tests (Flush path) ---
+
+func TestSaveCoordinator_Flush_OnSuccess_InvalidatesImmediately(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	// settleDelay 1s, but Flush should invalidate WITHOUT sleep.
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		1*time.Second, inv)
+
+	t0 := time.Now()
+	if err := sc.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+	elapsed := time.Since(t0)
+
+	if got := inv.Calls(); got != 1 {
+		t.Errorf("invalidator calls: want 1, got %d", got)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("Flush should not sleep — elapsed %s, want < 500ms", elapsed)
+	}
+}
+
+func TestSaveCoordinator_Flush_OnFailure_DoesNotInvalidate(t *testing.T) {
+	poster := &fakePoster{}
+	poster.SetError(errors.New("boom"))
+	pub := &fakePublisher{}
+	inv := &mockInvalidator{}
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		10*time.Millisecond, inv)
+
+	if err := sc.Flush(context.Background()); err == nil {
+		t.Fatalf("Flush should have returned error")
+	}
+
+	if got := inv.Calls(); got != 0 {
+		t.Errorf("invalidator should not be called on Flush failure, got %d", got)
+	}
+}
+
+func TestSaveCoordinator_Flush_NilInvalidator_DoesNotPanic(t *testing.T) {
+	poster := &fakePoster{}
+	pub := &fakePublisher{}
+	// invalidator = nil
+	sc := NewSaveCoordinator(poster, pub, 5*time.Millisecond, 100*time.Millisecond,
+		10*time.Millisecond, nil)
+
+	if err := sc.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+	// Success — no panic.
+}

--- a/internal/ndms/command/wireguard_test.go
+++ b/internal/ndms/command/wireguard_test.go
@@ -12,7 +12,7 @@ import (
 func TestWireguardCommands_SetASCParams(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger()})
 	cmds := NewWireguardCommands(poster, sc, q)
 
@@ -31,7 +31,7 @@ func TestWireguardCommands_SetASCParams(t *testing.T) {
 func TestWireguardCommands_SetASCParams_InvalidJSON(t *testing.T) {
 	poster := &fakePoster{}
 	pub := &fakePublisher{}
-	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second)
+	sc := NewSaveCoordinator(poster, pub, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{Getter: query.NewFakeGetter(), Logger: query.NopLogger()})
 	cmds := NewWireguardCommands(poster, sc, q)
 

--- a/internal/ndms/transport/transport.go
+++ b/internal/ndms/transport/transport.go
@@ -6,12 +6,13 @@ import (
 )
 
 // sharedTransport is the HTTP transport reused across all RCI Client
-// instances. Settings mirror what the legacy rci.sharedTransport uses —
-// modestly-sized keep-alive pool so we don't pay TCP handshake cost on
-// every call, but capped to avoid leaking connections under bursts.
+// instances. Pool size synchronised with cap=30 default of the NDMS
+// concurrency semaphore (cmd/awg-manager/main.go): MaxIdleConnsPerHost
+// must exceed cap so that the 30 simultaneous in-flight requests never
+// pay TCP-handshake cost on a hot keep-alive pool.
 var sharedTransport = &http.Transport{
-	MaxIdleConns:        50,
-	MaxIdleConnsPerHost: 10,
+	MaxIdleConns:        64,
+	MaxIdleConnsPerHost: 50,
 	IdleConnTimeout:     90 * time.Second,
 	DisableKeepAlives:   false,
 }

--- a/internal/staticroute/impl_test.go
+++ b/internal/staticroute/impl_test.go
@@ -153,7 +153,7 @@ func (nopPublisher) Publish(string, any) {}
 // fakePoster so tests can observe outgoing payloads.
 func newTestRouteCommands() (*command.RouteCommands, *fakePoster) {
 	poster := &fakePoster{}
-	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second)
+	sc := command.NewSaveCoordinator(poster, nopPublisher{}, 500*time.Millisecond, 5*time.Second, 0, nil)
 	q := query.NewQueries(query.Deps{
 		Getter: query.NewFakeGetter(),
 		Logger: query.NopLogger(),

--- a/internal/sys/env/env.go
+++ b/internal/sys/env/env.go
@@ -1,0 +1,60 @@
+// Package env provides typed env-var helpers with safe defaults.
+//
+// Both helpers fall back to the provided default on any parse error or
+// out-of-range value, logging a WARN line via the stdlib log package so
+// the daemon's process log surfaces operator typos in init.d scripts.
+// They are called from main.go BEFORE the project's logging service is
+// initialised, hence the use of stdlib log instead of internal/logging.
+package env
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+// IntDefault returns the integer value of env var key. Falls back to def
+// when the variable is unset, empty, non-numeric, zero, or negative.
+// Logs a WARN for explicit-invalid values (non-numeric, negative); the
+// unset/empty/zero paths fall back silently to avoid log noise on
+// fresh installations.
+func IntDefault(key string, def int) int {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("env: %s=%q is not a valid integer, using default %d", key, raw, def)
+		return def
+	}
+	if n <= 0 {
+		if n < 0 {
+			log.Printf("env: %s=%d is non-positive, using default %d", key, n, def)
+		}
+		return def
+	}
+	return n
+}
+
+// DurationDefault returns the time.Duration value of env var key.
+// Accepts standard Go duration syntax ("2s", "500ms", "0s", "1m30s").
+// Falls back to def on parse error. Zero is allowed — it is a meaningful
+// "feature off" value for callers like SaveCoordinator settle delay.
+func DurationDefault(key string, def time.Duration) time.Duration {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("env: %s=%q is not a valid duration, using default %s", key, raw, def)
+		return def
+	}
+	if d < 0 {
+		log.Printf("env: %s=%s is negative, using default %s", key, d, def)
+		return def
+	}
+	return d
+}

--- a/internal/sys/env/env_test.go
+++ b/internal/sys/env/env_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestIntDefault_Unset(t *testing.T) {
@@ -44,5 +45,52 @@ func TestIntDefault_Empty(t *testing.T) {
 	t.Setenv("AWG_TEST_INT", "")
 	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
 		t.Errorf("empty: want default 42, got %d", got)
+	}
+}
+
+func TestDurationDefault_Unset(t *testing.T) {
+	os.Unsetenv("AWG_TEST_DUR")
+	want := 2 * time.Second
+	if got := DurationDefault("AWG_TEST_DUR", want); got != want {
+		t.Errorf("unset: want %s, got %s", want, got)
+	}
+}
+
+func TestDurationDefault_Valid(t *testing.T) {
+	t.Setenv("AWG_TEST_DUR", "500ms")
+	want := 500 * time.Millisecond
+	if got := DurationDefault("AWG_TEST_DUR", 2*time.Second); got != want {
+		t.Errorf("valid: want %s, got %s", want, got)
+	}
+}
+
+func TestDurationDefault_Zero(t *testing.T) {
+	t.Setenv("AWG_TEST_DUR", "0s")
+	if got := DurationDefault("AWG_TEST_DUR", 2*time.Second); got != 0 {
+		t.Errorf("zero: want 0 (feature off), got %s", got)
+	}
+}
+
+func TestDurationDefault_Invalid(t *testing.T) {
+	t.Setenv("AWG_TEST_DUR", "notduration")
+	want := 2 * time.Second
+	if got := DurationDefault("AWG_TEST_DUR", want); got != want {
+		t.Errorf("invalid: want default %s, got %s", want, got)
+	}
+}
+
+func TestDurationDefault_Negative(t *testing.T) {
+	t.Setenv("AWG_TEST_DUR", "-3s")
+	want := 2 * time.Second
+	if got := DurationDefault("AWG_TEST_DUR", want); got != want {
+		t.Errorf("negative: want default %s, got %s", want, got)
+	}
+}
+
+func TestDurationDefault_Empty(t *testing.T) {
+	t.Setenv("AWG_TEST_DUR", "")
+	want := 2 * time.Second
+	if got := DurationDefault("AWG_TEST_DUR", want); got != want {
+		t.Errorf("empty: want default %s, got %s", want, got)
 	}
 }

--- a/internal/sys/env/env_test.go
+++ b/internal/sys/env/env_test.go
@@ -1,0 +1,48 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIntDefault_Unset(t *testing.T) {
+	os.Unsetenv("AWG_TEST_INT")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
+		t.Errorf("unset: want 42, got %d", got)
+	}
+}
+
+func TestIntDefault_Valid(t *testing.T) {
+	t.Setenv("AWG_TEST_INT", "7")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 7 {
+		t.Errorf("valid: want 7, got %d", got)
+	}
+}
+
+func TestIntDefault_NonNumeric(t *testing.T) {
+	t.Setenv("AWG_TEST_INT", "abc")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
+		t.Errorf("non-numeric: want default 42, got %d", got)
+	}
+}
+
+func TestIntDefault_Zero(t *testing.T) {
+	t.Setenv("AWG_TEST_INT", "0")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
+		t.Errorf("zero: want default 42, got %d", got)
+	}
+}
+
+func TestIntDefault_Negative(t *testing.T) {
+	t.Setenv("AWG_TEST_INT", "-5")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
+		t.Errorf("negative: want default 42, got %d", got)
+	}
+}
+
+func TestIntDefault_Empty(t *testing.T) {
+	t.Setenv("AWG_TEST_INT", "")
+	if got := IntDefault("AWG_TEST_INT", 42); got != 42 {
+		t.Errorf("empty: want default 42, got %d", got)
+	}
+}


### PR DESCRIPTION
## Env-vars

| Переменная | Default | Эффект |

| `AWG_NDMS_CAP` | `30` | Размер ограничения кол-ва одновременных RCI запросов |
| `AWG_NDMS_SAVE_SETTLE_DELAY` | `2s` | Пауза после успешного save перед invalidate. `0s` отключает settle. |

Валидация: невалидное (нечисловое для CAP, нераспарсиваемое для DELAY, отрицательное) → WARN-лог + default. Пустое/unset → silent default.