### PR TITLE
fix(nwg): sync private-key + DNS на ReplaceConfig (#136 handshake-fail)

### DIFF
--- a/internal/tunnel/nwg/sync.go
+++ b/internal/tunnel/nwg/sync.go
@@ -100,6 +100,28 @@ func (o *OperatorNativeWG) SyncAddressMTU(ctx context.Context, stored *storage.A
 	return nil
 }
 
+// SyncPrivateKey pushes stored.Interface.PrivateKey to NDMS.
+//
+// Required when the interface section is replaced wholesale (ReplaceConfig)
+// or its PrivateKey changes via Update. CmdWireguardPrivateKey is otherwise
+// only emitted in Create — without explicit re-sync, NDMS keeps the original
+// key from import. WG kernel then signs handshake initiators with the
+// old identity; the new server (whose peer entry expects the public key
+// derived from the NEW private key) silently drops them → handshake never
+// completes. Symptom: tx grows, rx stays at 0, last-handshake never updates.
+func (o *OperatorNativeWG) SyncPrivateKey(ctx context.Context, stored *storage.AWGTunnel) error {
+	ndmsName := NewNWGNames(stored.NWGIndex).NDMSName
+	cmds := []any{
+		payloads.CmdWireguardPrivateKey(ndmsName, stored.Interface.PrivateKey),
+		payloads.CmdSave(),
+	}
+	if _, err := o.transport.PostBatch(ctx, cmds); err != nil {
+		return fmt.Errorf("sync private-key: %w", err)
+	}
+	o.log.Infof("nwg: synced private-key on %s", ndmsName)
+	return nil
+}
+
 // SyncPeer pushes the stored peer configuration to the NDMS interface.
 // This applies key/allowed-ips/keepalive/preshared-key from storage.
 //

--- a/internal/tunnel/nwg/sync_test.go
+++ b/internal/tunnel/nwg/sync_test.go
@@ -111,6 +111,48 @@ func TestSyncPeer_SameKey_DoesNotRemovePeer(t *testing.T) {
 	}
 }
 
+// TestSyncPrivateKey_SendsKeyAndSave is the regression test for issue #136
+// handshake-fail-after-replace path.
+//
+// ReplaceConfig replaces stored.Interface (including PrivateKey) wholesale,
+// but CmdWireguardPrivateKey is otherwise only emitted in Create. Without
+// explicit re-sync, NDMS keeps the old key from the original import — WG
+// kernel signs handshake initiators with that old identity, the new
+// server's peer entry (which expects the public key derived from the NEW
+// PrivateKey) silently rejects them, handshake never completes.
+//
+// Fix lives in nwg/sync.go:SyncPrivateKey and service/impl.go ReplaceConfig
+// (calls SyncPrivateKey before SyncPeer) + applyDiffNWG (calls it on
+// PrivateKey diff).
+func TestSyncPrivateKey_SendsKeyAndSave(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+
+	stored := &storage.AWGTunnel{
+		NWGIndex: 5,
+		Interface: storage.AWGInterface{
+			PrivateKey: "newPrivateKey000000000000000000000000000000=",
+		},
+	}
+
+	if err := op.SyncPrivateKey(context.Background(), stored); err != nil {
+		t.Fatalf("SyncPrivateKey: %v", err)
+	}
+	if len(cs.bodies) != 1 {
+		t.Fatalf("want 1 POST batch, got %d", len(cs.bodies))
+	}
+	body := cs.bodies[0]
+	if !strings.Contains(body, "private-key") {
+		t.Errorf("batch must contain private-key field:\n%s", body)
+	}
+	if !strings.Contains(body, "newPrivateKey000000000000000000000000000000=") {
+		t.Errorf("batch must contain the new key value:\n%s", body)
+	}
+	if !strings.Contains(body, "save") {
+		t.Errorf("batch must contain save command:\n%s", body)
+	}
+}
+
 // TestSyncPeer_DifferentPreviousKey_RemovesOldPeer is the regression test
 // for issue #136 (https://github.com/hoaxisr/awg-manager/issues/136).
 //

