### PR TITLE
fix(hrneo):geo-data-actions-layout

### DIFF
--- a/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
@@ -350,18 +350,24 @@
 
 <div class="geo-pane">
 	<header class="pane-header">
-		<h2>Гео-данные</h2>
-		<span class="pane-meta">{files.length} файла</span>
-		<Button
-			variant="ghost"
-			size="sm"
-			disabled={routeActionsDisabled}
-			loading={busy === 'sync'}
-			onclick={syncFromHR}
-			title="Подтянуть пути из hrneo.conf (External) и перекачать файлы AWGM (External не трогаем — обновляйте в HR Neo)"
-		>
-			Синхронизировать
-		</Button>
+		<div class="pane-title">
+			<h2>Гео-данные</h2>
+			<span class="pane-meta">{files.length} файла</span>
+		</div>
+
+		<div class="pane-actions">
+			<Button
+				variant="secondary"
+				size="sm"
+				fullWidth
+				disabled={routeActionsDisabled}
+				loading={busy === 'sync'}
+				onclick={syncFromHR}
+				title="Подтянуть пути из hrneo.conf (External) и перекачать файлы AWGM (External не трогаем — обновляйте в HR Neo)"
+			>
+				Синхронизировать
+			</Button>
+		</div>
 	</header>
 
 	{#if err}<div class="error-banner">{err}</div>{/if}
@@ -452,7 +458,7 @@
 						{/if}
 						{#if canUpdate(f)}
 							<Button
-								variant="ghost"
+								variant="secondary"
 								size="sm"
 								disabled={routeActionsDisabled}
 								loading={busy === f.path}
@@ -461,9 +467,8 @@
 								Обновить
 							</Button>
 						{/if}
-						<!-- TODO Phase 1: ghost variant with red danger hover (was .row-danger) -->
 						<Button
-							variant="ghost"
+							variant="secondary"
 							size="sm"
 							disabled={busy !== null}
 							onclick={() => requestRemove(f)}
@@ -601,15 +606,29 @@
 	}
 
 	.pane-header {
-		display: flex;
-		align-items: baseline;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
 		gap: 10px;
-		flex-wrap: wrap;
 		padding-bottom: 10px;
 		border-bottom: 1px solid var(--border);
 	}
-	.pane-header :global(button) {
-		margin-left: auto;
+
+	.pane-title {
+		display: flex;
+		align-items: baseline;
+		gap: 10px;
+		min-width: 0;
+	}
+
+	.pane-actions {
+		display: flex;
+		justify-content: flex-end;
+		min-width: 0;
+	}
+
+	.pane-actions :global(.btn) {
+		min-width: 150px;
 	}
 	.pane-header h2 {
 		margin: 0;
@@ -728,8 +747,15 @@
 
 	.file-actions {
 		display: flex;
-		gap: 4px;
+		gap: 6px;
 		flex-shrink: 0;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	.file-actions :global(.btn) {
+		width: auto;
+		min-width: auto;
 	}
 
 	.add-form {
@@ -874,6 +900,24 @@
 	}
 
 	@media (max-width: 640px) {
+		.pane-header {
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+			align-items: center;
+		}
+
+		.pane-title {
+			min-width: 0;
+		}
+
+		.pane-actions {
+			width: 100%;
+		}
+
+		.pane-actions :global(.btn) {
+			width: 100%;
+			min-width: 0;
+		}
+
 		.file-row {
 			flex-direction: column;
 			align-items: stretch;
@@ -884,8 +928,48 @@
 			row-gap: 4px;
 		}
 		.file-actions {
-			justify-content: flex-end;
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 6px;
+			width: 100%;
+			justify-content: stretch;
 		}
+
+		.file-actions :global(.btn) {
+			width: 100%;
+			min-width: 0;
+			height: 28px;
+			min-height: 28px;
+			max-height: 28px;
+		}
+
+		.file-actions :global(.btn):only-child {
+			grid-column: 1 / -1;
+		}
+
+		.file-actions :global(.btn:first-child:nth-last-child(3)) {
+			grid-column: 1 / -1;
+		}
+
+		.preset-row {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 6px;
+			align-items: stretch;
+		}
+
+		.preset-row :global(.btn) {
+			width: 100%;
+			min-width: 0;
+			height: 28px;
+			min-height: 28px;
+			max-height: 28px;
+		}
+
+		.preset-hint {
+			grid-column: 1 / -1;
+		}
+
 		.add-row {
 			grid-template-columns: 1fr;
 		}


### PR DESCRIPTION
Проверено по diff.

Вердикт: можно принимать

Что сделано:
- кнопка "Синхронизировать" в HR Neo → Гео-данные переведена с ghost на нормальную secondary-кнопку;
- header "Гео-данные" разделён на title/actions;
- на mobile header стал 50/50: слева заголовок и счётчик файлов, справа кнопка "Синхронизировать";
- "Обновить" и "Удалить" в строке geo-файла переведены с ghost на secondary;
- desktop file actions возвращены к компактному виду справа, без растягивания на половину строки;
- на mobile file actions стали grid 50/50;
- preset-кнопки Ground-Zerro на mobile стали 50/50;
- высота mobile action/preset кнопок зафиксирована на стандартные 28px, как у Button size="sm";
- hint пресетов уходит отдельной строкой ниже;
- логика sync/update/delete/take-control не менялась.

Что проверить руками:
1. Mobile 390px:
   - "Синхронизировать" занимает правую половину header;
   - "Взять под управление" / "Удалить" идут 50/50 и такой же высоты, как sync;
   - "+ geoip_GA.dat" / "+ geosite_GA.dat" идут 50/50 и такой же высоты;
   - нет горизонтального скролла.

2. Desktop:
   - "Синхронизировать" выглядит как обычная secondary-кнопка справа;
   - file row читается нормально: type/name/meta слева, компактные кнопки справа;
   - "Взять под управление" и "Удалить" не растягиваются на половину строки;
   - preset-кнопки остаются компактными слева, hint рядом.

Проверка:
npm run check --prefix frontend

before:
<img width="490" height="1055" alt="2026-06-03_12-35-08" src="https://github.com/user-attachments/assets/4f17c267-ebdd-48b5-8938-ecf7edc7d3aa" />

after:
<img width="488" height="1055" alt="image" src="https://github.com/user-attachments/assets/70b9438b-4e1d-4d80-8aba-ca685ee0165c" />
