### PR TITLE
fix(hrneo): tighten desktop rule card layout

### DIFF
--- a/frontend/src/lib/components/hrneo/HrNeoRuleCard.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoRuleCard.svelte
@@ -70,14 +70,16 @@
 
 <style>
 	.hr-card {
-		display: flex;
-		justify-content: space-between;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
 		gap: 12px;
 		border-radius: 8px;
 		padding: 12px 14px;
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
 		transition: border-color 0.2s;
+		min-width: 0;
 	}
 	.hr-card:hover {
 		border-color: var(--border-hover);
@@ -91,7 +93,6 @@
 		gap: 12px;
 		align-items: center;
 		min-width: 0;
-		flex: 1;
 	}
 
 	.card-info {
@@ -99,6 +100,7 @@
 		flex-direction: column;
 		gap: 2px;
 		min-width: 0;
+		max-width: 100%;
 	}
 
 	.card-title {
@@ -106,6 +108,7 @@
 		align-items: center;
 		gap: 6px;
 		min-width: 0;
+		max-width: 100%;
 	}
 
 	.card-title h3 {
@@ -113,12 +116,12 @@
 		font-size: 0.9375rem;
 		color: var(--text-primary);
 		font-weight: 600;
-		/* min-width: 0 нужен, чтобы flex-item с nowrap-текстом
-		   сжимался ниже min-content и срабатывал ellipsis. */
 		min-width: 0;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		max-width: 100%;
+		white-space: normal;
+		overflow-wrap: anywhere;
+		word-break: break-word;
+		line-height: 1.2;
 	}
 
 	.led {
@@ -151,11 +154,15 @@
 		gap: 6px;
 		flex-wrap: wrap;
 		margin-top: 2px;
+		min-width: 0;
 	}
 
 	.card-stat {
 		font-size: 0.75rem;
 		color: var(--text-muted);
+		white-space: normal;
+		overflow-wrap: anywhere;
+		word-break: break-word;
 	}
 	.card-stat.geo {
 		color: var(--info);
@@ -165,7 +172,16 @@
 		display: flex;
 		gap: 4px;
 		align-items: center;
+		justify-content: flex-end;
 		flex-shrink: 0;
+	}
+
+	@media (max-width: 640px) {
+		.hr-card {
+			grid-template-columns: minmax(0, 1fr) auto;
+			padding: 10px 12px;
+			align-items: start;
+		}
 	}
 
 	.icon-btn {

--- a/frontend/src/lib/components/hrneo/HrNeoRulesList.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoRulesList.svelte
@@ -130,6 +130,18 @@
 		border-radius: 8px;
 	}
 
+	.route-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 12px;
+	}
+
+	@media (min-width: 760px) {
+		.route-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
 	@media (max-width: 640px) {
 		.list-header {
 			flex-wrap: wrap;


### PR DESCRIPTION
- Добавлена отдельная сетка для плиток HR Neo: одна колонка на мобильных и две колонки на desktop.
- Карточка правила HR Neo переведена на grid-layout, чтобы область текста и кнопки действий не мешали друг другу.
- Названия и счётчики в карточке теперь могут переноситься, а не обрезаются слишком рано.
- Кнопки редактирования и удаления остаются закреплены справа.
- Логика, backend и общие стили action-кнопок не затронуты.

<img width="2145" height="1250" alt="image" src="https://github.com/user-attachments/assets/a07670e0-453d-410a-94b4-271b1f03ec40" />
<img width="488" height="1055" alt="image" src="https://github.com/user-attachments/assets/d3eeef15-59a1-44f6-b836-a8fa1b88354c" />
