### PR TITLE
feat(connections): человеко-читаемые имена outbound в чипе

### DIFF
--- a/frontend/src/lib/components/routing/singboxRouter/ConnectionsSubTab.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/ConnectionsSubTab.svelte
@@ -12,6 +12,7 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
 	import { formatBytes } from '$lib/utils/format';
+	import { subscriptionsStore } from '$lib/stores/subscriptions';
 	import { resolveMemberLabel } from '$lib/utils/memberLabel';
 	import ConnectionsBreakdown from './ConnectionsBreakdown.svelte';
 	import ConnectionsFilters from './ConnectionsFilters.svelte';
@@ -37,7 +38,7 @@
 	let staleTimer: ReturnType<typeof setInterval> | null = null;
 
 	function displayOutbound(tag: string): string {
-		return resolveMemberLabel(tag, null, $routerOutboundOptions);
+		return resolveMemberLabel(tag, $subscriptionsStore.data, $routerOutboundOptions);
 	}
 
 	const displayConns = $derived(

--- a/frontend/src/lib/utils/memberLabel.test.ts
+++ b/frontend/src/lib/utils/memberLabel.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMemberLabel } from './memberLabel';
+import type { Subscription } from '$lib/types';
+import type { OutboundGroup } from '$lib/components/routing/singboxRouter/outboundOptions';
+
+const subs = [
+	{
+		selectorTag: 'sub-58dea6ef-c0ca6dbc',
+		label: 'Veesp LV',
+		members: [
+			{ tag: 'sub-58dea6ef-node3', label: 'LV node 3', server: '1.2.3.4' },
+			{ tag: 'sub-58dea6ef-node4', server: '5.6.7.8' },
+		],
+	},
+	{ selectorTag: 'sub-empty', label: '', members: [] },
+] as unknown as Subscription[];
+
+const options: OutboundGroup[] = [
+	{ group: 'Специальные', items: [{ value: 'direct', label: 'direct (мимо VPN)' }] },
+	{ group: 'AWG туннели', items: [{ value: 'awg-awg10', label: 'Office VPN (t2s10)' }] },
+];
+
+describe('resolveMemberLabel', () => {
+	it('тег-селектор подписки → чистое имя подписки', () => {
+		expect(resolveMemberLabel('sub-58dea6ef-c0ca6dbc', subs, options)).toBe('Veesp LV');
+	});
+
+	it('селектор с пустым label → сырой тег (fallback)', () => {
+		expect(resolveMemberLabel('sub-empty', subs, options)).toBe('sub-empty');
+	});
+
+	it('тег члена с label → label', () => {
+		expect(resolveMemberLabel('sub-58dea6ef-node3', subs, options)).toBe('LV node 3');
+	});
+
+	it('тег члена без label → server', () => {
+		expect(resolveMemberLabel('sub-58dea6ef-node4', subs, options)).toBe('5.6.7.8');
+	});
+
+	it('AWG туннель → label из outboundOptions', () => {
+		expect(resolveMemberLabel('awg-awg10', subs, options)).toBe('Office VPN (t2s10)');
+	});
+
+	it('direct → label из outboundOptions', () => {
+		expect(resolveMemberLabel('direct', subs, options)).toBe('direct (мимо VPN)');
+	});
+
+	it('неизвестный тег → сырой тег (fallback)', () => {
+		expect(resolveMemberLabel('mystery', subs, options)).toBe('mystery');
+	});
+
+	it('подписки null — туннель резолвится по outboundOptions', () => {
+		expect(resolveMemberLabel('awg-awg10', null, options)).toBe('Office VPN (t2s10)');
+	});
+
+	it('пустой тег → пустой тег', () => {
+		expect(resolveMemberLabel('', subs, options)).toBe('');
+	});
+});

--- a/frontend/src/lib/utils/memberLabel.ts
+++ b/frontend/src/lib/utils/memberLabel.ts
@@ -3,12 +3,14 @@
 // cards / dropdowns (issue #214).
 //
 // Resolution order:
-//   1. Subscription member: sub.members[i].label (or server) когда tag
+//   1. Subscription selector: sub.label когда tag совпадает с sub.selectorTag —
+//      покрывает чистое имя подписки для тэга-селектора (sub-XXXX).
+//   2. Subscription member: sub.members[i].label (or server) когда tag
 //      совпадает с одним из sub.members[i].tag — это покрывает
 //      sub-XXX-YYY формат.
-//   2. outboundOptions flat lookup (покрывает awg-awgN тэги — там label
+//   3. outboundOptions flat lookup (покрывает awg-awgN тэги — там label
 //      уже сделан билдером как "${t.label} (${t.iface})").
-//   3. Fallback: исходный тэг (не теряем информацию когда мапа неполная).
+//   4. Fallback: исходный тэг (не теряем информацию когда мапа неполная).
 
 import type { Subscription } from '$lib/types';
 import type { OutboundGroup } from '$lib/components/routing/singboxRouter/outboundOptions';
@@ -21,6 +23,10 @@ export function resolveMemberLabel(
 	if (!tag) return tag;
 
 	if (subscriptions && subscriptions.length > 0) {
+		const selector = subscriptions.find((s) => s.selectorTag === tag);
+		if (selector) {
+			return selector.label || tag;
+		}
 		for (const sub of subscriptions) {
 			const m = sub.members?.find((x) => x.tag === tag);
 			if (m) {


### PR DESCRIPTION
resolveMemberLabel резолвит тег-селектор подписки в чистое имя (sub.label); ConnectionsSubTab передаёт реальные подписки вместо null. Без новой обёртки — ветка в общий резолвер, чтобы не плодить копию selectorTag→label.