### PR TITLE
fix(nwg): внятная причина при сбое import wireguard (пустой created)

### DIFF
--- a/internal/ndms/command/wireguard.go
+++ b/internal/ndms/command/wireguard.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/ndms/query"
 )
@@ -59,13 +60,20 @@ func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData 
 		return "", fmt.Errorf("import wireguard: %w", err)
 	}
 
-	// Real NDMS response shape:
-	// {"interface":{"wireguard":{"import":{"created":"Wireguard0",...}}}}
+	// Real NDMS response shape (captured on 5.01.A.x):
+	// {"interface":{"wireguard":{"import":{
+	//   "intersects":"", "created":"Wireguard3",
+	//   "status":[{"status":"message","code":"...","ident":"...","message":"..."}]}}}}
 	var parsed struct {
 		Interface struct {
 			Wireguard struct {
 				Import struct {
-					Created string `json:"created"`
+					Intersects string `json:"intersects"`
+					Created    string `json:"created"`
+					Status     []struct {
+						Status  string `json:"status"`
+						Message string `json:"message"`
+					} `json:"status"`
 				} `json:"import"`
 			} `json:"wireguard"`
 		} `json:"interface"`
@@ -73,8 +81,23 @@ func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData 
 	if err := json.Unmarshal(resp, &parsed); err != nil {
 		return "", fmt.Errorf("import wireguard: decode: %w", err)
 	}
-	if parsed.Interface.Wireguard.Import.Created == "" {
-		return "", fmt.Errorf("import wireguard: empty created field in response")
+	imp := parsed.Interface.Wireguard.Import
+	if imp.Created == "" {
+		// The router accepted the request (HTTP 200) but did not return a
+		// created interface. The reason lives in the nested status[] array,
+		// which the top-level error envelope check does not inspect — surface
+		// it instead of an opaque message.
+		var msgs []string
+		for _, s := range imp.Status {
+			if s.Message != "" {
+				msgs = append(msgs, s.Message)
+			}
+		}
+		detail := strings.Join(msgs, "; ")
+		if detail == "" {
+			detail = "no status message"
+		}
+		return "", fmt.Errorf("import wireguard: router returned no created interface (intersects=%q; status: %s)", imp.Intersects, detail)
 	}
-	return parsed.Interface.Wireguard.Import.Created, nil
+	return imp.Created, nil
 }

--- a/internal/ndms/command/wireguard.go
+++ b/internal/ndms/command/wireguard.go
@@ -41,10 +41,21 @@ func (c *WireguardCommands) SetASCParams(ctx context.Context, name string, param
 		c.queries.RunningConfig.InvalidateAll)
 }
 
-// ImportWireguardConfig uploads a .conf file to NDMS and returns the
-// NDMS interface name created from the import (e.g. "Wireguard1").
+// ImportResult holds the parsed outcome of a wireguard config import.
+// Intersects names a pre-existing interface the imported config collides
+// with (empty if none); Messages are the human-readable status[] lines the
+// router returned. Both are kept so the caller does not lose context even
+// on a successful import.
+type ImportResult struct {
+	Created    string
+	Intersects string
+	Messages   []string
+}
+
+// ImportWireguardConfig uploads a .conf file to NDMS and returns the import
+// result, including the created NDMS interface name (e.g. "Wireguard1").
 // confData is the raw .conf body (NOT base64 — encoded internally).
-func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData []byte, filename string) (string, error) {
+func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData []byte, filename string) (ImportResult, error) {
 	encoded := base64.StdEncoding.EncodeToString(confData)
 	payload := map[string]any{
 		"interface": map[string]any{
@@ -57,7 +68,7 @@ func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData 
 	}
 	resp, err := c.poster.Post(ctx, payload)
 	if err != nil {
-		return "", fmt.Errorf("import wireguard: %w", err)
+		return ImportResult{}, fmt.Errorf("import wireguard: %w", err)
 	}
 
 	// Real NDMS response shape (captured on 5.01.A.x):
@@ -79,25 +90,27 @@ func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData 
 		} `json:"interface"`
 	}
 	if err := json.Unmarshal(resp, &parsed); err != nil {
-		return "", fmt.Errorf("import wireguard: decode: %w", err)
+		return ImportResult{}, fmt.Errorf("import wireguard: decode: %w", err)
 	}
 	imp := parsed.Interface.Wireguard.Import
