### PR TITLE
fix(singbox-router): не плодить фантомный draft при правке правил при…

### DIFF
--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -471,6 +471,28 @@ func (s *ServiceImpl) persistConfig(ctx context.Context, cfg *RouterConfig) erro
 		if err != nil {
 			return fmt.Errorf("marshal router config: %w", err)
 		}
+		// Phantom-draft guard: an inline rule-set's rules live in sidecar
+		// artifacts, not in 20-router.json (which carries only a
+		// {type:local,format:binary,path} reference). Editing only the rules
+		// of an already-applied inline rule-set therefore leaves the
+		// materialized config byte-identical to active — materializeConfig
+		// has already rewritten the live .srs and sing-box hot-reloads it
+		// without SIGHUP. There is no real config change to stage, so a draft
+		// would only raise a phantom "unsaved changes" banner. Drop any stale
+		// draft and return. This guard's safety rests on the invariant that
+		// any genuinely structural change (new rule-set, tag rename, route/DNS/
+		// outbound edit) perturbs the materialized bytes and so is never
+		// byte-equal. A missing/unreadable active file (router disabled, first
+		// Enable, slot parked under disabled/) is NOT equal — fall through to
+		// staging so the change is applied normally.
+		activePath := filepath.Join(s.deps.Orch.ConfigDir(), "20-router.json")
+		if existing, rerr := os.ReadFile(activePath); rerr == nil && bytes.Equal(existing, data) {
+			if err := s.deps.Orch.DiscardDraft(orchestrator.SlotRouter); err != nil {
+				return err
+			}
+			s.emitStagingEvent("discarded")
+			return nil
+		}
 		if err := s.deps.Orch.SaveDraft(orchestrator.SlotRouter, data); err != nil {
 			return err
 		}

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -1050,6 +1050,120 @@ func TestUpdateRuleSet_InlineRenameRewritesVisibleAndMaterializedRefs(t *testing
 	}
 }
 
