### PR TITLE
fix(ci): стабильный ключ кэша sing-box — убрать embedded.go из hashFiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,13 @@ jobs:
         id: singbox-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          key: sing-box-${{ matrix.arch }}-${{ env.SINGBOX_VERSION }}-${{ env.SINGBOX_REF }}-repo-${{ hashFiles('scripts/build-singbox.sh', 'scripts/patches/**', 'internal/singbox/installer/embedded.go') }}
+          # embedded.go is intentionally NOT in the key: build-singbox.sh
+          # rewrites it (per-arch URL/SHA256/Size) during "Build sing-box", so
+          # hashing it makes the save-time key differ from the restore-time key
+          # → permanent cache miss. The version it carries (RequiredVersion) is
+          # already in the key via SINGBOX_VERSION/SINGBOX_REF. It stays in the
+          # cache path (the built output is restored on a hit).
+          key: sing-box-${{ matrix.arch }}-${{ env.SINGBOX_VERSION }}-${{ env.SINGBOX_REF }}-repo-${{ hashFiles('scripts/build-singbox.sh', 'scripts/patches/**') }}
           path: |
             dist/sing-box-${{ env.SINGBOX_VERSION }}-${{ matrix.arch }}
             dist/sing-box-${{ env.SINGBOX_VERSION }}-${{ matrix.arch }}.sha256
@@ -148,7 +154,8 @@ jobs:
         if: steps.singbox-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          key: sing-box-${{ matrix.arch }}-${{ env.SINGBOX_VERSION }}-${{ env.SINGBOX_REF }}-repo-${{ hashFiles('scripts/build-singbox.sh', 'scripts/patches/**', 'internal/singbox/installer/embedded.go') }}
+          # Key MUST match the restore step above (see its comment).
+          key: sing-box-${{ matrix.arch }}-${{ env.SINGBOX_VERSION }}-${{ env.SINGBOX_REF }}-repo-${{ hashFiles('scripts/build-singbox.sh', 'scripts/patches/**') }}
           path: |
             dist/sing-box-${{ env.SINGBOX_VERSION }}-${{ matrix.arch }}
             dist/sing-box-${{ env.SINGBOX_VERSION }}-${{ matrix.arch }}.sha256


### PR DESCRIPTION
embedded.go был в ключе кэша sing-box, но build-singbox.sh ПЕРЕПИСЫВАЕТ его (per-arch URL/SHA256/Size) на шаге «Build sing-box».