+
+	var msgs []string
+	for _, s := range imp.Status {
+		if s.Message != "" {
+			msgs = append(msgs, s.Message)
+		}
+	}
+
 	if imp.Created == "" {
 		// The router accepted the request (HTTP 200) but did not return a
 		// created interface. The reason lives in the nested status[] array,
 		// which the top-level error envelope check does not inspect — surface
 		// it instead of an opaque message.
-		var msgs []string
-		for _, s := range imp.Status {
-			if s.Message != "" {
-				msgs = append(msgs, s.Message)
-			}
-		}
 		detail := strings.Join(msgs, "; ")
 		if detail == "" {
 			detail = "no status message"
 		}
-		return "", fmt.Errorf("import wireguard: router returned no created interface (intersects=%q; status: %s)", imp.Intersects, detail)
+		return ImportResult{}, fmt.Errorf("import wireguard: router returned no created interface (intersects=%q; status: %s)", imp.Intersects, detail)
 	}
-	return imp.Created, nil
+	return ImportResult{Created: imp.Created, Intersects: imp.Intersects, Messages: msgs}, nil
 }

--- a/internal/ndms/command/wireguard_test.go
+++ b/internal/ndms/command/wireguard_test.go
@@ -3,11 +3,77 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/ndms/query"
 )