+// TestUpdateRuleSet_InlineRulesEditOnAppliedSet_NoPhantomDraft verifies the
+// phantom-draft guard: editing only the rules of an already-applied inline
+// rule-set recompiles the live .srs (sing-box hot-reloads it) but does NOT
+// create a pending draft, because the materialized 20-router.json is
+// byte-identical to active (the rules live in a sidecar, not in the config).
+func TestUpdateRuleSet_InlineRulesEditOnAppliedSet_NoPhantomDraft(t *testing.T) {
+	svc, dir := newOrchedTestService(t)
+	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"
+	compileCalls := 0
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		compileCalls++
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	// SlotBase provides "direct" so ApplyStaging's cross-slot validation passes.
+	_ = svc.deps.Orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotBase, Filename: "00-base.json", AlwaysOn: true})
+	_ = os.WriteFile(filepath.Join(dir, "00-base.json"),
+		[]byte(`{"outbounds":[{"tag":"direct","type":"direct"}]}`), 0644)
+
+	// Create the inline rule-set and apply it so it lives in active/20-router.json.
+	if err := svc.AddRuleSet(context.Background(), RuleSet{
+		Tag:   "custom-inline",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".one.example"}}},
+	}); err != nil {
+		t.Fatalf("AddRuleSet: %v", err)
+	}
+	if res, err := svc.ApplyStaging(context.Background()); err != nil || !res.Ok() {
+		t.Fatalf("ApplyStaging: err=%v res=%s", err, res.Error())
+	}
+	if svc.StagingStatus(context.Background()).HasDraft {
+		t.Fatal("draft should be cleared after Apply")
+	}
+
+	bus := svc.deps.Bus.(*mockBus)
+	bus.Reset()
+	callsBefore := compileCalls
+
+	// Edit ONLY the rules of the already-applied inline rule-set.
+	if err := svc.UpdateRuleSet(context.Background(), "custom-inline", RuleSet{
+		Tag:   "custom-inline",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".two.example"}}},
+	}); err != nil {
+		t.Fatalf("UpdateRuleSet: %v", err)
+	}
+
+	// No phantom draft: a rules-only edit must not stage anything.
+	if svc.StagingStatus(context.Background()).HasDraft {
+		t.Fatal("rules-only edit must NOT create a pending draft")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "pending", "20-router.json")); !os.IsNotExist(err) {
+		t.Fatalf("pending file should not exist after rules-only edit: %v", err)
+	}
+	// The guard emits a "discarded" staging event so the UI banner clears.
+	if !bus.HasEvent("singbox.router.staging") {
+		t.Errorf("expected staging event from phantom-draft guard; got: %v", bus.Events())
+	}
+	// The live .srs was recompiled — this is what sing-box hot-reloads.
+	if compileCalls <= callsBefore {
+		t.Fatalf("expected recompile of .srs, calls %d -> %d", callsBefore, compileCalls)
+	}
+	// The source sidecar reflects the new rule content.
+	srcRaw, err := os.ReadFile(filepath.Join(dir, "rule-sets", "inline", "custom-inline.json"))
+	if err != nil {
+		t.Fatalf("source sidecar missing: %v", err)
+	}
+	if !strings.Contains(string(srcRaw), "two.example") {
+		t.Fatalf("sidecar not updated with new rule: %s", srcRaw)
+	}
+}
+
+// TestAddRule_StructuralChangeAfterApply_StillDrafts pins the invariant the
+// phantom-draft guard relies on: a genuinely structural change (here, adding a
+// route rule that references the rule-set) perturbs the materialized
+// 20-router.json, so it is never byte-equal to active and must create a draft.
+func TestAddRule_StructuralChangeAfterApply_StillDrafts(t *testing.T) {
+	svc, dir := newOrchedTestService(t)
+	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"
+	withFakeRuleSetCompiler(t, func(binary string, args []string) (string, string, error) {
+		writeCompiledOutput(t, args, "compiled")
+		return "", "", nil
+	})
+	_ = svc.deps.Orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotBase, Filename: "00-base.json", AlwaysOn: true})
+	_ = os.WriteFile(filepath.Join(dir, "00-base.json"),
+		[]byte(`{"outbounds":[{"tag":"direct","type":"direct"}]}`), 0644)
+
+	if err := svc.AddRuleSet(context.Background(), RuleSet{
+		Tag:   "custom-inline",
+		Type:  "inline",
+		Rules: []map[string]any{{"domain_suffix": []any{".one.example"}}},
+	}); err != nil {
+		t.Fatalf("AddRuleSet: %v", err)
+	}
+	if res, err := svc.ApplyStaging(context.Background()); err != nil || !res.Ok() {
+		t.Fatalf("ApplyStaging: err=%v res=%s", err, res.Error())
+	}
+	if svc.StagingStatus(context.Background()).HasDraft {
+		t.Fatal("draft should be cleared after Apply")
+	}
+
+	// Structural change: add a route rule referencing the rule-set.
+	if err := svc.AddRule(context.Background(), Rule{
+		RuleSet:  []string{"custom-inline"},
+		Action:   "route",
+		Outbound: "direct",
+	}); err != nil {
+		t.Fatalf("AddRule: %v", err)
+	}
+	if !svc.StagingStatus(context.Background()).HasDraft {
+		t.Fatal("structural change must create a pending draft (Apply required)")
+	}
+}
+
 func TestDeleteRuleSet_StagedInlineKeepsSRSCompanionFiles(t *testing.T) {
 	svc, dir := newOrchedTestService(t)
 	svc.deps.Singbox.(*fakeSingbox).binary = "/opt/bin/sing-box"


### PR DESCRIPTION
Правки правил inline-рулсета меняют только (.srs/.json), а не 20-router.json (там лишь ссылка type:local). materializeConfig уже перезаписал живой .srs, sing-box подхватывает его без SIGHUP — ставить в staging нечего. Если материализованный конфиг байт-равен active — снимаем висящий draft и выходим, иначе (структурные правки) как раньше.