--- a/internal/tunnel/service/impl.go
+++ b/internal/tunnel/service/impl.go
@@ -476,6 +476,13 @@ func (s *ServiceImpl) applyDiffNWG(ctx context.Context, oldStored, newStored *st
 	tunnelID := newStored.ID
 	var errs []error
 
+	if oldStored.Interface.PrivateKey != newStored.Interface.PrivateKey {
+		if err := s.nwgOperator.SyncPrivateKey(ctx, newStored); err != nil {
+			s.logWarn("update", tunnelID, "Failed to sync NWG private-key: "+err.Error())
+			errs = append(errs, fmt.Errorf("sync private-key: %w", err))
+		}
+	}
+
 	if oldStored.Interface.Address != newStored.Interface.Address ||
 		oldStored.Interface.MTU != newStored.Interface.MTU {
 		if err := s.nwgOperator.SyncAddressMTU(ctx, newStored); err != nil {
@@ -760,6 +767,11 @@ func (s *ServiceImpl) ReplaceConfig(ctx context.Context, tunnelID, confContent, 
 	// ends up with both old and new peers (NDMS indexes by key).
 	oldPublicKey := stored.Peer.PublicKey
 
+	// Capture old DNS for the non-running sync branch below — handler skips
+	// Stop+Start when the tunnel isn't running, leaving NDMS DNS entries
+	// orphaned (pointing to the previous conf's servers).
+	oldDNS := stored.Interface.DNS
+
 	// Replace Interface + Peer entirely
 	stored.Interface = parsed.Interface
 	stored.Peer = parsed.Peer
@@ -792,6 +804,19 @@ func (s *ServiceImpl) ReplaceConfig(ctx context.Context, tunnelID, confContent, 
 			if err := s.nwgOperator.Stop(ctx, stored); err != nil {
 				s.logWarn("replace-config", tunnelID, "Stop before peer sync failed: "+err.Error())
 			}
+		} else if oldDNS != stored.Interface.DNS {
+			// Tunnel was not running — handler skipped Stop (which would
+			// clear OLD DNS) and will skip Start (which would set NEW DNS).
+			// Sync DNS here so NDMS doesn't keep orphan entries from the
+			// previous conf.
+			oldList := tunnel.ParseDNSList(oldDNS)
+			newList := tunnel.ParseDNSList(stored.Interface.DNS)
+			if err := s.nwgOperator.SyncDNS(ctx, stored, oldList, newList); err != nil {
+				s.logWarn("replace-config", tunnelID, "SyncDNS failed: "+err.Error())
+			}
+		}
+		if err := s.nwgOperator.SyncPrivateKey(ctx, stored); err != nil {
+			s.logWarn("replace-config", tunnelID, "SyncPrivateKey failed: "+err.Error())
 		}
 		if err := s.nwgOperator.SyncPeer(ctx, stored, oldPublicKey); err != nil {
 			s.logWarn("replace-config", tunnelID, "SyncPeer failed: "+err.Error())


### PR DESCRIPTION
CmdWireguardPrivateKey вызывался только в Create. ReplaceConfig обновлял storage.Interface.PrivateKey, но NDMS interface оставался со старой приваткой → WG kernel подписывал handshake initiator OLD identity'ю → новый сервер silently rejected → handshake never completed.

Симптом: после replace running tunnel'a интерфейс up, peer endpoint = 127.0.0.1:proxy_port (правильно), kmod proxy entry правильный, но tx растёт без rx, last-handshake=MAX_INT.

Подтверждено на test-роутере:
  без fix: peer online=false last-handshake=MAX_INT, kmod rx=0
  с  fix: peer online=true last-handshake=9s, kmod rx=88798

Также fix DNS gap: ReplaceConfig на non-running tunnel'е не вызывает handler.Stop+Start, оставлял orphan DNS entries в NDMS. Захват oldDNS до перезаписи storage + SyncDNS если DNS изменилась.

+ SyncPrivateKey метод (nwg/sync.go)
+ Вызов в ReplaceConfig перед SyncPeer (service/impl.go)
+ Вызов в applyDiffNWG на diff PrivateKey (service/impl.go)
+ DNS sync для non-running ReplaceConfig branch (service/impl.go)
+ Regression test TestSyncPrivateKey_SendsKeyAndSave (nwg/sync_test.go)

Fixes #136 (handshake-fail-after-replace).