### PR TITLE
Feat/nwg config coherence broken

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -893,7 +893,7 @@
 			case 'running':
 				return tunnel.pingCheck.status === 'recovering' ? 'Восстанавливается' : 'Активен';
 			case 'broken':
-				return 'Ошибка';
+				return 'Сломан';
 			case 'starting':
 				return 'Запускается';
 			case 'needs_stop':

--- a/internal/ndms/types/interface.go
+++ b/internal/ndms/types/interface.go
@@ -31,6 +31,9 @@ type WGPeer struct {
 	RxBytes       int64  `json:"rxbytes"`
 	TxBytes       int64  `json:"txbytes"`
 	Via           string `json:"via"`
+
+	RemoteEndpointAddress string `json:"remote-endpoint-address"`
+	RemotePort            int    `json:"remote-port"`
 }
 
 // WGSummary holds the layer summary nested under WGInterface.

--- a/internal/tunnel/nwg/classify_state_test.go
+++ b/internal/tunnel/nwg/classify_state_test.go
@@ -1,0 +1,56 @@
+package nwg
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/tunnel"
+)
+
+func TestClassifyNWGState(t *testing.T) {
+	slotPresent := func(int) bool { return true }
+	slotAbsent := func(int) bool { return false }
+
+	cases := []struct {
+		name        string
+		rci         NWGState
+		supportsASC bool
+		hasSlot     func(int) bool
+		want        tunnel.State
+	}{
+		{"running+online -> Running",
+			NWGState{ConfLayer: "running", PeerOnline: true}, false, slotAbsent, tunnel.StateRunning},
+		{"proxy running+offline, no slot -> Broken",
+			NWGState{ConfLayer: "running", PeerOnline: false, PeerRemoteAddr: "127.0.0.1", PeerRemotePort: 51958}, false, slotAbsent, tunnel.StateBroken},
+		{"proxy running+offline, remote not localhost -> Broken",
+			NWGState{ConfLayer: "running", PeerOnline: false, PeerRemoteAddr: "46.149.74.35", PeerRemotePort: 443}, false, slotPresent, tunnel.StateBroken},
+		{"proxy running+offline, coherent -> Starting",
+			NWGState{ConfLayer: "running", PeerOnline: false, PeerRemoteAddr: "127.0.0.1", PeerRemotePort: 51958}, false, slotPresent, tunnel.StateStarting},
+		{"ASC running+offline -> Starting (no kmod)",
+			NWGState{ConfLayer: "running", PeerOnline: false, PeerRemoteAddr: "1.2.3.4", PeerRemotePort: 51820}, true, slotAbsent, tunnel.StateStarting},
+		{"disabled -> Stopped",
+			NWGState{ConfLayer: "disabled"}, false, slotAbsent, tunnel.StateStopped},
+		{"unknown conf -> Unknown",
+			NWGState{ConfLayer: ""}, false, slotAbsent, tunnel.StateUnknown},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyNWGState(c.rci, c.supportsASC, c.hasSlot)
+			if got != c.want {
+				t.Errorf("classifyNWGState = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestClassifyNWGState_RunningSkipsSlotCheck(t *testing.T) {
+	called := false
+	probe := func(int) bool { called = true; return false }
+	got := classifyNWGState(NWGState{ConfLayer: "running", PeerOnline: true}, false, probe)
+	if got != tunnel.StateRunning {
+		t.Fatalf("got %v, want Running", got)
+	}
+	if called {
+		t.Error("hasProxySlot must NOT be called when peer is online")
+	}
+}

--- a/internal/tunnel/nwg/kmod_manager.go
+++ b/internal/tunnel/nwg/kmod_manager.go
@@ -229,6 +229,20 @@ func countProxySlotsList(data string) int {
 	return count
 }
 
+// hasSlotListeningInList reports whether the /proc/awg_proxy/list contents contain
+// a slot listening on 127.0.0.1:listenPort.
+func hasSlotListeningInList(data string, listenPort int) bool {
+	want := fmt.Sprintf("listen=127.0.0.1:%d", listenPort)
+	for _, line := range strings.Split(data, "\n") {
+		for _, field := range strings.Fields(line) {
+			if field == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // readListenPortLocked reads /proc/awg_proxy/list and finds the listen port
 // for the given endpoint. Must be called with km.mu held.
 func (km *KmodManager) readListenPortLocked(endpointIP string, endpointPort int) (int, error) {
@@ -286,6 +300,16 @@ func (km *KmodManager) RemoveTunnel(tunnelID string) error {
 	delete(km.tunnels, tunnelID)
 	km.appLog.Info("remove-tunnel", tunnelID, "removed")
 	return nil
+}
+
+// HasSlotListening reports whether a live kmod proxy slot is listening on
+// 127.0.0.1:listenPort (read from /proc/awg_proxy/list).
+func (km *KmodManager) HasSlotListening(listenPort int) bool {
+	data, err := os.ReadFile("/proc/awg_proxy/list")
+	if err != nil {
+		return false
+	}
+	return hasSlotListeningInList(string(data), listenPort)
 }
 
 // IsLoaded checks if /proc/awg_proxy/version exists.

--- a/internal/tunnel/nwg/kmod_manager_test.go
+++ b/internal/tunnel/nwg/kmod_manager_test.go
@@ -52,3 +52,20 @@ func TestCountProxySlotsListEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestHasSlotListeningInList(t *testing.T) {
+	const list = `46.149.74.35:443 listen=127.0.0.1:51958 rx=10 tx=20
+1.2.3.4:51820 listen=127.0.0.1:40001 rx=0 tx=0`
+	if !hasSlotListeningInList(list, 51958) {
+		t.Error("want true for listen port 51958")
+	}
+	if !hasSlotListeningInList(list, 40001) {
+		t.Error("want true for listen port 40001")
+	}
+	if hasSlotListeningInList(list, 99999) {
+		t.Error("want false for absent listen port 99999")
+	}
+	if hasSlotListeningInList("", 51958) {
+		t.Error("want false for empty list")
+	}
+}

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -55,18 +55,28 @@ type OperatorNativeWG struct {
 	// to persist storage.AWGTunnel.ResolvedEndpointIP.
 	trackedMu sync.RWMutex
 	trackedIP map[string]string
+
+	// supportsASC reports native ASC firmware support. Default:
+	// ndmsinfo.SupportsWireguardASC; overridable in tests.
+	supportsASC func() bool
+	// hasProxySlot reports a live kmod proxy slot on a listen port. Default:
+	// kmod.HasSlotListening; overridable in tests.
+	hasProxySlot func(listenPort int) bool
 }
 
 // NewOperator creates a new NativeWG operator.
 func NewOperator(queries *query.Queries, commands *command.Commands, tr *transport.Client, appLogger logging.AppLogger) *OperatorNativeWG {
-	return &OperatorNativeWG{
-		queries:   queries,
-		commands:  commands,
-		transport: tr,
-		kmod:      NewKmodManager(appLogger),
-		appLog:    logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubOps),
-		resolveFn: netutil.ResolveEndpoint,
+	op := &OperatorNativeWG{
+		queries:     queries,
+		commands:    commands,
+		transport:   tr,
+		kmod:        NewKmodManager(appLogger),
+		appLog:      logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubOps),
+		resolveFn:   netutil.ResolveEndpoint,
+		supportsASC: ndmsinfo.SupportsWireguardASC,
 	}
+	op.hasProxySlot = op.kmod.HasSlotListening
+	return op
 }
 
 // SetHookNotifier sets the hook notifier for registering expected NDMS hooks.
@@ -460,6 +470,30 @@ func (o *OperatorNativeWG) Delete(ctx context.Context, stored *storage.AWGTunnel
 	return nil
 }
 
+// classifyNWGState decides the tunnel State for a NativeWG interface from parsed
+// RCI state. For the awg_proxy path (no ASC), conf=running with an offline peer is
+// StateBroken when the config is incoherent — NDMS peer not pointing at 127.0.0.1
+// or no live kmod slot on the peer's remote-port — otherwise StateStarting.
+// hasProxySlot is only consulted on the proxy path with an offline peer.
+func classifyNWGState(rci NWGState, supportsASC bool, hasProxySlot func(listenPort int) bool) tunnel.State {
+	switch {
+	case rci.ConfLayer == "running" && rci.PeerOnline:
+		return tunnel.StateRunning
+	case rci.ConfLayer == "running" && !rci.PeerOnline:
+		if supportsASC {
+			return tunnel.StateStarting
+		}
+		if rci.PeerRemoteAddr != "127.0.0.1" || !hasProxySlot(rci.PeerRemotePort) {
+			return tunnel.StateBroken
+		}
+		return tunnel.StateStarting
+	case rci.ConfLayer == "disabled":
+		return tunnel.StateStopped
+	default:
+		return tunnel.StateUnknown
+	}
+}
+
 // GetState returns the state of a NativeWG tunnel via RCI.
 // KmodManager does NOT participate in state detection — RCI is the single source of truth.
 func (o *OperatorNativeWG) GetState(ctx context.Context, stored *storage.AWGTunnel) tunnel.StateInfo {
@@ -494,21 +528,12 @@ func (o *OperatorNativeWG) GetState(ctx context.Context, stored *storage.AWGTunn
 
 	o.appLog.Debug("state", stored.Name, fmt.Sprintf("RCI state: conf=%s link=%v peer=%v", rciState.ConfLayer, rciState.LinkUp, rciState.PeerOnline))
 
-	// State matrix (simplified — no proxy/kmod tracking needed):
-	//   ConfLayer==running && PeerOnline     -> StateRunning
-	//   ConfLayer==running && !PeerOnline    -> StateStarting
-	//   ConfLayer==disabled                  -> StateStopped
-	//   !Exists                              -> StateNotCreated
-	switch {
-	case rciState.ConfLayer == "running" && rciState.PeerOnline:
-		info.State = tunnel.StateRunning
-	case rciState.ConfLayer == "running" && !rciState.PeerOnline:
-		info.State = tunnel.StateStarting
-	case rciState.ConfLayer == "disabled":
-		info.State = tunnel.StateStopped
-	default:
-		info.State = tunnel.StateUnknown
-	}
+	// State (see classifyNWGState):
+	//   running & peer online                         -> Running
+	//   running & peer offline & proxy & incoherent   -> Broken
+	//   running & peer offline (coherent / ASC)        -> Starting
+	//   disabled                                       -> Stopped
+	info.State = classifyNWGState(rciState, o.supportsASC(), o.hasProxySlot)
 
 	return info
 }

--- a/internal/tunnel/nwg/state_parser.go
+++ b/internal/tunnel/nwg/state_parser.go
@@ -17,16 +17,18 @@ const neverHandshake int64 = types.NeverHandshake
 // NWGState holds parsed state from an RCI response for a single
 // Wireguard interface.
 type NWGState struct {
-	Exists        bool
-	ConfLayer     string // "running" | "disabled"
-	LinkUp        bool
-	WGStatus      string // "up" | "down"
-	PeerOnline    bool
-	LastHandshake int64  // unix timestamp, 2147483647 = never
-	RxBytes       int64
-	TxBytes       int64
-	PeerVia       string // NDMS WAN name from peer "via" field (e.g. "PPPoE0")
-	Connected     string // RFC3339 timestamp converted from NDMS "connected" field (unix ts or string)
+	Exists         bool
+	ConfLayer      string // "running" | "disabled"
+	LinkUp         bool
+	WGStatus       string // "up" | "down"
+	PeerOnline     bool
+	LastHandshake  int64 // unix timestamp, 2147483647 = never
+	RxBytes        int64
+	TxBytes        int64
+	PeerVia        string // NDMS WAN name from peer "via" field (e.g. "PPPoE0")
+	PeerRemoteAddr string // peer "remote-endpoint-address" (127.0.0.1 for proxy path)
+	PeerRemotePort int    // peer "remote-port" (kmod proxy listen port for proxy path)
+	Connected      string // RFC3339 timestamp converted from NDMS "connected" field (unix ts or string)
 }
 
 // parseRCIInterfaceResponse parses a raw RCI JSON response for a single
@@ -66,6 +68,8 @@ func parseRCIInterfaceResponse(data []byte) (NWGState, error) {
 			state.RxBytes = peer.RxBytes
 			state.TxBytes = peer.TxBytes
 			state.PeerVia = peer.Via
+			state.PeerRemoteAddr = peer.RemoteEndpointAddress
+			state.PeerRemotePort = peer.RemotePort
 		}
 	}
 
@@ -125,4 +129,3 @@ func parseRCIInterfaceList(data []byte) ([]string, error) {
 	}
 	return names, nil
 }
-

--- a/internal/tunnel/nwg/state_parser_test.go
+++ b/internal/tunnel/nwg/state_parser_test.go
@@ -156,6 +156,35 @@ func TestParseRCIResponse_NoWireguardSection(t *testing.T) {
 	}
 }
 
+func TestParseRCIInterfaceResponse_PeerEndpoint(t *testing.T) {
+	const j = `{
+      "id": "Wireguard0",
+      "link": "up",
+      "wireguard": {
+        "listen-port": 42109,
+        "status": "up",
+        "peer": [{
+          "public-key": "k",
+          "remote-port": 51958,
+          "remote-endpoint-address": "127.0.0.1",
+          "online": false,
+          "last-handshake": 200
+        }]
+      },
+      "summary": { "layer": { "conf": "running" } }
+    }`
+	state, err := parseRCIInterfaceResponse([]byte(j))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if state.PeerRemoteAddr != "127.0.0.1" {
+		t.Errorf("PeerRemoteAddr = %q, want 127.0.0.1", state.PeerRemoteAddr)
+	}
+	if state.PeerRemotePort != 51958 {
+		t.Errorf("PeerRemotePort = %d, want 51958", state.PeerRemotePort)
+	}
+}
+
 func TestParseRCIInterfaceList(t *testing.T) {
 	data := []byte(`{
 		"ISP": {"id": "ISP", "type": "PPPoE"},


### PR DESCRIPTION
  Описание:
  ## Проблема

  NativeWG-туннель поверх awg_proxy при `conf=running`, но без онлайн-пира, в `GetState`
  всегда получал `StateStarting` → в UI вечно «Запускается». Один из реальных корней —
  **некогерентный конфиг**: kmod-прокси не получил слот (например, RestoreKmod упал на
  резолве endpoint), NDMS шлёт WG на `127.0.0.1:<port>`, где никто не слушает → handshake
  невозможен. 

  ### Матрица (proxy-путь, conf=running)
  peer online                                  → Running
  peer offline & remote≠127.0.0.1              → Broken
  peer offline & нет слота на remote-port      → Broken
  peer offline & когерентно (или ASC-путь)     → Starting
  disabled                                     → Stopped
  Проверка `/proc` — только при offline-пире (при online конфиг заведомо цел, kmod не
  дёргаем).

    ## Коммиты

  - `1fc53778` парсинг remote-endpoint-address/remote-port пира из RCI
  - `9eb2f896` KmodManager.HasSlotListening — проверка живого слота по порту
  - `59636220` StateBroken при некогерентном конфиге proxy-туннеля
  - `8ae84507` фронт: отображение состояния broken в списке туннелей

  ## Тест-план

  - [x] `go build ./...`, `go vet ./...` — чисто
  - [x] `go test ./internal/tunnel/nwg/... ./internal/ndms/...` — passing
  - [x] `cd frontend && npm run check` — 0 ошибок
  - [x] Юнит-тесты: матрица classifyNWGState (Broken/Starting/Running/Stopped/Unknown/ASC),
        HasSlotListening, парсинг peer endpoint
  - [ ] На роутере: уронить пир proxy-туннеля без слота → статус «Сломан» 