### PR TITLE
feat(servers): improve peer tables on mobile and desktop

### DIFF
--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -73,70 +73,71 @@
 	}
 </script>
 
-<div class="table-wrap">
-	<table class="managed-peer-table">
-		<thead>
-			<tr>
-				<th class="col-name">Имя</th>
-				<th class="col-ip">IP</th>
-				<th class="col-endpoint col-desktop">Endpoint</th>
-				<th class="col-traffic">Трафик</th>
-				<th class="col-handshake col-desktop">Handshake</th>
-				<th class="col-actions">Действия</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each peers as peer (peer.publicKey)}
-				{@const peerStats = getPeerStats(peer.publicKey)}
-				{@const status = peerStatus(peer, peerStats)}
-				<tr class:peer-disabled={!peer.enabled}>
-					<td
-						class="peer-name-cell"
-						role="button"
-						tabindex="0"
-						title={peer.enabled ? `Отключить «${peerName(peer)}»` : `Включить «${peerName(peer)}»`}
-						onclick={(e) => {
-							if (isInsideInlineToggle(e)) return;
-							onTogglePeer(peer);
-						}}
-						onkeydown={(e) => {
-							if (isInsideInlineToggle(e)) return;
-							if (e.key === 'Enter' || e.key === ' ') {
-								e.preventDefault();
+<div class="desktop-peer-table">
+	<div class="table-wrap">
+		<table class="managed-peer-table">
+			<thead>
+				<tr>
+					<th class="col-name">Имя</th>
+					<th class="col-ip">IP</th>
+					<th class="col-endpoint">Endpoint</th>
+					<th class="col-traffic">Трафик</th>
+					<th class="col-handshake">Handshake</th>
+					<th class="col-actions">Действия</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each peers as peer (peer.publicKey)}
+					{@const peerStats = getPeerStats(peer.publicKey)}
+					{@const status = peerStatus(peer, peerStats)}
+					{@const endpointValue = peerStats?.endpoint || '-'}
+					{@const ep = splitEndpoint(endpointValue)}
+					{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
+					<tr class:peer-disabled={!peer.enabled}>
+						<td
+							class="peer-name-cell"
+							role="button"
+							tabindex="0"
+							title={peer.enabled ? `Отключить «${peerName(peer)}»` : `Включить «${peerName(peer)}»`}
+							onclick={(e) => {
+								if (isInsideInlineToggle(e)) return;
 								onTogglePeer(peer);
-							}
-						}}
-					>
-						<div class="peer-name-row">
-							<span
-								class="status-dot"
-								class:dot-online={status === 'online'}
-								class:dot-offline={status === 'offline'}
-								class:dot-disabled={status === 'disabled'}
-							></span>
-							<span class="peer-name">{peerName(peer)}</span>
-						</div>
-						<div class="peer-status-sub">
-							<div class="peer-inline-toggle">
-								<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
-							</div>
-							<span>{status}</span>
-						</div>
-					</td>
-					<td class="col-ip">
-						<button
-							type="button"
-							class="cell-copy mono tech-value"
-							onclick={() => void copyCellValue(peer.tunnelIP, 'IP')}
-							title={`Скопировать IP ${peer.tunnelIP}`}
+							}}
+							onkeydown={(e) => {
+								if (isInsideInlineToggle(e)) return;
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									onTogglePeer(peer);
+								}
+							}}
 						>
-							{peer.tunnelIP}
-						</button>
-					</td>
-					<td class="col-endpoint col-desktop">
-						{#if true}
-							{@const endpointValue = peerStats?.endpoint || '-'}
-							{@const ep = splitEndpoint(endpointValue)}
+							<div class="peer-name-row">
+								<span
+									class="status-dot"
+									class:dot-online={status === 'online'}
+									class:dot-offline={status === 'offline'}
+									class:dot-disabled={status === 'disabled'}
+								></span>
+								<span class="peer-name">{peerName(peer)}</span>
+							</div>
+							<div class="peer-status-sub">
+								<div class="peer-inline-toggle">
+									<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
+								</div>
+								<span>{status}</span>
+							</div>
+						</td>
+						<td class="col-ip">
+							<button
+								type="button"
+								class="cell-copy mono tech-value"
+								onclick={() => void copyCellValue(peer.tunnelIP, 'IP')}
+								title={`Скопировать IP ${peer.tunnelIP}`}
+							>
+								{peer.tunnelIP}
+							</button>
+						</td>
+						<td class="col-endpoint">
 							<button
 								type="button"
 								class="cell-copy endpoint-copy mono tech-value"
@@ -148,67 +149,175 @@
 									<span class="endpoint-port">{ep.port}</span>
 								{/if}
 							</button>
-						{/if}
-					</td>
-					<td class="col-traffic">
-						<div class="traffic-cell mono tech-value">
-							<div>RX: {formatBytes(peerStats?.rxBytes ?? 0)}</div>
-							<div>TX: {formatBytes(peerStats?.txBytes ?? 0)}</div>
-						</div>
-					</td>
-					<td class="col-handshake col-desktop tech-value">
-						{#if peerStats?.lastHandshake}
-							{@const hs = splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake))}
-							<span class="handshake-text">{hs.main}</span>
-							{#if hs.suffix}
-								<span class="handshake-suffix">{hs.suffix}</span>
+						</td>
+						<td class="col-traffic">
+							<div class="traffic-cell mono tech-value">
+								<span class="traffic-rx">RX: {formatBytes(peerStats?.rxBytes ?? 0)}</span>
+								<span class="traffic-tx">TX: {formatBytes(peerStats?.txBytes ?? 0)}</span>
+							</div>
+						</td>
+						<td class="col-handshake tech-value">
+							{#if hs}
+								<span class="handshake-text">{hs.main}</span>
+								{#if hs.suffix}
+									<span class="handshake-suffix">{" "}{hs.suffix}</span>
+								{/if}
+							{:else}
+								-
 							{/if}
+						</td>
+						<td class="col-actions">
+							<div class="peer-actions">
+								<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
+									<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+										<polyline points="7 10 12 15 17 10" />
+										<line x1="12" y1="15" x2="12" y2="3" />
+									</svg>
+								</button>
+								<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
+									<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+										<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+									</svg>
+								</button>
+								<button
+									class="peer-action-btn peer-action-btn-danger"
+									class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
+									onclick={() => onDeletePeerClick(peer)}
+									title={confirmDeletePeerKey === peer.publicKey
+										? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
+										: `Удалить «${peerName(peer)}»`}
+								>
+									<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<line x1="18" y1="6" x2="6" y2="18" />
+										<line x1="6" y1="6" x2="18" y2="18" />
+									</svg>
+								</button>
+							</div>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div class="mobile-peer-list">
+	{#each peers as peer (peer.publicKey)}
+		{@const peerStats = getPeerStats(peer.publicKey)}
+		{@const status = peerStatus(peer, peerStats)}
+		{@const endpointValue = peerStats?.endpoint || '-'}
+		{@const ep = splitEndpoint(endpointValue)}
+		{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
+		<article class="mobile-peer-card" class:peer-disabled={!peer.enabled} class:has-actions={true}>
+			<div class="mobile-peer-main">
+				<div class="mobile-peer-title-row">
+					<span
+						class="status-dot"
+						class:dot-online={status === 'online'}
+						class:dot-offline={status === 'offline'}
+						class:dot-disabled={status === 'disabled'}
+					></span>
+					<span class="mobile-peer-name">{peerName(peer)}</span>
+				</div>
+
+				<div class="mobile-peer-status-row">
+					<span class="mobile-peer-status-left">
+						<span class="peer-inline-toggle">
+							<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
+						</span>
+						<span>{status}</span>
+					</span>
+
+					<span class="mobile-peer-handshake">
+						{#if hs}
+							{hs.main}{#if hs.suffix}{" "}{hs.suffix}{/if}
 						{:else}
 							-
 						{/if}
-					</td>
-					<td class="col-actions">
-						<div class="peer-actions">
-							<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
-								</svg>
-							</button>
-							<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-								</svg>
-							</button>
-							<button
-								class="peer-action-btn peer-action-btn-danger"
-								class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
-								onclick={() => onDeletePeerClick(peer)}
-								title={confirmDeletePeerKey === peer.publicKey
-									? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
-									: `Удалить «${peerName(peer)}»`}
-							>
-								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-								</svg>
-							</button>
-						</div>
-					</td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+					</span>
+				</div>
+
+				<div class="mobile-peer-net-row mono tech-value">
+					<button
+						type="button"
+						class="cell-copy mobile-peer-ip"
+						onclick={() => void copyCellValue(peer.tunnelIP, 'IP')}
+						title={`Скопировать IP ${peer.tunnelIP}`}
+					>
+						<span class="mobile-label">IP</span> {peer.tunnelIP}
+					</button>
+
+					<button
+						type="button"
+						class="cell-copy mobile-peer-endpoint"
+						onclick={() => void copyCellValue(endpointValue, 'Endpoint')}
+						title={endpointValue !== '-' ? `Скопировать Endpoint ${endpointValue}` : 'Endpoint отсутствует'}
+					>
+						<span class="mobile-label">EP</span>
+						<span class="mobile-endpoint-value">{endpointValue}</span>
+					</button>
+				</div>
+
+				<div class="mobile-peer-traffic-row mono tech-value">
+					<span>RX: {formatBytes(peerStats?.rxBytes ?? 0)}</span>
+					<span>TX: {formatBytes(peerStats?.txBytes ?? 0)}</span>
+				</div>
+			</div>
+
+			<div class="mobile-peer-actions">
+				<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+						<polyline points="7 10 12 15 17 10" />
+						<line x1="12" y1="15" x2="12" y2="3" />
+					</svg>
+				</button>
+				<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+						<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+					</svg>
+				</button>
+				<button
+					class="peer-action-btn peer-action-btn-danger"
+					class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
+					onclick={() => onDeletePeerClick(peer)}
+					title={confirmDeletePeerKey === peer.publicKey
+						? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
+						: `Удалить «${peerName(peer)}»`}
+				>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<line x1="18" y1="6" x2="6" y2="18" />
+						<line x1="6" y1="6" x2="18" y2="18" />
+					</svg>
+				</button>
+			</div>
+		</article>
+	{/each}
 </div>
 
 <style>
 	.table-wrap {
 		overflow-x: auto;
 	}
+
+	.desktop-peer-table {
+		display: block;
+	}
+
+	.mobile-peer-list {
+		display: none;
+	}
+
 	.managed-peer-table {
 		width: 100%;
 		border-collapse: collapse;
 		font-size: 12px;
 		table-layout: auto;
 	}
+
 	.managed-peer-table th {
 		text-align: center;
 		background: color-mix(in srgb, var(--accent) 16%, transparent);
@@ -219,93 +328,113 @@
 		border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
 		white-space: nowrap;
 	}
+
 	.managed-peer-table td {
 		padding: 0.55rem 0.5rem;
 		border-bottom: 1px solid var(--border);
 		vertical-align: middle;
 		transition: background-color 0.15s ease, box-shadow 0.15s ease;
 	}
+
 	.managed-peer-table tbody tr:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
 		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 35%, transparent);
 	}
+
 	.managed-peer-table tbody tr.peer-disabled:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 45%, transparent);
 		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--text-muted) 35%, transparent);
 	}
+
 	.peer-disabled {
 		opacity: 0.5;
 	}
+
 	td.peer-name-cell {
 		min-width: 140px;
 		text-align: left;
 		cursor: pointer;
 	}
+
 	.peer-name {
 		font-weight: 500;
+		font-size: 13px;
+		line-height: 1.15;
 		color: var(--text-primary);
 		white-space: normal;
 		overflow-wrap: anywhere;
 		word-break: break-word;
-		line-height: 1.25;
 	}
+
 	.peer-name-row {
 		display: flex;
 		align-items: center;
-		gap: 0.35rem;
+		gap: 0.3rem;
 		min-width: 0;
 	}
+
 	.peer-name-row .status-dot {
 		flex-shrink: 0;
 	}
+
 	.peer-name-row .peer-name {
 		min-width: 0;
 	}
+
 	.peer-status-sub {
 		display: flex;
 		align-items: center;
 		justify-content: flex-start;
 		width: 100%;
-		gap: 0.35rem;
+		gap: 0.25rem;
 		font-size: 10px;
 		color: var(--text-muted);
-		line-height: 1.1;
-		margin-top: 0.25rem;
+		line-height: 1;
+		margin-top: 0.1rem;
 	}
+
 	.peer-inline-toggle {
 		display: inline-flex;
 		align-items: center;
 		line-height: 1;
 	}
+
 	.peer-inline-toggle :global(.toggle-container) {
 		gap: 0;
 		padding: 0;
 		min-height: 0;
 	}
+
 	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider) {
 		width: 24px;
 		height: 14px;
 	}
