### PR TITLE
Fix/route final router owned

### DIFF
--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -686,6 +686,41 @@ func patchBaseDirectOutbound(basePath string) {
 	_ = writeJSONFile(basePath, m)
 }
 
+// removeFinalFromBase strips the legacy route.final key from
+// 00-base.json. Pre-spec installs wrote {route:{final:"direct"}} in
+// base; under config.d merge semantics (scalar = first-file-wins),
+// that base value shadowed any router-slot final. This patch lets
+// 20-router.json own route.final exclusively.
+//
+// Sing-box behavior when route.final is absent: "The first outbound
+// will be used if empty" (per upstream docs). 00-base.json's outbound
+// list starts with {type:"direct", tag:"direct"} (also self-healed by
+// patchBaseDirectOutbound), so the implicit fallback stays direct —
+// same observable behavior as the old explicit "final":"direct".
+//
+// Idempotent: no-op when route.final is already absent. Silent skip on
+// missing file / read error / malformed JSON / missing route section
+// (matches patchBaseDirectOutbound and patchTunnelsSlotStripBaseDNS).
+func removeFinalFromBase(basePath string) {
+	data, err := os.ReadFile(basePath)
+	if err != nil {
+		return
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return
+	}
+	route, _ := m["route"].(map[string]any)
+	if route == nil {
+		return
+	}
+	if _, has := route["final"]; !has {
+		return
+	}
+	delete(route, "final")
+	_ = writeJSONFile(basePath, m)
+}
+
 // stripStrayDirectPlaceholder removes the canonical
 // {type:"direct", tag:"direct"} placeholder from every slot file in
 // configDir EXCEPT 00-base.json. Sing-box rejects the merged config

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -903,7 +903,10 @@ func freshBaseConfig() map[string]any {
 			map[string]any{"type": "direct", "tag": "direct"},
 		},
 		"route": map[string]any{
-			"final":                   "direct",
+			// route.final intentionally omitted — owned by 20-router.json.
+			// Sing-box uses first outbound (= direct, see outbounds above)
+			// as fallback when final is absent. See spec
+			// 2026-05-21-route-final-router-owned-design.md.
 			"default_domain_resolver": "dns-bootstrap",
 		},
 	}

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -190,6 +190,7 @@ func NewOperator(d OperatorDeps) *Operator {
 	ensureLegacyConfigMigrated(dir)
 	patchTunnelsSlotStripBaseDNS(filepath.Join(configPath, "10-tunnels.json"))
 	stripStrayDirectPlaceholder(configPath)
+	removeFinalFromBase(filepath.Join(configPath, "00-base.json"))
 
 	op := &Operator{
 		log:               log,

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -348,7 +348,10 @@ func TestEnsureBaseConfig_PatchesMissingDomainResolver(t *testing.T) {
 	if route["default_domain_resolver"] != "dns-bootstrap" {
 		t.Errorf("default_domain_resolver want dns-bootstrap, got %v", route["default_domain_resolver"])
 	}
-	// Existing route fields preserved (for now; removal wired in Task 3).
+	// ensureBaseConfig preserves existing route.final — removal is done
+	// separately by removeFinalFromBase, called after ensureBaseConfig in
+	// Operator.New. This test only exercises ensureBaseConfig, so final
+	// stays "direct" here.
 	if route["final"] != "direct" {
 		t.Errorf("route.final lost: %v", route["final"])
 	}

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -165,8 +165,8 @@ func TestEnsureBaseConfig_FullSkeleton(t *testing.T) {
 	if !ok {
 		t.Fatalf("route block missing: %#v", base["route"])
 	}
-	if route["final"] != "direct" {
-		t.Errorf("route.final: want direct, got %v", route["final"])
+	if _, has := route["final"]; has {
+		t.Errorf("route.final should be absent (owned by 20-router.json), got %v", route["final"])
 	}
 	if route["default_domain_resolver"] != "dns-bootstrap" {
 		t.Errorf("default_domain_resolver: want dns-bootstrap, got %v", route["default_domain_resolver"])
@@ -348,7 +348,7 @@ func TestEnsureBaseConfig_PatchesMissingDomainResolver(t *testing.T) {
 	if route["default_domain_resolver"] != "dns-bootstrap" {
 		t.Errorf("default_domain_resolver want dns-bootstrap, got %v", route["default_domain_resolver"])
 	}
-	// Existing route fields preserved.
+	// Existing route fields preserved (for now; removal wired in Task 3).
 	if route["final"] != "direct" {
 		t.Errorf("route.final lost: %v", route["final"])
 	}

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -1066,3 +1066,154 @@ func TestPreflightConfigDir_FallsThroughToValidator(t *testing.T) {
 		t.Errorf("validator error must propagate verbatim, got: %s", err)
 	}
 }
+
+// --- removeFinalFromBase tests ---
+
+func TestRemoveFinalFromBase_DropsKey(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+	if err := os.WriteFile(basePath,
+		[]byte(`{"log":{"level":"trace"},"route":{"final":"direct","rules":[]},"outbounds":[{"type":"direct","tag":"direct"}]}`),
+		0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeFinalFromBase(basePath)
+
+	raw, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	route, _ := m["route"].(map[string]any)
+	if _, has := route["final"]; has {
+		t.Errorf("route.final should be removed, got %v", route["final"])
+	}
+	// Other route keys preserved.
+	if _, has := route["rules"]; !has {
+		t.Errorf("route.rules unexpectedly removed")
+	}
+	// Outbounds preserved.
+	if _, has := m["outbounds"]; !has {
+		t.Errorf("outbounds unexpectedly removed")
+	}
+}
+
+func TestRemoveFinalFromBase_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+	original := `{"route":{"rules":[]},"outbounds":[{"type":"direct","tag":"direct"}]}`
+	if err := os.WriteFile(basePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeFinalFromBase(basePath)
+	removeFinalFromBase(basePath) // second call: should be no-op
+
+	raw, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	route, _ := m["route"].(map[string]any)
+	if _, has := route["final"]; has {
+		t.Errorf("route.final should remain absent")
+	}
+}
+
+func TestRemoveFinalFromBase_PreservesOtherRouteFields(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+	if err := os.WriteFile(basePath,
+		[]byte(`{"route":{"final":"direct","default_domain_resolver":"dns-bootstrap","rules":[{"action":"sniff"}]}}`),
+		0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeFinalFromBase(basePath)
+
+	raw, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	route, _ := m["route"].(map[string]any)
+	if _, has := route["final"]; has {
+		t.Errorf("route.final not removed")
+	}
+	if route["default_domain_resolver"] != "dns-bootstrap" {
+		t.Errorf("default_domain_resolver lost: %v", route["default_domain_resolver"])
+	}
+	rules, _ := route["rules"].([]any)
+	if len(rules) != 1 {
+		t.Errorf("rules lost: %v", route["rules"])
+	}
+}
+
+func TestRemoveFinalFromBase_NoRouteSection_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+	original := `{"log":{"level":"trace"},"outbounds":[{"type":"direct","tag":"direct"}]}`
+	if err := os.WriteFile(basePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeFinalFromBase(basePath)
+
+	raw, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) == "" {
+		t.Errorf("file truncated")
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("file became invalid JSON: %v", err)
+	}
+	if _, has := m["outbounds"]; !has {
+		t.Errorf("outbounds lost")
+	}
+}
+
+func TestRemoveFinalFromBase_MissingFile_NoPanic(t *testing.T) {
+	// No setup — file does not exist.
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+
+	// Should not panic, should not create the file.
+	removeFinalFromBase(basePath)
+
+	if _, err := os.Stat(basePath); !os.IsNotExist(err) {
+		t.Errorf("file should not be created when missing")
+	}
+}
+
+func TestRemoveFinalFromBase_MalformedJSON_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+	garbage := `{this is not json`
+	if err := os.WriteFile(basePath, []byte(garbage), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeFinalFromBase(basePath)
+
+	// Файл должен остаться неизменным — мы не должны trash bad config.
+	raw, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != garbage {
+		t.Errorf("malformed file mutated: got %q, want %q", string(raw), garbage)
+	}
+}

--- a/internal/singbox/router_final_merge_test.go
+++ b/internal/singbox/router_final_merge_test.go
@@ -1,0 +1,185 @@
+package singbox
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// locateSingboxBinary returns the host-arch sing-box binary path, or "" if
+// none is available. Test should t.Skip when this returns "".
+func locateSingboxBinary(t *testing.T) string {
+	t.Helper()
+	// Prefer PATH (developer-installed sing-box).
+	if p, err := exec.LookPath("sing-box"); err == nil {
+		return p
+	}
+	// Fall back to dist/ build artifacts. Skip ARM/MIPS targets.
+	if runtime.GOOS != "linux" || (runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64") {
+		return ""
+	}
+	// Match files like dist/singbox-binaries/1.14.0-alpha.21/sing-box-...-linux-amd64*/sing-box
+	matches, err := filepath.Glob(filepath.FromSlash(
+		"../../dist/singbox-binaries/*/sing-box-*-linux-" + runtime.GOARCH + "*/sing-box"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// writeBaseNoFinal writes a freshBaseConfig-shaped 00-base.json AFTER the
+// route.final has been removed (post-spec layout).
+func writeBaseNoFinal(t *testing.T, dir string) {
+	t.Helper()
+	base := map[string]any{
+		"outbounds": []any{
+			map[string]any{"type": "direct", "tag": "direct"},
+		},
+		"route": map[string]any{
+			"rules": []any{map[string]any{"action": "sniff"}},
+		},
+	}
+	raw, err := json.MarshalIndent(base, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "00-base.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRouterSlot(t *testing.T, dir, finalTag, selectorTag string) {
+	t.Helper()
+	router := map[string]any{
+		"outbounds": []any{
+			map[string]any{
+				"type":      "selector",
+				"tag":       selectorTag,
+				"outbounds": []any{"direct"},
+			},
+		},
+		"route": map[string]any{
+			"final": finalTag,
+			"rules": []any{},
+		},
+	}
+	raw, err := json.MarshalIndent(router, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "20-router.json"), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mergeViaSingbox runs `sing-box merge <out> -C <dir>` and returns the
+// parsed merged config.
+func mergeViaSingbox(t *testing.T, binPath, configDir string) map[string]any {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "merged.json")
+	cmd := exec.Command(binPath, "merge", out, "-C", configDir)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("sing-box merge failed: %v\nstderr: %s", err, stderr.String())
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// TestIntegration_RouterFinal_OverridesAfterFreshBaseConfig — regression
+// for the dead-code scenario described in spec
+// 2026-05-21-route-final-router-owned-design.md. Without the fix
+// (removeFinalFromBase + freshBaseConfig change), base's "direct" would
+// shadow router's "myproxy". With the fix, router's value wins.
+func TestIntegration_RouterFinal_OverridesAfterFreshBaseConfig(t *testing.T) {
+	bin := locateSingboxBinary(t)
+	if bin == "" {
+		t.Skip("no host sing-box binary available; build via scripts/build-singbox.sh or `apt install sing-box`")
+	}
+
+	dir := t.TempDir()
+	writeBaseNoFinal(t, dir)
+	writeRouterSlot(t, dir, "myproxy", "myproxy")
+
+	merged := mergeViaSingbox(t, bin, dir)
+	route, _ := merged["route"].(map[string]any)
+	if route == nil {
+		t.Fatalf("merged config missing route block: %v", merged)
+	}
+	if route["final"] != "myproxy" {
+		t.Errorf("route.final: want myproxy, got %v", route["final"])
+	}
+}
+
+func TestIntegration_RouterFinal_DisabledRouter_NoFinal(t *testing.T) {
+	bin := locateSingboxBinary(t)
+	if bin == "" {
+		t.Skip("no host sing-box binary available")
+	}
+
+	dir := t.TempDir()
+	writeBaseNoFinal(t, dir)
+	// No 20-router.json — simulates router disabled.
+
+	merged := mergeViaSingbox(t, bin, dir)
+	route, _ := merged["route"].(map[string]any)
+	if route == nil {
+		t.Fatalf("merged config missing route block: %v", merged)
+	}
+	if _, has := route["final"]; has {
+		t.Errorf("route.final should be absent when no router slot, got %v", route["final"])
+	}
+	// First outbound is direct → sing-box will fall back to direct.
+	outbounds, _ := merged["outbounds"].([]any)
+	if len(outbounds) == 0 {
+		t.Fatalf("outbounds missing")
+	}
+	first, _ := outbounds[0].(map[string]any)
+	if first["tag"] != "direct" {
+		t.Errorf("first outbound should be direct, got %v", first["tag"])
+	}
+}
+
+func TestIntegration_RouterFinal_DefaultDirect_NoConflict(t *testing.T) {
+	bin := locateSingboxBinary(t)
+	if bin == "" {
+		t.Skip("no host sing-box binary available")
+	}
+
+	dir := t.TempDir()
+	writeBaseNoFinal(t, dir)
+	// Router-slot пишет тот же "direct" (default RouterConfig behavior).
+	writeRouterSlot(t, dir, "direct", "myproxy")
+
+	merged := mergeViaSingbox(t, bin, dir)
+	route, _ := merged["route"].(map[string]any)
+	if route["final"] != "direct" {
+		t.Errorf("route.final: want direct, got %v", route["final"])
+	}
+	// Make sure outbounds were concat'd (base direct + router myproxy).
+	outbounds, _ := merged["outbounds"].([]any)
+	tags := make(map[string]bool, len(outbounds))
+	for _, o := range outbounds {
+		m, _ := o.(map[string]any)
+		if tag, ok := m["tag"].(string); ok {
+			tags[tag] = true
+		}
+	}
+	if !tags["direct"] || !tags["myproxy"] {
+		// Diagnostic in case sing-box merge semantics ever change.
+		raw, _ := json.MarshalIndent(merged, "", "  ")
+		t.Errorf("outbounds should include both direct + myproxy:\n%s", raw)
+	}
+}


### PR DESCRIPTION
В нашей системе `00-base.json` всегда первый по lex (prefix `00-`). Его `route.final = "direct"` затыкал scalar merge'ем любое значение из `20-router.json`. UI отображал и сохранял "myproxy" в router-config, но в реальности sing-box получал `"direct"`.

- [ ] Чистый upgrade с 2.10.8: проверить что `cat /opt/etc/awg-manager/.../00-base.json | grep '"final"'` пуст (миграция отработала). Можно посмотреть лог запуска.
- [ ] UI → Маршрутизация → Правила → выпадающий список «Маршрутизация — Final» → выбрать composite outbound → проверить что **трафик** реально идёт через выбранный outbound (не через direct).
- [ ] Через Swagger вызвать `POST /api/singbox/router/route/final` с `{"final":"direct"}` → сохранение успешно + работает.