### PR TITLE
Feat/nwg endpoint dns resilience

### DIFF
--- a/internal/orchestrator/execute.go
+++ b/internal/orchestrator/execute.go
@@ -396,14 +396,25 @@ func (o *Orchestrator) executeRestoreKmod(ctx context.Context, action Action) er
 		return err
 	}
 
-	// Refresh ActiveWAN — at boot, the tunnel survived a router restart and
-	// NDMS may have picked a different WAN than what was previously stored.
+	// Refresh persisted runtime state in a single save:
+	//  - ActiveWAN: at boot NDMS may have picked a different WAN than stored.
+	//  - ResolvedEndpointIP: RestoreKmodTunnel resolved the endpoint (or used cache);
+	//    persist a freshly-resolved IP so the next boot has a current fallback.
+	dirty := false
 	if activeWAN := o.nwgOp.ResolveActiveWAN(ctx, stored); activeWAN != "" && stored.ActiveWAN != activeWAN {
 		stored.ActiveWAN = activeWAN
-		if err := o.store.Save(stored); err != nil {
-			o.appLog.Warn("persist-state", action.Tunnel, "refreshed ActiveWAN: "+err.Error())
-		}
+		dirty = true
 		o.appLog.Info("restore-kmod", action.Tunnel, fmt.Sprintf("active WAN refreshed to %s", activeWAN))
+	}
+	if trackedIP := o.nwgOp.GetTrackedEndpointIP(action.Tunnel); trackedIP != "" && trackedIP != stored.ResolvedEndpointIP {
+		stored.ResolvedEndpointIP = trackedIP
+		dirty = true
+		o.appLog.Info("restore-kmod", action.Tunnel, "resolved endpoint IP refreshed to "+trackedIP)
+	}
+	if dirty {
+		if err := o.store.Save(stored); err != nil {
+			o.appLog.Warn("persist-state", action.Tunnel, "refresh runtime state: "+err.Error())
+		}
 	}
 
 	return nil
@@ -547,7 +558,15 @@ func (o *Orchestrator) executePersistRunning(action Action) error {
 	if stored.StartedAt == "" {
 		stored.StartedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	if trackedIP := o.kernelOp.GetTrackedEndpointIP(action.Tunnel); trackedIP != "" {
+	var trackedIP string
+	if stored.Backend == "nativewg" {
+		if o.nwgOp != nil {
+			trackedIP = o.nwgOp.GetTrackedEndpointIP(action.Tunnel)
+		}
+	} else if o.kernelOp != nil {
+		trackedIP = o.kernelOp.GetTrackedEndpointIP(action.Tunnel)
+	}
+	if trackedIP != "" {
 		stored.ResolvedEndpointIP = trackedIP
 	}
 

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
@@ -38,6 +39,16 @@ type OperatorNativeWG struct {
 	kmod         *KmodManager
 	appLog       *logging.ScopedLogger
 	hookNotifier tunnel.HookNotifier
+
+	// resolveFn resolves "host:port" to (ip, port). Defaults to
+	// netutil.ResolveEndpoint; overridable in tests.
+	resolveFn func(endpoint string) (string, int, error)
+
+	// trackedIP holds the last freshly-resolved endpoint IP per tunnel ID
+	// (NOT cache fallbacks). The orchestrator reads it via GetTrackedEndpointIP
+	// to persist storage.AWGTunnel.ResolvedEndpointIP.
+	trackedMu sync.RWMutex
+	trackedIP map[string]string
 }
 
 // NewOperator creates a new NativeWG operator.
@@ -48,6 +59,7 @@ func NewOperator(queries *query.Queries, commands *command.Commands, tr *transpo
 		transport: tr,
 		kmod:      NewKmodManager(appLogger),
 		appLog:    logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubOps),
+		resolveFn: netutil.ResolveEndpoint,
 	}
 }
 
@@ -736,6 +748,25 @@ func (o *OperatorNativeWG) fallbackResolve(stored *storage.AWGTunnel, resolveErr
 	port, _ := strconv.Atoi(portStr)
 	o.appLog.Warn("resolve-endpoint", stored.Peer.Endpoint, "DNS failed, using cached IP "+stored.ResolvedEndpointIP)
 	return stored.ResolvedEndpointIP, port, nil
+}
+
+// trackEndpointIP records a freshly-resolved endpoint IP for a tunnel.
+// Lazy-inits the map so struct-literal construction (tests) is safe.
+func (o *OperatorNativeWG) trackEndpointIP(tunnelID, ip string) {
+	o.trackedMu.Lock()
+	defer o.trackedMu.Unlock()
+	if o.trackedIP == nil {
+		o.trackedIP = make(map[string]string)
+	}
+	o.trackedIP[tunnelID] = ip
+}
+
+// GetTrackedEndpointIP returns the last freshly-resolved endpoint IP for a
+// tunnel, or "" if none has been resolved this process lifetime.
+func (o *OperatorNativeWG) GetTrackedEndpointIP(tunnelID string) string {
+	o.trackedMu.RLock()
+	defer o.trackedMu.RUnlock()
+	return o.trackedIP[tunnelID]
 }
 
 // splitAddressMask splits a CIDR or bare IP into (address, mask).

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -144,8 +144,8 @@ func (o *OperatorNativeWG) createViaBatch(ctx context.Context, stored *storage.A
 	ndmsName := names.NDMSName
 
 	// Resolve endpoint hostname -> IP (for validation only at create time;
-	// the actual proxy endpoint is set at Start time)
-	endpointIP, endpointPort, err := netutil.ResolveEndpoint(stored.Peer.Endpoint)
+	// the actual proxy endpoint is set at Start time). Uses retry + cache fallback.
+	endpointIP, endpointPort, err := o.resolveEndpointWithFallback(stored)
 	if err != nil {
 		return 0, fmt.Errorf("resolve endpoint: %w", err)
 	}
@@ -260,13 +260,10 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 		}
 	}
 