+
+// respPoster returns a fixed body, mimicking a real NDMS POST response.
+type respPoster struct{ body string }
+
+func (r *respPoster) Post(ctx context.Context, payload any) (json.RawMessage, error) {
+	return json.RawMessage(r.body), nil
+}
+
+// Real success response captured from a router (5.01.A.x): the import
+// command returns the created interface name in import.created, plus an
+// informational status[] entry and an empty intersects field.
+const realImportSuccess = `{
+  "interface": {
+    "wireguard": {
+      "import": {
+        "intersects": "",
+        "created": "Wireguard3",
+        "status": [
+          {"status": "message", "code": "75507472", "ident": "Wireguard::Interface", "message": "\"Wireguard3\": imported settings."}
+        ]
+      }
+    }
+  }
+}`
+
+func TestImportWireguardConfig_Success_ReturnsCreated(t *testing.T) {
+	c := NewWireguardCommands(&respPoster{body: realImportSuccess}, nil, nil)
+
+	name, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "Wireguard3" {
+		t.Errorf("created name: want Wireguard3, got %q", name)
+	}
+}
+
+func TestImportWireguardConfig_EmptyCreated_SurfacesStatusMessage(t *testing.T) {
+	// Same object schema as the real response, but created is empty and the
+	// status[] carries the router's explanation. The current code throws
+	// this message away and reports an opaque "empty created field".
+	body := `{"interface":{"wireguard":{"import":{"intersects":"","created":"","status":[{"status":"error","code":"75507473","ident":"Wireguard::Interface","message":"interface limit reached"}]}}}}`
+	c := NewWireguardCommands(&respPoster{body: body}, nil, nil)
+
+	_, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
+	if err == nil {
+		t.Fatal("expected error when created is empty")
+	}
+	if !strings.Contains(err.Error(), "interface limit reached") {
+		t.Errorf("error should surface router status message, got: %v", err)
+	}
+}
+
+func TestImportWireguardConfig_EmptyCreated_IncludesIntersects(t *testing.T) {
+	body := `{"interface":{"wireguard":{"import":{"intersects":"Wireguard5","created":"","status":[]}}}}`
+	c := NewWireguardCommands(&respPoster{body: body}, nil, nil)
+
+	_, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
+	if err == nil {
+		t.Fatal("expected error when created is empty")
+	}
+	if !strings.Contains(err.Error(), "Wireguard5") {
+		t.Errorf("error should name the intersecting interface, got: %v", err)
+	}
+}
 
 func TestWireguardCommands_SetASCParams(t *testing.T) {
 	poster := &fakePoster{}

--- a/internal/ndms/command/wireguard_test.go
+++ b/internal/ndms/command/wireguard_test.go
@@ -37,12 +37,34 @@ const realImportSuccess = `{
 func TestImportWireguardConfig_Success_ReturnsCreated(t *testing.T) {
 	c := NewWireguardCommands(&respPoster{body: realImportSuccess}, nil, nil)
 
-	name, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
+	res, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != "Wireguard3" {
-		t.Errorf("created name: want Wireguard3, got %q", name)
+	if res.Created != "Wireguard3" {
+		t.Errorf("created name: want Wireguard3, got %q", res.Created)
+	}
+}
+
+func TestImportWireguardConfig_Success_PreservesIntersectAndMessages(t *testing.T) {
+	// Importing a config whose keys collide with an existing interface still
+	// creates a new one, but the router reports the collision in intersects.
+	// The caller must not lose that context.
+	body := `{"interface":{"wireguard":{"import":{"intersects":"Wireguard3","created":"Wireguard4","status":[{"status":"message","code":"75507472","ident":"Wireguard::Interface","message":"\"Wireguard4\": imported settings."}]}}}}`
+	c := NewWireguardCommands(&respPoster{body: body}, nil, nil)
+
+	res, err := c.ImportWireguardConfig(context.Background(), []byte("conf"), "x.conf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Created != "Wireguard4" {
+		t.Errorf("created: want Wireguard4, got %q", res.Created)
+	}
+	if res.Intersects != "Wireguard3" {
+		t.Errorf("intersects: want Wireguard3, got %q", res.Intersects)
+	}
+	if len(res.Messages) != 1 || !strings.Contains(res.Messages[0], "imported settings") {
+		t.Errorf("messages: want one 'imported settings', got %v", res.Messages)
 	}
 }
 

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -103,9 +103,18 @@ func (o *OperatorNativeWG) createViaImport(ctx context.Context, stored *storage.
 
 	// Import via RCI — NDMS creates the interface and parses all params.
 	// ImportWireguardConfig is a multipart-upload helper with no new-layer equivalent yet.
-	ndmsName, err := o.commands.Wireguard.ImportWireguardConfig(ctx, []byte(confData), stored.Name+".conf")
+	res, err := o.commands.Wireguard.ImportWireguardConfig(ctx, []byte(confData), stored.Name+".conf")
 	if err != nil {
 		return 0, fmt.Errorf("import wireguard config: %w", err)
+	}
+	ndmsName := res.Created
+
+	// The router may create the interface yet report that its config collides
+	// with an existing one (same keys) — surface it so the context is not lost.
+	if res.Intersects != "" {
+		o.appLog.Warn("create", stored.Name,
+			fmt.Sprintf("imported %s intersects existing %s; status: %s",
+				ndmsName, res.Intersects, strings.Join(res.Messages, "; ")))
 	}
 
 	// Extract index from "WireguardN"


### PR DESCRIPTION
## Проблема

Пользователь не мог добавить NativeWG-туннель: в логе только опаковое
`create NativeWG interface: import wireguard config: import wireguard: empty created field in response`. Реальная причина от роутера терялась.

## Разбор

Подтверждённая на роутере форма ответа RCI на import:
```json
{"interface":{"wireguard":{"import":{
  "intersects":"", "created":"Wireguard3",
  "status":[{"status":"message","message":"\"Wireguard3\": imported settings."}]}}}}
```
- `created` — имя созданного интерфейса (поле верное, в happy-path заполнено);
- `intersects` — имя существующего интерфейса, с которым пересекается конфиг (при дубле ключей);
- `status[]` — человекочитаемые сообщения.

Два дефекта:
1. `ExtractError` смотрит только top-level `status`/`message` и **не видит** вложенный `import.status[]`.
2. `ImportWireguardConfig` читал **только** `created`. При пустом `created` отдавал безликую ошибку, а `intersects`/`status[]` отбрасывал — и на ошибке, и на успехе.

> Реальную причину именно у пострадавшего роутера снять нельзя (чужое железо). Поэтому фикс делает так, чтобы приложение **само писало в лог** то, что вернул роутер.

## Изменения

- `ImportWireguardConfig` парсит `intersects` + `status[]` и возвращает `ImportResult{Created, Intersects, Messages}` вместо строки.
- При пустом `created` ошибка содержит реальный текст роутера: `router returned no created interface (intersects=%q; status: ...)`.
- `createViaImport` (operator.go) логирует warning при `intersects != ""` — контекст не теряется и на success-пути.

## Тесты (TDD)

- `Success_ReturnsCreated` — happy-path по реальному ответу;
- `Success_PreservesIntersectAndMessages` — `intersects`/`status[]` сохраняются;
- `EmptyCreated_SurfacesStatusMessage` — сообщение роутера попадает в ошибку;
- `EmptyCreated_IncludesIntersects` — имя пересекающегося интерфейса в ошибке.

## Чек-лист
- [x] `go build ./...` — OK
- [x] `go test ./internal/ndms/command/ ./internal/tunnel/nwg/` — OK
- [x] `go vet` — чисто
- [ ] Подтвердить на железе реальное `status[]`-сообщение при сбое и при необходимости добавить обработку конкретного сценария

## Что НЕ закрыто

Первопричина пустого `created` у пострадавшего роутера не установлена — для этого нужен реальный ответ. PR делает причину видимой в логах; дальнейшая обработка — по факту полученного сообщения.