### PR TITLE
feat(servers): add restart-or-start controls

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -903,6 +903,7 @@ func main() {
 			KmodLoader:          kmodLoader,
 			UpdaterService:      updaterService,
 			NdmsQueries:         ndmsQueries,
+			NdmsCommands:        ndmsCommands,
 			TrafficHistory:      trafficHistory,
 			DnsRouteService:     dnsRouteService,
 			StaticRouteService:  staticRouteService,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -838,6 +838,28 @@ class ApiClient {
 		return res.ip;
 	}
 
+	async restartManagedServer(serverId: string): Promise<{ id: string; accepted: boolean }> {
+		return this.request(`/managed-servers/${encodeURIComponent(serverId)}/restart`, {
+			method: 'POST'
+		});
+	}
+
+	async restartWireguardServer(name: string): Promise<{ id: string; accepted: boolean }> {
+		return this.request(`/servers/restart?name=${encodeURIComponent(name)}`, {
+			method: 'POST'
+		});
+	}
+
+	async setWireguardServerEnabled(
+		name: string,
+		enabled: boolean
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/enabled?name=${encodeURIComponent(name)}`, {
+			method: 'POST',
+			body: JSON.stringify({ enabled })
+		});
+	}
+
 	// #endregion
 
 	// ─────────────────────────────────────────────

--- a/frontend/src/lib/components/servers/ManagedServerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedServerCard.svelte
@@ -166,6 +166,7 @@
 	}
 
 	let togglingEnabled = $state(false);
+	let restartingServer = $state(false);
 
 	async function handleToggleEnabled() {
 		togglingEnabled = true;
@@ -177,6 +178,21 @@
 			notifications.error(e instanceof Error ? e.message : 'Ошибка переключения');
 		} finally {
 			togglingEnabled = false;
+		}
+	}
+
+	async function handleRestartOrStart() {
+		if (restartingServer) return;
+		restartingServer = true;
+
+		try {
+			await api.restartManagedServer(serverId);
+			notifications.success(isUp ? 'Команда рестарта отправлена' : 'Команда запуска отправлена');
+			servers.invalidate();
+		} catch {
+			notifications.warning('Команда могла быть отправлена, соединение могло временно прерваться');
+		} finally {
+			restartingServer = false;
 		}
 	}
 
@@ -281,9 +297,24 @@
 			<Toggle
 				checked={isUp}
 				onchange={handleToggleEnabled}
-				disabled={togglingEnabled}
+				disabled={togglingEnabled || restartingServer}
 				size="sm"
 			/>
+			<IconButton
+				ariaLabel={isUp
+					? `Перезапустить сервер ${serverDisplayName}`
+					: `Запустить сервер ${serverDisplayName}`}
+				title={isUp
+					? `Перезапустить сервер «${serverDisplayName}»`
+					: `Запустить сервер «${serverDisplayName}»`}
+				onclick={handleRestartOrStart}
+				disabled={restartingServer || togglingEnabled || deleting}
+			>
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M21 12a9 9 0 1 1-2.64-6.36" />
+					<path d="M21 3v6h-6" />
+				</svg>
+			</IconButton>
 			<IconButton
 				ariaLabel={`Открыть параметры обфускации сервера ${serverDisplayName}`}
 				title={`Параметры обфускации сервера «${serverDisplayName}»`}

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -2,11 +2,12 @@
 	import type { WireguardServer, WireguardServerConfig, ASCParams, WireguardServerPeer } from '$lib/types';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
+	import { servers } from '$lib/stores/servers';
 	import { formatBytes } from '$lib/utils/format';
 	import { comparePeerFieldsDirected } from '$lib/utils/peerSort';
 	import { peerSort } from '$lib/stores/peerSort';
 	import { PeerTable, ConfGeneratorModal, PeerSortControls } from '$lib/components/servers';
-	import { Button } from '$lib/components/ui';
+	import { Button, IconButton, Toggle } from '$lib/components/ui';
 
 	function peerIP(p: WireguardServerPeer): string {
 		return p.allowedIPs?.find(ip => ip.includes('/32'))
@@ -36,6 +37,11 @@
 	let totalPeers = $derived((server.peers ?? []).length);
 	let totalRx = $derived((server.peers ?? []).reduce((sum, p) => sum + p.rxBytes, 0));
 	let totalTx = $derived((server.peers ?? []).reduce((sum, p) => sum + p.txBytes, 0));
+	let serverName = $derived(server.description || server.id);
+	let isUp = $derived(server.status === 'up' || server.connected);
+
+	let togglingEnabled = $state(false);
+	let restartingServer = $state(false);
 
 	let sortedPeers = $derived.by(() => {
 		let peers: WireguardServerPeer[] = server.peers ?? [];
@@ -74,6 +80,33 @@
 		return sorted;
 	});
 
+	async function handleToggleEnabled() {
+		togglingEnabled = true;
+		try {
+			const fresh = await api.setWireguardServerEnabled(server.id, !isUp);
+			servers.applyMutationResponse(fresh);
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка переключения');
+		} finally {
+			togglingEnabled = false;
+		}
+	}
+
+	async function handleRestartOrStart() {
+		if (restartingServer) return;
+		restartingServer = true;
+
+		try {
+			await api.restartWireguardServer(server.id);
+			notifications.success(isUp ? 'Команда рестарта отправлена' : 'Команда запуска отправлена');
+			servers.invalidate();
+		} catch {
+			notifications.warning('Команда могла быть отправлена, соединение могло временно прерваться');
+		} finally {
+			restartingServer = false;
+		}
+	}
+
 	async function openConfModal(publicKey: string) {
 		confPeerKey = publicKey;
 		loadingConfig = true;
@@ -99,7 +132,7 @@
 	);
 </script>
 
-<div class="card server-card" class:status-up={server.status === 'up'} class:status-down={server.status !== 'up'}>
+<div class="card server-card" class:status-up={isUp} class:status-down={!isUp}>
 	<!-- Header -->
 	<div class="server-header">
 		<div class="server-info">
@@ -115,9 +148,36 @@
 				<span class="meta-item mono">:{server.listenPort}</span>
 			</div>
 		</div>
-		<div class="server-status">
-			<span class="led" class:led-up={server.status === 'up'} class:led-down={server.status !== 'up'}></span>
-			<span class="peer-count">{onlineCount}/{totalPeers}</span>
+		<div class="server-header-right">
+			<div class="server-status">
+				<span class="led" class:led-up={isUp} class:led-down={!isUp}></span>
+				<span class="peer-count">{onlineCount}/{totalPeers}</span>
+			</div>
+
+			<div class="server-header-actions">
+				<Toggle
+					checked={isUp}
+					onchange={handleToggleEnabled}
+					disabled={togglingEnabled || restartingServer}
+					size="sm"
+				/>
+
+				<IconButton
+					ariaLabel={isUp
+						? `Перезапустить сервер ${serverName}`
+						: `Запустить сервер ${serverName}`}
+					title={isUp
+						? `Перезапустить сервер «${serverName}»`
+						: `Запустить сервер «${serverName}»`}
+					onclick={handleRestartOrStart}
+					disabled={restartingServer || togglingEnabled}
+				>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M21 12a9 9 0 1 1-2.64-6.36" />
+						<path d="M21 3v6h-6" />
+					</svg>
+				</IconButton>
+			</div>
 		</div>
 	</div>
 
@@ -251,6 +311,19 @@
 	.badge-builtin {
 		background: rgba(59, 130, 246, 0.15);
 		color: var(--accent);
+	}
+
+	.server-header-right {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-shrink: 0;
+	}
+
+	.server-header-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
 	}
 
 	.server-status {

--- a/internal/api/managed.go
+++ b/internal/api/managed.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/managed"
 	"github.com/hoaxisr/awg-manager/internal/response"
@@ -412,6 +413,8 @@ func (h *ManagedServerHandler) Subtree(w http.ResponseWriter, r *http.Request) {
 			h.NAT(w, r, id)
 		case "enabled":
 			h.SetEnabled(w, r, id)
+		case "restart":
+			h.Restart(w, r, id)
 		case "asc":
 			h.ASC(w, r, id)
 		case "peers":
@@ -761,6 +764,55 @@ func (h *ManagedServerHandler) SetEnabled(w http.ResponseWriter, r *http.Request
 	h.svc.InvalidateCache(id)
 	h.publishServerUpdated()
 	h.writeServersSnapshot(w, r)
+}
+
+// Restart accepts a restart/start command for one managed server.
+// POST /api/managed-servers/{id}/restart
+//
+//	@Summary		Restart or start managed server
+//	@Description	If the managed server is up, restarts it with down -> pause -> up. If it is down, starts it. The command is accepted quickly and executed in background so a client connected through this server does not cancel the operation.
+//	@Tags			managed-servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			id	path	string	true	"Server id"
+//	@Success		200	{object}	APIEnvelope
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		404	{object}	APIErrorEnvelope
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Router			/managed-servers/{id}/restart [post]
+func (h *ManagedServerHandler) Restart(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	if _, err := h.svc.Get(id); err != nil {
+		response.Error(w, err.Error(), "NOT_FOUND")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 20*time.Second)
+
+	go func() {
+		defer cancel()
+
+		// Give the HTTP response a small window to leave the router before the
+		// interface is brought down. This keeps same-server restart from being
+		// cancelled by the browser connection disappearing mid-request.
+		time.Sleep(300 * time.Millisecond)
+
+		if err := h.svc.RestartOrStart(ctx, id); err != nil {
+			return
+		}
+
+		h.svc.InvalidateCache(id)
+		h.publishServerUpdated()
+	}()
+
+	response.Success(w, map[string]any{
+		"id":       id,
+		"accepted": true,
+	})
 }
 
 // ASC handles GET/PUT for ASC parameters of a managed server.

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/managed"
 	"github.com/hoaxisr/awg-manager/internal/ndms"
+	ndmscommand "github.com/hoaxisr/awg-manager/internal/ndms/command"
 	"github.com/hoaxisr/awg-manager/internal/ndms/query"
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -125,6 +128,7 @@ func isValidWireguardName(name string) bool {
 // subscribers refetch immediately instead of waiting for the next poll.
 type ServersHandler struct {
 	queries  *query.Queries
+	commands *ndmscommand.Commands
 	settings *storage.SettingsStore
 	awgStore *storage.AWGTunnelStore
 	bus      *events.Bus
@@ -138,6 +142,11 @@ func (h *ServersHandler) SetEventBus(bus *events.Bus) {
 
 // SetManagedHandler sets the managed server handler for shared publishing.
 func (h *ServersHandler) SetManagedHandler(m *ManagedServerHandler) { h.managed = m }
+
+// SetCommands wires NDMS interface commands used by server up/down/restart
+// controls. Kept as a setter so tests using NewServersHandler do not need to
+// construct the full command registry.
+func (h *ServersHandler) SetCommands(commands *ndmscommand.Commands) { h.commands = commands }
 
 // PublishServerSnapshot broadcasts a resource:invalidated hint. Kept
 // as a method on *ServersHandler because ndms/metrics.Poller calls it
@@ -158,6 +167,10 @@ func NewServersHandler(queries *query.Queries, settings *storage.SettingsStore, 
 	return &ServersHandler{queries: queries, settings: settings, awgStore: awgStore}
 }
 
+type serverEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 func (h *ServersHandler) validateName(w http.ResponseWriter, name string) bool {
 	if name == "" {
 		response.Error(w, "missing name parameter", "MISSING_NAME")
@@ -168,6 +181,26 @@ func (h *ServersHandler) validateName(w http.ResponseWriter, name string) bool {
 		return false
 	}
 	return true
+}
+
+func (h *ServersHandler) getListedServer(ctx context.Context, name string) (*ndms.WireguardServer, error) {
+	servers, err := h.listServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range servers {
+		server := servers[i]
+		if server.ID == name || server.InterfaceName == name {
+			return &server, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func serverIsUp(server *ndms.WireguardServer) bool {
+	return server != nil && (server.Status == "up" || server.Connected)
 }
 
 // listServers builds the filtered server list for API response and SSE snapshots.
@@ -360,6 +393,138 @@ func (h *ServersHandler) Mark(w http.ResponseWriter, r *http.Request) {
 
 	publishInvalidated(h.bus, ResourceServers, "mark-changed")
 	h.writeAll(w, r)
+}
+
+// SetEnabled enables or disables a built-in/marked WireGuard server interface.
+// POST /api/servers/enabled?name=Wireguard0
+//
+//	@Summary		Toggle WireGuard server enabled state
+//	@Description	Brings a built-in or marked WireGuard server interface up or down.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	query	string				true	"Interface name"
+//	@Param			body	body	serverEnabledRequest	true	"Enabled flag"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Router			/servers/enabled [post]
+func (h *ServersHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.commands == nil || h.commands.Interfaces == nil {
+		response.Error(w, "ndms commands not initialized", "INTERNAL_ERROR")
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if !h.validateName(w, name) {
+		return
+	}
+
+	var req serverEnabledRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.Error(w, "invalid request body", "INVALID_BODY")
+		return
+	}
+
+	server, err := h.getListedServer(r.Context(), name)
+	if err != nil {
+		response.Error(w, err.Error(), "GET_FAILED")
+		return
+	}
+	if server == nil {
+		response.Error(w, "server not found", "NOT_FOUND")
+		return
+	}
+
+	if req.Enabled {
+		if err := h.commands.Interfaces.InterfaceUp(r.Context(), name); err != nil {
+			response.Error(w, err.Error(), "INTERFACE_UP_FAILED")
+			return
+		}
+	} else {
+		if err := h.commands.Interfaces.InterfaceDown(r.Context(), name); err != nil {
+			response.Error(w, err.Error(), "INTERFACE_DOWN_FAILED")
+			return
+		}
+	}
+
+	publishInvalidated(h.bus, ResourceServers, "server-enabled-changed")
+	h.writeAll(w, r)
+}
+
+// Restart accepts a restart/start command for a built-in/marked WireGuard server.
+// POST /api/servers/restart?name=Wireguard0
+//
+//	@Summary		Restart or start WireGuard server
+//	@Description	If the server interface is up, restarts it with down -> pause -> up. If it is down, starts it. The command is accepted quickly and executed in background so a client connected through this server does not cancel the operation.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	query	string	true	"Interface name"
+//	@Success		200		{object}	APIEnvelope
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Router			/servers/restart [post]
+func (h *ServersHandler) Restart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.commands == nil || h.commands.Interfaces == nil {
+		response.Error(w, "ndms commands not initialized", "INTERNAL_ERROR")
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	if !h.validateName(w, name) {
+		return
+	}
+
+	server, err := h.getListedServer(r.Context(), name)
+	if err != nil {
+		response.Error(w, err.Error(), "GET_FAILED")
+		return
+	}
+	if server == nil {
+		response.Error(w, "server not found", "NOT_FOUND")
+		return
+	}
+
+	wasUp := serverIsUp(server)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 20*time.Second)
+
+	go func() {
+		defer cancel()
+
+		// Give the accepted response a chance to reach the browser before we
+		// drop the server interface.
+		time.Sleep(300 * time.Millisecond)
+
+		if wasUp {
+			if err := h.commands.Interfaces.InterfaceDown(ctx, name); err != nil {
+				return
+			}
+			time.Sleep(1200 * time.Millisecond)
+		}
+
+		if err := h.commands.Interfaces.InterfaceUp(ctx, name); err != nil {
+			return
+		}
+
+		publishInvalidated(h.bus, ResourceServers, "server-restart")
+	}()
+
+	response.Success(w, map[string]any{
+		"id":       name,
+		"accepted": true,
+	})
 }
 
 // WANIP returns the external WAN IP for .conf generation.

--- a/internal/managed/service.go
+++ b/internal/managed/service.go
@@ -31,6 +31,7 @@ type ManagedServerService interface {
 
 	// Enable/disable
 	SetEnabled(ctx context.Context, id string, enabled bool) error
+	RestartOrStart(ctx context.Context, id string) error
 
 	// NAT
 	SetNAT(ctx context.Context, id string, enabled bool) error

--- a/internal/managed/service_server.go
+++ b/internal/managed/service_server.go
@@ -245,6 +245,35 @@ func (s *Service) SetEnabled(ctx context.Context, id string, enabled bool) error
 	return nil
 }
 
+// RestartOrStart restarts a running managed server or starts a stopped one.
+// The desired/persisted state is not changed: this only flips the NDMS
+// interface state so clients connected through the server can recover without
+// requiring a second frontend request.
+func (s *Service) RestartOrStart(ctx context.Context, id string) error {
+	server, ok := s.settings.GetManagedServerByID(id)
+	if !ok {
+		return fmt.Errorf("managed server not found: %s", id)
+	}
+
+	stats, err := s.GetStats(ctx, id)
+	wasUp := err == nil && stats != nil && stats.Status == "up"
+
+	if wasUp {
+		if err := s.rciInterfaceDown(ctx, server.InterfaceName); err != nil {
+			return fmt.Errorf("interface down: %w", err)
+		}
+		time.Sleep(1200 * time.Millisecond)
+	}
+
+	if err := s.rciInterfaceUp(ctx, server.InterfaceName); err != nil {
+		return fmt.Errorf("interface up: %w", err)
+	}
+
+	s.log.Info("managed server restart-or-start", "interface", server.InterfaceName, "wasUp", wasUp)
+	s.appLog.Info("restart", server.InterfaceName, "Managed server restart/start command completed")
+	return nil
+}
+
 // Delete removes the managed server and all its peers.
 //
 // Order matters: NDMS interface deletion happens FIRST. If it fails, storage

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -4697,6 +4697,11 @@ definitions:
         example: 524288
         type: integer
     type: object
+  api.serverEnabledRequest:
+    properties:
+      enabled:
+        type: boolean
+    type: object
   diagnostics.DNSProxy:
     properties:
       displayName:
@@ -7290,6 +7295,42 @@ paths:
       summary: Set managed-server IP policy
       tags:
       - managed-servers
+  /managed-servers/{id}/restart:
+    post:
+      description: If the managed server is up, restarts it with down -> pause ->
+        up. If it is down, starts it. The command is accepted quickly and executed
+        in background so a client connected through this server does not cancel the
+        operation.
+      parameters:
+      - description: Server id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Restart or start managed server
+      tags:
+      - managed-servers
   /managed-servers/{id}/stats:
     get:
       description: Returns per-peer runtime stats (handshake, rx/tx) for the named
@@ -8251,6 +8292,47 @@ paths:
       summary: Get all servers snapshot
       tags:
       - servers
+  /servers/enabled:
+    post:
+      consumes:
+      - application/json
+      description: Brings a built-in or marked WireGuard server interface up or down.
+      parameters:
+      - description: Interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: Enabled flag
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.serverEnabledRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Toggle WireGuard server enabled state
+      tags:
+      - servers
   /servers/mark:
     delete:
       description: POST marks the named WG interface as a server (visible under Servers,
@@ -8329,6 +8411,42 @@ paths:
       security:
       - CookieAuth: []
       summary: Get marked server interfaces
+      tags:
+      - servers
+  /servers/restart:
+    post:
+      description: If the server interface is up, restarts it with down -> pause ->
+        up. If it is down, starts it. The command is accepted quickly and executed
+        in background so a client connected through this server does not cancel the
+        operation.
+      parameters:
+      - description: Interface name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.APIEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Restart or start WireGuard server
       tags:
       - servers
   /servers/wan-ip:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,6 +94,7 @@ type Server struct {
 	kmodLoader             *kmod.Loader
 	updaterService         *updater.Service
 	ndmsQueries            *ndmsquery.Queries
+	ndmsCommands           *ndmscommand.Commands
 	trafficHistory         *traffic.History
 	dnsRouteService        api.DNSRouteService
 	staticRouteService     api.StaticRouteService
@@ -166,6 +167,7 @@ type Deps struct {
 	KmodLoader           *kmod.Loader
 	UpdaterService       *updater.Service
 	NdmsQueries          *ndmsquery.Queries
+	NdmsCommands         *ndmscommand.Commands
 	TrafficHistory       *traffic.History
 	DnsRouteService      api.DNSRouteService
 	StaticRouteService   api.StaticRouteService
@@ -224,6 +226,7 @@ func New(cfg Config, deps Deps) *Server {
 		kmodLoader:             deps.KmodLoader,
 		updaterService:         deps.UpdaterService,
 		ndmsQueries:            deps.NdmsQueries,
+		ndmsCommands:           deps.NdmsCommands,
 		trafficHistory:         deps.TrafficHistory,
 		dnsRouteService:        deps.DnsRouteService,
 		staticRouteService:     deps.StaticRouteService,
@@ -862,18 +865,24 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 
 	// VPN Servers (protected + boot guarded)
 	serverHandler := api.NewServersHandler(s.ndmsQueries, s.settings, s.tunnels)
+	serverHandler.SetCommands(s.ndmsCommands)
+	serverHandler.SetEventBus(s.bus)
 	mux.HandleFunc("/api/servers", guarded(serverHandler.List))
 	mux.HandleFunc("/api/servers/all", guarded(serverHandler.GetAll))
 	mux.HandleFunc("/api/servers/get", guarded(serverHandler.Get))
 	mux.HandleFunc("/api/servers/config", guarded(serverHandler.Config))
 	mux.HandleFunc("/api/servers/mark", guarded(serverHandler.Mark))
 	mux.HandleFunc("/api/servers/marked", guarded(serverHandler.Marked))
+	mux.HandleFunc("/api/servers/enabled", guarded(serverHandler.SetEnabled))
+	mux.HandleFunc("/api/servers/restart", guarded(serverHandler.Restart))
 	mux.HandleFunc("/api/servers/wan-ip", guarded(serverHandler.WANIP))
 
 	// Managed WireGuard Servers (protected + boot guarded). The new
 	// route table is id-keyed: see ManagedServerHandler.Subtree for the
 	// full sub-path dispatch (peers, conf, asc, etc).
 	managedHandler := api.NewManagedServerHandler(s.managedService)
+	managedHandler.SetServersHandler(serverHandler)
+	serverHandler.SetManagedHandler(managedHandler)
 	mux.HandleFunc("/api/managed-servers", guarded(managedHandler.Collection))
 	mux.HandleFunc("/api/managed-servers/", guarded(managedHandler.Subtree))
 


### PR DESCRIPTION
Добавлен restart/start control для всех типов серверов в разделе /servers: managed, built-in Wireguard VPN Server и marked WG. Если сервер up, backend выполняет down -> pause -> up; если down — только up. Команда restart принимается быстро и выполняется в background/detached context, чтобы обрыв соединения через этот же сервер не отменял обратный запуск. OpenAPI обновлён через генерацию из Go-аннотаций.