-	// Resolve endpoint (fallback to cached IP if DNS unavailable at boot)
-	endpointIP, endpointPort, err := netutil.ResolveEndpoint(stored.Peer.Endpoint)
+	// Resolve endpoint (retry + cached IP fallback if DNS unavailable at boot)
+	endpointIP, endpointPort, err := o.resolveEndpointWithFallback(stored)
 	if err != nil {
-		endpointIP, endpointPort, err = o.fallbackResolve(stored, err)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	o.appLog.Full("start", stored.Name, fmt.Sprintf("Resolving endpoint %s -> %s:%d", stored.Peer.Endpoint, endpointIP, endpointPort))
 
@@ -311,14 +308,11 @@ func (o *OperatorNativeWG) startProxy(ctx context.Context, stored *storage.AWGTu
 	names := NewNWGNames(stored.NWGIndex)
 	pubkey := stored.Peer.PublicKey
 
-	// Resolve endpoint — kmod proxy connects to this IP
-	// Fallback to cached IP if DNS unavailable at boot
-	endpointIP, endpointPort, err := netutil.ResolveEndpoint(stored.Peer.Endpoint)
+	// Resolve endpoint — kmod proxy connects to this IP.
+	// Retry + cached IP fallback if DNS unavailable at boot.
+	endpointIP, endpointPort, err := o.resolveEndpointWithFallback(stored)
 	if err != nil {
-		endpointIP, endpointPort, err = o.fallbackResolve(stored, err)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	// Ensure kernel module is loaded
@@ -630,7 +624,13 @@ func (o *OperatorNativeWG) EnsureKmodLoaded() error {
 func (o *OperatorNativeWG) RestoreKmodTunnel(ctx context.Context, stored *storage.AWGTunnel) error {
 	bindIface := o.ResolveActiveWAN(ctx, stored)
 
-	kmodCfg, err := buildKmodConfig(stored, bindIface)
+	// Resolve with retry + cached IP fallback — boot DNS on the router may be
+	// slow/uncached (this is the path that previously failed hard).
+	endpointIP, endpointPort, err := o.resolveEndpointWithFallback(stored)
+	if err != nil {
+		return fmt.Errorf("build kmod config: %w", err)
+	}
+	kmodCfg, err := buildKmodConfigResolved(stored, endpointIP, endpointPort, bindIface)
 	if err != nil {
 		return fmt.Errorf("build kmod config: %w", err)
 	}
@@ -710,16 +710,6 @@ func (o *OperatorNativeWG) nextFreeIndex(ctx context.Context) (int, error) {
 		}
 	}
 	return 0, fmt.Errorf("all %d Wireguard slots are occupied", MaxTunnels)
-}
-
-// buildKmodConfig resolves the endpoint and builds a KmodConfig.
-// Used by RestoreKmodTunnel where we don't need the resolved IP separately.
-func buildKmodConfig(stored *storage.AWGTunnel, bindIface string) (KmodConfig, error) {
-	ip, port, err := netutil.ResolveEndpoint(stored.Peer.Endpoint)
-	if err != nil {
-		return KmodConfig{}, fmt.Errorf("resolve endpoint: %w", err)
-	}
-	return buildKmodConfigResolved(stored, ip, port, bindIface)
 }
 
 // buildKmodConfigResolved builds a KmodConfig with a pre-resolved endpoint IP.

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -31,6 +31,12 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/netutil"
 )
 
+const (
+	resolveAttempts       = 3
+	resolveAttemptTimeout = 1500 * time.Millisecond
+	resolveRetryGap       = 300 * time.Millisecond
+)
+
 // OperatorNativeWG manages tunnels via Keenetic native WireGuard + awg_proxy.ko.
 type OperatorNativeWG struct {
 	queries      *query.Queries
@@ -748,6 +754,49 @@ func (o *OperatorNativeWG) fallbackResolve(stored *storage.AWGTunnel, resolveErr
 	port, _ := strconv.Atoi(portStr)
 	o.appLog.Warn("resolve-endpoint", stored.Peer.Endpoint, "DNS failed, using cached IP "+stored.ResolvedEndpointIP)
 	return stored.ResolvedEndpointIP, port, nil
+}
+
+// resolveEndpointWithFallback resolves the tunnel's endpoint with a short retry
+// budget, then falls back to the cached ResolvedEndpointIP. On a fresh DNS
+// success it records the IP via trackEndpointIP (cache fallbacks are NOT tracked).
+func (o *OperatorNativeWG) resolveEndpointWithFallback(stored *storage.AWGTunnel) (string, int, error) {
+	var lastErr error
+	for attempt := 1; attempt <= resolveAttempts; attempt++ {
+		ip, port, err := o.resolveOnce(stored.Peer.Endpoint, resolveAttemptTimeout)
+		if err == nil {
+			o.trackEndpointIP(stored.ID, ip)
+			return ip, port, nil
+		}
+		lastErr = err
+		o.appLog.Debug("resolve-endpoint", stored.Peer.Endpoint,
+			fmt.Sprintf("attempt %d/%d failed: %v", attempt, resolveAttempts, err))
+		if attempt < resolveAttempts {
+			time.Sleep(resolveRetryGap)
+		}
+	}
+	return o.fallbackResolve(stored, lastErr)
+}
+
+// resolveOnce runs the injected resolver under a per-attempt timeout. A resolver
+// that outlives the timeout is abandoned (its goroutine finishes and the result
+// is discarded) and the attempt is reported as a timeout failure.
+func (o *OperatorNativeWG) resolveOnce(endpoint string, timeout time.Duration) (string, int, error) {
+	type result struct {
+		ip   string
+		port int
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ip, port, err := o.resolveFn(endpoint)
+		ch <- result{ip, port, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.ip, r.port, r.err
+	case <-time.After(timeout):
+		return "", 0, fmt.Errorf("resolve %s: timeout after %s", endpoint, timeout)
+	}
 }
 
 // trackEndpointIP records a freshly-resolved endpoint IP for a tunnel.

--- a/internal/tunnel/nwg/resolve_fallback_test.go
+++ b/internal/tunnel/nwg/resolve_fallback_test.go
@@ -1,0 +1,17 @@
+package nwg
+
+import "testing"
+
+func TestTrackEndpointIP_GetReturnsTracked(t *testing.T) {
+	o := &OperatorNativeWG{}
+	if got := o.GetTrackedEndpointIP("awg10"); got != "" {
+		t.Fatalf("empty operator: GetTrackedEndpointIP = %q, want \"\"", got)
+	}
+	o.trackEndpointIP("awg10", "1.2.3.4")
+	if got := o.GetTrackedEndpointIP("awg10"); got != "1.2.3.4" {
+		t.Fatalf("GetTrackedEndpointIP = %q, want 1.2.3.4", got)
+	}
+	if got := o.GetTrackedEndpointIP("other"); got != "" {
+		t.Fatalf("unknown id: GetTrackedEndpointIP = %q, want \"\"", got)
+	}
+}

--- a/internal/tunnel/nwg/resolve_fallback_test.go
+++ b/internal/tunnel/nwg/resolve_fallback_test.go
@@ -1,6 +1,14 @@
 package nwg
 
-import "testing"
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
 
 func TestTrackEndpointIP_GetReturnsTracked(t *testing.T) {
 	o := &OperatorNativeWG{}
@@ -13,5 +21,87 @@ func TestTrackEndpointIP_GetReturnsTracked(t *testing.T) {
 	}
 	if got := o.GetTrackedEndpointIP("other"); got != "" {
 		t.Fatalf("unknown id: GetTrackedEndpointIP = %q, want \"\"", got)
+	}
+}
+
+func newTestOperator(resolveFn func(string) (string, int, error)) *OperatorNativeWG {
+	return &OperatorNativeWG{
+		appLog:    logging.NewScopedLogger(nil, logging.GroupTunnel, logging.SubOps),
+		resolveFn: resolveFn,
+	}
+}
+
+func TestResolveWithFallback_FreshSuccessTracks(t *testing.T) {
+	o := newTestOperator(func(string) (string, int, error) { return "9.9.9.9", 51820, nil })
+	stored := &storage.AWGTunnel{ID: "awg10", Peer: storage.AWGPeer{Endpoint: "host.example:51820"}}
+
+	ip, port, err := o.resolveEndpointWithFallback(stored)
+	if err != nil || ip != "9.9.9.9" || port != 51820 {
+		t.Fatalf("got (%q,%d,%v), want (9.9.9.9,51820,nil)", ip, port, err)
+	}
+	if got := o.GetTrackedEndpointIP("awg10"); got != "9.9.9.9" {
+		t.Fatalf("tracked = %q, want 9.9.9.9", got)
+	}
+}
+
+func TestResolveWithFallback_RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	o := newTestOperator(func(string) (string, int, error) {
+		if atomic.AddInt32(&calls, 1) < 2 {
+			return "", 0, fmt.Errorf("dns timeout")
+		}
+		return "9.9.9.9", 51820, nil
+	})
+	stored := &storage.AWGTunnel{ID: "awg10", Peer: storage.AWGPeer{Endpoint: "host.example:51820"}}
+
+	ip, _, err := o.resolveEndpointWithFallback(stored)
+	if err != nil || ip != "9.9.9.9" {
+		t.Fatalf("got (%q,%v), want (9.9.9.9,nil)", ip, err)
+	}
+	if calls < 2 {
+		t.Fatalf("calls = %d, want >= 2 (retry happened)", calls)
+	}
+}
+
+func TestResolveWithFallback_AllFailUsesCacheNoTrack(t *testing.T) {
+	o := newTestOperator(func(string) (string, int, error) { return "", 0, fmt.Errorf("dns down") })
+	stored := &storage.AWGTunnel{
+		ID:                 "awg10",
+		Peer:               storage.AWGPeer{Endpoint: "host.example:51820"},
+		ResolvedEndpointIP: "5.5.5.5",
+	}
+
+	ip, port, err := o.resolveEndpointWithFallback(stored)
+	if err != nil || ip != "5.5.5.5" || port != 51820 {
+		t.Fatalf("got (%q,%d,%v), want (5.5.5.5,51820,nil)", ip, port, err)
+	}
+	if got := o.GetTrackedEndpointIP("awg10"); got != "" {
+		t.Fatalf("cache fallback must NOT track; tracked = %q", got)
+	}
+}
+
+func TestResolveWithFallback_AllFailNoCacheErrors(t *testing.T) {
+	o := newTestOperator(func(string) (string, int, error) { return "", 0, fmt.Errorf("dns down") })
+	stored := &storage.AWGTunnel{ID: "awg10", Peer: storage.AWGPeer{Endpoint: "host.example:51820"}}
+
+	if _, _, err := o.resolveEndpointWithFallback(stored); err == nil {
+		t.Fatal("want error when DNS fails and no cache, got nil")
+	}
+}
+
+func TestResolveWithFallback_SlowAttemptTimesOut(t *testing.T) {
+	o := newTestOperator(func(string) (string, int, error) {
+		time.Sleep(resolveAttemptTimeout + 500*time.Millisecond)
+		return "9.9.9.9", 51820, nil
+	})
+	stored := &storage.AWGTunnel{
+		ID:                 "awg10",
+		Peer:               storage.AWGPeer{Endpoint: "host.example:51820"},
+		ResolvedEndpointIP: "5.5.5.5",
+	}
+
+	ip, _, err := o.resolveEndpointWithFallback(stored)
+	if err != nil || ip != "5.5.5.5" {
+		t.Fatalf("got (%q,%v), want (5.5.5.5,nil) via cache after timeouts", ip, err)
 	}
 }


### PR DESCRIPTION
  ## Проблема

  NativeWG-туннель поверх awg_proxy kmod на boot падал с жёсткой ошибкой при
  медленном/недоступном DNS роутера:

  [WARN] [tunnel/orchestrator] execute-action awg10: action type 5 failed:
    build kmod config: resolve endpoint: resolve engage.cloudflareclient.com:
    lookup engage.cloudflareclient.com on 127.0.0.1:53: ... i/o timeout

  `action type 5` = `ActionRestoreKmod` → `RestoreKmodTunnel` → `buildKmodConfig` —
  единственный resolve-путь без фоллбэка. Кеш `ResolvedEndpointIP` и `fallbackResolve`
  уже существовали, но были подключены только к `startNative`/`startProxy`.

  ## Что изменено

  - **`resolveEndpointWithFallback`** (`internal/tunnel/nwg/operator.go`) — единый
    хелпер: ретрай DNS (3 попытки, per-attempt timeout 1.5с, зазор 300мс), затем
    фоллбэк на кешированный `ResolvedEndpointIP`. Свежий резолв трекается, фоллбэк — нет.
  - **Все 4 resolve-callsite'а** (`Create`, `startNative`, `startProxy`,
    `RestoreKmodTunnel`) переведены на хелпер; неиспользуемый `buildKmodConfig` удалён.
  - **`GetTrackedEndpointIP`** на nwg-операторе (по паттерну kernel-оператора);
    оркестратор (`executePersistRunning`, `executeRestoreKmod`) персистит свежий IP
    для nativewg-туннелей.
  - `netutil` не менялся (остаётся чистым резолвером).

  ## Эффект

  Boot-путь `RestoreKmodTunnel` при DNS-таймауте теперь фоллбэкает на кеш вместо
  жёсткого падения. Каждый удачный резолв обновляет `ResolvedEndpointIP`, давая
  актуальный fallback для следующего boot. Поведение kernel-туннелей не затронуто.

  ## Коммиты

  - `5071d7ea` трекинг свежерезолвнутого endpoint IP + resolveFn seam
  - `cd125da1` resolveEndpointWithFallback — ретрай DNS + фоллбэк на кеш
  - `c78249d6` резолв через resolveEndpointWithFallback во всех путях (вкл. boot RestoreKmod)
  - `b47f21e7` персист ResolvedEndpointIP для nativewg (PersistRunning + RestoreKmod)

  ## Тест-план

  - [x] `go build ./...` — чисто
  - [x] `go vet ./...` — чисто
  - [x] `go test ./internal/tunnel/nwg/... ./internal/orchestrator/...` — passing
  - [x] Юнит-тесты хелпера: свежий резолв+трек, ретрай→успех, все-фейл→кеш (без трека),
        все-фейл-без-кеша→ошибка, медленная попытка→timeout→кеш
  - [ ] Проверка на роутере: boot при недоступном DNS — туннель поднимается на кешированном
  IP