### PR TITLE
fix(subscription): не ломать 40-subscriptions.json при создании подпи…

### DIFF
--- a/internal/singbox/subscription/issue_287_test.go
+++ b/internal/singbox/subscription/issue_287_test.go
@@ -1,0 +1,188 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+)
+
+// raceMutator models the REAL adapter's scan-without-reserve allocation:
+// AllocListenPort returns the lowest port not yet committed via AddInbound.
+// Two Creates that interleave between allocate and commit would otherwise both
+// get the same port — issue #287 Defect 1.
+type raceMutator struct {
+	fakeMutator
+	mu        sync.Mutex
+	committed map[uint16]bool
+	nextProxy int
+}
+
+func (m *raceMutator) AllocListenPort() (uint16, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p := uint16(11000)
+	for m.committed[p] {
+		p++
+	}
+	return p, nil
+}
+
+func (m *raceMutator) AllocProxyIndex(context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextProxy++
+	return m.nextProxy, nil
+}
+
+func (m *raceMutator) AddInbound(tag string, body []byte) error {
+	m.mu.Lock()
+	var ib map[string]any
+	_ = json.Unmarshal(body, &ib)
+	if p, ok := toAnyInt(ib["listen_port"]); ok {
+		if m.committed == nil {
+			m.committed = map[uint16]bool{}
+		}
+		m.committed[uint16(p)] = true
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+// Issue #287 Defect 1 — concurrent Create must not hand out the same
+// listen_port. createMu serializes Create so the first commits its inbound
+// (reserving the port) before the second allocates.
+func TestIssue287_ConcurrentCreate_DistinctListenPorts(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(store, &raceMutator{})
+
+	const inline = "vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@h1.example:443?security=tls&sni=h\n"
+	var wg sync.WaitGroup
+	ports := make([]uint16, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sub, cerr := svc.Create(context.Background(), CreateInput{Label: "x", Inline: inline})
+			if cerr != nil {
+				t.Errorf("Create %d: %v", idx, cerr)
+				return
+			}
+			ports[idx] = sub.ListenPort
+		}(i)
+	}
+	wg.Wait()
+
+	if ports[0] == 0 || ports[1] == 0 {
+		t.Fatalf("a Create failed to allocate a port: %v", ports)
+	}
+	if ports[0] == ports[1] {
+		t.Fatalf("BUG #287: two concurrent Creates shared listen_port %d", ports[0])
+	}
+}
+
+// Issue #287 defense-in-depth — AddInbound rejects a second inbound on a
+// listen_port already taken by a different tag.
+func TestIssue287_AddInbound_RejectsDuplicateListenPort(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	a := NewOperatorAdapter(orch, nil, nil)
+
+	// A slot with an inbound but zero outbounds fails Pass-1 validation, so
+	// seed one valid outbound first.
+	validVless := []byte(`{"type":"vless","server":"ex.com","server_port":443,"uuid":"3a3b1c2e-9999-4321-aaaa-1234567890ab","tls":{"enabled":true,"server_name":"h"}}`)
+	if err := a.AddOutbound("sub-aaaa-x", validVless); err != nil {
+		t.Fatalf("seed outbound: %v", err)
+	}
+
+	if err := a.AddInbound("sub-aaaa-in", BuildMixedInbound("sub-aaaa-in", 11000)); err != nil {
+		t.Fatalf("first AddInbound: %v", err)
+	}
+	if err := a.AddInbound("sub-bbbb-in", BuildMixedInbound("sub-bbbb-in", 11000)); err == nil {
+		t.Fatal("BUG #287: AddInbound accepted a duplicate listen_port 11000")
+	}
+
+	count := 0
+	for _, v := range a.cfg.Inbounds {
+		if ib, ok := v.(map[string]any); ok {
+			if p, ok := toAnyInt(ib["listen_port"]); ok && p == 11000 {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly 1 inbound on port 11000, got %d", count)
+	}
+}
+
+// reloadFailMutator is a fakeMutator whose Reload fails after applyDiff has
+// committed member outbounds — modelling a Create that errors late (slow link,
+// or a duplicate listen_port the daemon rejects). DeclaredOutboundTags mirrors
+// the live slot (added minus removed) so the rollback purge can enumerate it.
+type reloadFailMutator struct {
+	fakeMutator
+}
+
+func (m *reloadFailMutator) Reload(context.Context) error {
+	return errors.New("simulated reload failure")
+}
+
+func (m *reloadFailMutator) DeclaredOutboundTags() []string {
+	removed := map[string]bool{}
+	for _, t := range m.removedOutbounds {
+		removed[t] = true
+	}
+	var live []string
+	for _, t := range m.addedOutbounds {
+		if !removed[t] {
+			live = append(live, t)
+		}
+	}
+	return live
+}
+
+// Issue #287 Defect 2 — a failed Create must not leave orphan outbounds in the
+// subscription slot.
+func TestIssue287_FailedCreate_LeavesNoOrphans(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mut := &reloadFailMutator{}
+	svc := NewService(store, mut)
+
+	_, createErr := svc.Create(context.Background(), CreateInput{
+		Label:  "mifa",
+		Inline: "vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@h1.example:443?security=tls&sni=h\n",
+	})
+	if createErr == nil {
+		t.Fatal("expected Create to fail (Reload errors), got nil")
+	}
+	if len(store.List()) != 0 {
+		t.Errorf("store should be empty after failed Create, has %d", len(store.List()))
+	}
+
+	removed := map[string]bool{}
+	for _, tag := range mut.removedOutbounds {
+		removed[tag] = true
+	}
+	var orphans []string
+	for _, tag := range mut.addedOutbounds {
+		if !removed[tag] {
+			orphans = append(orphans, tag)
+		}
+	}
+	if len(orphans) > 0 {
+		t.Fatalf("BUG #287: failed Create left %d orphan outbound(s): %v", len(orphans), orphans)
+	}
+}

--- a/internal/singbox/subscription/operator_adapter.go
+++ b/internal/singbox/subscription/operator_adapter.go
@@ -242,20 +242,32 @@ func (a *OperatorAdapter) AddInbound(tag string, jsonBody []byte) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for _, v := range a.cfg.Inbounds {
-		ib, ok := v.(map[string]any)
-		if !ok {
-			continue
-		}
-		if t, _ := ib["tag"].(string); t == tag {
-			return nil // already present
-		}
-	}
 	var ib map[string]any
 	if err := json.Unmarshal(jsonBody, &ib); err != nil {
 		return fmt.Errorf("subscription adapter: AddInbound %q: bad json: %w", tag, err)
 	}
 	ib["tag"] = tag
+	newPort, hasPort := toAnyInt(ib["listen_port"])
+
+	for _, v := range a.cfg.Inbounds {
+		existing, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := existing["tag"].(string); t == tag {
+			return nil // already present (same tag) — idempotent
+		}
+		// Defense-in-depth (issue #287): reject a second inbound on a
+		// listen_port already taken by a different tag. Two subscription
+		// inbounds on one port make the merged config structurally invalid,
+		// which the flush's index-based outbound-drop cannot repair.
+		if hasPort {
+			if p, ok := toAnyInt(existing["listen_port"]); ok && p == newPort {
+				et, _ := existing["tag"].(string)
+				return fmt.Errorf("subscription adapter: AddInbound %q: listen_port %d already used by inbound %q", tag, newPort, et)
+			}
+		}
+	}
 	a.cfg.Inbounds = append(a.cfg.Inbounds, ib)
 	return a.flush()
 }

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -49,9 +49,15 @@ type ConfigMutator interface {
 
 // Service is the subscription business-logic facade.
 type Service struct {
-	store     *Store
-	mutator   ConfigMutator
-	muById    sync.Map // map[string]*sync.Mutex
+	store   *Store
+	mutator ConfigMutator
+	muById  sync.Map // map[string]*sync.Mutex
+	// createMu serializes Create across all subscriptions. Allocation
+	// (AllocListenPort / AllocProxyIndex) scans the slot without reserving,
+	// so two concurrent Creates would hand out the same listen_port / ProxyN
+	// — the documented "subscriptions are created one at a time" invariant
+	// (issue #287). This lock enforces it.
+	createMu  sync.Mutex
 	fetchOpts FetchOpts
 	log       *logging.ScopedLogger // nil-safe; sing-box journal (runtime)
 	appLog    *logging.ScopedLogger // nil-safe; app journal (subscription partition)
@@ -119,6 +125,13 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Subscription, er
 	case in.URL != "" && in.Inline != "":
 		return nil, errors.New("subscription: URL and inline content are mutually exclusive")
 	}
+	// Serialize the whole Create: allocation scans-without-reserve, so two
+	// concurrent Creates must not interleave between allocate and commit
+	// (issue #287). Per-subscription locks below don't help — each Create has
+	// a fresh random ID, hence a distinct lock.
+	s.createMu.Lock()
+	defer s.createMu.Unlock()
+
 	sub, err := s.store.Create(in)
 	if err != nil {
 		s.logWarn("subscription-create", in.Label, "failed to create store row: "+err.Error())
@@ -159,6 +172,15 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Subscription, er
 	}
 
 	if _, err := s.refreshLocked(ctx, sub.ID); err != nil {
+		// refreshLocked commits to the slot incrementally (each AddOutbound
+		// flushes + persists), so a mid-failure may have already written
+		// member outbounds / selector / inbound / route to
+		// 40-subscriptions.json. Purge them — otherwise they linger as
+		// orphans referencing a subscription that is about to be deleted,
+		// and (issue #287) break every later flush. Reads the live slot via
+		// DeclaredOutboundTags since the store's MemberTags are not written
+		// on a failed refresh.
+		s.purgeCreatedSlotEntries(sub)
 		// EnsureProxy succeeded above — the NDMS Proxy interface is now
 		// live in the router. We must roll it back before dropping the
 		// storage row; otherwise every failed Create leaks a ProxyN that
@@ -166,6 +188,7 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Subscription, er
 		// the RemoveProxy error: the storage row is going away regardless,
 		// and a stranded ProxyN is recoverable via Settings → cleanup.
 		_ = s.mutator.RemoveProxy(ctx, proxyIdx)
+		_ = s.mutator.Reload(ctx)
 		s.store.Delete(sub.ID)
 		s.logWarn("subscription-create", sub.ID, "initial refresh failed: "+err.Error())
 		return nil, fmt.Errorf("subscription: initial fetch failed: %w", err)
@@ -359,6 +382,25 @@ func filterDeclaredMembers(members []MemberInfo, declared map[string]bool) (kept
 		}
 	}
 	return kept, dropped
+}
+
+// purgeCreatedSlotEntries removes everything a partial Create committed to the
+// subscription slot: member outbounds (enumerated from the live slot by the
+// subscription's tag prefix), the selector, the mixed inbound and the route
+// rule. Used to roll back a failed Create so it cannot leave orphans in
+// 40-subscriptions.json (issue #287). Reads the actual slot via
+// DeclaredOutboundTags rather than the store, because the store's MemberTags
+// are not written when refreshLocked fails mid-commit. The caller is
+// responsible for the subsequent Reload.
+func (s *Service) purgeCreatedSlotEntries(sub *Subscription) {
+	memberPrefix := sub.SelectorTag + "-" // "sub-<short>-"
+	for _, tag := range s.mutator.DeclaredOutboundTags() {
+		if tag == sub.SelectorTag || strings.HasPrefix(tag, memberPrefix) {
+			s.mutator.RemoveOutbound(tag)
+		}
+	}
+	s.mutator.RemoveInbound(sub.InboundTag)
+	s.mutator.RemoveRouteRule(sub.InboundTag, sub.SelectorTag)
 }
 
 // applyDiff commits the diff to sing-box config. Selector + mixed inbound +


### PR DESCRIPTION
(#287)

Три дефекта, вскрытые добавлением подписки на медленном линке (retry while in-flight):
- Гонка аллокации
- Defense-in-depth: AddInbound отклоняет дубль listen_port (дедуп был только по тегу), а не по порту.
- Неполный откат: refreshLocked коммитит в slot инкрементально, а откат Create делал только RemoveProxy+store.Delete → орфаны outbound оставались в файле. Фикс: purgeCreatedSlotEntries чистит slot по живым тегам перед удалением.

+3 воспроизводящих теста (были красные до фикса).