### PR TITLE
fix(orchestrator): починка race незапуска туннелей при старте роутера

### DIFF
--- a/internal/orchestrator/actions.go
+++ b/internal/orchestrator/actions.go
@@ -20,6 +20,7 @@ const (
 	ActionReconcileKernel
 	ActionSuspendKernel
 	ActionResumeKernel
+	ActionReconcileNativeWG
 
 	// Live config
 	ActionApplyConfig

--- a/internal/orchestrator/decide.go
+++ b/internal/orchestrator/decide.go
@@ -228,10 +228,15 @@ func decideNDMSHook(event Event, state *State) []Action {
 		if !t.Running {
 			return nil
 		}
-		// User intent (admin UI toggle) is respected. The previous nativewg
-		// branch fired ActionExternalRestart on every external disable —
-		// that caused the "tunnel re-enables itself after a manual disable"
-		// bug. Both backends now persist the disabled state cleanly.
+		// Boot-quiescence: ignore a transient conf=disabled that arrives while
+		// we are still bringing this tunnel up. NDMS emits its own disabled→
+		// running churn as it settles its WireGuard; acting on it here tears
+		// down a tunnel we just started (observed at boot: tunnel handshakes,
+		// then a stray disabled kills it ~1s later).
+		if !event.Now.IsZero() && event.Now.Before(t.quiescentUntil) {
+			return nil
+		}
+		// Outside the quiescence window, treat conf=disabled as user intent and stop.
 		return decideStop(Event{Type: EventStop, Tunnel: t.ID}, state)
 	}
 

--- a/internal/orchestrator/decide.go
+++ b/internal/orchestrator/decide.go
@@ -50,10 +50,12 @@ func decideBoot(state *State) []Action {
 
 		case "nativewg":
 			if !state.supportsASC {
-				actions = append(actions,
-					Action{Type: ActionStopNativeWG, Tunnel: t.ID},
-					Action{Type: ActionStartNativeWG, Tunnel: t.ID},
-				)
+				// Reconcile-to-desired instead of unconditional Stop+Start:
+				// the executor skips the disruptive restart when the tunnel
+				// is already running WITH a handshake, and still re-attaches
+				// the proxy for the #183 case (NDMS brought the interface up
+				// without our kmod proxy → conf=running but no handshake).
+				actions = append(actions, Action{Type: ActionReconcileNativeWG, Tunnel: t.ID})
 				actions = appendPostStartActions(actions, t)
 			}
 		}

--- a/internal/orchestrator/decide_test.go
+++ b/internal/orchestrator/decide_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
@@ -1467,5 +1468,45 @@ func TestDecideNDMSHook_ExternalDisabled_KernelTunnel(t *testing.T) {
 	}, &s)
 	if !hasAction(actions, ActionPersistStopped) {
 		t.Error("kernel tunnel: expected normal PersistStopped")
+	}
+}
+
+func TestDecide_NDMSHook_DisabledIgnoredDuringQuiescence(t *testing.T) {
+	s := newState()
+	now := time.Unix(2000, 0)
+	tun := &tunnelState{
+		ID: "awg11", Backend: "nativewg", Enabled: true, Running: true, NWGIndex: 2,
+		quiescentUntil: now.Add(10 * time.Second), // still settling
+	}
+	s.tunnels["awg11"] = tun
+	ev := Event{
+		Type: EventNDMSHook, Layer: "conf", Level: "disabled",
+		NDMSName: tun.ndmsName(), Now: now,
+	}
+
+	actions := decide(ev, &s)
+
+	if len(actions) != 0 {
+		t.Fatalf("a transient conf=disabled during quiescence must NOT stop the tunnel, got %d actions", len(actions))
+	}
+}
+
+func TestDecide_NDMSHook_DisabledStopsAfterQuiescence(t *testing.T) {
+	s := newState()
+	now := time.Unix(2000, 0)
+	tun := &tunnelState{
+		ID: "awg11", Backend: "nativewg", Enabled: true, Running: true, NWGIndex: 2,
+		quiescentUntil: now.Add(-1 * time.Second), // window elapsed
+	}
+	s.tunnels["awg11"] = tun
+	ev := Event{
+		Type: EventNDMSHook, Layer: "conf", Level: "disabled",
+		NDMSName: tun.ndmsName(), Now: now,
+	}
+
+	actions := decide(ev, &s)
+
+	if !hasAction(actions, ActionStopNativeWG) {
+		t.Fatal("a conf=disabled after the quiescence window must stop the tunnel (user intent honoured)")
 	}
 }