+
 	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider::before) {
 		width: 10px;
 		height: 10px;
 		left: 2px;
 		bottom: 2px;
 	}
+
 	.peer-inline-toggle :global(.toggle-container.sm input:checked ~ .toggle-slider::before) {
 		transform: translateX(10px);
 	}
+
 	.peer-inline-toggle :global(.toggle-spinner-slot) {
 		width: 0;
 		margin: 0;
 	}
+
 	.mono {
 		font-family: var(--font-mono, monospace);
 	}
+
 	.tech-value {
 		font-size: 10px;
 		line-height: 1.15;
 	}
+
 	.status-dot {
 		display: inline-block;
 		width: 6px;
@@ -314,34 +443,42 @@
 		margin-right: 0.35rem;
 		vertical-align: middle;
 	}
+
 	.dot-online {
 		background: var(--success, #22c55e);
 		box-shadow: 0 0 3px var(--success, #22c55e);
 	}
+
 	.dot-offline {
 		background: var(--text-muted);
 	}
+
 	.dot-disabled {
 		background: var(--text-muted);
 	}
+
 	.traffic-cell {
 		display: flex;
 		flex-direction: column;
-		gap: 0.1rem;
-		line-height: 1.2;
+		gap: 0;
+		line-height: 1.05;
 		white-space: nowrap;
 	}
+
 	.col-name {
 		width: 24%;
 	}
+
 	.col-ip {
 		width: 12%;
 		white-space: nowrap;
 	}
+
 	.col-endpoint {
 		width: auto;
 		max-width: 180px;
 	}
+
 	.endpoint-text {
 		display: block;
 		white-space: normal;
@@ -349,35 +486,43 @@
 		word-break: break-word;
 		line-height: 1.15;
 	}
+
 	.endpoint-port {
 		display: block;
 		white-space: nowrap;
 		line-height: 1.15;
 	}
+
 	.col-traffic {
 		width: 14%;
 	}
+
 	.col-handshake {
 		width: 12%;
 		white-space: nowrap;
 	}
+
 	.handshake-text,
 	.handshake-suffix {
 		display: block;
 	}
+
 	.col-actions {
 		width: 11%;
 		white-space: nowrap;
 	}
+
 	td.col-ip,
 	td.col-endpoint,
 	td.col-traffic,
 	td.col-handshake {
 		text-align: center;
 	}
+
 	td.col-actions {
 		text-align: right;
 	}
+
 	.peer-actions {
 		display: inline-flex;
 		align-items: center;
@@ -385,6 +530,7 @@
 		width: 100%;
 		gap: 0.375rem;
 	}
+
 	.peer-action-btn {
 		display: inline-flex;
 		align-items: center;
@@ -397,22 +543,27 @@
 		border-radius: var(--radius-sm);
 		transition: color 0.15s ease, background 0.15s ease;
 	}
+
 	.peer-action-btn:hover {
 		background: var(--bg-hover);
 		color: var(--text-primary);
 	}
+
 	.peer-action-btn-danger:hover {
 		color: var(--error, #ef4444);
 	}
+
 	.peer-action-btn-confirm {
 		background: var(--error, #ef4444);
 		color: white;
 	}
+
 	.peer-action-btn-confirm:hover {
 		background: var(--error, #ef4444);
 		color: white;
 		filter: brightness(1.1);
 	}
+
 	.cell-copy {
 		padding: 0;
 		border: 0;
@@ -421,21 +572,190 @@
 		cursor: pointer;
 		text-align: left;
 	}
+
 	.cell-copy:hover {
 		text-decoration: underline;
 		color: var(--text-primary);
 	}
-	.endpoint-copy {
-		display: inline-flex;
-		flex-direction: column;
-		align-items: center;
-	}
-	.traffic-cell {
-		align-items: center;
-	}
+
 	@media (max-width: 640px) {
-		.col-desktop {
+		.desktop-peer-table {
 			display: none;
+		}
+
+		.mobile-peer-list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.4rem;
+		}
+
+		.mobile-peer-card {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 0.5rem;
+			padding: 0.55rem 0.65rem;
+			border: 1px solid var(--border);
+			border-radius: var(--radius);
+			background: var(--bg-primary);
+		}
+
+		.mobile-peer-card:not(.has-actions) {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.mobile-peer-main {
+			min-width: 0;
+		}
+
+		.mobile-peer-title-row {
+			display: flex;
+			align-items: center;
+			gap: 0.3rem;
+			min-width: 0;
+		}
+
+		.mobile-peer-name {
+			min-width: 0;
+			max-width: 100%;
+			font-size: 13px;
+			font-weight: 600;
+			line-height: 1.15;
+			color: var(--text-primary);
+			overflow-wrap: anywhere;
+		}
+
+		.mobile-peer-status-row {
+			display: flex;
+			justify-content: flex-start;
+			align-items: center;
+			gap: 0.35rem;
+			margin-top: 0.1rem;
+			font-size: 10px;
+			line-height: 1;
+			color: var(--text-muted);
+		}
+
+		.mobile-peer-status-left {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			min-width: 0;
+		}
+
+		.mobile-peer-handshake {
+			text-align: left;
+			white-space: nowrap;
+			color: var(--text-muted);
+			margin-left: 0.1rem;
+		}
+
+		.mobile-peer-net-row {
+			display: grid;
+			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
+			gap: 0.5rem;
+			margin-top: 0.35rem;
+			line-height: 1.1;
+		}
+
+		.mobile-peer-ip {
+			min-width: 0;
+			text-align: left;
+			white-space: nowrap;
+		}
+
+		.mobile-peer-endpoint {
+			display: inline-flex;
+			flex-direction: row;
+			align-items: flex-end;
+			justify-content: flex-end;
+			gap: 0.25rem;
+			min-width: 0;
+			justify-self: end;
+			max-width: 100%;
+			text-align: right;
+			white-space: nowrap;
+		}
+
+		.mobile-endpoint-value {
+			display: block;
+			min-width: 0;
+			max-width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.mobile-label {
+			flex: 0 0 auto;
+			color: var(--text-muted);
+			font-size: 9px;
+			line-height: 1;
+			letter-spacing: 0.04em;
+		}
+
+		.mobile-peer-traffic-row {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+			gap: 0.5rem;
+			margin-top: 0.25rem;
+			line-height: 1.1;
+		}
+
+		.mobile-peer-traffic-row > span:first-child {
+			justify-self: start;
+		}
+
+		.mobile-peer-traffic-row > span:last-child {
+			justify-self: end;
+			text-align: right;
+		}
+
+		.mobile-peer-actions {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-end;
+			justify-content: flex-end;
+			gap: 0.25rem;
+			align-self: start;
+			flex-wrap: nowrap;
+		}
+
+		.mobile-peer-actions .peer-action-btn {
+			width: 32px;
+			height: 32px;
+			padding: 0;
+			border: 1px solid var(--border);
+			border-radius: var(--radius-sm);
+			background: var(--bg-secondary);
+		}
+
+		@media (max-width: 360px) {
+			.mobile-peer-actions {
+				display: grid;
+				grid-template-columns: repeat(2, 32px);
+				grid-auto-rows: 32px;
+				gap: 0.25rem;
+				justify-content: end;
+			}
+
+			.mobile-peer-actions .peer-action-btn:nth-child(1) {
+				grid-column: 2;
+				grid-row: 1;
+			}
+
+			.mobile-peer-actions .peer-action-btn:nth-child(2) {
+				grid-column: 1;
+				grid-row: 2;
+			}
+
+			.mobile-peer-actions .peer-action-btn:nth-child(3) {
+				grid-column: 2;
+				grid-row: 2;
+			}
+		}
+
+		.peer-disabled {
+			opacity: 0.6;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -5,7 +5,8 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { peerSort } from '$lib/stores/peerSort';
-	import type { PeerSortKey } from '$lib/utils/peerSort';
+	import { peerAriaSort } from '$lib/utils/peerSort';
+	import PeerTableSortHeader from './PeerTableSortHeader.svelte';
 
 	interface Props {
 		peers: ManagedPeer[];
@@ -74,102 +75,28 @@
 		}
 	}
 
-	function ariaSort(key: PeerSortKey): 'ascending' | 'descending' | 'none' {
-		if ($peerSort.sortBy !== key) return 'none';
-		return $peerSort.sortAsc ? 'ascending' : 'descending';
-	}
-
-	function toggleHeaderSort(key: PeerSortKey) {
-		if ($peerSort.sortBy === key) {
-			peerSort.toggleDir();
-		} else {
-			peerSort.setSortBy(key);
-		}
-	}
-
-	function cycleNameHeaderSort() {
-		const { sortBy, sortAsc } = $peerSort;
-
-		if (sortBy !== 'name' && sortBy !== 'online') {
-			peerSort.setSort('name', true);
-			return;
-		}
-
-		if (sortBy === 'name' && sortAsc) {
-			peerSort.setSort('name', false);
-			return;
-		}
-
-		if (sortBy === 'name' && !sortAsc) {
-			peerSort.setSort('online', false);
-			return;
-		}
-
-		if (sortBy === 'online' && !sortAsc) {
-			peerSort.setSort('online', true);
-			return;
-		}
-
-		peerSort.setSort('name', true);
-	}
-
-	function isNameHeaderActive(): boolean {
-		return $peerSort.sortBy === 'name' || $peerSort.sortBy === 'online';
-	}
-
-	function nameHeaderIndicator(): string {
-		if ($peerSort.sortBy === 'name') return $peerSort.sortAsc ? 'A↑' : 'A↓';
-		if ($peerSort.sortBy === 'online') return $peerSort.sortAsc ? '○↑' : '●↓';
-		return '↕';
-	}
-
-	function nameAriaSort(): 'ascending' | 'descending' | 'none' {
-		if ($peerSort.sortBy !== 'name' && $peerSort.sortBy !== 'online') return 'none';
-		return $peerSort.sortAsc ? 'ascending' : 'descending';
-	}
 </script>
-
-{#snippet SortHeader(label: string, key: PeerSortKey)}
-	<button
-		type="button"
-		class="sort-header-btn"
-		class:active={$peerSort.sortBy === key}
-		onclick={() => toggleHeaderSort(key)}
-		title={`Сортировать по колонке «${label}»`}
-	>
-		<span>{label}</span>
-		<span class="sort-indicator" aria-hidden="true">
-			{#if $peerSort.sortBy === key}
-				{$peerSort.sortAsc ? '↑' : '↓'}
-			{:else}
-				↕
-			{/if}
-		</span>
-	</button>
-{/snippet}
 
 <div class="desktop-peer-table">
 	<div class="table-wrap">
 		<table class="managed-peer-table">
 			<thead>
 				<tr>
-					<th class="col-name" aria-sort={nameAriaSort()}>
-						<button
-							type="button"
-							class="sort-header-btn name-sort-header"
-							class:active={isNameHeaderActive()}
-							onclick={cycleNameHeaderSort}
-							title="Сортировка: имя A→Z, имя Z→A, онлайн сверху, офлайн сверху"
-						>
-							<span>Имя</span>
-							<span class="sort-subhint" aria-hidden="true">/ онлайн</span>
-							<span class="sort-indicator" aria-hidden="true">{nameHeaderIndicator()}</span>
-						</button>
+					<th class="col-name" aria-sort={peerAriaSort($peerSort, 'name')}>
+						<PeerTableSortHeader label="Имя" sortKey="name" />
 					</th>
-					<th class="col-ip" aria-sort={ariaSort('ip')}>{@render SortHeader('IP', 'ip')}</th>
-					<th class="col-endpoint" aria-sort={ariaSort('endpoint')}>{@render SortHeader('Endpoint', 'endpoint')}</th>
-					<th class="col-traffic" aria-sort={ariaSort('traffic')}>{@render SortHeader('Трафик', 'traffic')}</th>
-					<th class="col-handshake" aria-sort={ariaSort('handshake')}>{@render SortHeader('Handshake', 'handshake')}</th>
+					<th class="col-ip" aria-sort={peerAriaSort($peerSort, 'ip')}>
+						<PeerTableSortHeader label="IP" sortKey="ip" />
+					</th>
+					<th class="col-endpoint" aria-sort={peerAriaSort($peerSort, 'endpoint')}>
+						<PeerTableSortHeader label="Endpoint" sortKey="endpoint" />
+					</th>
+					<th class="col-traffic" aria-sort={peerAriaSort($peerSort, 'traffic')}>
+						<PeerTableSortHeader label="Трафик" sortKey="traffic" />
+					</th>
+					<th class="col-handshake" aria-sort={peerAriaSort($peerSort, 'handshake')}>
+						<PeerTableSortHeader label="Handshake" sortKey="handshake" />
+					</th>
 					<th class="col-actions">Действия</th>
 				</tr>
 			</thead>
@@ -199,6 +126,9 @@
 							}}
 						>
 							<div class="peer-name-row">
+								<span class="peer-inline-toggle">
+									<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
+								</span>
 								<span
 									class="status-dot"
 									class:dot-online={status === 'online'}
@@ -208,9 +138,6 @@
 								<span class="peer-name">{peerName(peer)}</span>
 							</div>
 							<div class="peer-status-sub">
-								<div class="peer-inline-toggle">
-									<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
-								</div>
 								<span>{status}</span>
 							</div>
 						</td>
@@ -295,11 +222,13 @@
 		{@const peerStats = getPeerStats(peer.publicKey)}
 		{@const status = peerStatus(peer, peerStats)}
 		{@const endpointValue = peerStats?.endpoint || '-'}
-		{@const ep = splitEndpoint(endpointValue)}
 		{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
 		<article class="mobile-peer-card" class:peer-disabled={!peer.enabled} class:has-actions={true}>
-			<div class="mobile-peer-main">
+			<div class="mobile-peer-card-top">
 				<div class="mobile-peer-title-row">
+					<span class="peer-inline-toggle">
+						<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
+					</span>
 					<span
 						class="status-dot"
 						class:dot-online={status === 'online'}
@@ -309,11 +238,39 @@
 					<span class="mobile-peer-name">{peerName(peer)}</span>
 				</div>
 
+				<div class="mobile-peer-actions">
+					<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+							<polyline points="7 10 12 15 17 10" />
+							<line x1="12" y1="15" x2="12" y2="3" />
+						</svg>
+					</button>
+					<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+							<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+						</svg>
+					</button>
+					<button
+						class="peer-action-btn peer-action-btn-danger"
+						class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
+						onclick={() => onDeletePeerClick(peer)}
+						title={confirmDeletePeerKey === peer.publicKey
+							? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
+							: `Удалить «${peerName(peer)}»`}
+					>
+						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<line x1="18" y1="6" x2="6" y2="18" />
+							<line x1="6" y1="6" x2="18" y2="18" />
+						</svg>
+					</button>
+				</div>
+			</div>
+
+			<div class="mobile-peer-card-middle">
 				<div class="mobile-peer-status-row">
 					<span class="mobile-peer-status-left">
-						<span class="peer-inline-toggle">
-							<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
-						</span>
 						<span>{status}</span>
 					</span>
 
@@ -346,40 +303,13 @@
 						<span class="mobile-endpoint-value">{endpointValue}</span>
 					</button>
 				</div>
+			</div>
 
+			<div class="mobile-peer-card-bottom">
 				<div class="mobile-peer-traffic-row mono tech-value">
 					<span>RX: {formatBytes(peerStats?.rxBytes ?? 0)}</span>
 					<span>TX: {formatBytes(peerStats?.txBytes ?? 0)}</span>
 				</div>
-			</div>
-
-			<div class="mobile-peer-actions">
-				<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-						<polyline points="7 10 12 15 17 10" />
-						<line x1="12" y1="15" x2="12" y2="3" />
-					</svg>
-				</button>
-				<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-						<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-					</svg>
-				</button>
-				<button
-					class="peer-action-btn peer-action-btn-danger"
-					class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
-					onclick={() => onDeletePeerClick(peer)}
-					title={confirmDeletePeerKey === peer.publicKey
-						? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
-						: `Удалить «${peerName(peer)}»`}
-				>
-					<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<line x1="18" y1="6" x2="6" y2="18" />
-						<line x1="6" y1="6" x2="18" y2="18" />
-					</svg>
-				</button>
 			</div>
 		</article>
 	{/each}
@@ -420,17 +350,15 @@
 		padding: 0.55rem 0.5rem;
 		border-bottom: 1px solid var(--border);
 		vertical-align: middle;
-		transition: background-color 0.15s ease, box-shadow 0.15s ease;
+		transition: background-color 0.15s ease;
 	}
 
 	.managed-peer-table tbody tr:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
-		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 35%, transparent);
 	}
 
 	.managed-peer-table tbody tr.peer-disabled:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 45%, transparent);
-		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--text-muted) 35%, transparent);
 	}
 
 	.peer-disabled {
@@ -473,7 +401,7 @@
 		align-items: center;
 		justify-content: flex-start;
 		width: 100%;
-		gap: 0.25rem;
+		gap: 0.35rem;
 		font-size: 10px;
 		color: var(--text-muted);
 		line-height: 1;
@@ -493,19 +421,19 @@
 	}
 
 	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider) {
-		width: 24px;
-		height: 14px;
+		width: 30px;
+		height: 18px;
 	}
 
 	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider::before) {
-		width: 10px;
-		height: 10px;
+		width: 14px;
+		height: 14px;
 		left: 2px;
 		bottom: 2px;
 	}
 
 	.peer-inline-toggle :global(.toggle-container.sm input:checked ~ .toggle-slider::before) {
-		transform: translateX(10px);
+		transform: translateX(12px);
 	}
 
 	.peer-inline-toggle :global(.toggle-spinner-slot) {
@@ -564,6 +492,24 @@
 	.col-endpoint {
 		width: auto;
 		max-width: 180px;
+	}
+
+	.managed-peer-table th.col-endpoint {
+		text-align: center;
+	}
+
+	.managed-peer-table td.col-endpoint {
+		text-align: left;
+		vertical-align: middle;
+	}
+
+	.managed-peer-table td.col-endpoint .endpoint-copy {
+		display: inline-flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		max-width: 100%;
+		text-align: left;
 	}
 
 	.endpoint-text {
@@ -665,59 +611,6 @@
 		color: var(--text-primary);
 	}
 
-	.sort-header-btn {
-		width: 100%;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.3rem;
-		padding: 0;
-		border: 0;
-		background: transparent;
-		color: inherit;
-		font: inherit;
-		font-weight: inherit;
-		text-transform: inherit;
-		letter-spacing: inherit;
-		cursor: pointer;
-	}
-
-	.sort-header-btn:hover {
-		color: var(--text-primary);
-	}
-
-	.sort-header-btn.active {
-		color: var(--accent);
-	}
-
-	.name-sort-header {
-		justify-content: center;
-	}
-
-	.sort-subhint {
-		opacity: 0.65;
-		font-size: 0.85em;
-		font-weight: inherit;
-		text-transform: none;
-		letter-spacing: normal;
-	}
-
-	.sort-header-btn.active .sort-subhint {
-		opacity: 0.85;
-	}
-
-	.sort-indicator {
-		min-width: 1.8em;
-		text-align: left;
-		flex: 0 0 auto;
-		opacity: 0.65;
-		font-size: 0.8em;
-	}
-
-	.sort-header-btn.active .sort-indicator {
-		opacity: 1;
-	}
-
 	@media (max-width: 640px) {
 		.desktop-peer-table {
 			display: none;
@@ -726,31 +619,36 @@
 		.mobile-peer-list {
 			display: flex;
 			flex-direction: column;
-			gap: 0.4rem;
+			gap: 0.6rem;
 		}
 
 		.mobile-peer-card {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) auto;
-			gap: 0.5rem;
-			padding: 0.55rem 0.65rem;
+			display: flex;
+			flex-direction: column;
+			gap: 0.65rem;
+			padding: 0.7rem 0.75rem;
 			border: 1px solid var(--border);
 			border-radius: var(--radius);
 			background: var(--bg-primary);
 		}
 
-		.mobile-peer-card:not(.has-actions) {
-			grid-template-columns: minmax(0, 1fr);
+		.mobile-peer-card-top {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			align-items: start;
+			gap: 0.5rem;
 		}
 
-		.mobile-peer-main {
+		.mobile-peer-card-middle,
+		.mobile-peer-card-bottom,
+		.mobile-peer-title-row {
 			min-width: 0;
 		}
 
 		.mobile-peer-title-row {
 			display: flex;
 			align-items: center;
-			gap: 0.3rem;
+			gap: 0.45rem;
 			min-width: 0;
 		}
 
@@ -769,7 +667,7 @@
 			justify-content: flex-start;
 			align-items: center;
 			gap: 0.35rem;
-			margin-top: 0.1rem;
+			margin-top: 0.2rem;
 			font-size: 10px;
 			line-height: 1;
 			color: var(--text-muted);
@@ -793,7 +691,7 @@
 			display: grid;
 			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
 			gap: 0.5rem;
-			margin-top: 0.35rem;
+			margin-top: 0.45rem;
 			line-height: 1.1;
 		}
 
@@ -837,7 +735,7 @@
 			display: grid;
 			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 			gap: 0.5rem;
-			margin-top: 0.25rem;
+			margin-top: 0.35rem;
 			line-height: 1.1;
 		}
 
@@ -853,16 +751,16 @@
 		.mobile-peer-actions {
 			display: flex;
 			flex-direction: row;
-			align-items: flex-end;
+			align-items: flex-start;
 			justify-content: flex-end;
 			gap: 0.25rem;
 			align-self: start;
-			flex-wrap: nowrap;
 		}
 
 		.mobile-peer-actions .peer-action-btn {
 			width: 32px;
 			height: 32px;
+			flex: 0 0 32px;
 			padding: 0;
 			border: 1px solid var(--border);
 			border-radius: var(--radius-sm);
@@ -870,27 +768,19 @@
 		}
 
 		@media (max-width: 360px) {
+			.mobile-peer-card-top {
+				grid-template-columns: minmax(0, 1fr) auto;
+			}
+
 			.mobile-peer-actions {
-				display: grid;
-				grid-template-columns: repeat(2, 32px);
-				grid-auto-rows: 32px;
-				gap: 0.25rem;
-				justify-content: end;
+				flex-wrap: nowrap;
+				gap: 0.2rem;
 			}
 
-			.mobile-peer-actions .peer-action-btn:nth-child(1) {
-				grid-column: 2;
-				grid-row: 1;
-			}
-
-			.mobile-peer-actions .peer-action-btn:nth-child(2) {
-				grid-column: 1;
-				grid-row: 2;
-			}
-
-			.mobile-peer-actions .peer-action-btn:nth-child(3) {
-				grid-column: 2;
-				grid-row: 2;
+			.mobile-peer-actions .peer-action-btn {
+				width: 30px;
+				height: 30px;
+				flex-basis: 30px;
 			}
 		}
 

--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -4,6 +4,8 @@
 	import { formatBytes, formatRelativeTime } from '$lib/utils/format';
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { peerSort } from '$lib/stores/peerSort';
+	import type { PeerSortKey } from '$lib/utils/peerSort';
 
 	interface Props {
 		peers: ManagedPeer[];
@@ -71,18 +73,103 @@
 			notifications.error(`Не удалось скопировать ${label.toLowerCase()}`);
 		}
 	}
+
+	function ariaSort(key: PeerSortKey): 'ascending' | 'descending' | 'none' {
+		if ($peerSort.sortBy !== key) return 'none';
+		return $peerSort.sortAsc ? 'ascending' : 'descending';
+	}
+
+	function toggleHeaderSort(key: PeerSortKey) {
+		if ($peerSort.sortBy === key) {
+			peerSort.toggleDir();
+		} else {
+			peerSort.setSortBy(key);
+		}
+	}
+
+	function cycleNameHeaderSort() {
+		const { sortBy, sortAsc } = $peerSort;
+
+		if (sortBy !== 'name' && sortBy !== 'online') {
+			peerSort.setSort('name', true);
+			return;
+		}
+
+		if (sortBy === 'name' && sortAsc) {
+			peerSort.setSort('name', false);
+			return;
+		}
+
+		if (sortBy === 'name' && !sortAsc) {
+			peerSort.setSort('online', false);
+			return;
+		}
+
+		if (sortBy === 'online' && !sortAsc) {
+			peerSort.setSort('online', true);
+			return;
+		}
+
+		peerSort.setSort('name', true);
+	}
+
+	function isNameHeaderActive(): boolean {
+		return $peerSort.sortBy === 'name' || $peerSort.sortBy === 'online';
+	}
+
+	function nameHeaderIndicator(): string {
+		if ($peerSort.sortBy === 'name') return $peerSort.sortAsc ? 'A↑' : 'A↓';
+		if ($peerSort.sortBy === 'online') return $peerSort.sortAsc ? '○↑' : '●↓';
+		return '↕';
+	}
+
+	function nameAriaSort(): 'ascending' | 'descending' | 'none' {
+		if ($peerSort.sortBy !== 'name' && $peerSort.sortBy !== 'online') return 'none';
+		return $peerSort.sortAsc ? 'ascending' : 'descending';
+	}
 </script>
+
+{#snippet SortHeader(label: string, key: PeerSortKey)}
+	<button
+		type="button"
+		class="sort-header-btn"
+		class:active={$peerSort.sortBy === key}
+		onclick={() => toggleHeaderSort(key)}
+		title={`Сортировать по колонке «${label}»`}
+	>
+		<span>{label}</span>
+		<span class="sort-indicator" aria-hidden="true">
+			{#if $peerSort.sortBy === key}
+				{$peerSort.sortAsc ? '↑' : '↓'}
+			{:else}
+				↕
+			{/if}
+		</span>
+	</button>
+{/snippet}
 
 <div class="desktop-peer-table">
 	<div class="table-wrap">
 		<table class="managed-peer-table">
 			<thead>
 				<tr>
-					<th class="col-name">Имя</th>
-					<th class="col-ip">IP</th>
-					<th class="col-endpoint">Endpoint</th>
-					<th class="col-traffic">Трафик</th>
-					<th class="col-handshake">Handshake</th>
+					<th class="col-name" aria-sort={nameAriaSort()}>
+						<button
+							type="button"
+							class="sort-header-btn name-sort-header"
+							class:active={isNameHeaderActive()}
+							onclick={cycleNameHeaderSort}
+							title="Сортировка: имя A→Z, имя Z→A, онлайн сверху, офлайн сверху"
+						>
+							<span>Имя</span>
+							<span class="sort-subhint" aria-hidden="true">/ онлайн</span>
+							<span class="sort-indicator" aria-hidden="true">{nameHeaderIndicator()}</span>
+						</button>
+					</th>
+					<th class="col-ip" aria-sort={ariaSort('ip')}>{@render SortHeader('IP', 'ip')}</th>
+					<th class="col-endpoint" aria-sort={ariaSort('endpoint')}>{@render SortHeader('Endpoint', 'endpoint')}</th>
+					<th class="col-traffic" aria-sort={ariaSort('traffic')}>{@render SortHeader('Трафик', 'traffic')}</th>
+					<th class="col-handshake" aria-sort={ariaSort('handshake')}>{@render SortHeader('Handshake', 'handshake')}</th>
 					<th class="col-actions">Действия</th>
 				</tr>
 			</thead>
@@ -576,6 +663,59 @@
 	.cell-copy:hover {
 		text-decoration: underline;
 		color: var(--text-primary);
+	}
+
+	.sort-header-btn {
+		width: 100%;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.3rem;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-weight: inherit;
+		text-transform: inherit;
+		letter-spacing: inherit;
+		cursor: pointer;
+	}
+
+	.sort-header-btn:hover {
+		color: var(--text-primary);
+	}
+
+	.sort-header-btn.active {
+		color: var(--accent);
+	}
+
+	.name-sort-header {
+		justify-content: center;
+	}
+
+	.sort-subhint {
+		opacity: 0.65;
+		font-size: 0.85em;
+		font-weight: inherit;
+		text-transform: none;
+		letter-spacing: normal;
+	}
+
+	.sort-header-btn.active .sort-subhint {
+		opacity: 0.85;
+	}
+
+	.sort-indicator {
+		min-width: 1.8em;
+		text-align: left;
+		flex: 0 0 auto;
+		opacity: 0.65;
+		font-size: 0.8em;
+	}
+
+	.sort-header-btn.active .sort-indicator {
+		opacity: 1;
 	}
 
 	@media (max-width: 640px) {

--- a/frontend/src/lib/components/servers/ManagedServerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedServerCard.svelte
@@ -69,6 +69,7 @@
 				{
 					name: a.description || a.publicKey,
 					ip: a.tunnelIP,
+					endpoint: sa?.endpoint || '-',
 					rxBytes: sa?.rxBytes ?? null,
 					txBytes: sa?.txBytes ?? null,
 					online: sa?.online ?? null,
@@ -77,6 +78,7 @@
 				{
 					name: b.description || b.publicKey,
 					ip: b.tunnelIP,
+					endpoint: sb?.endpoint || '-',
 					rxBytes: sb?.rxBytes ?? null,
 					txBytes: sb?.txBytes ?? null,
 					online: sb?.online ?? null,
@@ -399,6 +401,7 @@
 				<PeerSortControls
 					bind:searchQuery
 					showSearch={(server.peers ?? []).length >= 5}
+					hideSortOnDesktop
 				/>
 				<Button variant="secondary" size="sm" onclick={() => addPeerOpen = true} iconBefore={addPeerIcon}>
 					Добавить клиента

--- a/frontend/src/lib/components/servers/ManagedServerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedServerCard.svelte
@@ -686,4 +686,25 @@
 		}
 
 	}
+
+	@media (max-width: 640px) {
+		.managed-card {
+			overflow: hidden;
+		}
+
+		.peers-controls {
+			display: grid;
+			grid-template-columns: 1fr;
+			width: 100%;
+			gap: 0.4rem;
+		}
+
+		.peers-controls :global(.peer-sort-controls) {
+			width: 100%;
+		}
+
+		.peers-controls :global(.btn) {
+			width: 100%;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/servers/PeerSortControls.svelte
+++ b/frontend/src/lib/components/servers/PeerSortControls.svelte
@@ -80,4 +80,30 @@
 		background: var(--bg-hover);
 		color: var(--text-primary);
 	}
+
+	@media (max-width: 640px) {
+		.peer-sort-controls {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 0.375rem;
+			width: 100%;
+		}
+
+		.peer-search {
+			grid-column: 1 / -1;
+			width: 100%;
+			min-width: 0;
+		}
+
+		.peer-sort-select {
+			min-width: 0;
+			width: 100%;
+		}
+
+		.peer-sort-dir {
+			width: 34px;
+			min-width: 34px;
+			height: 34px;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/servers/PeerSortControls.svelte
+++ b/frontend/src/lib/components/servers/PeerSortControls.svelte
@@ -6,23 +6,26 @@
 	interface Props {
 		searchQuery: string;
 		showSearch?: boolean;
+		hideSortOnDesktop?: boolean;
 	}
 
 	let {
 		searchQuery = $bindable(),
 		showSearch = false,
+		hideSortOnDesktop = false,
 	}: Props = $props();
 
 	const sortOptions: DropdownOption<PeerSortKey>[] = [
 		{ value: 'name', label: 'По имени' },
 		{ value: 'traffic', label: 'По трафику' },
 		{ value: 'ip', label: 'По IP' },
+		{ value: 'endpoint', label: 'Endpoint' },
 		{ value: 'online', label: 'Онлайн' },
 		{ value: 'handshake', label: 'Handshake' },
 	];
 </script>
 
-<div class="peer-sort-controls">
+<div class="peer-sort-controls" class:hide-sort-on-desktop={hideSortOnDesktop}>
 	{#if showSearch}
 		<input
 			class="peer-search"
@@ -31,12 +34,14 @@
 			bind:value={searchQuery}
 		/>
 	{/if}
-	<div class="peer-sort-select">
-		<Dropdown value={$peerSort.sortBy} options={sortOptions} onchange={(k) => peerSort.setSortBy(k)} fullWidth />
+	<div class="peer-sort-ui">
+		<div class="peer-sort-select">
+			<Dropdown value={$peerSort.sortBy} options={sortOptions} onchange={(k) => peerSort.setSortBy(k)} fullWidth />
+		</div>
+		<button class="peer-sort-dir" onclick={() => peerSort.toggleDir()} title="Направление сортировки">
+			{$peerSort.sortAsc ? '↑' : '↓'}
+		</button>
 	</div>
-	<button class="peer-sort-dir" onclick={() => peerSort.toggleDir()} title="Направление сортировки">
-		{$peerSort.sortAsc ? '↑' : '↓'}
-	</button>
 </div>
 
 <style>
@@ -44,6 +49,16 @@
 		display: flex;
 		align-items: center;
 		gap: 0.375rem;
+	}
+
+	.peer-sort-ui {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+	}
+
+	.peer-sort-controls.hide-sort-on-desktop .peer-sort-ui {
+		display: none;
 	}
 
 	.peer-search {
@@ -104,6 +119,12 @@
 			width: 34px;
 			min-width: 34px;
 			height: 34px;
+		}
+
+		.peer-sort-controls.hide-sort-on-desktop .peer-sort-ui {
+			display: inline-flex;
+			grid-column: 1 / -1;
+			width: 100%;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/PeerTable.svelte
+++ b/frontend/src/lib/components/servers/PeerTable.svelte
@@ -4,6 +4,8 @@
 	import { IconButton } from '$lib/components/ui';
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { peerSort } from '$lib/stores/peerSort';
+	import type { PeerSortKey } from '$lib/utils/peerSort';
 
 	interface Props {
 		peers: WireguardServerPeer[];
@@ -58,7 +60,80 @@
 			notifications.error(`Не удалось скопировать ${label.toLowerCase()}`);
 		}
 	}
+
+	function ariaSort(key: PeerSortKey): 'ascending' | 'descending' | 'none' {
+		if ($peerSort.sortBy !== key) return 'none';
+		return $peerSort.sortAsc ? 'ascending' : 'descending';
+	}
+
+	function toggleHeaderSort(key: PeerSortKey) {
+		if ($peerSort.sortBy === key) {
+			peerSort.toggleDir();
+		} else {
+			peerSort.setSortBy(key);
+		}
+	}
+
+	function cycleNameHeaderSort() {
+		const { sortBy, sortAsc } = $peerSort;
+
+		if (sortBy !== 'name' && sortBy !== 'online') {
+			peerSort.setSort('name', true);
+			return;
+		}
+
+		if (sortBy === 'name' && sortAsc) {
+			peerSort.setSort('name', false);
+			return;
+		}
+
+		if (sortBy === 'name' && !sortAsc) {
+			peerSort.setSort('online', false);
+			return;
+		}
+
+		if (sortBy === 'online' && !sortAsc) {
+			peerSort.setSort('online', true);
+			return;
+		}
+
+		peerSort.setSort('name', true);
+	}
+
+	function isNameHeaderActive(): boolean {
+		return $peerSort.sortBy === 'name' || $peerSort.sortBy === 'online';
+	}
+
+	function nameHeaderIndicator(): string {
+		if ($peerSort.sortBy === 'name') return $peerSort.sortAsc ? 'A↑' : 'A↓';
+		if ($peerSort.sortBy === 'online') return $peerSort.sortAsc ? '○↑' : '●↓';
+		return '↕';
+	}
+
+	function nameAriaSort(): 'ascending' | 'descending' | 'none' {
+		if ($peerSort.sortBy !== 'name' && $peerSort.sortBy !== 'online') return 'none';
+		return $peerSort.sortAsc ? 'ascending' : 'descending';
+	}
 </script>
+
+{#snippet SortHeader(label: string, key: PeerSortKey)}
+	<button
+		type="button"
+		class="sort-header-btn"
+		class:active={$peerSort.sortBy === key}
+		onclick={() => toggleHeaderSort(key)}
+		title={`Сортировать по колонке «${label}»`}
+	>
+		<span>{label}</span>
+		<span class="sort-indicator" aria-hidden="true">
+			{#if $peerSort.sortBy === key}
+				{$peerSort.sortAsc ? '↑' : '↓'}
+			{:else}
+				↕
+			{/if}
+		</span>
+	</button>
+{/snippet}
 
 {#if peers.length === 0}
 	<p class="text-muted">Нет пиров</p>
@@ -68,11 +143,23 @@
 			<table class="peer-table" class:has-actions={!!onDownloadConf}>
 				<thead>
 					<tr>
-						<th class="col-name">Имя</th>
-						<th class="col-ip">IP</th>
-						<th class="col-endpoint">Endpoint</th>
-						<th class="col-traffic">Трафик</th>
-						<th class="col-handshake">Handshake</th>
+						<th class="col-name" aria-sort={nameAriaSort()}>
+							<button
+								type="button"
+								class="sort-header-btn name-sort-header"
+								class:active={isNameHeaderActive()}
+								onclick={cycleNameHeaderSort}
+								title="Сортировка: имя A→Z, имя Z→A, онлайн сверху, офлайн сверху"
+							>
+								<span>Имя</span>
+								<span class="sort-subhint" aria-hidden="true">/ онлайн</span>
+								<span class="sort-indicator" aria-hidden="true">{nameHeaderIndicator()}</span>
+							</button>
+						</th>
+						<th class="col-ip" aria-sort={ariaSort('ip')}>{@render SortHeader('IP', 'ip')}</th>
+						<th class="col-endpoint" aria-sort={ariaSort('endpoint')}>{@render SortHeader('Endpoint', 'endpoint')}</th>
+						<th class="col-traffic" aria-sort={ariaSort('traffic')}>{@render SortHeader('Трафик', 'traffic')}</th>
+						<th class="col-handshake" aria-sort={ariaSort('handshake')}>{@render SortHeader('Handshake', 'handshake')}</th>
 						{#if onDownloadConf}
 							<th class="col-action"></th>
 						{/if}
@@ -413,6 +500,59 @@
 	.cell-copy:hover {
 		text-decoration: underline;
 		color: var(--text-primary);
+	}
+
+	.sort-header-btn {
+		width: 100%;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.3rem;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-weight: inherit;
+		text-transform: inherit;
+		letter-spacing: inherit;
+		cursor: pointer;
+	}
+
+	.sort-header-btn:hover {
+		color: var(--text-primary);
+	}
+
+	.sort-header-btn.active {
+		color: var(--accent);
+	}
+
+	.name-sort-header {
+		justify-content: center;
+	}
+
+	.sort-subhint {
+		opacity: 0.65;
+		font-size: 0.85em;
+		font-weight: inherit;
+		text-transform: none;
+		letter-spacing: normal;
+	}
+
+	.sort-header-btn.active .sort-subhint {
+		opacity: 0.85;
+	}
+
+	.sort-indicator {
+		min-width: 1.8em;
+		text-align: left;
+		flex: 0 0 auto;
+		opacity: 0.65;
+		font-size: 0.8em;
+	}
+
+	.sort-header-btn.active .sort-indicator {
+		opacity: 1;
 	}
 
 	@media (max-width: 640px) {

--- a/frontend/src/lib/components/servers/PeerTable.svelte
+++ b/frontend/src/lib/components/servers/PeerTable.svelte
@@ -22,10 +22,7 @@
 	}
 
 	function peerIP(peer: WireguardServerPeer): string {
-		const raw =
-			peer.allowedIPs?.find((ip) => ip.includes('/32')) ||
-			peer.allowedIPs?.[0] ||
-			'-';
+		const raw = peer.allowedIPs?.find((ip) => ip.includes('/32')) || peer.allowedIPs?.[0] || '-';
 		// Убираем маску одиночного хоста (/32, /128) — показываем и копируем чистый IP.
 		return raw.replace(/\/(32|128)$/, '');
 	}
@@ -66,39 +63,52 @@
 {#if peers.length === 0}
 	<p class="text-muted">Нет пиров</p>
 {:else}
-	<div class="peer-table-wrap">
-		<table class="peer-table">
-			<thead>
-				<tr>
-					<th class="col-name">Имя</th>
-					<th class="col-ip">IP</th>
-					<th class="col-endpoint">Endpoint</th>
-					<th class="col-traffic">Трафик</th>
-					<th class="col-handshake">Handshake</th>
-					{#if onDownloadConf}
-						<th class="col-action"></th>
-					{/if}
-				</tr>
-			</thead>
-			<tbody>
-				{#each peers as peer (peer.publicKey)}
-					{@const status = peerStatus(peer)}
-					{@const ipValue = peerIP(peer)}
-					{@const endpointValue = peer.endpoint || '-'}
-					<tr class:peer-offline={!peer.online} class:peer-disabled={!peer.enabled}>
-						<td class="col-name peer-name-cell">
-							<div class="peer-name-row">
-								<span class="led" class:led-online={status === 'online'} class:led-offline={status === 'offline'} class:led-disabled={status === 'disabled'}></span>
-								<span class="peer-name">{peerName(peer)}</span>
-							</div>
-							<div class="peer-status-sub">{status}</div>
-						</td>
-						<td class="mono tech-value col-ip">
-							<button type="button" class="cell-copy mono tech-value" onclick={() => void copyCellValue(ipValue, 'IP')} title={`Скопировать IP ${ipValue}`}>{ipValue}</button>
-						</td>
-						<td class="col-endpoint">
-							{#if true}
-								{@const ep = splitEndpoint(endpointValue)}
+	<div class="desktop-peer-table">
+		<div class="peer-table-wrap">
+			<table class="peer-table" class:has-actions={!!onDownloadConf}>
+				<thead>
+					<tr>
+						<th class="col-name">Имя</th>
+						<th class="col-ip">IP</th>
+						<th class="col-endpoint">Endpoint</th>
+						<th class="col-traffic">Трафик</th>
+						<th class="col-handshake">Handshake</th>
+						{#if onDownloadConf}
+							<th class="col-action"></th>
+						{/if}
+					</tr>
+				</thead>
+				<tbody>
+					{#each peers as peer (peer.publicKey)}
+						{@const status = peerStatus(peer)}
+						{@const ipValue = peerIP(peer)}
+						{@const endpointValue = peer.endpoint || '-'}
+						{@const ep = splitEndpoint(endpointValue)}
+						{@const hs = peer.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peer.lastHandshake)) : null}
+						<tr class:peer-offline={!peer.online} class:peer-disabled={!peer.enabled}>
+							<td class="col-name peer-name-cell">
+								<div class="peer-name-row">
+									<span
+										class="led"
+										class:led-online={status === 'online'}
+										class:led-offline={status === 'offline'}
+										class:led-disabled={status === 'disabled'}
+									></span>
+									<span class="peer-name">{peerName(peer)}</span>
+								</div>
+								<div class="peer-status-sub">{status}</div>
+							</td>
+							<td class="mono tech-value col-ip">
+								<button
+									type="button"
+									class="cell-copy mono tech-value"
+									onclick={() => void copyCellValue(ipValue, 'IP')}
+									title={`Скопировать IP ${ipValue}`}
+								>
+									{ipValue}
+								</button>
+							</td>
+							<td class="col-endpoint">
 								<button
 									type="button"
 									class="cell-copy endpoint-copy mono tech-value"
@@ -110,44 +120,119 @@
 										<span class="endpoint-port">{ep.port}</span>
 									{/if}
 								</button>
-							{/if}
-						</td>
-						<td class="col-traffic">
-							<div class="traffic-cell mono tech-value">
-								<div>RX: {formatBytes(peer.rxBytes)}</div>
-								<div>TX: {formatBytes(peer.txBytes)}</div>
-							</div>
-						</td>
-						<td class="mono tech-value col-handshake">
-							{#if peer.lastHandshake}
-								{@const hs = splitHandshakeLabel(formatRelativeTime(peer.lastHandshake))}
-								<span class="handshake-text">{hs.main}</span>
-								{#if hs.suffix}
-									<span class="handshake-suffix">{hs.suffix}</span>
+							</td>
+							<td class="col-traffic">
+								<div class="traffic-cell mono tech-value">
+									<span class="traffic-rx">RX: {formatBytes(peer.rxBytes)}</span>
+									<span class="traffic-tx">TX: {formatBytes(peer.txBytes)}</span>
+								</div>
+							</td>
+							<td class="mono tech-value col-handshake">
+								{#if hs}
+									<span class="handshake-text">{hs.main}</span>
+									{#if hs.suffix}
+										<span class="handshake-suffix">{" "}{hs.suffix}</span>
+									{/if}
+								{:else}
+									-
 								{/if}
+							</td>
+							{#if onDownloadConf}
+								<td class="col-action">
+									<IconButton
+										ariaLabel={`Скачать .conf для «${peerName(peer)}»`}
+										title={`Скачать .conf для «${peerName(peer)}»`}
+										onclick={() => onDownloadConf?.(peer.publicKey)}
+									>
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+											<polyline points="7,10 12,15 17,10" />
+											<line x1="12" y1="15" x2="12" y2="3" />
+										</svg>
+									</IconButton>
+								</td>
+							{/if}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<div class="mobile-peer-list">
+		{#each peers as peer (peer.publicKey)}
+			{@const status = peerStatus(peer)}
+			{@const ipValue = peerIP(peer)}
+			{@const endpointValue = peer.endpoint || '-'}
+			{@const ep = splitEndpoint(endpointValue)}
+			{@const hs = peer.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peer.lastHandshake)) : null}
+			<article class="mobile-peer-card" class:peer-offline={!peer.online} class:peer-disabled={!peer.enabled} class:has-actions={!!onDownloadConf}>
+				<div class="mobile-peer-main">
+					<div class="mobile-peer-title-row">
+						<span
+							class="led"
+							class:led-online={status === 'online'}
+							class:led-offline={status === 'offline'}
+							class:led-disabled={status === 'disabled'}
+						></span>
+						<span class="mobile-peer-name">{peerName(peer)}</span>
+					</div>
+
+					<div class="mobile-peer-status-row">
+						<span>{status}</span>
+						<span class="mobile-peer-handshake">
+							{#if hs}
+								{hs.main}{#if hs.suffix}{" "}{hs.suffix}{/if}
 							{:else}
 								-
 							{/if}
-						</td>
-						{#if onDownloadConf}
-							<td class="col-action">
-								<IconButton
-									ariaLabel={`Скачать .conf для «${peerName(peer)}»`}
-									title={`Скачать .conf для «${peerName(peer)}»`}
-									onclick={() => onDownloadConf?.(peer.publicKey)}
-								>
-									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-										<polyline points="7,10 12,15 17,10"/>
-										<line x1="12" y1="15" x2="12" y2="3"/>
-									</svg>
-								</IconButton>
-							</td>
-						{/if}
-					</tr>
-				{/each}
-			</tbody>
-		</table>
+						</span>
+					</div>
+
+					<div class="mobile-peer-net-row mono tech-value">
+						<button
+							type="button"
+							class="cell-copy mobile-peer-ip"
+							onclick={() => void copyCellValue(ipValue, 'IP')}
+							title={`Скопировать IP ${ipValue}`}
+						>
+							{ipValue}
+						</button>
+
+						<button
+							type="button"
+							class="cell-copy mobile-peer-endpoint"
+							onclick={() => void copyCellValue(endpointValue, 'Endpoint')}
+							title={endpointValue !== '-' ? `Скопировать Endpoint ${endpointValue}` : 'Endpoint отсутствует'}
+						>
+							<span class="mobile-label">EP</span>
+							<span class="mobile-endpoint-value">{endpointValue}</span>
+						</button>
+					</div>
+
+					<div class="mobile-peer-traffic-row mono tech-value">
+						<span>RX: {formatBytes(peer.rxBytes)}</span>
+						<span>TX: {formatBytes(peer.txBytes)}</span>
+					</div>
+				</div>
+
+				{#if onDownloadConf}
+					<div class="mobile-peer-actions">
+						<IconButton
+							ariaLabel={`Скачать .conf для «${peerName(peer)}»`}
+							title={`Скачать .conf для «${peerName(peer)}»`}
+							onclick={() => onDownloadConf?.(peer.publicKey)}
+						>
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+								<polyline points="7,10 12,15 17,10" />
+								<line x1="12" y1="15" x2="12" y2="3" />
+							</svg>
+						</IconButton>
+					</div>
+				{/if}
+			</article>
+		{/each}
 	</div>
 {/if}
 
@@ -155,6 +240,14 @@
 	.peer-table-wrap {
 		overflow-x: auto;
 		margin-top: 0.75rem;
+	}
+
+	.desktop-peer-table {
+		display: block;
+	}
+
+	.mobile-peer-list {
+		display: none;
 	}
 
 	.peer-table {
@@ -169,6 +262,12 @@
 		background: color-mix(in srgb, var(--accent) 16%, transparent);
 		color: var(--accent);
 		border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+		font-weight: 500;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 0.65rem 0.75rem;
+		line-height: 1.2;
 	}
 
 	.peer-table td {
@@ -188,15 +287,6 @@
 		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--text-muted) 35%, transparent);
 	}
 
-	.peer-table th {
-		font-weight: 500;
-		font-size: 0.75rem;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		padding: 0.65rem 0.75rem;
-		line-height: 1.2;
-	}
-
 	.peer-name-cell {
 		text-align: left;
 	}
@@ -204,30 +294,32 @@
 	.peer-name-row {
 		display: flex;
 		align-items: center;
-		gap: 0.35rem;
+		gap: 0.3rem;
 		min-width: 0;
 	}
 
 	.peer-name {
 		font-weight: 500;
+		font-size: 13px;
+		line-height: 1.15;
 		max-width: 150px;
 		white-space: normal;
 		overflow-wrap: anywhere;
 		word-break: break-word;
-		line-height: 1.25;
 	}
 
 	.peer-status-sub {
 		font-size: 10px;
 		color: var(--text-muted);
-		line-height: 1.1;
-		margin-top: 0.25rem;
+		line-height: 1;
+		margin-top: 0.1rem;
 	}
 
 	.mono {
 		font-family: var(--font-mono, monospace);
 		color: var(--text-secondary);
 	}
+
 	.tech-value {
 		font-size: 10px;
 		line-height: 1.15;
@@ -277,20 +369,21 @@
 	.traffic-cell {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
-		gap: 0.1rem;
-		line-height: 1.2;
+		align-items: flex-start;
+		gap: 0;
+		line-height: 1.05;
 		white-space: nowrap;
 	}
 
 	.endpoint-copy {
 		display: inline-flex;
-		flex-direction: column;
-		align-items: center;
+		flex-direction: row;
+		align-items: baseline;
+		gap: 0;
 	}
 
 	.endpoint-text {
-		display: block;
+		display: inline;
 		white-space: normal;
 		overflow-wrap: anywhere;
 		word-break: break-word;
@@ -298,14 +391,14 @@
 	}
 
 	.endpoint-port {
-		display: block;
+		display: inline;
 		white-space: nowrap;
 		line-height: 1.15;
 	}
 
 	.handshake-text,
 	.handshake-suffix {
-		display: block;
+		display: inline;
 	}
 
 	.cell-copy {
@@ -323,8 +416,134 @@
 	}
 
 	@media (max-width: 640px) {
-		.peer-table {
-			min-width: 680px;
+		.desktop-peer-table {
+			display: none;
+		}
+
+		.mobile-peer-list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.4rem;
+		}
+
+		.mobile-peer-card {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 0.5rem;
+			padding: 0.55rem 0.65rem;
+			border: 1px solid var(--border);
+			border-radius: var(--radius);
+			background: var(--bg-primary);
+		}
+
+		.mobile-peer-card:not(.has-actions) {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.mobile-peer-main {
+			min-width: 0;
+		}
+
+		.mobile-peer-title-row {
+			display: flex;
+			align-items: center;
+			gap: 0.3rem;
+			min-width: 0;
+		}
+
+		.mobile-peer-name {
+			min-width: 0;
+			max-width: 100%;
+			font-size: 13px;
+			font-weight: 600;
+			line-height: 1.15;
+			color: var(--text-primary);
+			overflow-wrap: anywhere;
+		}
+
+		.mobile-peer-status-row {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			gap: 0.5rem;
+			margin-top: 0.1rem;
+			font-size: 10px;
+			line-height: 1;
+			color: var(--text-muted);
+		}
+
+		.mobile-peer-handshake {
+			text-align: right;
+			white-space: nowrap;
+			color: var(--text-muted);
+		}
+
+		.mobile-peer-net-row {
+			display: grid;
+			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
+			gap: 0.5rem;
+			margin-top: 0.35rem;
+			line-height: 1.1;
+		}
+
+		.mobile-peer-ip {
+			min-width: 0;
+			text-align: left;
+			white-space: nowrap;
+		}
+
+		.mobile-peer-endpoint {
+			display: inline-flex;
+			flex-direction: row;
+			align-items: flex-end;
+			justify-content: flex-end;
+			gap: 0.25rem;
+			min-width: 0;
+			justify-self: end;
+			max-width: 100%;
+			text-align: right;
+			white-space: nowrap;
+		}
+
+		.mobile-endpoint-value {
+			display: block;
+			min-width: 0;
+			max-width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.mobile-label {
+			flex: 0 0 auto;
+			color: var(--text-muted);
+			font-size: 9px;
+			line-height: 1;
+			letter-spacing: 0.04em;
+		}
+
+		.mobile-peer-traffic-row {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+			gap: 0.5rem;
+			margin-top: 0.25rem;
+			line-height: 1.1;
+		}
+
+		.mobile-peer-traffic-row > span:first-child {
+			justify-self: start;
+		}
+
+		.mobile-peer-traffic-row > span:last-child {
+			justify-self: end;
+			text-align: right;
+		}
+
+		.mobile-peer-actions {
+			display: flex;
+			align-items: flex-start;
+			justify-content: flex-end;
+			gap: 0.25rem;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/PeerTable.svelte
+++ b/frontend/src/lib/components/servers/PeerTable.svelte
@@ -5,7 +5,8 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { peerSort } from '$lib/stores/peerSort';
-	import type { PeerSortKey } from '$lib/utils/peerSort';
+	import { peerAriaSort } from '$lib/utils/peerSort';
+	import PeerTableSortHeader from './PeerTableSortHeader.svelte';
 
 	interface Props {
 		peers: WireguardServerPeer[];
@@ -61,79 +62,7 @@
 		}
 	}
 
-	function ariaSort(key: PeerSortKey): 'ascending' | 'descending' | 'none' {
-		if ($peerSort.sortBy !== key) return 'none';
-		return $peerSort.sortAsc ? 'ascending' : 'descending';
-	}
-
-	function toggleHeaderSort(key: PeerSortKey) {
-		if ($peerSort.sortBy === key) {
-			peerSort.toggleDir();
-		} else {
-			peerSort.setSortBy(key);
-		}
-	}
-
-	function cycleNameHeaderSort() {
-		const { sortBy, sortAsc } = $peerSort;
-
-		if (sortBy !== 'name' && sortBy !== 'online') {
-			peerSort.setSort('name', true);
-			return;
-		}
-
-		if (sortBy === 'name' && sortAsc) {
-			peerSort.setSort('name', false);
-			return;
-		}
-
-		if (sortBy === 'name' && !sortAsc) {
-			peerSort.setSort('online', false);
-			return;
-		}
-
-		if (sortBy === 'online' && !sortAsc) {
-			peerSort.setSort('online', true);
-			return;
-		}
-
-		peerSort.setSort('name', true);
-	}
-
-	function isNameHeaderActive(): boolean {
-		return $peerSort.sortBy === 'name' || $peerSort.sortBy === 'online';
-	}
-
-	function nameHeaderIndicator(): string {
-		if ($peerSort.sortBy === 'name') return $peerSort.sortAsc ? 'A↑' : 'A↓';
-		if ($peerSort.sortBy === 'online') return $peerSort.sortAsc ? '○↑' : '●↓';
-		return '↕';
-	}
-
-	function nameAriaSort(): 'ascending' | 'descending' | 'none' {
-		if ($peerSort.sortBy !== 'name' && $peerSort.sortBy !== 'online') return 'none';
-		return $peerSort.sortAsc ? 'ascending' : 'descending';
-	}
 </script>
-
-{#snippet SortHeader(label: string, key: PeerSortKey)}
-	<button
-		type="button"
-		class="sort-header-btn"
-		class:active={$peerSort.sortBy === key}
-		onclick={() => toggleHeaderSort(key)}
-		title={`Сортировать по колонке «${label}»`}
-	>
-		<span>{label}</span>
-		<span class="sort-indicator" aria-hidden="true">
-			{#if $peerSort.sortBy === key}
-				{$peerSort.sortAsc ? '↑' : '↓'}
-			{:else}
-				↕
-			{/if}
-		</span>
-	</button>
-{/snippet}
 
 {#if peers.length === 0}
 	<p class="text-muted">Нет пиров</p>
@@ -143,23 +72,21 @@
 			<table class="peer-table" class:has-actions={!!onDownloadConf}>
 				<thead>
 					<tr>
-						<th class="col-name" aria-sort={nameAriaSort()}>
-							<button
-								type="button"
-								class="sort-header-btn name-sort-header"
-								class:active={isNameHeaderActive()}
-								onclick={cycleNameHeaderSort}
-								title="Сортировка: имя A→Z, имя Z→A, онлайн сверху, офлайн сверху"
-							>
-								<span>Имя</span>
-								<span class="sort-subhint" aria-hidden="true">/ онлайн</span>
-								<span class="sort-indicator" aria-hidden="true">{nameHeaderIndicator()}</span>
-							</button>
+						<th class="col-name" aria-sort={peerAriaSort($peerSort, 'name')}>
+							<PeerTableSortHeader label="Имя" sortKey="name" />
 						</th>
-						<th class="col-ip" aria-sort={ariaSort('ip')}>{@render SortHeader('IP', 'ip')}</th>
-						<th class="col-endpoint" aria-sort={ariaSort('endpoint')}>{@render SortHeader('Endpoint', 'endpoint')}</th>
-						<th class="col-traffic" aria-sort={ariaSort('traffic')}>{@render SortHeader('Трафик', 'traffic')}</th>
-						<th class="col-handshake" aria-sort={ariaSort('handshake')}>{@render SortHeader('Handshake', 'handshake')}</th>
+						<th class="col-ip" aria-sort={peerAriaSort($peerSort, 'ip')}>
+							<PeerTableSortHeader label="IP" sortKey="ip" />
+						</th>
+						<th class="col-endpoint" aria-sort={peerAriaSort($peerSort, 'endpoint')}>
+							<PeerTableSortHeader label="Endpoint" sortKey="endpoint" />
+						</th>
+						<th class="col-traffic" aria-sort={peerAriaSort($peerSort, 'traffic')}>
+							<PeerTableSortHeader label="Трафик" sortKey="traffic" />
+						</th>
+						<th class="col-handshake" aria-sort={peerAriaSort($peerSort, 'handshake')}>
+							<PeerTableSortHeader label="Handshake" sortKey="handshake" />
+						</th>
 						{#if onDownloadConf}
 							<th class="col-action"></th>
 						{/if}
@@ -251,10 +178,9 @@
 			{@const status = peerStatus(peer)}
 			{@const ipValue = peerIP(peer)}
 			{@const endpointValue = peer.endpoint || '-'}
-			{@const ep = splitEndpoint(endpointValue)}
 			{@const hs = peer.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peer.lastHandshake)) : null}
 			<article class="mobile-peer-card" class:peer-offline={!peer.online} class:peer-disabled={!peer.enabled} class:has-actions={!!onDownloadConf}>
-				<div class="mobile-peer-main">
+				<div class="mobile-peer-card-top">
 					<div class="mobile-peer-title-row">
 						<span
 							class="led"
@@ -265,6 +191,24 @@
 						<span class="mobile-peer-name">{peerName(peer)}</span>
 					</div>
 
+					{#if onDownloadConf}
+						<div class="mobile-peer-actions">
+							<IconButton
+								ariaLabel={`Скачать .conf для «${peerName(peer)}»`}
+								title={`Скачать .conf для «${peerName(peer)}»`}
+								onclick={() => onDownloadConf?.(peer.publicKey)}
+							>
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+									<polyline points="7,10 12,15 17,10" />
+									<line x1="12" y1="15" x2="12" y2="3" />
+								</svg>
+							</IconButton>
+						</div>
+					{/if}
+				</div>
+
+				<div class="mobile-peer-card-middle">
 					<div class="mobile-peer-status-row">
 						<span>{status}</span>
 						<span class="mobile-peer-handshake">
@@ -296,28 +240,14 @@
 							<span class="mobile-endpoint-value">{endpointValue}</span>
 						</button>
 					</div>
+				</div>
 
+				<div class="mobile-peer-card-bottom">
 					<div class="mobile-peer-traffic-row mono tech-value">
 						<span>RX: {formatBytes(peer.rxBytes)}</span>
 						<span>TX: {formatBytes(peer.txBytes)}</span>
 					</div>
 				</div>
-
-				{#if onDownloadConf}
-					<div class="mobile-peer-actions">
-						<IconButton
-							ariaLabel={`Скачать .conf для «${peerName(peer)}»`}
-							title={`Скачать .conf для «${peerName(peer)}»`}
-							onclick={() => onDownloadConf?.(peer.publicKey)}
-						>
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-								<polyline points="7,10 12,15 17,10" />
-								<line x1="12" y1="15" x2="12" y2="3" />
-							</svg>
-						</IconButton>
-					</div>
-				{/if}
 			</article>
 		{/each}
 	</div>
@@ -360,18 +290,16 @@
 	.peer-table td {
 		padding: 0.5rem 0.75rem;
 		border-bottom: 1px solid var(--border);
-		transition: background-color 0.15s ease, box-shadow 0.15s ease;
+		transition: background-color 0.15s ease;
 	}
 
 	.peer-table tbody tr:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
-		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 35%, transparent);
 	}
 
 	.peer-table tbody tr.peer-offline:hover td,
 	.peer-table tbody tr.peer-disabled:hover td {
 		background: color-mix(in srgb, var(--bg-hover) 45%, transparent);
-		box-shadow: inset 2px 0 0 color-mix(in srgb, var(--text-muted) 35%, transparent);
 	}
 
 	.peer-name-cell {
@@ -442,10 +370,18 @@
 	}
 
 	.col-ip,
-	.col-endpoint,
 	.col-traffic,
 	.col-handshake {
 		text-align: center;
+	}
+
+	.peer-table th.col-endpoint {
+		text-align: center;
+	}
+
+	.peer-table td.col-endpoint {
+		text-align: left;
+		vertical-align: middle;
 	}
 
 	.col-action {
@@ -464,9 +400,12 @@
 
 	.endpoint-copy {
 		display: inline-flex;
-		flex-direction: row;
-		align-items: baseline;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
 		gap: 0;
+		max-width: 100%;
+		text-align: left;
 	}
 
 	.endpoint-text {
@@ -502,59 +441,6 @@
 		color: var(--text-primary);
 	}
 
-	.sort-header-btn {
-		width: 100%;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.3rem;
-		padding: 0;
-		border: 0;
-		background: transparent;
-		color: inherit;
-		font: inherit;
-		font-weight: inherit;
-		text-transform: inherit;
-		letter-spacing: inherit;
-		cursor: pointer;
-	}
-
-	.sort-header-btn:hover {
-		color: var(--text-primary);
-	}
-
-	.sort-header-btn.active {
-		color: var(--accent);
-	}
-
-	.name-sort-header {
-		justify-content: center;
-	}
-
-	.sort-subhint {
-		opacity: 0.65;
-		font-size: 0.85em;
-		font-weight: inherit;
-		text-transform: none;
-		letter-spacing: normal;
-	}
-
-	.sort-header-btn.active .sort-subhint {
-		opacity: 0.85;
-	}
-
-	.sort-indicator {
-		min-width: 1.8em;
-		text-align: left;
-		flex: 0 0 auto;
-		opacity: 0.65;
-		font-size: 0.8em;
-	}
-
-	.sort-header-btn.active .sort-indicator {
-		opacity: 1;
-	}
-
 	@media (max-width: 640px) {
 		.desktop-peer-table {
 			display: none;
@@ -563,31 +449,36 @@
 		.mobile-peer-list {
 			display: flex;
 			flex-direction: column;
-			gap: 0.4rem;
+			gap: 0.6rem;
 		}
 
 		.mobile-peer-card {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) auto;
-			gap: 0.5rem;
-			padding: 0.55rem 0.65rem;
+			display: flex;
+			flex-direction: column;
+			gap: 0.65rem;
+			padding: 0.7rem 0.75rem;
 			border: 1px solid var(--border);
 			border-radius: var(--radius);
 			background: var(--bg-primary);
 		}
 
-		.mobile-peer-card:not(.has-actions) {
-			grid-template-columns: minmax(0, 1fr);
+		.mobile-peer-card-top {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			align-items: start;
+			gap: 0.5rem;
 		}
 
-		.mobile-peer-main {
+		.mobile-peer-card-middle,
+		.mobile-peer-card-bottom,
+		.mobile-peer-title-row {
 			min-width: 0;
 		}
 
 		.mobile-peer-title-row {
 			display: flex;
 			align-items: center;
-			gap: 0.3rem;
+			gap: 0.45rem;
 			min-width: 0;
 		}
 
@@ -606,7 +497,7 @@
 			justify-content: space-between;
 			align-items: center;
 			gap: 0.5rem;
-			margin-top: 0.1rem;
+			margin-top: 0.2rem;
 			font-size: 10px;
 			line-height: 1;
 			color: var(--text-muted);
@@ -622,7 +513,7 @@
 			display: grid;
 			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
 			gap: 0.5rem;
-			margin-top: 0.35rem;
+			margin-top: 0.45rem;
 			line-height: 1.1;
 		}
 
@@ -666,7 +557,7 @@
 			display: grid;
 			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 			gap: 0.5rem;
-			margin-top: 0.25rem;
+			margin-top: 0.35rem;
 			line-height: 1.1;
 		}
 
@@ -684,6 +575,31 @@
 			align-items: flex-start;
 			justify-content: flex-end;
 			gap: 0.25rem;
+			align-self: start;
+		}
+
+		.mobile-peer-actions :global(button) {
+			width: 32px;
+			height: 32px;
+			flex: 0 0 32px;
+			padding: 0;
+		}
+
+		@media (max-width: 360px) {
+			.mobile-peer-card-top {
+				grid-template-columns: minmax(0, 1fr) auto;
+			}
+
+			.mobile-peer-actions {
+				flex-wrap: nowrap;
+				gap: 0.2rem;
+			}
+
+			.mobile-peer-actions :global(button) {
+				width: 30px;
+				height: 30px;
+				flex-basis: 30px;
+			}
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/PeerTableSortHeader.svelte
+++ b/frontend/src/lib/components/servers/PeerTableSortHeader.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { peerSort } from '$lib/stores/peerSort';
+	import type { PeerSortKey } from '$lib/utils/peerSort';
+
+	interface Props {
+		label: string;
+		sortKey: PeerSortKey;
+	}
+
+	let { label, sortKey }: Props = $props();
+
+	function toggleSort() {
+		if ($peerSort.sortBy === sortKey) {
+			peerSort.toggleDir();
+		} else {
+			peerSort.setSortBy(sortKey);
+		}
+	}
+</script>
+
+<button
+	type="button"
+	class="sort-header-btn"
+	class:active={$peerSort.sortBy === sortKey}
+	onclick={toggleSort}
+	title={`Сортировать по колонке «${label}»`}
+>
+	<span>{label}</span>
+	<span class="sort-indicator" aria-hidden="true">
+		{#if $peerSort.sortBy === sortKey}
+			{$peerSort.sortAsc ? '↑' : '↓'}
+		{:else}
+			↕
+		{/if}
+	</span>
+</button>
+
+<style>
+	.sort-header-btn {
+		width: 100%;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.3rem;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-weight: inherit;
+		text-transform: inherit;
+		letter-spacing: inherit;
+		cursor: pointer;
+	}
+
+	.sort-header-btn:hover {
+		color: var(--text-primary);
+	}
+
+	.sort-header-btn.active {
+		color: var(--accent);
+	}
+
+	.sort-indicator {
+		width: 1em;
+		flex: 0 0 auto;
+		opacity: 0.65;
+		font-size: 0.8em;
+	}
+
+	.sort-header-btn.active .sort-indicator {
+		opacity: 1;
+	}
+</style>

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -388,4 +388,38 @@
 		color: var(--text-secondary);
 	}
 
+	@media (max-width: 640px) {
+		.server-header {
+			flex-direction: column;
+		}
+
+		.server-header-right {
+			width: 100%;
+			justify-content: space-between;
+		}
+
+		.server-stats {
+			display: grid;
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 0.5rem;
+		}
+
+		.stat {
+			min-width: 0;
+			padding: 0.5rem;
+			border: 1px solid var(--border);
+			border-radius: var(--radius-sm);
+			background: var(--bg-primary);
+		}
+
+		.peers-header {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.peers-header :global(.peer-sort-controls) {
+			width: 100%;
+		}
+	}
+
 </style>

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -58,6 +58,7 @@
 				{
 					name: a.description || a.publicKey,
 					ip: peerIP(a),
+					endpoint: a.endpoint || '-',
 					rxBytes: a.rxBytes,
 					txBytes: a.txBytes,
 					online: a.online,
@@ -66,6 +67,7 @@
 				{
 					name: b.description || b.publicKey,
 					ip: peerIP(b),
+					endpoint: b.endpoint || '-',
 					rxBytes: b.rxBytes,
 					txBytes: b.txBytes,
 					online: b.online,
@@ -185,6 +187,7 @@
 				<PeerSortControls
 					bind:searchQuery
 					showSearch={(server.peers ?? []).length >= 5}
+					hideSortOnDesktop
 				/>
 			</div>
 			<PeerTable
@@ -337,17 +340,23 @@
 	}
 
 	.server-stats {
-		display: flex;
-		gap: 1.5rem;
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0.5rem;
 		padding: 0.5rem 0;
 		border-top: 1px solid var(--border);
 		border-bottom: 1px solid var(--border);
 	}
 
 	.stat {
+		min-width: 0;
 		display: flex;
 		flex-direction: column;
 		gap: 0.125rem;
+		padding: 0.5rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
 	}
 
 	.stat-label {
@@ -396,20 +405,6 @@
 		.server-header-right {
 			width: 100%;
 			justify-content: space-between;
-		}
-
-		.server-stats {
-			display: grid;
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-			gap: 0.5rem;
-		}
-
-		.stat {
-			min-width: 0;
-			padding: 0.5rem;
-			border: 1px solid var(--border);
-			border-radius: var(--radius-sm);
-			background: var(--bg-primary);
 		}
 
 		.peers-header {

--- a/frontend/src/lib/components/servers/index.ts
+++ b/frontend/src/lib/components/servers/index.ts
@@ -1,5 +1,6 @@
 export { default as ServerCard } from './ServerCard.svelte';
 export { default as PeerTable } from './PeerTable.svelte';
+export { default as PeerTableSortHeader } from './PeerTableSortHeader.svelte';
 export { default as PeerSortControls } from './PeerSortControls.svelte';
 export { default as ConfGeneratorModal } from './ConfGeneratorModal.svelte';
 export { default as AddServerModal } from './AddServerModal.svelte';

--- a/frontend/src/lib/stores/peerSort.ts
+++ b/frontend/src/lib/stores/peerSort.ts
@@ -4,7 +4,7 @@ import { PEER_SORT_DEFAULTS, type PeerSortKey } from '$lib/utils/peerSort';
 
 const storageKey = 'awg-manager-peer-sort';
 
-const VALID_KEYS = new Set<PeerSortKey>(['name', 'traffic', 'ip', 'online', 'handshake']);
+const VALID_KEYS = new Set<PeerSortKey>(['name', 'traffic', 'ip', 'endpoint', 'online', 'handshake']);
 
 export interface PeerSortState {
 	sortBy: PeerSortKey;
@@ -43,10 +43,15 @@ function persist(state: PeerSortState) {
 }
 
 function createPeerSortStore() {
-	const { subscribe, update } = writable<PeerSortState>(getInitial());
+	const { subscribe, set, update } = writable<PeerSortState>(getInitial());
 
 	return {
 		subscribe,
+		setSort(sortBy: PeerSortKey, sortAsc: boolean) {
+			const next: PeerSortState = { sortBy, sortAsc };
+			persist(next);
+			set(next);
+		},
 		setSortBy(key: PeerSortKey) {
 			update((s) => {
 				if (s.sortBy === key) return s;

--- a/frontend/src/lib/utils/peerSort.ts
+++ b/frontend/src/lib/utils/peerSort.ts
@@ -1,9 +1,10 @@
-export type PeerSortKey = 'name' | 'traffic' | 'ip' | 'online' | 'handshake';
+export type PeerSortKey = 'name' | 'traffic' | 'ip' | 'endpoint' | 'online' | 'handshake';
 
 export const PEER_SORT_DEFAULTS: Record<PeerSortKey, boolean> = {
 	name: true,       // A→Z
 	traffic: false,   // most first
 	ip: true,         // low→high
+	endpoint: true,   // A→Z
 	online: false,    // online first
 	handshake: false, // recent first
 };
@@ -11,6 +12,7 @@ export const PEER_SORT_DEFAULTS: Record<PeerSortKey, boolean> = {
 export interface PeerSortFields {
 	name: string;
 	ip: string;
+	endpoint: string;
 	rxBytes: number | null;
 	txBytes: number | null;
 	online: boolean | null;
@@ -31,6 +33,21 @@ function compareNullableNumbers(a: number | null, b: number | null, sortAsc: boo
 	return sortAsc ? a - b : b - a;
 }
 
+function normalizeEndpointSortValue(endpoint: string): string | null {
+	const trimmed = endpoint.trim();
+	if (!trimmed || trimmed === '-') return null;
+	return trimmed.toLowerCase();
+}
+
+function compareNullableStrings(a: string | null, b: string | null, sortAsc: boolean): number {
+	// Missing values are always last, regardless of direction.
+	if (a === null && b === null) return 0;
+	if (a === null) return 1;
+	if (b === null) return -1;
+	const cmp = a.localeCompare(b);
+	return sortAsc ? cmp : -cmp;
+}
+
 export function parseIPv4(ip: string): number {
 	const bare = ip.split('/')[0] ?? '';
 	const parts = bare.split('.').map((s) => {
@@ -49,6 +66,14 @@ function comparePeerFields(a: PeerSortFields, b: PeerSortFields, sortBy: PeerSor
 			return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
 		case 'ip':
 			return parseIPv4(a.ip) - parseIPv4(b.ip);
+		case 'endpoint': {
+			const ea = normalizeEndpointSortValue(a.endpoint);
+			const eb = normalizeEndpointSortValue(b.endpoint);
+			if (ea === null && eb === null) return 0;
+			if (ea === null) return 1;
+			if (eb === null) return -1;
+			return ea.localeCompare(eb);
+		}
 		case 'traffic': {
 			const ta = a.rxBytes !== null && a.txBytes !== null ? a.rxBytes + a.txBytes : -1;
 			const tb = b.rxBytes !== null && b.txBytes !== null ? b.rxBytes + b.txBytes : -1;
@@ -84,6 +109,11 @@ export function comparePeerFieldsDirected(
 		const ta = a.rxBytes !== null && a.txBytes !== null ? a.rxBytes + a.txBytes : null;
 		const tb = b.rxBytes !== null && b.txBytes !== null ? b.rxBytes + b.txBytes : null;
 		return compareNullableNumbers(ta, tb, sortAsc);
+	}
+	if (sortBy === 'endpoint') {
+		const ea = normalizeEndpointSortValue(a.endpoint);
+		const eb = normalizeEndpointSortValue(b.endpoint);
+		return compareNullableStrings(ea, eb, sortAsc);
 	}
 	if (sortBy === 'online') {
 		const oa = a.online === null ? null : (a.online ? 1 : 0);

--- a/frontend/src/lib/utils/peerSort.ts
+++ b/frontend/src/lib/utils/peerSort.ts
@@ -1,4 +1,5 @@
 export type PeerSortKey = 'name' | 'traffic' | 'ip' | 'endpoint' | 'online' | 'handshake';
+export type PeerAriaSort = 'ascending' | 'descending' | 'none';
 
 export const PEER_SORT_DEFAULTS: Record<PeerSortKey, boolean> = {
 	name: true,       // A→Z
@@ -17,6 +18,16 @@ export interface PeerSortFields {
 	txBytes: number | null;
 	online: boolean | null;
 	lastHandshake: string | null;
+}
+
+export interface PeerSortStateLike {
+	sortBy: PeerSortKey;
+	sortAsc: boolean;
+}
+
+export function peerAriaSort(state: PeerSortStateLike, key: PeerSortKey): PeerAriaSort {
+	if (state.sortBy !== key) return 'none';
+	return state.sortAsc ? 'ascending' : 'descending';
 }
 
 function parseHandshakeOrNull(v: string | null): number | null {


### PR DESCRIPTION
## Что сделано

PR объединяет две связанные правки серверных таблиц клиентов:

1. Мобильная адаптация таблиц пиров:
   - desktop-таблицы сохранены отдельно;
   - на mobile таблицы заменены на compact-card layout;
   - карточки показывают имя, статус, handshake, IP, Endpoint, RX/TX и действия без горизонтального скролла;
   - Endpoint удерживается цельной строкой с ellipsis и копируется полностью;
   - actions/toggle/download/edit/delete сохранены.

2. Улучшение desktop-таблиц:
   - сортировка вынесена в кликабельные заголовки колонок;
   - добавлена сортировка по Endpoint;
   - первая колонка получила умный цикл `Имя / онлайн`:
     - имя A→Z;
     - имя Z→A;
     - online first;
     - offline/disabled first;
   - desktop dropdown-сортировка скрыта, mobile dropdown оставлен для карточного режима;
   - блок статистики обычной server card растянут на всю доступную ширину.

## Затронутые зоны

- `ManagedPeerTable`
- `PeerTable`
- `PeerSortControls`
- `ManagedServerCard`
- `ServerCard`
- `peerSort` store/util

## Не затрагивалось

- backend
- OpenAPI
- VERSION
- package-lock
- API логика серверов
- бизнес-логика toggle/edit/delete/download/copy

## Проверка

- `cd frontend && npm run check`
- desktop: сортировка по заголовкам обеих серверных таблиц
- mobile 390px: карточки клиентов без горизонтального скролла
- проверка длинных endpoint, offline/disabled клиентов и действий

<img width="488" height="2314" alt="image" src="https://github.com/user-attachments/assets/4aea566b-4a02-4c2b-b840-d5b42016cc32" />

<img width="2145" height="1250" alt="image" src="https://github.com/user-attachments/assets/8f59e2d6-f388-461f-997a-c3d356e3a96a" />
