### PR TITLE
fix(dns-rewrite): single-stack перезапись гасит противоположную семью (NODATA)

### DIFF
--- a/internal/singbox/dnsrewrite/compile.go
+++ b/internal/singbox/dnsrewrite/compile.go
@@ -28,14 +28,21 @@ func compileRewrite(r DNSRewrite) ([]map[string]any, error) {
 		return nil, fmt.Errorf("перезапись %q: нужен хотя бы один IP", r.Pattern)
 	}
 
+	// Each rule is scoped to one query_type. The family that has IPs answers
+	// directly; the opposite family gets a predefined rule WITHOUT an answer,
+	// which sing-box returns as NODATA. This stops a single-stack rewrite from
+	// being silently bypassed: an IPv4-only rewrite must suppress AAAA (else an
+	// IPv6-capable client resolves the real address over IPv6 and never uses
+	// the override), and an IPv6-only rewrite must suppress A. Dual-stack just
+	// answers both families.
 	mk := func(answers []string, qtype string) map[string]any {
 		rule := map[string]any{
-			matcherKey: []string{matcher},
-			"action":   "predefined",
-			"answer":   answers,
+			matcherKey:   []string{matcher},
+			"action":     "predefined",
+			"query_type": []string{qtype},
 		}
-		if qtype != "" {
-			rule["query_type"] = []string{qtype}
+		if len(answers) > 0 {
+			rule["answer"] = answers
 		}
 		return rule
 	}
@@ -48,23 +55,10 @@ func compileRewrite(r DNSRewrite) ([]map[string]any, error) {
 		return out
 	}
 
-	dual := len(v4) > 0 && len(v6) > 0
-	var rules []map[string]any
-	if len(v4) > 0 {
-		qt := ""
-		if dual {
-			qt = "A"
-		}
-		rules = append(rules, mk(answersFor(v4, "A"), qt))
-	}
-	if len(v6) > 0 {
-		qt := ""
-		if dual {
-			qt = "AAAA"
-		}
-		rules = append(rules, mk(answersFor(v6, "AAAA"), qt))
-	}
-	return rules, nil
+	return []map[string]any{
+		mk(answersFor(v4, "A"), "A"),
+		mk(answersFor(v6, "AAAA"), "AAAA"),
+	}, nil
 }
 
 // parsePattern разбирает glob-паттерн в (ключ-матчера, значение, абсолютное answer-имя).

--- a/internal/singbox/dnsrewrite/compile_test.go
+++ b/internal/singbox/dnsrewrite/compile_test.go
@@ -10,11 +10,20 @@ func TestCompileRewriteExact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []map[string]any{{
-		"domain": []string{"nas.lan"},
-		"action": "predefined",
-		"answer": []string{"nas.lan. IN A 192.168.1.10"},
-	}}
+	// IPv4-only → A answers + AAAA suppressed (predefined, no answer = NODATA).
+	want := []map[string]any{
+		{
+			"domain":     []string{"nas.lan"},
+			"action":     "predefined",
+			"query_type": []string{"A"},
+			"answer":     []string{"nas.lan. IN A 192.168.1.10"},
+		},
+		{
+			"domain":     []string{"nas.lan"},
+			"action":     "predefined",
+			"query_type": []string{"AAAA"},
+		},
+	}
 	if !reflect.DeepEqual(rules, want) {
 		t.Errorf("got %#v", rules)
 	}
@@ -25,11 +34,19 @@ func TestCompileRewriteSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []map[string]any{{
-		"domain_suffix": []string{"discord.media"},
-		"action":        "predefined",
-		"answer":        []string{"*.discord.media. IN A 104.25.158.178"},
-	}}
+	want := []map[string]any{
+		{
+			"domain_suffix": []string{"discord.media"},
+			"action":        "predefined",
+			"query_type":    []string{"A"},
+			"answer":        []string{"*.discord.media. IN A 104.25.158.178"},
+		},
+		{
+			"domain_suffix": []string{"discord.media"},
+			"action":        "predefined",
+			"query_type":    []string{"AAAA"},
+		},
+	}
 	if !reflect.DeepEqual(rules, want) {
 		t.Errorf("got %#v", rules)
 	}
@@ -40,11 +57,43 @@ func TestCompileRewriteInLabelRegex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []map[string]any{{
-		"domain_regex": []string{`^finland10[^.]*\.discord\.media$`},
-		"action":       "predefined",
-		"answer":       []string{"*.discord.media. IN A 104.25.158.178"},
-	}}
+	want := []map[string]any{
+		{
+			"domain_regex": []string{`^finland10[^.]*\.discord\.media$`},
+			"action":       "predefined",
+			"query_type":   []string{"A"},
+			"answer":       []string{"*.discord.media. IN A 104.25.158.178"},
+		},
+		{
+			"domain_regex": []string{`^finland10[^.]*\.discord\.media$`},
+			"action":       "predefined",
+			"query_type":   []string{"AAAA"},
+		},
+	}
+	if !reflect.DeepEqual(rules, want) {
+		t.Errorf("got %#v", rules)
+	}
+}
+
+func TestCompileRewriteIPv6OnlySuppressesA(t *testing.T) {
+	rules, err := compileRewrite(DNSRewrite{Pattern: "v6.lan", IPs: []string{"fd00::9"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// IPv6-only → A suppressed (NODATA) + AAAA answers.
+	want := []map[string]any{
+		{
+			"domain":     []string{"v6.lan"},
+			"action":     "predefined",
+			"query_type": []string{"A"},
+		},
+		{
+			"domain":     []string{"v6.lan"},
+			"action":     "predefined",
+			"query_type": []string{"AAAA"},
+			"answer":     []string{"v6.lan. IN AAAA fd00::9"},
+		},
+	}
 	if !reflect.DeepEqual(rules, want) {
 		t.Errorf("got %#v", rules)
 	}

--- a/internal/singbox/dnsrewrite/service_test.go
+++ b/internal/singbox/dnsrewrite/service_test.go
@@ -44,11 +44,21 @@ func TestServiceAddFlushesCompiledRules(t *testing.T) {
 	if err := json.Unmarshal(data, &slot); err != nil {
 		t.Fatal(err)
 	}
-	if len(slot.DNS.Rules) != 1 {
-		t.Fatalf("want 1 rule, got %d", len(slot.DNS.Rules))
+	// IPv4-only rewrite → A answer + AAAA NODATA suppression = 2 rules.
+	if len(slot.DNS.Rules) != 2 {
+		t.Fatalf("want 2 rules (answer + opposite-family NODATA), got %d", len(slot.DNS.Rules))
 	}
-	if slot.DNS.Rules[0]["action"] != "predefined" {
-		t.Errorf("rule: %#v", slot.DNS.Rules[0])
+	withAnswer := 0
+	for _, r := range slot.DNS.Rules {
+		if r["action"] != "predefined" {
+			t.Errorf("rule not predefined: %#v", r)
+		}
+		if _, ok := r["answer"]; ok {
+			withAnswer++
+		}
+	}
+	if withAnswer != 1 {
+		t.Errorf("want exactly 1 rule with an answer (the A family), got %d", withAnswer)
 	}
 	if !orch.enabled[SlotName] {
 		t.Error("slot must be enabled after add")


### PR DESCRIPTION
IPv4-only перезапись обходилась IPv6-клиентами (AAAA → реальный адрес). Теперь противоположная семья получает predefined без answer (NODATA). Проверено sing-box check 1.14.0-alpha.25.