### PR TITLE
fix(httpclient): use cumulative timings matching curl semantics

### DIFF
--- a/internal/monitoring/prober_test.go
+++ b/internal/monitoring/prober_test.go
@@ -23,6 +23,8 @@ func (s stubDoer) Do(_ context.Context, _ httpclient.CallConfig) (*httpclient.Re
 }
 
 // HTTPProber latency = (time_connect - time_namelookup) * 1000 ms.
+// TimeConnect and TimeNameLookup are cumulative-from-start (matching curl
+// semantics), so the subtraction yields pure TCP RTT.
 func TestHTTPProber_ParseLatency(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -53,6 +55,14 @@ func TestHTTPProber_ParseLatency(t *testing.T) {
 				Metrics: httpclient.Metrics{HTTPCode: 0, TimeNameLookup: 0, TimeConnect: 0, TimeTotal: 5.0},
 			},
 			wantOK: false,
+		},
+		{
+			name: "DNS slow — cumulative timings preserve correct RTT",
+			result: &httpclient.Result{
+				Metrics: httpclient.Metrics{HTTPCode: 200, TimeNameLookup: 0.200, TimeConnect: 0.280, TimeTotal: 0.390},
+			},
+			wantOK: true,
+			wantMs: 80,
 		},
 		{
 			name: "fallback to time_total when timings invalid",

--- a/internal/sys/httpclient/client.go
+++ b/internal/sys/httpclient/client.go
@@ -19,9 +19,9 @@ import (
 // Metrics mirrors curl's -w output fields used across the codebase.
 type Metrics struct {
 	HTTPCode       int     // e.g. 204, 200, 404
-	TimeNameLookup float64 // DNS resolution in seconds
-	TimeConnect    float64 // TCP connect in seconds
-	TimeTotal      float64 // Full request in seconds
+	TimeNameLookup float64 // Cumulative: time from start to DNS done (seconds)
+	TimeConnect    float64 // Cumulative: time from start to TCP connect done (seconds)
+	TimeTotal      float64 // Cumulative: full request duration (seconds)
 }
 
 // Result is the unified return type for all operations.
@@ -172,11 +172,14 @@ func (c *Client) Do(ctx context.Context, cfg CallConfig) (*Result, error) {
 	metrics := Metrics{
 		HTTPCode: resp.StatusCode,
 	}
-	if !timings.dnsStart.IsZero() && !timings.dnsDone.IsZero() {
-		metrics.TimeNameLookup = timings.dnsDone.Sub(timings.dnsStart).Seconds()
+	// Cumulative-from-start timings, matching curl's time_namelookup /
+	// time_connect semantics so downstream `TimeConnect - TimeNameLookup`
+	// yields pure TCP-RTT.
+	if !timings.dnsDone.IsZero() {
+		metrics.TimeNameLookup = timings.dnsDone.Sub(start).Seconds()
 	}
-	if !timings.connectStart.IsZero() && !timings.connectDone.IsZero() {
-		metrics.TimeConnect = timings.connectDone.Sub(timings.connectStart).Seconds()
+	if !timings.connectDone.IsZero() {
+		metrics.TimeConnect = timings.connectDone.Sub(start).Seconds()
 	}
 
 	// Read body (or discard).

--- a/internal/sys/httpclient/client_test.go
+++ b/internal/sys/httpclient/client_test.go
@@ -255,6 +255,30 @@ func TestDo_UserAgent_SetToCurl(t *testing.T) {
 	}
 }
 
+func TestDo_Metrics_CumulativeTimings(t *testing.T) {
+	// When DNS is involved, cumulative timings must satisfy:
+	// TimeNameLookup <= TimeConnect <= TimeTotal.
+	ts := newTestServer(t, handler200)
+	// Use "localhost" to trigger a DNS lookup (unlike 127.0.0.1).
+	uri := strings.Replace(ts.URL, "127.0.0.1", "localhost", 1)
+	c := New()
+	res, err := c.Do(context.Background(), CallConfig{URL: uri})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Metrics.TimeNameLookup < 0 {
+		t.Errorf("TimeNameLookup = %f, want >= 0", res.Metrics.TimeNameLookup)
+	}
+	if res.Metrics.TimeConnect < res.Metrics.TimeNameLookup {
+		t.Errorf("TimeConnect (%f) < TimeNameLookup (%f) — timings must be cumulative",
+			res.Metrics.TimeConnect, res.Metrics.TimeNameLookup)
+	}
+	if res.Metrics.TimeTotal < res.Metrics.TimeConnect {
+		t.Errorf("TimeTotal (%f) < TimeConnect (%f) — timings must be cumulative",
+			res.Metrics.TimeTotal, res.Metrics.TimeConnect)
+	}
+}
+
 func TestDo_URL_Missing(t *testing.T) {
 	c := New()
 	_, err := c.Do(context.Background(), CallConfig{})

--- a/internal/testing/ping.go
+++ b/internal/testing/ping.go
@@ -34,7 +34,13 @@ func (s *Service) PingByIface(ctx context.Context, ifaceName, host string, port 
 		return -1, fmt.Errorf("ping %s via %s: %w", host, ifaceName, err)
 	}
 
-	ms := httpclient.SecToMs(res.Metrics.TimeConnect)
+	// TimeConnect and TimeNameLookup are cumulative from request start
+	// (matching curl semantics), so subtract to get pure TCP RTT.
+	rtt := res.Metrics.TimeConnect - res.Metrics.TimeNameLookup
+	if rtt <= 0 {
+		rtt = res.Metrics.TimeConnect
+	}
+	ms := httpclient.SecToMs(rtt)
 	if ms < 1 {
 		ms = 1
 	}


### PR DESCRIPTION
## Summary

PR #190 replaced curl with Go's native HTTP client. The httpclient computes `TimeNameLookup` and `TimeConnect` as independent durations (`dnsDone - dnsStart`, `connectDone - connectStart`), but all 4 downstream consumers expect curl-like cumulative offsets from request start. They compute TCP RTT as `TimeConnect - TimeNameLookup`.

With duration semantics, slow DNS breaks the subtraction:
- DNS takes 200ms → `TimeNameLookup = 0.200` (duration)
- TCP connect takes 80ms → `TimeConnect = 0.080` (duration)
- `0.080 < 0.200` → falls into `TimeTotal` fallback → reports **390ms**
- After DNS cache warms up, `TimeNameLookup = 0`, so `0.080 - 0 = 80ms` (correct by accident)

This matches what users see: tunnel cards show ~390ms right after startup, then drop to ~80ms.

### Fix

Compute `TimeNameLookup` and `TimeConnect` as cumulative from `start` (`dnsDone.Sub(start)`, `connectDone.Sub(start)`), matching curl's `time_namelookup` / `time_connect` semantics. `TimeConnect - TimeNameLookup` now gives the correct TCP RTT regardless of DNS cache state.

Also fixed `PingByIface` in `testing/ping.go` which used `TimeConnect` directly — with cumulative semantics it needs to subtract `TimeNameLookup`.

Per review comment on PR #190: https://github.com/hoaxisr/awg-manager/pull/190#pullrequestreview-4357048708

### Affected consumers (all correct without changes)

- `monitoring/prober.go` — matrix card latency
- `pingcheck/checker.go` — connectivity check latency
- `testing/connectivity.go` — two call sites for HTTP connectivity check
- `testing/ping.go` — fixed to subtract `TimeNameLookup`

## Test plan

- [x] `TestDo_Metrics_CumulativeTimings` — verifies `TimeNameLookup <= TimeConnect <= TimeTotal` with DNS involved
- [x] `TestHTTPProber_ParseLatency` — added "DNS slow" case: `TimeNameLookup=0.200, TimeConnect=0.280` → RTT=80ms
- [x] Full `httpclient` test suite passes (14 tests)
- [x] Linux cross-compilation clean
- [x] Verified against curl on a live endpoint (`connectivitycheck.gstatic.com`): both Go httpclient and curl produce the same TCP RTT (~11ms), and the cumulative ordering `namelookup <= connect <= total` holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)