### PR TITLE
fix(sb-router): outbounds — имя подписки вместо sub-<hash>

### DIFF
--- a/frontend/src/lib/components/sb-router/ExpertPanel.svelte
+++ b/frontend/src/lib/components/sb-router/ExpertPanel.svelte
@@ -16,6 +16,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
+  import { subscriptionsStore } from '$lib/stores/subscriptions';
   import { notifications } from '$lib/stores/notifications';
   import { api } from '$lib/api/client';
   import { computeRuleSetUsage } from '$lib/components/routing/singboxRouter';
@@ -436,6 +437,7 @@
       >
         <OutboundsCompact
           outbounds={$storeOutbounds}
+          subscriptions={$subscriptionsStore.data ?? []}
           onEdit={(tag) => (outboundEditTag = tag)}
         />
       </SidePanel>

--- a/frontend/src/lib/components/sb-router/OutboundsCompact.svelte
+++ b/frontend/src/lib/components/sb-router/OutboundsCompact.svelte
@@ -3,15 +3,18 @@
 -->
 
 <script lang="ts">
-  import type { SingboxRouterOutbound } from '$lib/types';
+  import type { SingboxRouterOutbound, Subscription } from '$lib/types';
   import { Badge } from '$lib/components/ui';
+  import { outboundDisplay } from './outboundLabel';
 
   interface Props {
     outbounds: SingboxRouterOutbound[];
     onEdit: (tag: string) => void;
+    /** Subscriptions, to resolve sub-<hash> composite tags to their names. */
+    subscriptions?: Subscription[];
   }
 
-  let { outbounds, onEdit }: Props = $props();
+  let { outbounds, onEdit, subscriptions = [] }: Props = $props();
 
   function toneFor(type: string): 'success' | 'accent' | 'info' | 'muted' | 'error' {
     if (type === 'direct') return 'muted';
@@ -23,23 +26,16 @@
     if (type === 'selector' || type === 'urltest' || type === 'loadbalance') return 'composite';
     return type;
   }
-
-  function subFor(o: SingboxRouterOutbound): string {
-    if (o.type === 'selector') return 'selector';
-    if (o.type === 'urltest') return 'urltest';
-    if (o.type === 'loadbalance') return 'loadbalance';
-    if (o.type === 'direct') return o.bind_interface ? `direct · → ${o.bind_interface}` : 'direct';
-    return o.type;
-  }
 </script>
 
 <div class="list">
   {#each outbounds as o (o.tag)}
+    {@const d = outboundDisplay(o, subscriptions)}
     <button type="button" class="row" onclick={() => onEdit(o.tag)}>
       <span class="dot" data-tone={toneFor(o.type)}></span>
       <div class="meta">
-        <div class="tag">{o.tag}</div>
-        <div class="sub">{subFor(o)}</div>
+        <div class="tag">{d.title}</div>
+        <div class="sub">{d.subtitle}</div>
       </div>
       <Badge variant="default" size="sm">{kindLabel(o.type)}</Badge>
     </button>

--- a/frontend/src/lib/components/sb-router/outboundLabel.test.ts
+++ b/frontend/src/lib/components/sb-router/outboundLabel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { outboundDisplay } from './outboundLabel';
+import type { Subscription } from '$lib/types';
+
+const subs = [
+	{ selectorTag: 'sub-1a98d416', label: 'Veesp LV' },
+	{ selectorTag: 'sub-58dea6ef', label: 'Veesp NL' },
+] as unknown as Subscription[];
+
+describe('outboundDisplay', () => {
+	it('subscription composite → subscription label, not raw tag', () => {
+		expect(outboundDisplay({ type: 'urltest', tag: 'sub-1a98d416', source: 'subscription' }, subs)).toEqual({
+			title: 'Veesp LV',
+			subtitle: 'подписка',
+		});
+	});
+
+	it('subscription composite without a matching subscription → falls back to tag', () => {
+		expect(outboundDisplay({ type: 'urltest', tag: 'sub-unknown', source: 'subscription' }, subs)).toEqual({
+			title: 'sub-unknown',
+			subtitle: 'подписка',
+		});
+	});
+
+	it('router composite → tag + type subtitle', () => {
+		expect(outboundDisplay({ type: 'selector', tag: 'my-selector', source: 'router' }, subs)).toEqual({
+			title: 'my-selector',
+			subtitle: 'selector',
+		});
+	});
+
+	it('direct with bind_interface → arrow subtitle', () => {
+		expect(outboundDisplay({ type: 'direct', tag: 'direct-eth3', bind_interface: 'eth3' }, subs)).toEqual({
+			title: 'direct-eth3',
+			subtitle: 'direct · → eth3',
+		});
+	});
+
+	it('no subscriptions list → tag fallback', () => {
+		expect(outboundDisplay({ type: 'urltest', tag: 'sub-1a98d416', source: 'subscription' }, null)).toEqual({
+			title: 'sub-1a98d416',
+			subtitle: 'подписка',
+		});
+	});
+});

--- a/frontend/src/lib/components/sb-router/outboundLabel.ts
+++ b/frontend/src/lib/components/sb-router/outboundLabel.ts
@@ -1,0 +1,31 @@
+import type { SingboxRouterOutbound, Subscription } from '$lib/types';
+
+export interface OutboundDisplay {
+	title: string;
+	subtitle: string;
+}
+
+function typeSubtitle(o: SingboxRouterOutbound): string {
+	if (o.type === 'direct') return o.bind_interface ? `direct · → ${o.bind_interface}` : 'direct';
+	return o.type; // selector / urltest / loadbalance
+}
+
+/**
+ * Resolves how a composite outbound is shown in the outbounds list.
+ *
+ * Subscription-sourced composites carry a generated `sub-<hash>` tag; the
+ * human name lives on the Subscription (matched by selectorTag === o.tag).
+ * Show that name instead of the raw tag so the outbounds list matches the
+ * subscriptions section ("Veesp LV", not "sub-1a98d416"). Same mapping the
+ * dropdown already does via buildOutboundOptions.
+ */
+export function outboundDisplay(
+	o: SingboxRouterOutbound,
+	subscriptions: Subscription[] | undefined | null,
+): OutboundDisplay {
+	if (o.source === 'subscription') {
+		const sub = subscriptions?.find((s) => s.selectorTag === o.tag);
+		return { title: sub?.label || o.tag, subtitle: 'подписка' };
+	}
+	return { title: o.tag, subtitle: typeSubtitle(o) };
+}


### PR DESCRIPTION
Composite-outbound подписки показывался сырым тегом (sub-1a98d416 / urltest) вместо дружелюбного имени. outboundDisplay резолвит source='subscription' через selectorTag → Subscription.label («RU», подзаголовок «подписка»). Тот же маппинг, что уже делает buildOutboundOptions для dropdown'а.