### PR TITLE
fix(hrneo): не дёргать neo restart когда HR Neo не установлен

### DIFF
--- a/internal/hydraroute/service.go
+++ b/internal/hydraroute/service.go
@@ -55,7 +55,7 @@ func (s *Service) HealInvalidRuntimeConfig() {
 		return
 	}
 	s.appLog.Warn("config-heal", "IpsetMaxElem", fmt.Sprintf("invalid or duplicate IpsetMaxElem healed to %d", chosen))
-	if !s.status.Running {
+	if s.status.Installed && !s.status.Running {
 		s.scheduleRestart("config-heal")
 	}
 }
@@ -106,7 +106,18 @@ func (s *Service) Control(action string) error {
 }
 
 // scheduleRestart debounces neo restart: resets timer on each call.
+//
+// Central guard: при !Installed silently skip — это покрывает все
+// callsite'ы (rules-write/config-heal/config-write/policy-order/geo-sync)
+// одной защитой. Без guard'а AfterFunc через 2s делал fork/exec
+// /opt/bin/neo restart, что на чистой системе без HR Neo приводило к
+// шуму "neo restart failed: no such file or directory". Решение:
+// systematic-debugging session 2026-05-23.
 func (s *Service) scheduleRestart(reason string) {
+	if !s.status.Installed {
+		s.appLog.Debug("restart-schedule", "", "skipped: HR Neo не установлен (reason: "+reason+")")
+		return
+	}
 	if s.restartTimer != nil {
 		s.restartTimer.Stop()
 	}
@@ -255,7 +266,13 @@ func (s *Service) SetPolicyOrder(order []string) error {
 }
 
 // SyncGeoFilesToConfig updates only GeoIPFile/GeoSiteFile in hrneo.conf.
+// При !Installed — no-op: если HR Neo удалили, мы не обновляем его
+// конфиг "на будущее" (решено session 2026-05-23).
 func (s *Service) SyncGeoFilesToConfig() error {
+	if !s.status.Installed {
+		s.appLog.Debug("sync-geo", "", "skipped: HR Neo не установлен")
+		return nil
+	}
 	geoIP, geoSite := 0, 0
 	var ips []string
 	var sites []string

--- a/internal/hydraroute/service_neo_guard_test.go
+++ b/internal/hydraroute/service_neo_guard_test.go
@@ -1,0 +1,86 @@
+package hydraroute
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScheduleRestart_SkipsWhenNotInstalled verifies that the central
+// scheduleRestart no longer schedules a fork/exec when HR Neo binary is
+// absent. Это central guard: одной защитой покрываем все 5 callsite'ов
+// (rules-write/config-heal/config-write/policy-order/geo-sync).
+//
+// Bug repro: при отсутствующем /opt/bin/neo сборка планировала рестарт,
+// AfterFunc через 2s делал fork/exec → лог "neo restart failed:
+// no such file or directory". См. systematic-debugging session
+// 2026-05-23.
+func TestScheduleRestart_SkipsWhenNotInstalled(t *testing.T) {
+	svc := &Service{}
+	svc.SetStatusForTest(false) // not installed
+	svc.scheduleRestart("test-reason")
+	if svc.restartTimer != nil {
+		t.Errorf("restartTimer установлен при !Installed — fork/exec будет вызван")
+		svc.restartTimer.Stop()
+	}
+}
+
+// TestScheduleRestart_SchedulesWhenInstalled regression-guard: при
+// Installed=true прежнее поведение сохраняется.
+func TestScheduleRestart_SchedulesWhenInstalled(t *testing.T) {
+	svc := &Service{}
+	svc.SetStatusForTest(true)
+	svc.scheduleRestart("test-reason")
+	if svc.restartTimer == nil {
+		t.Fatalf("restartTimer должен быть установлен при Installed=true")
+	}
+	// Останавливаем чтобы AfterFunc не дёрнул реальный fork/exec в тестах.
+	svc.restartTimer.Stop()
+}
+
+// TestSyncGeoFilesToConfig_NoOpWhenNotInstalled проверяет что при
+// !Installed файл hrneo.conf не пишется и restart не планируется.
+// Если neo удалили после awg-manager — мы не должны обновлять его
+// конфиг "на будущее" (решено в session 2026-05-23).
+func TestSyncGeoFilesToConfig_NoOpWhenNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "hrneo.conf")
+	origPath := hrConfPath
+	hrConfPath = confPath
+	t.Cleanup(func() { hrConfPath = origPath })
+
+	svc := &Service{}
+	svc.SetStatusForTest(false)
+	svc.SetGeoDataStore(&GeoDataStore{}) // ненулевой, чтобы пройти первую защиту
+
+	if err := svc.SyncGeoFilesToConfig(); err != nil {
+		t.Fatalf("SyncGeoFilesToConfig вернул ошибку при !Installed: %v", err)
+	}
+	if _, err := os.Stat(confPath); err == nil {
+		t.Errorf("hrneo.conf создан при !Installed — не должен")
+	}
+	if svc.restartTimer != nil {
+		t.Errorf("restartTimer установлен — restart будет вызван")
+		svc.restartTimer.Stop()
+	}
+}
+
+// TestHealInvalidRuntimeConfig_NoRestartWhenNotInstalled закрывает
+// логический баг service.go:58 — раньше проверял `!Running`, что при
+// !Installed (Running=false автоматом) приводило к планированию
+// рестарта. Должно: только при Installed && !Running.
+func TestHealInvalidRuntimeConfig_NoRestartWhenNotInstalled(t *testing.T) {
+	svc := &Service{}
+	svc.SetStatusForTest(false) // not installed → Running=false тоже
+
+	// HealInvalidRuntimeConfig вызывает HealInvalidRuntimeConfig() (package
+	// func), который ReadConfig'ом не найдёт файл — changed=false, выйдет
+	// без побочек. Этого нам и достаточно: если бы он вошёл в горячую ветку,
+	// то старый код бы planиrovaл restart. Тест ловит regression и для
+	// fixed-logic-but-future-changes case.
+	svc.HealInvalidRuntimeConfig()
+	if svc.restartTimer != nil {
+		t.Errorf("HealInvalidRuntimeConfig планирует restart при !Installed")
+		svc.restartTimer.Stop()
+	}
+}


### PR DESCRIPTION
Bug: на чистом роутере без /opt/bin/neo в логах постоянно появлялось 'restart : neo restart failed: fork/exec /opt/bin/neo: no such file or directory'. Триггер — boot-time SyncGeoFilesToConfig (cmd/awg-manager/ main.go:382) дёргал scheduleRestart без проверки install state.

Архитектурный root cause: scheduleRestart был asymmetric defense — Control() и saveEntries() проверяли Installed, но scheduleRestart, SyncGeoFilesToConfig и HealInvalidRuntimeConfig — нет.

Фиксы:
1. scheduleRestart: central guard — silent skip при !Installed. Покрывает все 5 callsite'ов (rules-write/config-heal/config-write/ policy-order/geo-sync) одним местом.
2. SyncGeoFilesToConfig: no-op при !Installed (по решению — если neo удалили после awg-manager, не обновляем его конфиг 'на будущее').
3. HealInvalidRuntimeConfig: исправлен логический баг — было 'if !Running', стало 'if Installed && !Running'. При !Installed Running тоже false, что триггерило restart.

Тесты: 4 кейса в service_neo_guard_test.go, regression-guard + positive path (всё ещё планирует restart при Installed=true).