--- a/internal/orchestrator/decide_test.go
+++ b/internal/orchestrator/decide_test.go
@@ -22,17 +22,18 @@ func TestDecide_Boot_StartsEnabledKernelTunnels(t *testing.T) {
 	assertNoActionForTunnel(t, actions, "awg2", ActionColdStartKernel)
 }
 
-func TestDecide_Boot_StartsNativeWGWithoutASC(t *testing.T) {
+func TestDecide_Boot_ReconcilesNativeWGWithoutASC(t *testing.T) {
 	s := newState()
 	s.supportsASC = false
 	s.tunnels["awg0"] = &tunnelState{ID: "awg0", Backend: "nativewg", Enabled: true, NWGIndex: 0}
 
 	actions := decide(Event{Type: EventBoot}, &s)
 
-	stops := filterActions(actions, ActionStopNativeWG)
-	starts := filterActions(actions, ActionStartNativeWG)
-	if len(stops) != 1 || len(starts) != 1 {
-		t.Errorf("expected Stop+Start for NativeWG without ASC, got %d stops, %d starts", len(stops), len(starts))
+	if n := len(filterActions(actions, ActionReconcileNativeWG)); n != 1 {
+		t.Errorf("expected 1 ReconcileNativeWG for non-ASC nativewg, got %d", n)
+	}
+	if n := len(filterActions(actions, ActionStopNativeWG)); n != 0 {
+		t.Errorf("boot must NOT Stop a nativewg tunnel (Stop+Start churns NDMS edges → race), got %d stops", n)
 	}
 }
 

--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"time"
+
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/tunnel"
 )
@@ -10,26 +12,30 @@ type EventType int
 
 const (
 	EventBoot            EventType = iota // Router boot — start all enabled
-	EventReconnect                         // Daemon restart — restore state
-	EventStart                             // User clicks Start
-	EventStop                              // User clicks Stop
-	EventRestart                           // User clicks Restart
-	EventCreate                            // User creates tunnel
-	EventDelete                            // User deletes tunnel
-	EventUpdate                            // User updates config
-	EventImport                            // User imports .conf
-	EventSetEnabled                        // User toggles enabled
-	EventSetDefaultRoute                   // User toggles default route
-	EventWANUp                             // WAN interface came up
-	EventWANDown                           // WAN interface went down
-	EventNDMSHook                          // NDMS iflayerchanged.d hook
-	EventPingCheckFailed                   // Connectivity loss detected
+	EventReconnect                        // Daemon restart — restore state
+	EventStart                            // User clicks Start
+	EventStop                             // User clicks Stop
+	EventRestart                          // User clicks Restart
+	EventCreate                           // User creates tunnel
+	EventDelete                           // User deletes tunnel
+	EventUpdate                           // User updates config
+	EventImport                           // User imports .conf
+	EventSetEnabled                       // User toggles enabled
+	EventSetDefaultRoute                  // User toggles default route
+	EventWANUp                            // WAN interface came up
+	EventWANDown                          // WAN interface went down
+	EventNDMSHook                         // NDMS iflayerchanged.d hook
+	EventPingCheckFailed                  // Connectivity loss detected
 )
 
 // Event is the input to the orchestrator.
 type Event struct {
-	Type    EventType
-	Tunnel  string // tunnel ID for tunnel-specific events
+	Type   EventType
+	Tunnel string // tunnel ID for tunnel-specific events
+
+	// Now is the decision-time clock, stamped by HandleEvent. Lets the pure
+	// decide functions compare against per-tunnel time windows without I/O.
+	Now time.Time
 
 	// NDMS hook data
 	NDMSName string

--- a/internal/orchestrator/execute.go
+++ b/internal/orchestrator/execute.go
@@ -20,6 +20,8 @@ func (o *Orchestrator) executeOne(ctx context.Context, action Action) error {
 		return o.executeColdStartKernel(ctx, action)
 	case ActionStartNativeWG:
 		return o.executeStartNativeWG(ctx, action)
+	case ActionReconcileNativeWG:
+		return o.executeReconcileNativeWG(ctx, action)
 	case ActionStopKernel:
 		return o.executeStopKernel(ctx, action)
 	case ActionStopNativeWG:
@@ -321,6 +323,30 @@ func (o *Orchestrator) executeStartNativeWG(ctx context.Context, action Action) 
 	}
 	o.appLog.Info("start", action.Tunnel, fmt.Sprintf("NativeWG started, active WAN: %s", wan))
 	return nil
+}
+
+// executeReconcileNativeWG brings a non-ASC NativeWG tunnel to its desired
+// state idempotently. If the tunnel is already running WITH a handshake we
+// skip the disruptive restart (which churns NDMS conf edges and feeds the
+// boot race). If it is NOT handshaking — including the #183 case where NDMS
+// brought the interface up without our kmod proxy (conf=running, peer up,
+// but no handshake) — we run the full Start to (re)attach the proxy.
+func (o *Orchestrator) executeReconcileNativeWG(ctx context.Context, action Action) error {
+	if o.nwgOp == nil {
+		return fmt.Errorf("NativeWG backend not available")
+	}
+	stored, err := o.store.Get(action.Tunnel)
+	if err != nil {
+		return tunnel.ErrNotFound
+	}
+
+	info := o.nwgOp.GetState(ctx, stored)
+	if info.State == tunnel.StateRunning && info.HasHandshake {
+		o.appLog.Info("reconcile", action.Tunnel, "NativeWG already running with handshake — skip restart")
+		return nil
+	}
+
+	return o.executeStartNativeWG(ctx, action)
 }
 
 // executeStopKernel stops a kernel tunnel.

--- a/internal/orchestrator/group_test.go
+++ b/internal/orchestrator/group_test.go
@@ -1,0 +1,46 @@
+package orchestrator
+
+import "testing"
+
+func TestGroupContiguousByTunnel_NonContiguousSplitsIntoMultipleGroups(t *testing.T) {
+	// Documents the known limitation: interleaved per-tunnel actions (as
+	// decideWANDown can emit) produce a separate group each time the Tunnel
+	// value changes — so tunnel "a" here yields two groups, not one.
+	actions := []Action{
+		{Type: ActionSuspendProxy, Tunnel: "a"},
+		{Type: ActionSuspendProxy, Tunnel: "b"},
+		{Type: ActionStartNativeWG, Tunnel: "a"},
+		{Type: ActionStartNativeWG, Tunnel: "b"},
+	}
+
+	groups := groupContiguousByTunnel(actions)
+
+	if len(groups) != 4 {
+		t.Fatalf("non-contiguous input must split per change of Tunnel: want 4 groups, got %d", len(groups))
+	}
+}
+
+func TestGroupContiguousByTunnel(t *testing.T) {
+	actions := []Action{
+		{Type: ActionReconcileNativeWG, Tunnel: "a"},
+		{Type: ActionApplyStaticRoutes, Tunnel: "a"},
+		{Type: ActionReconcileNativeWG, Tunnel: "b"},
+		{Type: ActionReconcileStaticRoutes, Tunnel: ""},
+		{Type: ActionReconcileDNSRoutes, Tunnel: ""},
+	}
+
+	groups := groupContiguousByTunnel(actions)
+
+	if len(groups) != 3 {
+		t.Fatalf("want 3 groups, got %d", len(groups))
+	}
+	if len(groups[0]) != 2 || groups[0][0].Tunnel != "a" {
+		t.Errorf("group 0 should be the two 'a' actions, got %+v", groups[0])
+	}
+	if len(groups[1]) != 1 || groups[1][0].Tunnel != "b" {
+		t.Errorf("group 1 should be the single 'b' action, got %+v", groups[1])
+	}
+	if len(groups[2]) != 2 || groups[2][0].Tunnel != "" {
+		t.Errorf("group 2 should be the two tunnel-less route actions, got %+v", groups[2])
+	}
+}

--- a/internal/orchestrator/matcher_test.go
+++ b/internal/orchestrator/matcher_test.go
@@ -1,0 +1,53 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConsumeExpectedHook_ExpiredNotConsumed(t *testing.T) {
+	base := time.Unix(1000, 0)
+	cur := base
+	o := &Orchestrator{clock: func() time.Time { return cur }}
+
+	o.ExpectHook("Wireguard2", "disabled") // expires at base+TTL
+
+	cur = base.Add(expectedHookTTL + time.Second) // advance past TTL
+
+	if o.consumeExpectedHook("Wireguard2", "disabled") {
+		t.Fatal("expired expected-hook must not be consumed (would absorb a real later edge)")
+	}
+}
+
+func TestConsumeExpectedHook_FreshConsumedOnce(t *testing.T) {
+	base := time.Unix(1000, 0)
+	cur := base
+	o := &Orchestrator{clock: func() time.Time { return cur }}
+
+	o.ExpectHook("Wireguard2", "running")
+	cur = base.Add(5 * time.Second)
+
+	if !o.consumeExpectedHook("Wireguard2", "running") {
+		t.Fatal("fresh expected-hook must be consumed")
+	}
+	if o.consumeExpectedHook("Wireguard2", "running") {
+		t.Fatal("expected-hook must be consumed only once")
+	}
+}
+
+func TestConsumeExpectedHook_PrunesExpiredButKeepsFresh(t *testing.T) {
+	base := time.Unix(1000, 0)
+	cur := base
+	o := &Orchestrator{clock: func() time.Time { return cur }}
+
+	o.ExpectHook("Wireguard2", "disabled") // stale soon
+	cur = base.Add(expectedHookTTL + time.Second)
+	o.ExpectHook("Wireguard2", "disabled") // fresh, registered after advance
+
+	if !o.consumeExpectedHook("Wireguard2", "disabled") {
+		t.Fatal("fresh expected-hook must still be consumable after pruning")
+	}
+	if o.consumeExpectedHook("Wireguard2", "disabled") {
+		t.Fatal("only one fresh expectation existed")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -145,7 +145,7 @@ func (o *Orchestrator) SetSupportsASC(fn func() bool) {
 // the next lifecycle event and triggers NDMS "interface has no
 // assigned profile" warnings.
 //
-// Runtime-only fields (Running, Monitoring, ExternalRestart counters)
+// Runtime-only fields (Running, Monitoring, quiescentUntil)
 // live only in the orchestrator's cache, so they are preserved across
 // the refresh — reloading them from storage would clobber the action
 // layer's view of the world.
@@ -161,6 +161,7 @@ func (o *Orchestrator) RefreshTunnelState(tunnelID string) {
 	if cur, ok := o.state.tunnels[tunnelID]; ok {
 		fresh.Running = cur.Running
 		fresh.Monitoring = cur.Monitoring
+		fresh.quiescentUntil = cur.quiescentUntil
 	}
 	o.state.tunnels[tunnelID] = fresh
 }
@@ -229,7 +230,7 @@ func (o *Orchestrator) consumeExpectedHook(ndmsName, level string) bool {
 	now := o.nowFn()
 	kept := o.expectedHooks[:0]
 	for _, h := range o.expectedHooks {
-		if now.After(h.expiresAt) {
+		if !now.Before(h.expiresAt) {
 			continue
 		}
 		kept = append(kept, h)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -279,8 +279,11 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event Event) error {
 	// Per-tunnel lock for execution
 	tunnelID := event.Tunnel
 	if tunnelID == "" {
-		// Multi-tunnel events (Boot, Reconnect, WAN): execute inline
-		return o.executeActions(ctx, actions)
+		// Multi-tunnel events (Boot, Reconnect, WAN): group actions per
+		// tunnel and run each group under that tunnel's lock so a concurrent
+		// single-tunnel NDMS hook for the same tunnel cannot interleave a
+		// Stop into the middle of our Start sequence (the boot kill race).
+		return o.executeActionsGrouped(ctx, actions)
 	}
 
 	// Single-tunnel event: lock that tunnel
@@ -324,6 +327,59 @@ func (o *Orchestrator) executeActions(ctx context.Context, actions []Action) err
 		o.updateState(action)
 	}
 	return firstErr
+}
+
+// groupContiguousByTunnel splits a flat action list into contiguous runs
+// sharing the same Tunnel value, preserving order. Boot/Reconnect/WANUp emit
+// each tunnel's actions contiguously, so those events are fully serialized
+// per tunnel. decideWANDown's non-ASC immediate-failover can emit a tunnel's
+// Suspend and failover-Start in separate phases (non-contiguous) → that
+// tunnel gets two groups and its lock is taken twice with a gap between;
+// still deadlock-free and correct in execution order, just not gap-free
+// against a concurrent hook. Tightening decideWANDown's ordering is tracked
+// separately (out of scope for the boot-race fix).
+func groupContiguousByTunnel(actions []Action) [][]Action {
+	var groups [][]Action
+	i := 0
+	for i < len(actions) {
+		tid := actions[i].Tunnel
+		j := i
+		for j < len(actions) && actions[j].Tunnel == tid {
+			j++
+		}
+		groups = append(groups, actions[i:j])
+		i = j
+	}
+	return groups
+}
+
+// executeActionsGrouped runs a multi-tunnel action list with per-tunnel
+// serialization. Each tunnel's contiguous group runs under that tunnel's
+// per-tunnel lock, acquired and released per group — never holding two
+// tunnel locks at once, so there is no lock-ordering deadlock against
+// concurrent single-tunnel hook events. Tunnel-less groups (Tunnel=="")
+// run unlocked.
+func (o *Orchestrator) executeActionsGrouped(ctx context.Context, actions []Action) error {
+	var firstErr error
+	for _, group := range groupContiguousByTunnel(actions) {
+		if err := o.executeGroup(ctx, group); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// executeGroup runs one same-tunnel action group. The per-tunnel lock is
+// released via defer (iteration-scoped here, matching the single-tunnel
+// path in HandleEvent) so a panic in executeActions cannot leak the lock.
+func (o *Orchestrator) executeGroup(ctx context.Context, group []Action) error {
+	tid := group[0].Tunnel
+	if tid == "" {
+		return o.executeActions(ctx, group)
+	}
+	o.lockTunnel(tid)
+	defer o.unlockTunnel(tid)
+	return o.executeActions(ctx, group)
 }
 
 // executeOne is implemented in execute.go.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
@@ -14,6 +15,11 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/tunnel/state"
 	"github.com/hoaxisr/awg-manager/internal/tunnel/wan"
 )
+
+// expectedHookTTL bounds how long a self-induced NDMS hook expectation
+// stays valid. Past it, the token is pruned so a stale expectation can't
+// absorb a later, legitimate external edge.
+const expectedHookTTL = 15 * time.Second
 
 // PingCheckExecutor is the interface for monitoring operations.
 // Satisfied by *pingcheck.Facade.
@@ -58,11 +64,11 @@ type Orchestrator struct {
 	expectedHooks []expectedHook
 
 	// Executors (no decision logic, only execution)
-	store      *storage.AWGTunnelStore
-	kernelOp   ops.Operator
-	nwgOp      *nwg.OperatorNativeWG
-	stateMgr   state.Manager
-	wanModel   *wan.Model
+	store    *storage.AWGTunnelStore
+	kernelOp ops.Operator
+	nwgOp    *nwg.OperatorNativeWG
+	stateMgr state.Manager
+	wanModel *wan.Model
 
 	// Downstream executors
 	pingCheck   PingCheckExecutor
@@ -75,6 +81,9 @@ type Orchestrator struct {
 
 	// Logging
 	appLog *logging.ScopedLogger
+
+	// clock returns current time; injectable for tests. nil → time.Now.
+	clock func() time.Time
 }
 
 // New creates a new Orchestrator.
@@ -94,6 +103,7 @@ func New(
 		stateMgr: stateMgr,
 		wanModel: wanModel,
 		appLog:   logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubOrchestrator),
+		clock:    time.Now,
 	}
 }
 
@@ -181,21 +191,46 @@ func (o *Orchestrator) LoadState(ctx context.Context) {
 
 // expectedHook represents an NDMS hook we expect from our own actions.
 type expectedHook struct {
-	ndmsName string
-	level    string
+	ndmsName  string
+	level     string
+	expiresAt time.Time
+}
+
+// nowFn returns the current time, honouring an injected clock in tests.
+func (o *Orchestrator) nowFn() time.Time {
+	if o.clock != nil {
+		return o.clock()
+	}
+	return time.Now()
 }
 
 // ExpectHook registers an expected NDMS hook (implements tunnel.HookNotifier).
-// Called by operators before InterfaceUp/Down.
+// Called by operators before InterfaceUp/Down. The expectation expires after
+// expectedHookTTL so a stale token cannot absorb an unrelated later edge.
 func (o *Orchestrator) ExpectHook(ndmsName, level string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.expectedHooks = append(o.expectedHooks, expectedHook{ndmsName, level})
+	o.expectedHooks = append(o.expectedHooks, expectedHook{
+		ndmsName:  ndmsName,
+		level:     level,
+		expiresAt: o.nowFn().Add(expectedHookTTL),
+	})
 }
 
-// consumeExpectedHook checks if an NDMS hook matches an expected one.
-// If yes, removes it from the queue and returns true.
+// consumeExpectedHook checks if an NDMS hook matches a non-expired expected
+// one. It first prunes expired expectations, then removes and returns true on
+// the first matching live entry.
 func (o *Orchestrator) consumeExpectedHook(ndmsName, level string) bool {
+	now := o.nowFn()
+	kept := o.expectedHooks[:0]
+	for _, h := range o.expectedHooks {
+		if now.After(h.expiresAt) {
+			continue
+		}
+		kept = append(kept, h)
+	}
+	o.expectedHooks = kept
+
 	for i, h := range o.expectedHooks {
 		if h.ndmsName == ndmsName && h.level == level {
 			o.expectedHooks = append(o.expectedHooks[:i], o.expectedHooks[i+1:]...)
@@ -363,4 +398,3 @@ func publishInvalidatedBus(bus *events.Bus, resource, reason string) {
 		Reason:   reason,
 	})
 }
-

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,6 +21,11 @@ import (
 // absorb a later, legitimate external edge.
 const expectedHookTTL = 15 * time.Second
 
+// bootQuiescenceWindow is how long after we (re)start a NativeWG tunnel we
+// treat an incoming conf=disabled as transient NDMS settling rather than a
+// stop command. See decideNDMSHook + updateState.
+const bootQuiescenceWindow = 20 * time.Second
+
 // PingCheckExecutor is the interface for monitoring operations.
 // Satisfied by *pingcheck.Facade.
 type PingCheckExecutor interface {
@@ -254,6 +259,10 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event Event) error {
 		}
 	}
 
+	if event.Now.IsZero() {
+		event.Now = o.nowFn()
+	}
+
 	// Decide (under lock)
 	o.mu.Lock()
 	// Ensure tunnel is in cache (covers tunnels created/imported after startup)
@@ -332,6 +341,7 @@ func (o *Orchestrator) updateState(action Action) {
 	switch action.Type {
 	case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileKernel, ActionResumeKernel:
 		t.Running = true
+		t.quiescentUntil = o.nowFn().Add(bootQuiescenceWindow)
 		// Refresh ActiveWAN from store. Execute layer persists the resolved
 		// WAN; we mirror it into the in-memory cache so decideWANDown can
 		// match correctly via affectedByWANDown.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -339,7 +339,7 @@ func (o *Orchestrator) updateState(action Action) {
 	}
 
 	switch action.Type {
-	case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileKernel, ActionResumeKernel:
+	case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileNativeWG, ActionReconcileKernel, ActionResumeKernel:
 		t.Running = true
 		t.quiescentUntil = o.nowFn().Add(bootQuiescenceWindow)
 		// Refresh ActiveWAN from store. Execute layer persists the resolved
@@ -367,7 +367,7 @@ func (o *Orchestrator) updateState(action Action) {
 	// Publish SSE event
 	if o.bus != nil && t != nil {
 		switch action.Type {
-		case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileKernel, ActionResumeKernel:
+		case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileNativeWG, ActionReconcileKernel, ActionResumeKernel:
 			// tunnel:state is still consumed internally by
 			// connectivity.Monitor (listens for "running" to trigger an
 			// immediate check). Keep it until that dependency is

--- a/internal/orchestrator/refresh_test.go
+++ b/internal/orchestrator/refresh_test.go
@@ -1,0 +1,49 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// newTestStore creates a real AWGTunnelStore in a temp directory and saves a
+// tunnel with the given ID so that store.Get(id) succeeds.
+func newTestStore(t *testing.T) *storage.AWGTunnelStore {
+	t.Helper()
+	dir := t.TempDir()
+	store := storage.NewAWGTunnelStoreWithLockDir(dir, dir)
+	tunnel := &storage.AWGTunnel{
+		ID:       "awg0",
+		Backend:  "nativewg",
+		NWGIndex: 0,
+	}
+	if err := store.Save(tunnel); err != nil {
+		t.Fatalf("newTestStore: Save failed: %v", err)
+	}
+	return store
+}
+
+// RefreshTunnelState must preserve the runtime-only quiescentUntil window,
+// otherwise a settings mutation during boot silently defeats the
+// boot-quiescence guard in decideNDMSHook.
+func TestRefreshTunnelState_PreservesQuiescentUntil(t *testing.T) {
+	store := newTestStore(t)
+	o := &Orchestrator{store: store, clock: time.Now}
+	o.state = newState()
+
+	q := time.Unix(5000, 0)
+	o.state.tunnels["awg0"] = &tunnelState{
+		ID: "awg0", Backend: "nativewg", Running: true, quiescentUntil: q,
+	}
+
+	o.RefreshTunnelState("awg0")
+
+	got := o.state.tunnels["awg0"]
+	if got == nil {
+		t.Fatal("tunnel missing after refresh")
+	}
+	if !got.quiescentUntil.Equal(q) {
+		t.Fatalf("quiescentUntil not preserved across RefreshTunnelState: want %v, got %v", q, got.quiescentUntil)
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"time"
+
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/tunnel"
 	"github.com/hoaxisr/awg-manager/internal/tunnel/nwg"
@@ -12,14 +14,18 @@ type tunnelState struct {
 	Name         string
 	Backend      string // "kernel" | "nativewg"
 	Enabled      bool
-	Running      bool   // orchestrator's belief: tunnel is running
-	Monitoring   bool   // monitor goroutine is active
+	Running      bool // orchestrator's belief: tunnel is running
+	Monitoring   bool // monitor goroutine is active
 	ActiveWAN    string
 	NWGIndex     int
 	PingCheck    *storage.TunnelPingCheck
 	DefaultRoute bool
 	ISPInterface string
 	Endpoint     string // peer endpoint (host:port)
+
+	// quiescentUntil: while now < this, a conf=disabled edge for this tunnel
+	// is treated as transient NDMS settling (do not stop). Set on (re)start.
+	quiescentUntil time.Time
 }
 
 // ndmsName returns the NDMS interface name for this tunnel.
@@ -41,7 +47,7 @@ func (t *tunnelState) ifaceName() string {
 // State is the orchestrator's complete view of the system.
 type State struct {
 	tunnels     map[string]*tunnelState // tunnelID → state
-	anyWANUpFn  func() bool            // delegates to wanModel.AnyUp()
+	anyWANUpFn  func() bool             // delegates to wanModel.AnyUp()
 	supportsASC bool
 }
 


### PR DESCRIPTION
 - Корень незапуска — race в оркестраторе (подтверждён boot-логом + серией перезагрузки роутера по расписанию каждые 5 минут), НЕ отсутствие WAN.
  Добавлен:
  - Reconcile-to-desired для non-ASC nwg вместо безусловного Stop+Start (idempotent, прикрывает #183 через HasHandshake-gate) (т.е. для nativewg + awg_proxy туннелей в ОС <5.1 Альфа 3)
  - Сериализация multi-tunnel событий per-tunnel (группировка по туннелю, panic-safe, без удержания нескольких локов).
  - Все правки в internal/orchestrator; decide остаётся pure.

  ## Test plan
  - [x] Device: 5/5 ребутов роутера (mt7621, non-ASC) — все (3) туннеля nativewg поднимаются, handshake, держится; ноль stop/remove/disabled; все туннели HTTP-204 проверку прошли.
  
  не сделано: необходимо различить статус "сломан" который сейчас отображается при перезагрузке от реально "сломан". или переименовать его времено в "настраивается"