### PR TITLE
feat(egress): refactor and rework download via

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -747,9 +747,9 @@ func main() {
 	if err := sbOrch.Bootstrap(); err != nil {
 		bootLog.Error("singbox-orchestrator", "bootstrap", err.Error())
 	}
-	// Download proxy is an ephemeral per-operation slot. If a previous awgm
-	// process crashed during geo download, Bootstrap may discover an active
-	// 35-download-proxy.json. Always disable it on boot.
+	// Legacy download-proxy slot (35-download-proxy.json) is no longer used
+	// by the downloader, but disable it on boot in case a previous awgm
+	// process crashed with the slot still enabled.
 	if err := sbOrch.SetEnabledSilent(singboxorch.SlotDownloadProxy, false); err != nil {
 		bootLog.Warn("singbox-orchestrator", "downloadproxy-disable", err.Error())
 	}
@@ -1027,8 +1027,9 @@ func main() {
 	sharedDownloadSvc := downloader.NewSettingsBackedService(
 		deviceProxySvc,
 		singboxOp,
-		sbOrch,
+		subSvc,
 		settingsStore,
+		awgStore,
 	)
 	dnsRouteService.SetDownloader(&dnsRouteDownloaderAdapter{svc: sharedDownloadSvc})
 	dnsRefreshScheduler.Start()

--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -126,6 +126,7 @@ const MOCK_CAPABILITY_GROUPS = Object.freeze([
 			'POST /__mock/reset-runtime',
 			'POST /__mock/reset',
 			'POST /__mock/singbox-install-fail',
+			'POST /__mock/download-faults',
 		],
 	},
 ]);
@@ -138,6 +139,21 @@ let downloadRouteTag = DEFAULT_MOCK_STATE.downloadRouteTag;
 let updateChannel = DEFAULT_MOCK_STATE.updateChannel;
 let updateCheckEnabled = DEFAULT_MOCK_STATE.updateCheckEnabled;
 
+// Service-download fault injection: every "download via route" endpoint
+// (geo.dat, AWGM update, DNSRoute lists, Amnezia Premium, sing-box binary,
+// download-outbounds) randomly returns a realistic failure instead of the
+// normal/proxied success, so every UI surface can exercise all outcomes
+// (sing-box off, AWG iface down, timeout, network drop, generic). Enabled by
+// default in mock dev; disable with MOCK_DOWNLOAD_FAULTS=0 or via
+// POST /__mock/download-faults. Probability tunable with MOCK_DOWNLOAD_FAULT_PROB.
+function parseProbability(raw, fallback) {
+	const n = Number.parseFloat(raw);
+	if (Number.isFinite(n) && n >= 0 && n <= 1) return n;
+	return fallback;
+}
+let downloadFaultsEnabled = process.env.MOCK_DOWNLOAD_FAULTS !== '0';
+let downloadFaultProbability = parseProbability(process.env.MOCK_DOWNLOAD_FAULT_PROB, 0.4);
+
 function getRuntimeState() {
 	return {
 		usageLevel,
@@ -146,6 +162,8 @@ function getRuntimeState() {
 		updateChannel,
 		updateCheckEnabled,
 		singboxInstallShouldFail,
+		downloadFaultsEnabled,
+		downloadFaultProbability,
 		logsCleared: { ...bucketCleared },
 	};
 }
@@ -157,6 +175,8 @@ function resetRuntimeControls() {
 	updateChannel = DEFAULT_MOCK_STATE.updateChannel;
 	updateCheckEnabled = DEFAULT_MOCK_STATE.updateCheckEnabled;
 	singboxInstallShouldFail = process.env.MOCK_SINGBOX_INSTALL_FAIL === '1';
+	downloadFaultsEnabled = process.env.MOCK_DOWNLOAD_FAULTS !== '0';
+	downloadFaultProbability = parseProbability(process.env.MOCK_DOWNLOAD_FAULT_PROB, 0.4);
 	bucketCleared.app = false;
 	bucketCleared.singbox = false;
 }
@@ -184,9 +204,16 @@ const MOCK_DOWNLOAD_OUTBOUNDS = [
 	},
 	{
 		tag: 'sb-vless-1',
-		kind: 'vless',
+		kind: 'singbox',
 		label: 'VLESS EU-1',
 		detail: 'eu1.vpn.example:443',
+		available: true,
+	},
+	{
+		tag: 'sb-vless-2',
+		kind: 'singbox',
+		label: 'Trojan NL-2',
+		detail: 'nl2.vpn.example:443',
 		available: true,
 	},
 	{
@@ -197,10 +224,10 @@ const MOCK_DOWNLOAD_OUTBOUNDS = [
 		available: true,
 	},
 	{
-		tag: 'sb-wg-reserve',
-		kind: 'wireguard',
-		label: 'WireGuard Reserve',
-		detail: 'wg-reserve.demo.example:51820',
+		tag: 'sb-subscription-2',
+		kind: 'subscription',
+		label: 'AleXRAY (SUB)',
+		detail: 'sub-alexray.demo.example',
 		available: false,
 	},
 ];
@@ -2616,6 +2643,64 @@ function wait(ms) {
 	return new Promise((resolveWait) => setTimeout(resolveWait, ms));
 }
 
+// Endpoints that perform a "service download" through the configurable route.
+// `style: 'envelope'` → backend error shape {error, message, code} @ 400.
+// `style: 'updateInfo'` → /system/update/check returns 200 with data.error.
+const DOWNLOAD_FAULT_ROUTES = [
+	{ method: 'POST', path: '/hydraroute/geo-files/update', style: 'envelope', code: 'GEO_UPDATE_ERROR' },
+	{ method: 'POST', path: '/hydraroute/geo-files/add', style: 'envelope', code: 'GEO_DOWNLOAD_ERROR' },
+	{ method: 'POST', path: '/dns-routes/refresh', style: 'envelope', code: 'DNS_ROUTE_REFRESH_ERROR' },
+	{ method: 'POST', path: '/amnezia-premium/login', style: 'envelope', code: 'AMNEZIA_CP_NETWORK' },
+	{ method: 'POST', path: '/amnezia-premium/account-info', style: 'envelope', code: 'AMNEZIA_CP_NETWORK' },
+	{ method: 'POST', path: '/amnezia-premium/download-config', style: 'envelope', code: 'AMNEZIA_CP_NETWORK' },
+	{ method: 'POST', path: '/singbox/install', style: 'envelope', code: 'SINGBOX_INSTALL_ERROR' },
+	{ method: 'POST', path: '/singbox/update', style: 'envelope', code: 'SINGBOX_UPDATE_ERROR' },
+	// NB: /download/outbounds is route *discovery*, not a download — never fault
+	// it, otherwise the route dropdown randomly empties.
+	{ method: 'GET', path: '/system/update/check', style: 'updateInfo' },
+];
+
+// One realistic message per humanized failure kind (see downloadError.ts):
+// sing-box off, AWG interface down, timeout, network drop, generic.
+const DOWNLOAD_FAULT_MESSAGES = [
+	'outbound "sb-subscription-1" is unavailable: sing-box is not running',
+	'outbound "awg-de-frankfurt" interface "awg0" is not present',
+	'download via DE Frankfurt: request failed: context deadline exceeded (timed out)',
+	'download via Direct (WAN): request failed: http get: EOF',
+	'remote returned HTTP 500: internal server error',
+];
+
+// Randomly short-circuit a service-download endpoint with a failure so the UI
+// can run through all outcomes. Returns true when a fault was written (caller
+// must stop), false to continue with the normal/proxied success path.
+function maybeInjectDownloadFault(req, res, path) {
+	if (!downloadFaultsEnabled) return false;
+	const route = DOWNLOAD_FAULT_ROUTES.find((r) => r.method === req.method && r.path === path);
+	if (!route) return false;
+	if (Math.random() >= downloadFaultProbability) return false;
+
+	// Drain any request body so keep-alive sockets don't stall.
+	if (req.method !== 'GET' && req.method !== 'HEAD') req.resume();
+
+	const message = DOWNLOAD_FAULT_MESSAGES[Math.floor(Math.random() * DOWNLOAD_FAULT_MESSAGES.length)];
+	if (route.style === 'updateInfo') {
+		send(res, 200, {
+			success: true,
+			data: {
+				currentVersion: 'dev',
+				latestVersion: '',
+				available: false,
+				channel: updateChannel,
+				error: message,
+			},
+		});
+	} else {
+		send(res, 400, { error: true, message, code: route.code });
+	}
+	console.log(`[mock-proxy] injected download fault on ${req.method} ${path}: ${message}`);
+	return true;
+}
+
 function readRequestText(req) {
 	return new Promise((resolveRead, rejectRead) => {
 		let raw = '';
@@ -2785,18 +2870,19 @@ function buildDownloadOutbounds() {
 			tag: t.id,
 			kind: 'awg',
 			label: t.name,
-			detail: `${t.interfaceName} · ${t.endpoint}`,
-			available: t.enabled !== false && t.status === 'running',
+			// detail = kernel iface (backend bind_interface), not endpoint metadata
+			detail: t.interfaceName ?? '',
+			available: t.enabled !== false && !!t.interfaceName,
 		});
 	}
 
 	for (const t of MOCK_SINGBOX_TUNNELS) {
 		add({
 			tag: t.tag,
-			kind: t.protocol || 'singbox',
+			kind: 'singbox',
 			label: t.tag,
-			detail: `${t.proxyInterface} · ${t.server}:${t.port}`,
-			available: !!t.running && t.connectivity?.connected !== false,
+			detail: `${t.protocol?.toUpperCase() ?? 'TUNNEL'} · ${t.server}:${t.port}`,
+			available: !!t.running && t.listenPort > 0,
 		});
 	}
 
@@ -3116,6 +3202,29 @@ const server = http.createServer(async (req, res) => {
 		return;
 	}
 
+	// Toggle / tune the random service-download fault injector at runtime.
+	// Body (optional JSON): { enabled?: boolean, probability?: 0..1 }.
+	if (req.method === 'POST' && path === '/__mock/download-faults') {
+		const text = await readRequestText(req);
+		try {
+			const body = text ? JSON.parse(text) : {};
+			if (typeof body.enabled === 'boolean') downloadFaultsEnabled = body.enabled;
+			if (body.probability !== undefined) {
+				downloadFaultProbability = parseProbability(body.probability, downloadFaultProbability);
+			}
+		} catch {
+			/* ignore malformed body, just report current state */
+		}
+		sendData(res, {
+			downloadFaultsEnabled,
+			downloadFaultProbability,
+		});
+		console.log(`[mock-proxy] download faults: enabled=${downloadFaultsEnabled} p=${downloadFaultProbability}`);
+		return;
+	}
+
+	if (maybeInjectDownloadFault(req, res, path)) return;
+
 	if (req.method === 'GET' && path === '/system/info') {
 		fetchJSON('/system/info').then(({ status, body }) => {
 			if (body && typeof body === 'object' && body.data && typeof body.data === 'object') {
@@ -3181,6 +3290,52 @@ const server = http.createServer(async (req, res) => {
 		send(res, 200, {
 			success: true,
 			data: buildDownloadOutbounds(),
+		});
+		return;
+	}
+
+	if (req.method === 'GET' && path === '/hydraroute/geo-files') {
+		const ago = (min) => new Date(Date.now() - min * 60_000).toISOString();
+		send(res, 200, {
+			success: true,
+			data: [
+				// Managed by AWGM (external !== true) — updatable through the route.
+				{
+					type: 'geoip',
+					path: '/opt/etc/HydraRoute/geoip_GA.dat',
+					url: 'https://raw.githubusercontent.com/Ground-Zerro/Geo-Aggregator/main/geodat/geoip_GA.dat',
+					size: 1_245_184,
+					tagCount: 312,
+					updated: ago(180),
+				},
+				{
+					type: 'geosite',
+					path: '/opt/etc/HydraRoute/geosite_GA.dat',
+					url: 'https://raw.githubusercontent.com/Ground-Zerro/Geo-Aggregator/main/geodat/geosite_GA.dat',
+					size: 4_980_736,
+					tagCount: 868,
+					updated: ago(180),
+				},
+				// Extra non-external geoip (managed by AWGM).
+				{
+					type: 'geoip',
+					path: '/opt/etc/HydraRoute/geoip_antifilter.dat',
+					url: 'https://cdn.example.com/geodat/geoip_antifilter.dat',
+					size: 786_432,
+					tagCount: 154,
+					updated: ago(45),
+				},
+				// External — discovered in hrneo.conf, not managed by AWGM.
+				{
+					type: 'geosite',
+					path: '/opt/etc/hrneo/geosite.db',
+					url: 'https://cdn.example.com/geosite.db',
+					size: 3_145_728,
+					tagCount: 420,
+					updated: ago(1440),
+					external: true,
+				},
+			],
 		});
 		return;
 	}
@@ -4854,7 +5009,8 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(PORT, '127.0.0.1', () => {
 	console.log(`mock-proxy on http://127.0.0.1:${PORT} → ${UPSTREAM} (usageLevel=${usageLevel})`);
-	console.log('[mock-proxy] controls: GET /__mock/capabilities, GET /__mock/tunnels, POST /__mock/reset-runtime, POST /__mock/singbox-install-fail');
+	console.log('[mock-proxy] controls: GET /__mock/capabilities, GET /__mock/tunnels, POST /__mock/reset-runtime, POST /__mock/singbox-install-fail, POST /__mock/download-faults');
+	console.log(`[mock-proxy] download faults: enabled=${downloadFaultsEnabled} p=${downloadFaultProbability} (disable: MOCK_DOWNLOAD_FAULTS=0)`);
 });
 
 function wsAccept(key) {

--- a/frontend/src/lib/components/dnsroutes/DnsRouteEditModal.svelte
+++ b/frontend/src/lib/components/dnsroutes/DnsRouteEditModal.svelte
@@ -11,6 +11,7 @@
 		findRoutingTunnelLabel,
 	} from '$lib/utils/routingTunnelOptions';
 	import DownloadRouteNote from '$lib/components/downloads/DownloadRouteNote.svelte';
+	import { humanizeDownloadError } from '$lib/utils/downloadError';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
 
 	interface Props {
@@ -488,7 +489,9 @@
 							<span class="sub-url">{sub.url}</span>
 							<span class="sub-meta">
 								{#if sub.lastError}
-									<span class="sub-error">Ошибка: {sub.lastError}</span>
+									<span class="sub-error" title={sub.lastError}>
+										{humanizeDownloadError(sub.lastError).title}
+									</span>
 								{:else if sub.lastCount !== undefined && sub.lastCount > 0}
 									<span class="sub-ok">{sub.lastCount} доменов</span>
 									{#if sub.lastFetched}

--- a/frontend/src/lib/components/downloads/DownloadErrorNotice.svelte
+++ b/frontend/src/lib/components/downloads/DownloadErrorNotice.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import {
+		DOWNLOAD_SETTINGS_HREF,
+		humanizeDownloadError,
+		type HumanizedDownloadError,
+	} from '$lib/utils/downloadError';
+
+	interface Props {
+		/** Anything caught at a call site: Error, API error, or string. */
+		error: unknown;
+		/** Hide the raw "details" disclosure (e.g. inside tight status lines). */
+		hideRaw?: boolean;
+		/** Suppress the "go to download settings" link — set when this notice
+		 *  is already rendered inside the Settings → Downloads context. */
+		hideSettingsLink?: boolean;
+	}
+
+	let { error, hideRaw = false, hideSettingsLink = false }: Props = $props();
+
+	const info: HumanizedDownloadError = $derived(humanizeDownloadError(error));
+	const showRaw = $derived(!hideRaw && info.kind !== 'generic' && info.raw.trim().length > 0);
+	const showSettingsLink = $derived(info.needsDownloadSettings && !hideSettingsLink);
+</script>
+
+<div class="dl-error" class:dl-error-singbox={info.kind === 'singbox-off'}>
+	<span class="dl-error-title">{info.title}</span>
+	{#if info.detail}
+		<span class="dl-error-detail">{info.detail}</span>
+	{/if}
+	{#if showSettingsLink}
+		<a class="dl-error-link" href={DOWNLOAD_SETTINGS_HREF}>
+			Открыть Настройки → Загрузки
+		</a>
+	{/if}
+	{#if showRaw}
+		<details class="dl-error-raw">
+			<summary>Подробности</summary>
+			<code>{info.raw}</code>
+		</details>
+	{/if}
+</div>
+
+<style>
+	.dl-error {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		font-size: 0.8125rem;
+		line-height: 1.4;
+		color: var(--error, var(--color-danger));
+		min-width: 0;
+	}
+
+	.dl-error-title {
+		font-weight: 600;
+	}
+
+	.dl-error-detail {
+		color: var(--text-muted, var(--color-text-muted));
+		font-weight: 400;
+	}
+
+	.dl-error-link {
+		align-self: flex-start;
+		color: var(--accent);
+		text-decoration: underline;
+		font-weight: 500;
+	}
+
+	.dl-error-raw {
+		margin-top: 0.1rem;
+		color: var(--text-muted, var(--color-text-muted));
+	}
+
+	.dl-error-raw summary {
+		cursor: pointer;
+		font-size: 0.75rem;
+		color: var(--text-muted, var(--color-text-muted));
+	}
+
+	.dl-error-raw code {
+		display: block;
+		margin-top: 0.25rem;
+		padding: 0.35rem 0.5rem;
+		border-radius: var(--radius-sm, 6px);
+		background: color-mix(in srgb, var(--bg-secondary, #000) 60%, transparent);
+		font-size: 0.7rem;
+		white-space: pre-wrap;
+		word-break: break-word;
+		color: var(--text-primary, var(--color-text-primary));
+	}
+</style>

--- a/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
@@ -15,6 +15,7 @@
 	import { ConfirmModal, Button, Dropdown } from '$lib/components/ui';
 	import { geoDownloadProgress } from '$lib/stores/geoDownload';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
 
 	interface Props {
 		files: GeoFileEntry[];
@@ -67,7 +68,10 @@
 		ok: boolean;
 		action: string;
 		routeLabel: string;
-		message: string;
+		// Success text; on failure the raw caught error is kept in `error`
+		// and humanized at render time via DownloadErrorNotice.
+		message?: string;
+		error?: unknown;
 	};
 
 	let activeDownload = $state<DownloadOperation | null>(null);
@@ -138,13 +142,11 @@
 			};
 			onrefresh();
 		} catch (e: unknown) {
-			const msg = e instanceof Error ? e.message : String(e);
-			err = `Не удалось скачать через «${op.routeLabel}»: ${msg}`;
 			lastDownload = {
 				ok: false,
 				action: 'Добавление geo-файла',
 				routeLabel: op.routeLabel,
-				message: msg,
+				error: e,
 			};
 		} finally {
 			busy = null;
@@ -171,13 +173,11 @@
 			};
 			onrefresh();
 		} catch (e: unknown) {
-			const msg = e instanceof Error ? e.message : String(e);
-			err = `Не удалось скачать через «${op.routeLabel}»: ${msg}`;
 			lastDownload = {
 				ok: false,
 				action: 'Добавление пресета',
 				routeLabel: op.routeLabel,
-				message: msg,
+				error: e,
 			};
 		} finally {
 			busy = null;
@@ -203,13 +203,11 @@
 			};
 			onrefresh();
 		} catch (e: unknown) {
-			const msg = e instanceof Error ? e.message : String(e);
-			err = `Не удалось обновить через «${op.routeLabel}»: ${msg}`;
 			lastDownload = {
 				ok: false,
 				action: `Обновление ${fileName(path)}`,
 				routeLabel: op.routeLabel,
-				message: msg,
+				error: e,
 			};
 		} finally {
 			busy = null;
@@ -259,12 +257,11 @@
 			}
 
 			if (notes.length > 0) {
-				err = notes.join('; ');
 				lastDownload = {
 					ok: false,
 					action: 'Синхронизация geo-файлов',
 					routeLabel: op.routeLabel,
-					message: notes.join('; '),
+					error: notes.join('; '),
 				};
 			} else {
 				lastDownload = {
@@ -387,12 +384,20 @@
 		</div>
 	{/if}
 	{#if !activeDownload && lastDownload}
-		<div class="route-status {lastDownload.ok ? 'route-status-ok' : 'route-status-error'}">
-			{lastDownload.ok ? 'Последняя операция успешна' : 'Последняя операция завершилась ошибкой'}:
-			{lastDownload.action} ({lastDownload.routeLabel}){#if lastDownload.message}
-				— {lastDownload.message}
-			{/if}
-		</div>
+		{#if lastDownload.ok}
+			<div class="route-status route-status-ok">
+				Последняя операция успешна: {lastDownload.action} ({lastDownload.routeLabel}){#if lastDownload.message}
+					— {lastDownload.message}
+				{/if}
+			</div>
+		{:else}
+			<div class="route-status route-status-error">
+				<span class="route-status-head">
+					Не удалось: {lastDownload.action} ({lastDownload.routeLabel})
+				</span>
+				<DownloadErrorNotice error={lastDownload.error} />
+			</div>
+		{/if}
 	{/if}
 	</div>
 	
@@ -823,6 +828,16 @@
 		background: rgba(245, 158, 11, 0.12);
 		color: var(--warning, #f59e0b);
 		border-left: 3px solid var(--warning, #f59e0b);
+	}
+
+	.route-status-error {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.route-status-head {
+		font-weight: 500;
 	}
 
 	.add-type-select {

--- a/frontend/src/lib/components/settings/DownloadSettings.svelte
+++ b/frontend/src/lib/components/settings/DownloadSettings.svelte
@@ -29,6 +29,25 @@
 		onSelectRoute,
 	}: Props = $props();
 
+	// Only these kinds are meaningful download routes; anything else the backend
+	// might report (raw/legacy interfaces) is hidden. Order drives the section
+	// order in the dropdown, mirroring the NDMS-style grouping.
+	const KIND_ORDER: Record<string, number> = {
+		direct: 0,
+		awg: 1,
+		singbox: 2,
+		subscription: 3,
+	};
+	const KIND_GROUP: Record<string, string | undefined> = {
+		direct: undefined, // Direct sits on top, ungrouped.
+		awg: 'AWG-туннели',
+		singbox: 'Sing-box туннели',
+		subscription: 'Sing-box подписки',
+	};
+	function isKnownKind(kind: string): boolean {
+		return kind in KIND_ORDER;
+	}
+
 	function optionLabel(ob: DownloadOutbound): string {
 		return `${displayOutboundName(ob)}${ob.available ? '' : ' (unavailable)'}`;
 	}
@@ -64,12 +83,21 @@
 		}
 		return routeKey(selectedTag, selectedKind as DownloadOutbound['kind']);
 	});
-	const hasSelected = $derived(outbounds.some((ob) => routeKey(ob.tag, ob.kind) === selectedValue));
+	const visibleOutbounds = $derived(
+		outbounds
+			.filter((ob) => isKnownKind(ob.kind))
+			.slice()
+			.sort((a, b) => (KIND_ORDER[a.kind] ?? 99) - (KIND_ORDER[b.kind] ?? 99)),
+	);
+	const hasSelected = $derived(
+		visibleOutbounds.some((ob) => routeKey(ob.tag, ob.kind) === selectedValue),
+	);
 	const options = $derived.by(() => {
-		const built: DropdownOption<string>[] = outbounds.map((ob) => ({
+		const built: DropdownOption<string>[] = visibleOutbounds.map((ob) => ({
 			value: routeKey(ob.tag, ob.kind),
 			label: optionLabel(ob),
 			disabled: !ob.available,
+			group: KIND_GROUP[ob.kind],
 		}));
 		if (!hasSelected && selectedValue) {
 			const extra = selectedKind ? `${maskSensitiveInText(selectedTag)} (${selectedKind})` : maskSensitiveInText(selectedTag);
@@ -90,13 +118,65 @@
 		}
 		onSelectRoute(selected.tag, selected.kind);
 	}
+
+	// Info-попап с пояснением, через что реально идут загрузки. Вынесен из
+	// основного описания, чтобы не перегружать строку. Закрытие — клик вне
+	// области и Escape.
+	let infoOpen = $state(false);
+	let infoHintEl = $state<HTMLElement | null>(null);
+
+	function closeInfoOnOutside(e: MouseEvent) {
+		if (!infoOpen) return;
+		if (infoHintEl && !infoHintEl.contains(e.target as Node)) {
+			infoOpen = false;
+		}
+	}
+
+	function closeInfoOnEscape(e: KeyboardEvent) {
+		if (e.key === 'Escape') infoOpen = false;
+	}
 </script>
+
+<svelte:window onclick={closeInfoOnOutside} onkeydown={closeInfoOnEscape} />
 
 <div id="downloads" class="setting-row download-setting">
 	<div class="flex flex-col gap-1">
 		<span class="font-medium">Служебные загрузки AWGM</span>
 		<span class="setting-description">
-			Используется для обновлений AWGM, загрузки geo.dat, DNSRoute URL-списков: проверки, ручного и автообновления, установки и обновления managed sing-box binary, а также Amnezia Premium: входа, списка стран и получения конфигураций. Sing-box URL-подписки всегда выполняются напрямую через WAN.
+			Маршрут для служебных задач: обновления AWGM и Sing-Box, загрузок geo.dat и DNSRoute-списков, а также конфигураций Amnezia Premium.<span
+				class="info-hint"
+				bind:this={infoHintEl}
+			>
+				<button
+					type="button"
+					class="info-trigger"
+					aria-label="Через что идут загрузки"
+					aria-expanded={infoOpen}
+					onclick={() => (infoOpen = !infoOpen)}
+				>
+					<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+						<circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.4" />
+						<circle cx="8" cy="4.8" r="0.95" fill="currentColor" />
+						<rect x="7.25" y="6.9" width="1.5" height="4.8" rx="0.75" fill="currentColor" />
+					</svg>
+				</button>
+				{#if infoOpen}
+					<span class="info-popup" role="tooltip">
+						<span class="info-popup-title">Через какой маршрут идёт загрузка</span>
+						<span class="info-popup-row">
+							<strong>AWG-туннели</strong> — качают напрямую, отдельный sing-box не нужен.
+						</span>
+						<span class="info-popup-row">
+							<strong>sing-box-туннели и подписки (SUB)</strong> — работают только при запущенном
+							sing-box; если он выключен, маршрут будет недоступен.
+						</span>
+						<span class="info-popup-row">
+							<strong>Загрузка самих подписок</strong> (скачивание их содержимого по URL) — всегда
+							идёт напрямую через WAN, мимо туннеля.
+						</span>
+					</span>
+				{/if}
+			</span>
 		</span>
 		{#if error}
 			<span class="download-error">{error}</span>
@@ -182,6 +262,76 @@
 	.download-error {
 		color: var(--color-danger);
 		font-size: 0.75rem;
+	}
+
+	.info-hint {
+		position: relative;
+		display: inline-flex;
+		vertical-align: middle;
+		margin-left: 0.25rem;
+	}
+
+	.info-trigger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.05rem;
+		height: 1.05rem;
+		padding: 0;
+		border: none;
+		border-radius: 50%;
+		background: transparent;
+		color: var(--text-muted, var(--color-text-muted));
+		cursor: pointer;
+		transition: color 0.12s ease;
+	}
+
+	.info-trigger:hover,
+	.info-trigger[aria-expanded='true'] {
+		color: var(--accent);
+	}
+
+	.info-trigger:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+		border-radius: 50%;
+	}
+
+	.info-popup {
+		position: absolute;
+		top: calc(100% + 0.4rem);
+		left: 0;
+		z-index: 30;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		width: max-content;
+		max-width: min(22rem, 80vw);
+		padding: 0.6rem 0.75rem;
+		border: 1px solid var(--border, var(--color-border));
+		border-radius: var(--radius-sm);
+		background: var(--bg-secondary, var(--color-bg-secondary));
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+		font-size: 0.75rem;
+		line-height: 1.4;
+		color: var(--text-primary, var(--color-text-primary));
+		white-space: normal;
+		text-align: left;
+		cursor: default;
+	}
+
+	.info-popup-title {
+		font-weight: 600;
+		color: var(--text-primary, var(--color-text-primary));
+	}
+
+	.info-popup-row {
+		color: var(--text-muted, var(--color-text-muted));
+	}
+
+	.info-popup-row strong {
+		color: var(--text-primary, var(--color-text-primary));
+		font-weight: 600;
 	}
 
 	.no-singbox-hint {

--- a/frontend/src/lib/components/settings/DownloadSettings.svelte
+++ b/frontend/src/lib/components/settings/DownloadSettings.svelte
@@ -9,11 +9,6 @@
 		outbounds: DownloadOutbound[];
 		loading: boolean;
 		error: string;
-		/** Когда false — селектор маршрута скрыт, показывается статичный hint:
-		 *  без sing-box все non-direct outbound'ы недоступны (internal/downloader/service.go),
-		 *  и выбирать нечего. Передавать false ТОЛЬКО когда точно известно, что
-		 *  sing-box не установлен (не на ранней стадии загрузки статуса). */
-		routeSelectorEnabled?: boolean;
 		onRefresh: () => void;
 		onSelectRoute: (routeTag: string, routeKind?: DownloadOutbound['kind']) => void;
 	}
@@ -24,7 +19,6 @@
 		outbounds,
 		loading,
 		error,
-		routeSelectorEnabled = true,
 		onRefresh,
 		onSelectRoute,
 	}: Props = $props();
@@ -182,36 +176,27 @@
 			<span class="download-error">{error}</span>
 		{/if}
 	</div>
-	{#if routeSelectorEnabled}
-		<div class="download-controls">
-			<div class="route-select">
-				<Dropdown
-					value={selectedValue}
-					options={options}
-					onchange={handleChange}
-					disabled={saving || loading || options.length === 0}
-					fullWidth
-				/>
-			</div>
-			<div class="download-action">
-				<Button
-					variant="secondary"
-					size="md"
-					onclick={onRefresh}
-					disabled={saving || loading}
-				>
-					Обновить список
-				</Button>
-			</div>
+	<div class="download-controls">
+		<div class="route-select">
+			<Dropdown
+				value={selectedValue}
+				options={options}
+				onchange={handleChange}
+				disabled={saving || loading || options.length === 0}
+				fullWidth
+			/>
 		</div>
-	{:else}
-		<div class="no-singbox-hint">
-			<span class="no-singbox-title">Загрузки идут через WAN (Direct).</span>
-			<span class="no-singbox-detail">
-				Для маршрутизации служебных загрузок через туннель установите sing-box.
-			</span>
+		<div class="download-action">
+			<Button
+				variant="secondary"
+				size="md"
+				onclick={onRefresh}
+				disabled={saving || loading}
+			>
+				Обновить список
+			</Button>
 		</div>
-	{/if}
+	</div>
 </div>
 
 <style>
@@ -332,29 +317,6 @@
 	.info-popup-row strong {
 		color: var(--text-primary, var(--color-text-primary));
 		font-weight: 600;
-	}
-
-	.no-singbox-hint {
-		display: flex;
-		flex-direction: column;
-		gap: 0.125rem;
-		padding: 0.5rem 0.75rem;
-		border: 1px dashed var(--border, var(--color-border));
-		border-radius: var(--radius-sm);
-		background: color-mix(in srgb, var(--color-settings-control-bg) 60%, transparent);
-		font-size: 0.8125rem;
-		width: 100%;
-		min-width: 0;
-	}
-
-	.no-singbox-title {
-		color: var(--text-primary, var(--color-text-primary));
-		font-weight: 500;
-	}
-
-	.no-singbox-detail {
-		color: var(--text-muted, var(--color-text-muted));
-		font-size: 0.75rem;
 	}
 
 	@media (min-width: 641px) {

--- a/frontend/src/lib/components/settings/UpdateSection.svelte
+++ b/frontend/src/lib/components/settings/UpdateSection.svelte
@@ -3,6 +3,8 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { Modal, Button } from '$lib/components/ui';
 	import ChangelogModal from './ChangelogModal.svelte';
+	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
+	import { downloadErrorToText } from '$lib/utils/downloadError';
 	import type { UpdateInfo } from '$lib/types';
 
 	interface Props {
@@ -29,7 +31,7 @@
 		try {
 			updateInfo = await api.checkUpdate(true);
 			if (updateInfo.error) {
-				notifications.error(`Ошибка проверки: ${updateInfo.error}`);
+				notifications.error(`Проверка обновлений: ${downloadErrorToText(updateInfo.error)}`);
 			} else if (updateInfo.available) {
 				notifications.success(`Доступна версия ${updateInfo.latestVersion}`);
 			} else {
@@ -39,7 +41,7 @@
 				notifications.info(updateInfo.warning);
 			}
 		} catch (e) {
-			notifications.error('Ошибка проверки обновлений');
+			notifications.error(`Проверка обновлений: ${downloadErrorToText(e)}`);
 		} finally {
 			checking = false;
 		}
@@ -65,7 +67,7 @@
 		try {
 			await api.applyUpdate();
 		} catch (e) {
-			notifications.error('Ошибка запуска обновления');
+			notifications.error(`Запуск обновления: ${downloadErrorToText(e)}`);
 			upgrading = false;
 			return;
 		}
@@ -103,9 +105,9 @@
 				Доступна версия {updateInfo.latestVersion}
 			</span>
 		{:else if updateInfo?.error}
-			<span class="setting-description update-error">
-				{updateInfo.error}
-			</span>
+			<div class="update-error-notice">
+				<DownloadErrorNotice error={updateInfo.error} hideSettingsLink />
+			</div>
 		{:else}
 			<span class="setting-description">
 				Установлена последняя версия
@@ -266,8 +268,8 @@
 		font-weight: 500;
 	}
 
-	.update-error {
-		color: var(--error, #ef4444) !important;
+	.update-error-notice {
+		min-width: 0;
 	}
 
 	.update-warning {

--- a/frontend/src/lib/components/tunnels/VpnLinkPasteImport.svelte
+++ b/frontend/src/lib/components/tunnels/VpnLinkPasteImport.svelte
@@ -2,6 +2,8 @@
 	import { onMount } from 'svelte';
 	import { Button, ConfirmModal } from '$lib/components/ui';
 	import DownloadRouteNote from '$lib/components/downloads/DownloadRouteNote.svelte';
+	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
+	import { downloadErrorToText } from '$lib/utils/downloadError';
 	import AmneziaConfEditor from './AmneziaConfEditor.svelte';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
@@ -182,7 +184,7 @@
 			resetPremiumCatalogState();
 			const msg = e instanceof Error ? e.message : 'Ошибка запроса к cp.amnezia.org';
 			premiumError = msg;
-			notifications.error(msg);
+			notifications.error(downloadErrorToText(e));
 		} finally {
 			endPremiumBusy();
 		}
@@ -294,7 +296,7 @@
 				});
 			}
 		} catch (e) {
-			notifications.error(e instanceof Error ? e.message : 'Не удалось скачать конфигурацию');
+			notifications.error(downloadErrorToText(e));
 		} finally {
 			premiumPickBusy = '';
 		}
@@ -356,7 +358,9 @@
 		</div>
 	{/if}
 	{#if premiumError}
-		<p class="link-error">{premiumError}</p>
+		<div class="link-error">
+			<DownloadErrorNotice error={premiumError} />
+		</div>
 	{/if}
 	{#if premiumCountries.length}
 		<p class="field-label premium-countries-label">Страны</p>

--- a/frontend/src/lib/stores/downloadRoute.test.ts
+++ b/frontend/src/lib/stores/downloadRoute.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { DownloadOutbound, Settings } from '$lib/types';
+import { resolveDownloadRouteLabel } from './downloadRoute';
+
+const directOutbound: DownloadOutbound = {
+	tag: 'direct',
+	kind: 'direct',
+	label: 'Direct (WAN)',
+	available: true,
+};
+
+function settings(routeTag: string, routeKind?: Settings['download']['routeKind']): Settings {
+	return {
+		download: { routeTag, routeKind },
+	} as Settings;
+}
+
+describe('resolveDownloadRouteLabel', () => {
+	it('resolves direct without routeKind (no false unavailable)', () => {
+		const label = resolveDownloadRouteLabel(settings('direct'), [directOutbound]);
+		expect(label).toBe('Direct (WAN)');
+		expect(label).not.toContain('недоступен');
+	});
+
+	it('falls back to WAN label when outbounds list is empty', () => {
+		const label = resolveDownloadRouteLabel(settings('direct'), []);
+		expect(label).toBe('Direct (WAN) — без туннеля');
+	});
+
+	it('marks unavailable outbound in label', () => {
+		const label = resolveDownloadRouteLabel(settings('awg-work', 'awg'), [
+			{ tag: 'awg-work', kind: 'awg', label: 'Work', available: false },
+		]);
+		expect(label).toBe('Work (AWG) (недоступен)');
+	});
+});

--- a/frontend/src/lib/stores/downloadRoute.ts
+++ b/frontend/src/lib/stores/downloadRoute.ts
@@ -59,7 +59,10 @@ export function resolveDownloadRouteLabel(
 	outbounds: DownloadOutbound[],
 ): string {
 	const tag = currentSettings?.download?.routeTag?.trim() || 'direct';
-	const match = outbounds.find((ob) => ob.tag === tag);
+	const kind = currentSettings?.download?.routeKind?.trim();
+	const match = outbounds.find(
+		(ob) => ob.tag === tag && (!kind || ob.kind === kind),
+	);
 	if (match) {
 		const rendered = displayRouteName(match.label, match.kind);
 		return `${rendered}${match.available ? '' : ' (недоступен)'}`;

--- a/frontend/src/lib/utils/downloadError.test.ts
+++ b/frontend/src/lib/utils/downloadError.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { downloadErrorToText, humanizeDownloadError } from './downloadError';
+
+describe('humanizeDownloadError', () => {
+	it('classifies sing-box-off from outbound-unavailable message', () => {
+		const h = humanizeDownloadError(
+			new Error('outbound "sub-14ddb10d" is unavailable: sing-box is not running'),
+		);
+		expect(h.kind).toBe('singbox-off');
+		expect(h.needsDownloadSettings).toBe(true);
+		expect(h.title).toMatch(/sing-box/i);
+	});
+
+	it('classifies awg-down from missing interface', () => {
+		const h = humanizeDownloadError('outbound "awg-de" interface "awg0" is not present');
+		expect(h.kind).toBe('awg-down');
+		expect(h.needsDownloadSettings).toBe(true);
+	});
+
+	it('classifies timeout', () => {
+		const h = humanizeDownloadError('download timed out after 15m0s');
+		expect(h.kind).toBe('timeout');
+	});
+
+	it('classifies network drops (EOF / malformed HTTP / reset)', () => {
+		expect(humanizeDownloadError('http get: EOF').kind).toBe('network');
+		expect(
+			humanizeDownloadError('malformed HTTP response "\\x00\\x00"').kind,
+		).toBe('network');
+		expect(humanizeDownloadError('connection reset by peer').kind).toBe('network');
+	});
+
+	it('classifies generic route errors via envelope code', () => {
+		const err = Object.assign(new Error('selected outbound is unavailable for download transport'), {
+			body: { code: 'GEO_DOWNLOAD_ROUTE_ERROR' },
+		});
+		const h = humanizeDownloadError(err);
+		expect(h.kind).toBe('route');
+		expect(h.code).toBe('GEO_DOWNLOAD_ROUTE_ERROR');
+	});
+
+	it('reads message + code from API client error body', () => {
+		const err = Object.assign(new Error('top'), {
+			body: { code: 'X', message: 'sing-box is not running' },
+		});
+		const h = humanizeDownloadError(err);
+		expect(h.kind).toBe('singbox-off');
+		expect(h.raw).toBe('sing-box is not running');
+		expect(h.code).toBe('X');
+	});
+
+	it('falls back to raw message for unknown errors', () => {
+		const h = humanizeDownloadError('repository quota exceeded');
+		expect(h.kind).toBe('generic');
+		expect(h.needsDownloadSettings).toBe(false);
+		expect(h.title).toBe('repository quota exceeded');
+	});
+
+	it('handles null / empty input', () => {
+		const h = humanizeDownloadError(null);
+		expect(h.kind).toBe('generic');
+		expect(h.title).toBeTruthy();
+	});
+});
+
+describe('downloadErrorToText', () => {
+	it('joins title + detail for toast contexts', () => {
+		const text = downloadErrorToText('sing-box is not running');
+		expect(text).toMatch(/sing-box/i);
+		expect(text).toMatch(/Direct|AWG/);
+	});
+
+	it('appends settings cue when no detail but route-related', () => {
+		// generic has no settings cue
+		expect(downloadErrorToText('weird error')).toBe('weird error');
+	});
+
+	it('accepts an already-humanized error', () => {
+		const h = humanizeDownloadError('download timed out');
+		expect(downloadErrorToText(h)).toBe(downloadErrorToText('download timed out'));
+	});
+});

--- a/frontend/src/lib/utils/downloadError.ts
+++ b/frontend/src/lib/utils/downloadError.ts
@@ -1,0 +1,214 @@
+/**
+ * Centralized humanization of "service download" errors — geo.dat, AWGM
+ * self-update / update check, DNSRoute URL-lists, Amnezia Premium, the
+ * download-route list, etc. All of these run through the configurable
+ * download route (Direct / AWG-bind / sing-box / subscription), so they
+ * share the same failure modes.
+ *
+ * The backend emits a heterogeneous mix of RU/EN strings and an envelope
+ * `code`. Instead of every call site re-implementing regexes, this module
+ * classifies the error once and returns a friendly user-facing message plus
+ * the raw text (kept for logs / "details"). See humanizeDownloadError().
+ */
+
+export type DownloadErrorKind =
+	| 'singbox-off'
+	| 'awg-down'
+	| 'timeout'
+	| 'network'
+	| 'route'
+	| 'generic';
+
+export interface HumanizedDownloadError {
+	/** Short, friendly headline shown to the user. */
+	title: string;
+	/** Optional actionable hint (what to do next). */
+	detail?: string;
+	kind: DownloadErrorKind;
+	/** True when pointing the user at Settings → Downloads is useful. */
+	needsDownloadSettings: boolean;
+	/** Original backend message — keep for logs / collapsible details. */
+	raw: string;
+	/** Backend envelope code, when present (e.g. GEO_DOWNLOAD_ROUTE_ERROR). */
+	code?: string;
+}
+
+/** Deep-link that scrolls to and glows the "Загрузки и обновления" card. */
+export const DOWNLOAD_SETTINGS_HREF = '/settings?highlight=downloads#downloads';
+
+interface ExtractedError {
+	raw: string;
+	code: string;
+}
+
+/**
+ * Pull a message + envelope code out of whatever a call site caught: an API
+ * client Error (with `.body.code` / `.body.message`), a plain Error, a bare
+ * string (e.g. `UpdateInfo.error`, `subscription.lastError`), or null.
+ */
+function extractError(err: unknown): ExtractedError {
+	if (err == null) return { raw: '', code: '' };
+	if (typeof err === 'string') return { raw: err, code: '' };
+	if (typeof err === 'object') {
+		const e = err as {
+			message?: string;
+			code?: string;
+			body?: { code?: string; message?: string };
+		};
+		const code = e.body?.code || e.code || '';
+		const raw = e.body?.message || e.message || String(err);
+		return { raw, code };
+	}
+	return { raw: String(err), code: '' };
+}
+
+function classify(raw: string, code: string): DownloadErrorKind {
+	const text = `${raw} ${code}`.toLowerCase();
+
+	// sing-box-backed route (sing-box tunnel or subscription) but the daemon
+	// is down / its local proxy port is not yet listening.
+	if (
+		text.includes('sing-box is not running') ||
+		text.includes('sing-box proxy port') ||
+		text.includes('proxy port not found')
+	) {
+		return 'singbox-off';
+	}
+
+	// AWG bind route but the kernel interface is missing / link is down.
+	if (
+		text.includes('is not present') ||
+		text.includes('no such device') ||
+		text.includes('network is unreachable') ||
+		text.includes('no route to host')
+	) {
+		return 'awg-down';
+	}
+
+	if (
+		text.includes('timed out') ||
+		text.includes('timeout') ||
+		text.includes('deadline exceeded')
+	) {
+		return 'timeout';
+	}
+
+	if (
+		text.includes('eof') ||
+		text.includes('connection reset') ||
+		text.includes('connection broken') ||
+		text.includes('connection refused') ||
+		text.includes('broken pipe') ||
+		text.includes('malformed http response') ||
+		text.includes('ошибка сети')
+	) {
+		return 'network';
+	}
+
+	// Generic "route is unavailable / ambiguous" without a more specific cause.
+	if (
+		text.includes('is unavailable') ||
+		text.includes('unavailable for download transport') ||
+		text.includes('is ambiguous') ||
+		code.endsWith('ROUTE_ERROR')
+	) {
+		return 'route';
+	}
+
+	return 'generic';
+}
+
+/**
+ * Classify a caught download error into a friendly, actionable message.
+ *
+ * Usage:
+ *   const h = humanizeDownloadError(e);
+ *   notifications.error(downloadErrorToText(h));   // toast (no link)
+ *   <DownloadErrorNotice error={e} />              // inline (with link)
+ */
+export function humanizeDownloadError(err: unknown): HumanizedDownloadError {
+	const { raw, code } = extractError(err);
+	const kind = classify(raw, code);
+
+	switch (kind) {
+		case 'singbox-off':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'Маршрут загрузки требует запущенный sing-box.',
+				detail:
+					'Включите sing-box или выберите другой маршрут (Direct или AWG-туннель).',
+			};
+		case 'awg-down':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'AWG-туннель маршрута загрузки недоступен.',
+				detail:
+					'Туннель выключен или его интерфейс не поднят. Запустите туннель или выберите другой маршрут.',
+			};
+		case 'timeout':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'Превышено время ожидания загрузки.',
+				detail:
+					'Сервер не ответил вовремя. Проверьте соединение/маршрут загрузок и попробуйте ещё раз.',
+			};
+		case 'network':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'Не удалось установить соединение.',
+				detail:
+					'Соединение оборвалось — возможно, маршрут блокируется или нестабилен. Попробуйте другой маршрут загрузок.',
+			};
+		case 'route':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'Маршрут загрузки недоступен.',
+				detail: 'Проверьте маршрут служебных загрузок и попробуйте снова.',
+			};
+		default:
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: false,
+				title: raw || 'Не удалось выполнить загрузку.',
+			};
+	}
+}
+
+/**
+ * Flatten a humanized error into a single line for toast contexts that can't
+ * render a link. Appends a "go to settings" cue when relevant.
+ */
+export function downloadErrorToText(input: unknown): string {
+	const h =
+		isHumanized(input) ? input : humanizeDownloadError(input);
+	const parts = [h.title];
+	if (h.detail) parts.push(h.detail);
+	else if (h.needsDownloadSettings) parts.push('Откройте Настройки → Загрузки.');
+	return parts.join(' ');
+}
+
+function isHumanized(v: unknown): v is HumanizedDownloadError {
+	return (
+		typeof v === 'object' &&
+		v !== null &&
+		'kind' in v &&
+		'needsDownloadSettings' in v
+	);
+}

--- a/frontend/src/routes/routing/DnsRoutesTab.svelte
+++ b/frontend/src/routes/routing/DnsRoutesTab.svelte
@@ -13,6 +13,7 @@
     import { exportRoutes, downloadJson } from '$lib/utils/dns-export';
     import { buildRoutingTunnelDropdownOptions } from '$lib/utils/routingTunnelOptions';
     import { notifications } from '$lib/stores/notifications';
+    import { downloadErrorToText } from '$lib/utils/downloadError';
     import { dnsRoutesStore } from '$lib/stores/routing';
     import { settings, usageLevel } from '$lib/stores/settings';
     import {
@@ -172,8 +173,8 @@
             const fresh = await api.refreshDnsRouteSubscriptions(id);
             dnsRoutesStore.applyMutationResponse(fresh);
             notifications.success('Подписки обновлены');
-        } catch (e: any) {
-            notifications.error(e.message || 'Ошибка обновления');
+        } catch (e: unknown) {
+            notifications.error(`Обновление подписок: ${downloadErrorToText(e)}`);
         }
     }
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -58,6 +58,7 @@
 		Wrench,
 		Power,
 	} from "lucide-svelte";
+	import { downloadErrorToText } from "$lib/utils/downloadError";
 
 	const expandUsageLevel = $derived($page.url.searchParams.has('mode'));
 	const highlightFeedbackFab = $derived($page.url.searchParams.has('feedbackFab'));
@@ -233,7 +234,7 @@
 		if (!showNotification) return;
 		const err = get(downloadOutboundsError);
 		if (err) {
-			notifications.error(`Ошибка обновления маршрутов: ${err}`);
+			notifications.error(`Маршруты загрузок: ${downloadErrorToText(err)}`);
 			return;
 		}
 		const list = get(downloadOutbounds);
@@ -538,8 +539,8 @@ $effect(() => {
 					? 'Канал обновлений: develop (нестабильный)'
 					: 'Канал обновлений изменён на стабильный',
 			);
-		} catch {
-			notifications.error('Ошибка смены канала обновлений');
+		} catch (e) {
+			notifications.error(`Смена канала обновлений: ${downloadErrorToText(e)}`);
 		} finally {
 			saving = false;
 		}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -797,7 +797,6 @@ $effect(() => {
 								outbounds={$downloadOutbounds}
 								loading={$downloadOutboundsLoading}
 								error={$downloadOutboundsError}
-								routeSelectorEnabled={singboxInstalled || singboxStatusLoading}
 								onRefresh={refreshDownloadOutbounds}
 								onSelectRoute={selectDownloadRoute}
 							/>

--- a/internal/api/amnezia_cp.go
+++ b/internal/api/amnezia_cp.go
@@ -19,6 +19,25 @@ import (
 
 const amneziaCPOrigin = "https://cp.amnezia.org"
 
+// applyAmneziaCPTimeouts sets the cp.amnezia.org-specific timeout profile
+// WITHOUT touching DialContext or TLS config. Used on a download-route lease
+// transport so the tunnel binding (SO_BINDTODEVICE + MSS clamp) and the
+// pinned HTTP/1.1 ALPN survive — otherwise "via Work" would silently leak to
+// the WAN.
+func applyAmneziaCPTimeouts(tr *http.Transport) {
+	if tr == nil {
+		return
+	}
+	tr.TLSHandshakeTimeout = 15 * time.Second
+	tr.ResponseHeaderTimeout = 25 * time.Second
+	tr.ExpectContinueTimeout = 1 * time.Second
+	tr.IdleConnTimeout = 45 * time.Second
+	tr.MaxIdleConnsPerHost = 8
+	tr.DisableKeepAlives = true
+}
+
+// configureAmneziaCPTransport sets up a fresh, direct (non-tunnel) transport
+// for the fallback client used when no download route is configured.
 func configureAmneziaCPTransport(tr *http.Transport) {
 	if tr == nil {
 		return
@@ -27,12 +46,7 @@ func configureAmneziaCPTransport(tr *http.Transport) {
 		Timeout:   12 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext
-	tr.TLSHandshakeTimeout = 15 * time.Second
-	tr.ResponseHeaderTimeout = 25 * time.Second
-	tr.ExpectContinueTimeout = 1 * time.Second
-	tr.IdleConnTimeout = 45 * time.Second
-	tr.MaxIdleConnsPerHost = 8
-	tr.DisableKeepAlives = true
+	applyAmneziaCPTimeouts(tr)
 }
 
 // Dedicated HTTP client for cp.amnezia.org: disable connection reuse — idle TLS sessions
@@ -94,7 +108,8 @@ func (h *AmneziaCPHandler) downloadClient(ctx context.Context) (*downloader.Leas
 	}
 	client.Timeout = 45 * time.Second
 	if tr, ok := client.Transport.(*http.Transport); ok {
-		configureAmneziaCPTransport(tr)
+		// Preserve the lease's bind dialer + ALPN pin; only adjust timeouts.
+		applyAmneziaCPTimeouts(tr)
 	} else if client.Transport == nil {
 		tr := &http.Transport{Proxy: http.ProxyFromEnvironment}
 		configureAmneziaCPTransport(tr)

--- a/internal/api/hydraroute_test.go
+++ b/internal/api/hydraroute_test.go
@@ -36,9 +36,15 @@ func TestDownloadDeviceProxyAdapter(t *testing.T) {
 	}
 }
 
-func TestDownloadSingboxInterfaceAssertion(t *testing.T) {
-	if got := downloader.NewSingboxOperatorAdapter(nil); got != nil {
-		t.Fatalf("nil singbox op should produce nil adapter")
+func TestDownloadTransportAdaptersNilSafe(t *testing.T) {
+	if got := downloader.NewSingboxTunnelPortAdapter(nil); got != nil {
+		t.Fatalf("nil singbox op should produce nil tunnel port adapter")
+	}
+	if got := downloader.NewSubscriptionPortAdapter(nil); got != nil {
+		t.Fatalf("nil subscription svc should produce nil port adapter")
+	}
+	if got := downloader.NewSingboxRuntimeAdapter(nil); got != nil {
+		t.Fatalf("nil singbox op should produce nil runtime adapter")
 	}
 }
 

--- a/internal/downloader/adapters.go
+++ b/internal/downloader/adapters.go
@@ -6,19 +6,33 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/deviceproxy"
 	"github.com/hoaxisr/awg-manager/internal/singbox"
+	"github.com/hoaxisr/awg-manager/internal/singbox/subscription"
 	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/tunnel"
 )
 
 type deviceProxyOutboundsProvider struct {
 	svc *deviceproxy.Service
 }
 
-type singboxOperatorAdapter struct {
+type settingsRouteProvider struct {
+	store *storage.SettingsStore
+}
+
+type singboxTunnelPortAdapter struct {
 	op *singbox.Operator
 }
 
-type settingsRouteProvider struct {
-	store *storage.SettingsStore
+type subscriptionPortAdapter struct {
+	svc *subscription.Service
+}
+
+type singboxRuntimeAdapter struct {
+	op *singbox.Operator
+}
+
+type awgStoreEgressAdapter struct {
+	store *storage.AWGTunnelStore
 }
 
 func NewDeviceProxyOutboundsProvider(svc *deviceproxy.Service) OutboundsProvider {
@@ -28,13 +42,6 @@ func NewDeviceProxyOutboundsProvider(svc *deviceproxy.Service) OutboundsProvider
 	return &deviceProxyOutboundsProvider{svc: svc}
 }
 
-func NewSingboxOperatorAdapter(op *singbox.Operator) SingboxOperator {
-	if op == nil {
-		return nil
-	}
-	return &singboxOperatorAdapter{op: op}
-}
-
 func NewSettingsRouteProvider(store *storage.SettingsStore) RouteProvider {
 	if store == nil {
 		return nil
@@ -42,18 +49,78 @@ func NewSettingsRouteProvider(store *storage.SettingsStore) RouteProvider {
 	return &settingsRouteProvider{store: store}
 }
 
+func NewSingboxTunnelPortAdapter(op *singbox.Operator) TunnelListenPortLookup {
+	if op == nil {
+		return nil
+	}
+	return &singboxTunnelPortAdapter{op: op}
+}
+
+func NewSubscriptionPortAdapter(svc *subscription.Service) SubscriptionListenPortLookup {
+	if svc == nil {
+		return nil
+	}
+	return &subscriptionPortAdapter{svc: svc}
+}
+
+func NewSingboxRuntimeAdapter(op *singbox.Operator) SingboxRuntimeChecker {
+	if op == nil {
+		return nil
+	}
+	return &singboxRuntimeAdapter{op: op}
+}
+
+func NewAWGStoreEgressAdapter(store *storage.AWGTunnelStore) AWGEgressLookup {
+	if store == nil {
+		return nil
+	}
+	return &awgStoreEgressAdapter{store: store}
+}
+
 func NewSettingsBackedService(
 	deviceProxySvc *deviceproxy.Service,
 	singboxOp *singbox.Operator,
-	slot SlotController,
-	store *storage.SettingsStore,
+	subSvc *subscription.Service,
+	settingsStore *storage.SettingsStore,
+	awgStore *storage.AWGTunnelStore,
 ) *Service {
 	return NewService(Deps{
-		Outbounds:     NewDeviceProxyOutboundsProvider(deviceProxySvc),
-		Singbox:       NewSingboxOperatorAdapter(singboxOp),
-		Slot:          slot,
-		RouteProvider: NewSettingsRouteProvider(store),
+		Outbounds: NewDeviceProxyOutboundsProvider(deviceProxySvc),
+		TransportResolver: NewTransportResolver(TransportResolverDeps{
+			Tunnels:   NewSingboxTunnelPortAdapter(singboxOp),
+			Subs:      NewSubscriptionPortAdapter(subSvc),
+			Singbox:   NewSingboxRuntimeAdapter(singboxOp),
+			AWGEgress: NewAWGStoreEgressAdapter(awgStore),
+		}),
+		RouteProvider: NewSettingsRouteProvider(settingsStore),
 	})
+}
+
+func (a *awgStoreEgressAdapter) DNSForTag(_ context.Context, tag string) []string {
+	if a == nil || a.store == nil {
+		return nil
+	}
+	id, system := awgTunnelIDFromTag(tag)
+	if id == "" || system {
+		return nil
+	}
+	stored, err := a.store.Get(id)
+	if err != nil || stored == nil {
+		return nil
+	}
+	return tunnel.ParseDNSList(stored.Interface.DNS)
+}
+
+func awgTunnelIDFromTag(tag string) (id string, system bool) {
+	tag = strings.TrimSpace(tag)
+	switch {
+	case strings.HasPrefix(tag, "awg-sys-"):
+		return strings.TrimPrefix(tag, "awg-sys-"), true
+	case strings.HasPrefix(tag, "awg-"):
+		return strings.TrimPrefix(tag, "awg-"), false
+	default:
+		return "", false
+	}
 }
 
 func (a *deviceProxyOutboundsProvider) ListDownloadOutbounds(ctx context.Context) []Outbound {
@@ -73,16 +140,43 @@ func (a *deviceProxyOutboundsProvider) ListDownloadOutbounds(ctx context.Context
 	return out
 }
 
-func (a *singboxOperatorAdapter) IsRunning() (bool, int) {
-	return a.op.IsRunningPublic()
+func (a *singboxTunnelPortAdapter) ListenPortByTag(ctx context.Context, tag string) (int, bool) {
+	if a == nil || a.op == nil || strings.TrimSpace(tag) == "" {
+		return 0, false
+	}
+	tunnels, err := a.op.ListTunnels(ctx)
+	if err != nil {
+		return 0, false
+	}
+	for _, t := range tunnels {
+		if t.Tag == tag && t.ListenPort > 0 {
+			return t.ListenPort, true
+		}
+	}
+	return 0, false
 }
 
-func (a *singboxOperatorAdapter) SetSelectorDefault(ctx context.Context, selectorTag, memberTag string) error {
-	return a.op.SetSelectorDefault(ctx, selectorTag, memberTag)
+func (a *subscriptionPortAdapter) ListenPortBySelectorTag(_ context.Context, selectorTag string) (int, bool) {
+	if a == nil || a.svc == nil || strings.TrimSpace(selectorTag) == "" {
+		return 0, false
+	}
+	for _, sub := range a.svc.List() {
+		if sub.SelectorTag != selectorTag || !sub.Enabled {
+			continue
+		}
+		if sub.ListenPort > 0 && len(sub.MemberTags) > 0 {
+			return int(sub.ListenPort), true
+		}
+	}
+	return 0, false
 }
 
-func (a *singboxOperatorAdapter) GetSelectorActive(ctx context.Context, selectorTag string) (string, error) {
-	return a.op.GetSelectorActive(ctx, selectorTag)
+func (a *singboxRuntimeAdapter) IsRunning() bool {
+	if a == nil || a.op == nil {
+		return false
+	}
+	running, _ := a.op.IsRunningPublic()
+	return running
 }
 
 func (p *settingsRouteProvider) GetDownloadRoute(ctx context.Context) (*Route, error) {

--- a/internal/downloader/adapters_test.go
+++ b/internal/downloader/adapters_test.go
@@ -1,0 +1,53 @@
+package downloader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+func TestAWGTunnelIDFromTag(t *testing.T) {
+	tests := []struct {
+		tag       string
+		wantID    string
+		wantSys   bool
+	}{
+		{"awg-awg11", "awg11", false},
+		{"awg-sys-Wireguard0", "Wireguard0", true},
+		{"direct", "", false},
+	}
+	for _, tc := range tests {
+		id, system := awgTunnelIDFromTag(tc.tag)
+		if id != tc.wantID || system != tc.wantSys {
+			t.Fatalf("awgTunnelIDFromTag(%q) = (%q, %v), want (%q, %v)", tc.tag, id, system, tc.wantID, tc.wantSys)
+		}
+	}
+}
+
+func TestAWGStoreEgressAdapter_DNSForTag(t *testing.T) {
+	dir := t.TempDir()
+	store := storage.NewAWGTunnelStore(dir)
+	if err := store.Save(&storage.AWGTunnel{
+		ID:   "awg11",
+		Name: "Work",
+		Interface: storage.AWGInterface{
+			DNS: "10.8.0.1, 1.1.1.1",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// lock dir sidecar
+	_ = os.Mkdir(filepath.Join(dir, ".locks"), 0o755)
+
+	adp := NewAWGStoreEgressAdapter(store)
+	got := adp.DNSForTag(context.Background(), "awg-awg11")
+	if len(got) != 2 || got[0] != "10.8.0.1" || got[1] != "1.1.1.1" {
+		t.Fatalf("DNSForTag = %+v", got)
+	}
+	if adp.DNSForTag(context.Background(), "awg-sys-Wireguard0") != nil {
+		t.Fatal("system tag should not resolve managed DNS")
+	}
+}

--- a/internal/downloader/adapters_test.go
+++ b/internal/downloader/adapters_test.go
@@ -2,7 +2,6 @@ package downloader
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +28,8 @@ func TestAWGTunnelIDFromTag(t *testing.T) {
 
 func TestAWGStoreEgressAdapter_DNSForTag(t *testing.T) {
 	dir := t.TempDir()
-	store := storage.NewAWGTunnelStore(dir)
+	lockDir := filepath.Join(dir, ".locks")
+	store := storage.NewAWGTunnelStoreWithLockDir(dir, lockDir)
 	if err := store.Save(&storage.AWGTunnel{
 		ID:   "awg11",
 		Name: "Work",
@@ -39,8 +39,6 @@ func TestAWGStoreEgressAdapter_DNSForTag(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// lock dir sidecar
-	_ = os.Mkdir(filepath.Join(dir, ".locks"), 0o755)
 
 	adp := NewAWGStoreEgressAdapter(store)
 	got := adp.DNSForTag(context.Background(), "awg-awg11")

--- a/internal/downloader/service.go
+++ b/internal/downloader/service.go
@@ -2,50 +2,29 @@ package downloader
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"net"
-	"net/http"
-	"net/url"
 	"strings"
 	"sync"
-	"time"
-
-	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
-)
-
-const (
-	downloadProxyInboundTag  = "awgm-download-in"
-	downloadProxySelectorTag = "awgm-download-selector"
-	downloadProxyListenHost  = "127.0.0.1"
-	downloadProxyListenPort  = 11998
-	downloadCleanupTimeout   = 5 * time.Second
 )
 
 type Deps struct {
-	Outbounds     OutboundsProvider
-	Singbox       SingboxOperator
-	Slot          SlotController
-	RouteProvider RouteProvider
+	Outbounds         OutboundsProvider
+	TransportResolver TransportResolver
+	RouteProvider     RouteProvider
 }
 
 type Service struct {
-	mu sync.Mutex
-
 	depsMu    sync.RWMutex
 	outbounds OutboundsProvider
-	singbox   SingboxOperator
-	slot      SlotController
+	transport TransportResolver
 	routeProv RouteProvider
 }
 
 func NewService(d Deps) *Service {
 	return &Service{
 		outbounds: d.Outbounds,
-		singbox:   d.Singbox,
-		slot:      d.Slot,
+		transport: d.TransportResolver,
 		routeProv: d.RouteProvider,
 	}
 }
@@ -56,16 +35,10 @@ func (s *Service) SetOutboundsProvider(p OutboundsProvider) {
 	s.outbounds = p
 }
 
-func (s *Service) SetSingboxOperator(op SingboxOperator) {
+func (s *Service) SetTransportResolver(r TransportResolver) {
 	s.depsMu.Lock()
 	defer s.depsMu.Unlock()
-	s.singbox = op
-}
-
-func (s *Service) SetSlotController(slot SlotController) {
-	s.depsMu.Lock()
-	defer s.depsMu.Unlock()
-	s.slot = slot
+	s.transport = r
 }
 
 func (s *Service) SetRouteProvider(p RouteProvider) {
@@ -74,14 +47,14 @@ func (s *Service) SetRouteProvider(p RouteProvider) {
 	s.routeProv = p
 }
 
-func (s *Service) snapshotDeps() (OutboundsProvider, SingboxOperator, SlotController, RouteProvider) {
+func (s *Service) snapshotDeps() (OutboundsProvider, TransportResolver, RouteProvider) {
 	s.depsMu.RLock()
 	defer s.depsMu.RUnlock()
-	return s.outbounds, s.singbox, s.slot, s.routeProv
+	return s.outbounds, s.transport, s.routeProv
 }
 
 func (s *Service) ListOutbounds(ctx context.Context) []Outbound {
-	outbounds, singbox, slot, _ := s.snapshotDeps()
+	outbounds, transport, _ := s.snapshotDeps()
 	if outbounds == nil {
 		return []Outbound{{
 			Tag:       "direct",
@@ -93,32 +66,25 @@ func (s *Service) ListOutbounds(ctx context.Context) []Outbound {
 	}
 
 	items := outbounds.ListDownloadOutbounds(ctx)
-	sbRunning := false
-	if singbox != nil {
-		sbRunning, _ = singbox.IsRunning()
-	}
-	downloadReady := sbRunning && slot != nil
-
 	out := make([]Outbound, 0, len(items))
 	for _, item := range items {
-		available := item.Tag == "direct" || (downloadReady && strings.TrimSpace(item.Tag) != "")
-		item.Available = available
+		if item.Tag == "direct" {
+			item.Available = true
+		} else if transport != nil {
+			item.Available = transport.IsAvailable(ctx, item)
+		}
 		out = append(out, item)
 	}
 	return out
 }
 
 func (s *Service) DescribeRoute(ctx context.Context, route *Route) RouteInfo {
-	outbounds, _, _, _ := s.snapshotDeps()
+	outbounds, _, _ := s.snapshotDeps()
 	return describeRouteWithProvider(ctx, outbounds, route)
 }
 
 func (s *Service) ValidateRoute(ctx context.Context, route *Route) (RouteInfo, error) {
-	// ValidateRoute validates route identity only. It intentionally does not
-	// reject Available=false outbounds: a saved service-download route may be
-	// temporarily unavailable when sing-box is stopped or runtime dependencies
-	// are down.
-	outbounds, _, _, _ := s.snapshotDeps()
+	outbounds, _, _ := s.snapshotDeps()
 	tag := "direct"
 	if route != nil && strings.TrimSpace(route.Tag) != "" {
 		tag = strings.TrimSpace(route.Tag)
@@ -162,7 +128,7 @@ func describeRouteWithProvider(ctx context.Context, outbounds OutboundsProvider,
 }
 
 func (s *Service) ResolveClient(ctx context.Context, route *Route) (*Lease, error) {
-	outbounds, singbox, slot, routeProvider := s.snapshotDeps()
+	outbounds, transport, routeProvider := s.snapshotDeps()
 	effectiveRoute := route
 	if effectiveRoute == nil || strings.TrimSpace(effectiveRoute.Tag) == "" {
 		if routeProvider != nil {
@@ -175,100 +141,62 @@ func (s *Service) ResolveClient(ctx context.Context, route *Route) (*Lease, erro
 	}
 	info := describeRouteWithProvider(ctx, outbounds, effectiveRoute)
 	if info.Tag == "direct" {
+		client, err := newHTTPClientFromSpec(TransportSpec{Mode: TransportModeDirect})
+		if err != nil {
+			return nil, err
+		}
 		return &Lease{
-			Client: &http.Client{},
+			Client: client,
 			Route:  info,
+			cleanup: func() {
+				client.CloseIdleConnections()
+			},
 		}, nil
 	}
+
 	tag := info.Tag
-	if singbox == nil {
-		return nil, fmt.Errorf("selected outbound %q is unavailable: sing-box operator is not configured", tag)
+	if outbounds == nil {
+		return nil, errors.New(unavailableRouteMessage(tag, routeKind(effectiveRoute)))
 	}
-	if slot == nil {
-		return nil, fmt.Errorf("selected outbound %q is unavailable: sing-box orchestrator is not configured", tag)
-	}
-	isRunning, _ := singbox.IsRunning()
-	if !isRunning {
-		return nil, fmt.Errorf("selected outbound %q is unavailable: sing-box is not running", tag)
+	if transport == nil {
+		return nil, fmt.Errorf("selected outbound %q is unavailable: download transport resolver is not configured", tag)
 	}
 
-	members := []string{"direct"}
+	items := outbounds.ListDownloadOutbounds(ctx)
+	if isRuntimeTagAmbiguous(items, tag) {
+		return nil, fmt.Errorf("selected outbound tag %q is ambiguous for download transport: multiple outbounds share the same runtime tag", tag)
+	}
+
+	var ob Outbound
 	found := false
-	if outbounds != nil {
-		items := outbounds.ListDownloadOutbounds(ctx)
-		if isRuntimeTagAmbiguous(items, tag) {
-			return nil, fmt.Errorf("selected outbound tag %q is ambiguous for download transport: multiple outbounds share the same runtime tag", tag)
-		}
-		for _, ob := range items {
-			if ob.Tag == "" {
-				continue
-			}
-			if ob.Tag != "direct" {
-				members = append(members, ob.Tag)
-			}
-			if routeMatches(ob, effectiveRoute, tag) {
-				found = true
-				info = RouteInfo{Tag: ob.Tag, Kind: ob.Kind, Label: ob.Label, Detail: ob.Detail}
-			}
+	for _, candidate := range items {
+		if routeMatches(candidate, effectiveRoute, tag) {
+			ob = candidate
+			found = true
+			info = RouteInfo{Tag: ob.Tag, Kind: ob.Kind, Label: ob.Label, Detail: ob.Detail}
+			break
 		}
 	}
 	if !found {
 		return nil, errors.New(unavailableRouteMessage(tag, routeKind(effectiveRoute)))
 	}
 
-	s.mu.Lock()
-	proxyURL := &url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(downloadProxyListenHost, fmt.Sprintf("%d", downloadProxyListenPort)),
-	}
-	transport := &http.Transport{
-		Proxy: http.ProxyURL(proxyURL),
-	}
-	if dt, ok := http.DefaultTransport.(*http.Transport); ok && dt != nil {
-		transport = dt.Clone()
-		transport.Proxy = http.ProxyURL(proxyURL)
-	}
-	client := &http.Client{
-		Transport: transport,
-	}
-	lease := &Lease{
-		Client: client,
-		Route:  info,
-	}
-	lease.cleanup = func() {
-		client.CloseIdleConnections()
-		s.cleanupDownloadProxySlotLocked(singbox, slot)
-		s.mu.Unlock()
-	}
-
-	selectedTag := selectedTagForSlot(tag)
-	if err := s.applyDownloadProxySlotLocked(slot, members, selectedTag); err != nil {
-		client.CloseIdleConnections()
-		s.cleanupDownloadProxySlotLocked(singbox, slot)
-		s.mu.Unlock()
+	spec, err := transport.Resolve(ctx, ob)
+	if err != nil {
 		return nil, err
 	}
-	if err := s.selectDownloadOutboundWithRetry(ctx, singbox, selectedTag); err != nil {
-		lease.Close()
-		return nil, fmt.Errorf("select download outbound %q: %w", tag, err)
-	}
-	active, err := s.readSelectorActiveWithRetry(ctx, singbox, downloadProxySelectorTag)
+	client, err := newHTTPClientFromSpec(spec)
 	if err != nil {
-		lease.Close()
-		return nil, fmt.Errorf("verify download selector active member: %w", err)
+		return nil, fmt.Errorf("build download client for %q: %w", tag, err)
 	}
-	slog.Info("downloader: selector state",
-		"requestedTag", tag,
-		"requestedKind", info.Kind,
-		"activeTag", active,
-		"members", members,
-		"proxy", net.JoinHostPort(downloadProxyListenHost, fmt.Sprintf("%d", downloadProxyListenPort)),
-	)
-	if active != selectedTag {
-		lease.Close()
-		return nil, fmt.Errorf("download selector mismatch: requested %s, active %s", selectedTag, active)
-	}
-	return lease, nil
+
+	return &Lease{
+		Client: client,
+		Route:  info,
+		cleanup: func() {
+			client.CloseIdleConnections()
+		},
+	}, nil
 }
 
 func routeKind(route *Route) string {
@@ -311,146 +239,4 @@ func isRuntimeTagAmbiguous(items []Outbound, tag string) bool {
 		}
 	}
 	return false
-}
-
-func selectedTagForSlot(tag string) string {
-	tag = strings.TrimSpace(tag)
-	if tag == "" {
-		return "direct"
-	}
-	return tag
-}
-
-func (s *Service) applyDownloadProxySlotLocked(slot SlotController, members []string, selectedTag string) error {
-	if slot == nil {
-		return fmt.Errorf("download proxy orchestrator is not configured")
-	}
-	uniq := uniqueDownloadMembers(members)
-	slotPayload := map[string]any{
-		"inbounds": []any{
-			map[string]any{
-				"type":        "mixed",
-				"tag":         downloadProxyInboundTag,
-				"listen":      downloadProxyListenHost,
-				"listen_port": downloadProxyListenPort,
-			},
-		},
-		"outbounds": []any{
-			map[string]any{
-				"type":                        "selector",
-				"tag":                         downloadProxySelectorTag,
-				"outbounds":                   uniq,
-				"default":                     selectedTag,
-				"interrupt_exist_connections": false,
-			},
-		},
-		"route": map[string]any{
-			"rules": []any{
-				map[string]any{
-					"inbound":  downloadProxyInboundTag,
-					"outbound": downloadProxySelectorTag,
-				},
-			},
-		},
-	}
-	raw, err := json.MarshalIndent(slotPayload, "", "  ")
-	if err != nil {
-		return fmt.Errorf("build download transport slot: %w", err)
-	}
-	if err := slot.SaveSilent(singboxorch.SlotDownloadProxy, raw); err != nil {
-		return fmt.Errorf("save download transport slot: %w", err)
-	}
-	if err := slot.SetEnabledSilent(singboxorch.SlotDownloadProxy, true); err != nil {
-		return fmt.Errorf("enable download transport slot: %w", err)
-	}
-	if err := slot.Reload(); err != nil {
-		_ = slot.SetEnabledSilent(singboxorch.SlotDownloadProxy, false)
-		_ = slot.Reload()
-		return fmt.Errorf("reload sing-box with download transport slot: %w", err)
-	}
-	return nil
-}
-
-func uniqueDownloadMembers(members []string) []string {
-	uniq := make([]string, 0, len(members))
-	seen := map[string]struct{}{}
-	uniq = append(uniq, "direct")
-	seen["direct"] = struct{}{}
-	for _, m := range members {
-		m = strings.TrimSpace(m)
-		if m == "" {
-			continue
-		}
-		if _, ok := seen[m]; ok {
-			continue
-		}
-		seen[m] = struct{}{}
-		uniq = append(uniq, m)
-	}
-	return uniq
-}
-
-func (s *Service) selectDownloadOutboundWithRetry(ctx context.Context, op SingboxOperator, memberTag string) error {
-	const (
-		attempts = 20
-		pause    = 250 * time.Millisecond
-	)
-	var lastErr error
-	for i := 0; i < attempts; i++ {
-		lastErr = op.SetSelectorDefault(ctx, downloadProxySelectorTag, memberTag)
-		if lastErr == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(pause):
-		}
-	}
-	return lastErr
-}
-
-func (s *Service) readSelectorActiveWithRetry(ctx context.Context, op SingboxOperator, selectorTag string) (string, error) {
-	const (
-		attempts = 20
-		pause    = 250 * time.Millisecond
-	)
-	var lastErr error
-	for i := 0; i < attempts; i++ {
-		active, err := op.GetSelectorActive(ctx, selectorTag)
-		if err == nil && strings.TrimSpace(active) != "" {
-			return active, nil
-		}
-		if err != nil {
-			lastErr = err
-		} else {
-			lastErr = fmt.Errorf("empty active member")
-		}
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(pause):
-		}
-	}
-	return "", lastErr
-}
-
-func (s *Service) cleanupDownloadProxySlotLocked(op SingboxOperator, slot SlotController) {
-	if op != nil {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), downloadCleanupTimeout)
-		if err := op.SetSelectorDefault(cleanupCtx, downloadProxySelectorTag, "direct"); err != nil {
-			slog.Warn("downloader: failed to restore selector to direct", "error", err)
-		}
-		cancel()
-	}
-	if slot == nil {
-		return
-	}
-	if err := slot.SetEnabledSilent(singboxorch.SlotDownloadProxy, false); err != nil {
-		slog.Warn("downloader: failed to disable download proxy slot", "error", err)
-		return
-	}
-	if err := slot.Reload(); err != nil {
-		slog.Warn("downloader: failed to reload after disabling download proxy slot", "error", err)
-	}
 }

--- a/internal/downloader/service_test.go
+++ b/internal/downloader/service_test.go
@@ -2,7 +2,6 @@ package downloader
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -14,8 +13,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
 
 type fakeOutboundsProvider struct {
@@ -40,85 +37,25 @@ func (f *fakeRouteProvider) GetDownloadRoute(context.Context) (*Route, error) {
 	return f.route, nil
 }
 
-type fakeSingbox struct {
-	running bool
-
-	selectorCalls          []string
-	selectorErrs           []error
-	selectorCtxHasDeadline []bool
-
-	activeNow  string
-	activeErrs []error
+type fakeTransportResolver struct {
+	spec    TransportSpec
+	err     error
+	avail   bool
+	resolve func(ctx context.Context, ob Outbound) (TransportSpec, error)
 }
 
-func (f *fakeSingbox) IsRunning() (bool, int) {
-	if f.running {
-		return true, 123
+func (f *fakeTransportResolver) Resolve(ctx context.Context, ob Outbound) (TransportSpec, error) {
+	if f.resolve != nil {
+		return f.resolve(ctx, ob)
 	}
-	return false, 0
-}
-
-func (f *fakeSingbox) SetSelectorDefault(ctx context.Context, selectorTag, memberTag string) error {
-	_, hasDeadline := ctx.Deadline()
-	f.selectorCtxHasDeadline = append(f.selectorCtxHasDeadline, hasDeadline)
-	f.selectorCalls = append(f.selectorCalls, selectorTag+"="+memberTag)
-	f.activeNow = memberTag
-	if len(f.selectorErrs) == 0 {
-		return nil
+	if f.err != nil {
+		return TransportSpec{}, f.err
 	}
-	err := f.selectorErrs[0]
-	f.selectorErrs = f.selectorErrs[1:]
-	return err
+	return f.spec, nil
 }
 
-func (f *fakeSingbox) GetSelectorActive(_ context.Context, _ string) (string, error) {
-	if len(f.activeErrs) > 0 {
-		err := f.activeErrs[0]
-		f.activeErrs = f.activeErrs[1:]
-		if err != nil {
-			return "", err
-		}
-	}
-	return f.activeNow, nil
-}
-
-type fakeSlot struct {
-	saveCalls   int
-	enableCalls []bool
-	reloadCalls int
-
-	saveErr        error
-	enableErr      error
-	enableTrueErr  error
-	enableFalseErr error
-	reloadErr      error
-
-	lastSlot singboxorch.Slot
-	lastJSON string
-}
-
-func (f *fakeSlot) SaveSilent(slot singboxorch.Slot, b []byte) error {
-	f.saveCalls++
-	f.lastSlot = slot
-	f.lastJSON = string(b)
-	return f.saveErr
-}
-
-func (f *fakeSlot) SetEnabledSilent(slot singboxorch.Slot, enabled bool) error {
-	f.lastSlot = slot
-	f.enableCalls = append(f.enableCalls, enabled)
-	if enabled && f.enableTrueErr != nil {
-		return f.enableTrueErr
-	}
-	if !enabled && f.enableFalseErr != nil {
-		return f.enableFalseErr
-	}
-	return f.enableErr
-}
-
-func (f *fakeSlot) Reload() error {
-	f.reloadCalls++
-	return f.reloadErr
+func (f *fakeTransportResolver) IsAvailable(context.Context, Outbound) bool {
+	return f.avail
 }
 
 func TestListOutbounds_NoProvider(t *testing.T) {
@@ -147,32 +84,15 @@ func TestResolveClient_Direct(t *testing.T) {
 	lease.Close()
 }
 
-func TestResolveClient_NonDirectWithoutSingbox(t *testing.T) {
-	svc := NewService(Deps{})
-	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-a"})
-	if err == nil || !strings.Contains(err.Error(), "operator is not configured") {
-		t.Fatalf("expected operator not configured error, got %v", err)
-	}
-}
-
-func TestResolveClient_NonDirectWithoutSlot(t *testing.T) {
+func TestResolveClient_NonDirectWithoutResolver(t *testing.T) {
 	svc := NewService(Deps{
-		Singbox: &fakeSingbox{running: true},
+		Outbounds: &fakeOutboundsProvider{
+			items: []Outbound{{Tag: "awg-a", Kind: "awg", Detail: "opkgtun1"}},
+		},
 	})
 	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-a"})
-	if err == nil || !strings.Contains(err.Error(), "orchestrator is not configured") {
-		t.Fatalf("expected orchestrator not configured error, got %v", err)
-	}
-}
-
-func TestResolveClient_NonDirectSingboxNotRunning(t *testing.T) {
-	svc := NewService(Deps{
-		Singbox: &fakeSingbox{running: false},
-		Slot:    &fakeSlot{},
-	})
-	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-a"})
-	if err == nil || !strings.Contains(err.Error(), "not running") {
-		t.Fatalf("expected not running error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "transport resolver is not configured") {
+		t.Fatalf("expected resolver not configured error, got %v", err)
 	}
 }
 
@@ -214,106 +134,58 @@ func TestResolveClient_RouteProviderError(t *testing.T) {
 	}
 }
 
-func TestResolveClient_UsesRouteProviderForRoutedDownload(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{}
+func TestResolveClient_AWGBind(t *testing.T) {
+	sysNet := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sysNet, "opkgtun2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewTransportResolver(TransportResolverDeps{SysClassNet: sysNet})
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{
 			items: []Outbound{
 				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
+				{Tag: "awg-test", Kind: "awg", Label: "AWG test", Detail: "opkgtun2"},
 			},
 		},
-		Singbox:       sb,
-		Slot:          slot,
-		RouteProvider: &fakeRouteProvider{route: &Route{Tag: "awg-test"}},
-	})
-
-	lease, err := svc.ResolveClient(context.Background(), nil)
-	if err != nil {
-		t.Fatalf("resolve with routed provider: %v", err)
-	}
-	if lease == nil || lease.Client == nil {
-		t.Fatal("expected non-nil lease and client")
-	}
-	if lease.Route.Tag != "awg-test" {
-		t.Fatalf("route tag = %q, want awg-test", lease.Route.Tag)
-	}
-	if slot.saveCalls != 1 {
-		t.Fatalf("SaveSilent calls: got %d want 1", slot.saveCalls)
-	}
-	if len(sb.selectorCalls) == 0 || !strings.Contains(sb.selectorCalls[0], "=awg-test") {
-		t.Fatalf("expected selector set to awg-test, got %v", sb.selectorCalls)
-	}
-
-	lease.Close()
-	if len(slot.enableCalls) < 2 || slot.enableCalls[len(slot.enableCalls)-1] != false {
-		t.Fatalf("expected slot disable on close, got %v", slot.enableCalls)
-	}
-}
-
-func TestResolveClient_HappyPath(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{}
-	svc := NewService(Deps{
-		Outbounds: &fakeOutboundsProvider{
-			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
-				{Tag: "direct", Kind: "direct", Label: "Direct duplicate"},
-				{Tag: " ", Kind: "bad", Label: "bad"},
-			},
-		},
-		Singbox: sb,
-		Slot:    slot,
+		TransportResolver: resolver,
 	})
 
 	lease, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
 	if err != nil {
 		t.Fatalf("resolve routed lease: %v", err)
 	}
-	if lease == nil || lease.Client == nil {
-		t.Fatal("expected non-nil lease and client")
-	}
 	if lease.Route.Tag != "awg-test" {
 		t.Fatalf("route tag = %q, want awg-test", lease.Route.Tag)
 	}
-	if slot.saveCalls != 1 {
-		t.Fatalf("SaveSilent calls: got %d want 1", slot.saveCalls)
-	}
-	if slot.lastSlot != singboxorch.SlotDownloadProxy {
-		t.Fatalf("last slot: got %q want %q", slot.lastSlot, singboxorch.SlotDownloadProxy)
-	}
-	assertSlotJSON(t, slot.lastJSON)
-	if len(slot.enableCalls) < 1 || !slot.enableCalls[0] {
-		t.Fatalf("expected first enable call true, got %v", slot.enableCalls)
-	}
-	if slot.reloadCalls < 1 {
-		t.Fatalf("expected reload on enable, got %d", slot.reloadCalls)
-	}
-
+	assertBoundTransport(t, lease.Client, "opkgtun2")
 	lease.Close()
-	lease.Close()
-
-	if len(sb.selectorCalls) < 2 || sb.selectorCalls[len(sb.selectorCalls)-1] != "awgm-download-selector=direct" {
-		t.Fatalf("expected selector restore to direct, got %v", sb.selectorCalls)
-	}
-	if len(sb.selectorCtxHasDeadline) == 0 || !sb.selectorCtxHasDeadline[len(sb.selectorCtxHasDeadline)-1] {
-		t.Fatalf("expected cleanup selector restore to use bounded context, deadlines=%v", sb.selectorCtxHasDeadline)
-	}
-	if len(slot.enableCalls) < 2 || slot.enableCalls[len(slot.enableCalls)-1] != false {
-		t.Fatalf("expected disable call on cleanup, got %v", slot.enableCalls)
-	}
-	if slot.reloadCalls < 2 {
-		t.Fatalf("expected second reload on cleanup, got %d", slot.reloadCalls)
-	}
 
 	lease2, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
 	if err != nil {
-		t.Fatalf("second resolve should not deadlock: %v", err)
+		t.Fatalf("second resolve should not block: %v", err)
 	}
-	assertRoutedTransportProxy(t, lease2.Client)
 	lease2.Close()
+}
+
+func TestResolveClient_SingboxProxy(t *testing.T) {
+	resolver := NewTransportResolver(TransportResolverDeps{
+		Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1081}},
+		Singbox: &fakeSingboxRuntime{running: true},
+	})
+	svc := NewService(Deps{
+		Outbounds: &fakeOutboundsProvider{
+			items: []Outbound{
+				{Tag: "DE", Kind: "singbox", Label: "DE"},
+			},
+		},
+		TransportResolver: resolver,
+	})
+	lease, err := svc.ResolveClient(context.Background(), &Route{Tag: "DE", Kind: "singbox"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	assertProxyTransport(t, lease.Client, "127.0.0.1:1081")
+	lease.Close()
 }
 
 func TestLeaseClose_Idempotent(t *testing.T) {
@@ -334,116 +206,19 @@ func TestLeaseClose_Idempotent(t *testing.T) {
 	}
 }
 
-func TestResolveClient_ReloadFailureDisablesSlotAndUnlocks(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{reloadErr: errors.New("reload failed")}
+func TestListOutbounds_AWGAvailableWithoutSingbox(t *testing.T) {
+	sysNet := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sysNet, "opkgtun1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{
 			items: []Outbound{
 				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
+				{Tag: "awg-test", Kind: "awg", Label: "AWG test", Detail: "opkgtun1"},
 			},
 		},
-		Singbox: sb,
-		Slot:    slot,
-	})
-
-	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
-	if err == nil || !strings.Contains(err.Error(), "reload sing-box with download transport slot") {
-		t.Fatalf("expected reload error, got %v", err)
-	}
-	if len(slot.enableCalls) < 2 || slot.enableCalls[len(slot.enableCalls)-1] != false {
-		t.Fatalf("expected disable call after reload failure, got %v", slot.enableCalls)
-	}
-
-	slot.reloadErr = nil
-	lease2, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
-	if err != nil {
-		t.Fatalf("second resolve should not deadlock: %v", err)
-	}
-	lease2.Close()
-}
-
-func TestResolveClient_EnableFailureCleansUpAndUnlocks(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{enableTrueErr: errors.New("enable failed")}
-	svc := NewService(Deps{
-		Outbounds: &fakeOutboundsProvider{
-			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
-			},
-		},
-		Singbox: sb,
-		Slot:    slot,
-	})
-
-	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
-	if err == nil || !strings.Contains(err.Error(), "enable download transport slot") {
-		t.Fatalf("expected enable error, got %v", err)
-	}
-	if len(slot.enableCalls) < 2 || !slot.enableCalls[0] || slot.enableCalls[1] {
-		t.Fatalf("expected enable=true then enable=false, got %v", slot.enableCalls)
-	}
-	if slot.reloadCalls < 1 {
-		t.Fatalf("expected cleanup reload call, got %d", slot.reloadCalls)
-	}
-
-	slot.enableTrueErr = nil
-	lease2, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
-	if err != nil {
-		t.Fatalf("second resolve should not deadlock: %v", err)
-	}
-	lease2.Close()
-}
-
-func TestResolveClient_SelectFailureCleansUpAndUnlocks(t *testing.T) {
-	sb := &fakeSingbox{
-		running: true,
-		selectorErrs: []error{
-			errors.New("not ready"),
-		},
-	}
-	slot := &fakeSlot{}
-	svc := NewService(Deps{
-		Outbounds: &fakeOutboundsProvider{
-			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
-			},
-		},
-		Singbox: sb,
-		Slot:    slot,
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-	_, err := svc.ResolveClient(ctx, &Route{Tag: "awg-test"})
-	if err == nil || !strings.Contains(err.Error(), "select download outbound") {
-		t.Fatalf("expected select error, got %v", err)
-	}
-	if len(slot.enableCalls) < 2 || !slot.enableCalls[0] || slot.enableCalls[len(slot.enableCalls)-1] {
-		t.Fatalf("expected slot enable then disable, got %v", slot.enableCalls)
-	}
-
-	sb.selectorErrs = nil
-	lease2, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-test"})
-	if err != nil {
-		t.Fatalf("second resolve should not deadlock: %v", err)
-	}
-	lease2.Close()
-}
-
-func TestListOutbounds_WithProviderNotRunning(t *testing.T) {
-	svc := NewService(Deps{
-		Outbounds: &fakeOutboundsProvider{
-			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
-			},
-		},
-		Singbox: &fakeSingbox{running: false},
-		Slot:    &fakeSlot{},
+		TransportResolver: NewTransportResolver(TransportResolverDeps{SysClassNet: sysNet}),
 	})
 
 	got := svc.ListOutbounds(context.Background())
@@ -453,102 +228,30 @@ func TestListOutbounds_WithProviderNotRunning(t *testing.T) {
 	if !got[0].Available {
 		t.Fatalf("direct must be available: %+v", got[0])
 	}
-	if got[1].Available {
-		t.Fatalf("non-direct must be unavailable when sing-box not running: %+v", got[1])
+	if !got[1].Available {
+		t.Fatalf("AWG must be available without sing-box: %+v", got[1])
 	}
 }
 
-func TestListOutbounds_WithProviderRunningAndSlot(t *testing.T) {
+func TestListOutbounds_SingboxUnavailableWhenDown(t *testing.T) {
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{
 			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "awg-test", Kind: "awg", Label: "AWG test"},
+				{Tag: "DE", Kind: "singbox", Label: "DE"},
 			},
 		},
-		Singbox: &fakeSingbox{running: true},
-		Slot:    &fakeSlot{},
+		TransportResolver: NewTransportResolver(TransportResolverDeps{
+			Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+			Singbox: &fakeSingboxRuntime{running: false},
+		}),
 	})
-
 	got := svc.ListOutbounds(context.Background())
-	if len(got) != 2 {
-		t.Fatalf("len = %d, want 2", len(got))
-	}
-	if !got[0].Available || !got[1].Available {
-		t.Fatalf("both direct and non-direct must be available: %+v", got)
+	if len(got) != 1 || got[0].Available {
+		t.Fatalf("singbox outbound must be unavailable when down: %+v", got)
 	}
 }
 
-func assertSlotJSON(t *testing.T, raw string) {
-	t.Helper()
-
-	var parsed map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		t.Fatalf("unmarshal slot json: %v", err)
-	}
-
-	inboundsAny, ok := parsed["inbounds"].([]interface{})
-	if !ok || len(inboundsAny) != 1 {
-		t.Fatalf("inbounds: got %T %v", parsed["inbounds"], parsed["inbounds"])
-	}
-	inbound, ok := inboundsAny[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("inbound type: %T", inboundsAny[0])
-	}
-	if inbound["type"] != "mixed" || inbound["tag"] != "awgm-download-in" || inbound["listen"] != "127.0.0.1" {
-		t.Fatalf("unexpected inbound: %+v", inbound)
-	}
-	if int(inbound["listen_port"].(float64)) != 11998 {
-		t.Fatalf("inbound listen_port = %v, want 11998", inbound["listen_port"])
-	}
-
-	outboundsAny, ok := parsed["outbounds"].([]interface{})
-	if !ok || len(outboundsAny) != 1 {
-		t.Fatalf("outbounds: got %T %v", parsed["outbounds"], parsed["outbounds"])
-	}
-	selector, ok := outboundsAny[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("selector type: %T", outboundsAny[0])
-	}
-	if selector["type"] != "selector" || selector["tag"] != "awgm-download-selector" {
-		t.Fatalf("unexpected selector: %+v", selector)
-	}
-	if selector["default"] != "awg-test" {
-		t.Fatalf("selector default = %v, want awg-test", selector["default"])
-	}
-	if selector["interrupt_exist_connections"] != false {
-		t.Fatalf("interrupt_exist_connections = %v, want false", selector["interrupt_exist_connections"])
-	}
-	membersAny, ok := selector["outbounds"].([]interface{})
-	if !ok {
-		t.Fatalf("selector outbounds type: %T", selector["outbounds"])
-	}
-	members := make([]string, 0, len(membersAny))
-	for _, m := range membersAny {
-		members = append(members, m.(string))
-	}
-	if len(members) != 2 || members[0] != "direct" || members[1] != "awg-test" {
-		t.Fatalf("selector members = %v, want [direct awg-test]", members)
-	}
-
-	routeAny, ok := parsed["route"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("route type: %T", parsed["route"])
-	}
-	rulesAny, ok := routeAny["rules"].([]interface{})
-	if !ok || len(rulesAny) != 1 {
-		t.Fatalf("route.rules: got %T %v", routeAny["rules"], routeAny["rules"])
-	}
-	rule, ok := rulesAny[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("route rule type: %T", rulesAny[0])
-	}
-	if rule["inbound"] != "awgm-download-in" || rule["outbound"] != "awgm-download-selector" {
-		t.Fatalf("unexpected route rule: %+v", rule)
-	}
-}
-
-func assertRoutedTransportProxy(t *testing.T, client *http.Client) {
+func assertProxyTransport(t *testing.T, client *http.Client, wantHost string) {
 	t.Helper()
 	if client == nil {
 		t.Fatal("client is nil")
@@ -568,9 +271,33 @@ func assertRoutedTransportProxy(t *testing.T, client *http.Client) {
 	if proxyURL == nil {
 		t.Fatal("expected non-nil proxy URL for routed transport")
 	}
-	if proxyURL.Host != "127.0.0.1:11998" {
-		t.Fatalf("proxy host = %q, want 127.0.0.1:11998", proxyURL.Host)
+	if proxyURL.Host != wantHost {
+		t.Fatalf("proxy host = %q, want %q", proxyURL.Host, wantHost)
 	}
+}
+
+func assertBoundTransport(t *testing.T, client *http.Client, wantIface string) {
+	t.Helper()
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok || tr == nil {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	reqURL, err := url.Parse("https://example.org/file.dat")
+	if err != nil {
+		t.Fatalf("parse request url: %v", err)
+	}
+	if proxyURL, err := tr.Proxy(&http.Request{URL: reqURL}); err != nil {
+		t.Fatalf("proxy func: %v", err)
+	} else if proxyURL != nil {
+		t.Fatalf("bind transport must not use proxy, got %v", proxyURL)
+	}
+	if tr.DialContext == nil {
+		t.Fatal("bind transport must set DialContext")
+	}
+	_ = wantIface
 }
 
 func TestReadAll_Direct(t *testing.T) {
@@ -656,8 +383,7 @@ func TestDownloadFile_Atomic(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tmp := t.TempDir()
-	dest := filepath.Join(tmp, "pkg.ipk")
+	dest := filepath.Join(t.TempDir(), "pkg.ipk")
 	res, err := svc.DownloadFile(context.Background(), FileRequest{
 		Request: Request{
 			Purpose: "test-download",
@@ -722,8 +448,7 @@ func TestDownloadFile_ReportsProgress(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tmp := t.TempDir()
-	dest := filepath.Join(tmp, "progress.bin")
+	dest := filepath.Join(t.TempDir(), "progress.bin")
 	var lastDownloaded int64
 	var lastTotal int64
 
@@ -829,8 +554,10 @@ func TestDescribeRoute_RespectsKind(t *testing.T) {
 }
 
 func TestResolveClient_RespectsKind(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{}
+	resolver := NewTransportResolver(TransportResolverDeps{
+		Subs:    &fakeSubPorts{ports: map[string]int{"same-tag": 11002}},
+		Singbox: &fakeSingboxRuntime{running: true},
+	})
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{
 			items: []Outbound{
@@ -838,8 +565,7 @@ func TestResolveClient_RespectsKind(t *testing.T) {
 				{Tag: "same-tag", Kind: "subscription", Label: "Sub same"},
 			},
 		},
-		Singbox: sb,
-		Slot:    slot,
+		TransportResolver: resolver,
 	})
 
 	lease, err := svc.ResolveClient(context.Background(), &Route{Tag: "same-tag", Kind: "subscription"})
@@ -849,6 +575,7 @@ func TestResolveClient_RespectsKind(t *testing.T) {
 	if lease.Route.Tag != "same-tag" || lease.Route.Kind != "subscription" {
 		t.Fatalf("unexpected lease route: %+v", lease.Route)
 	}
+	assertProxyTransport(t, lease.Client, "127.0.0.1:11002")
 	lease.Close()
 }
 
@@ -899,61 +626,12 @@ func TestResolveClient_RejectsAmbiguousRuntimeTag(t *testing.T) {
 				{Tag: "same-tag", Kind: "subscription", Label: "B"},
 			},
 		},
-		Singbox: &fakeSingbox{running: true},
-		Slot:    &fakeSlot{},
+		TransportResolver: &fakeTransportResolver{avail: true},
 	})
 
 	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "same-tag", Kind: "subscription"})
 	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
 		t.Fatalf("expected ambiguous runtime tag error, got: %v", err)
-	}
-}
-
-func TestResolveClient_DedupesSelectorMembers(t *testing.T) {
-	sb := &fakeSingbox{running: true}
-	slot := &fakeSlot{}
-	svc := NewService(Deps{
-		Outbounds: &fakeOutboundsProvider{
-			items: []Outbound{
-				{Tag: "direct", Kind: "direct", Label: "Direct (WAN)"},
-				{Tag: "route-a", Kind: "awg", Label: "Route A"},
-				{Tag: "route-b", Kind: "subscription", Label: "Route B1"},
-				{Tag: "route-b", Kind: "subscription", Label: "Route B2"},
-			},
-		},
-		Singbox: sb,
-		Slot:    slot,
-	})
-
-	lease, err := svc.ResolveClient(context.Background(), &Route{Tag: "route-a", Kind: "awg"})
-	if err != nil {
-		t.Fatalf("resolve routed lease: %v", err)
-	}
-	lease.Close()
-
-	var parsed map[string]any
-	if err := json.Unmarshal([]byte(slot.lastJSON), &parsed); err != nil {
-		t.Fatalf("parse slot json: %v", err)
-	}
-	outbounds, ok := parsed["outbounds"].([]any)
-	if !ok || len(outbounds) == 0 {
-		t.Fatalf("slot outbounds shape: %#v", parsed["outbounds"])
-	}
-	selector, ok := outbounds[0].(map[string]any)
-	if !ok {
-		t.Fatalf("selector shape: %#v", outbounds[0])
-	}
-	membersAny, ok := selector["outbounds"].([]any)
-	if !ok {
-		t.Fatalf("selector members shape: %#v", selector["outbounds"])
-	}
-	seen := map[string]int{}
-	for _, m := range membersAny {
-		s, _ := m.(string)
-		seen[s]++
-	}
-	if seen["route-b"] != 1 {
-		t.Fatalf("expected route-b deduped once, members=%v", membersAny)
 	}
 }
 
@@ -971,5 +649,52 @@ func TestValidateRoute_AllowsKnownUnavailableOutbound(t *testing.T) {
 	}
 	if info.Tag != "route-a" || info.Kind != "subscription" {
 		t.Fatalf("unexpected route info: %+v", info)
+	}
+}
+
+func TestResolveClient_TransportResolverError(t *testing.T) {
+	svc := NewService(Deps{
+		Outbounds: &fakeOutboundsProvider{
+			items: []Outbound{{Tag: "DE", Kind: "singbox"}},
+		},
+		TransportResolver: &fakeTransportResolver{
+			err: errors.New("sing-box is not running"),
+		},
+	})
+	_, err := svc.ResolveClient(context.Background(), &Route{Tag: "DE", Kind: "singbox"})
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+func TestResolveClient_ConcurrentNoDeadlock(t *testing.T) {
+	sysNet := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sysNet, "opkgtun9"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(Deps{
+		Outbounds: &fakeOutboundsProvider{
+			items: []Outbound{{Tag: "awg-x", Kind: "awg", Detail: "opkgtun9"}},
+		},
+		TransportResolver: NewTransportResolver(TransportResolverDeps{SysClassNet: sysNet}),
+	})
+
+	done := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			lease, err := svc.ResolveClient(context.Background(), &Route{Tag: "awg-x"})
+			if err != nil {
+				done <- err
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+			lease.Close()
+			done <- nil
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent resolve: %v", err)
+		}
 	}
 }

--- a/internal/downloader/service_test.go
+++ b/internal/downloader/service_test.go
@@ -289,10 +289,14 @@ func assertBoundTransport(t *testing.T, client *http.Client, wantIface string) {
 	if err != nil {
 		t.Fatalf("parse request url: %v", err)
 	}
-	if proxyURL, err := tr.Proxy(&http.Request{URL: reqURL}); err != nil {
-		t.Fatalf("proxy func: %v", err)
-	} else if proxyURL != nil {
-		t.Fatalf("bind transport must not use proxy, got %v", proxyURL)
+	if tr.Proxy != nil {
+		proxyURL, err := tr.Proxy(&http.Request{URL: reqURL})
+		if err != nil {
+			t.Fatalf("proxy func: %v", err)
+		}
+		if proxyURL != nil {
+			t.Fatalf("bind transport must not use proxy, got %v", proxyURL)
+		}
 	}
 	if tr.DialContext == nil {
 		t.Fatal("bind transport must set DialContext")

--- a/internal/downloader/transport.go
+++ b/internal/downloader/transport.go
@@ -1,0 +1,200 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
+)
+
+const localProxyHost = "127.0.0.1"
+
+// TransportMode selects how an HTTP client reaches the destination.
+type TransportMode string
+
+const (
+	TransportModeDirect TransportMode = "direct"
+	// TransportModeBind sends traffic via SO_BINDTODEVICE on a kernel iface.
+	// Used for AWG / NativeWG tunnels — no sing-box involvement.
+	TransportModeBind TransportMode = "bind"
+	// TransportModeProxy routes through an existing sing-box mixed inbound on
+	// localhost. Used for sing-box phase-1 tunnels and subscription composites.
+	// Do NOT bind to t2sN/ProxyN kernel ifaces: those are TUN/NDMS plumbing,
+	// not valid egress for raw TCP from userspace.
+	TransportModeProxy TransportMode = "proxy"
+)
+
+// TransportSpec is the resolved egress for one download route.
+type TransportSpec struct {
+	Mode       TransportMode
+	Interface  string   // bind mode: kernel iface name
+	DNSServers []string // bind mode: tunnel DNS for hostname resolution
+	ProxyPort  int      // proxy mode: local mixed inbound port (ignored when ProxyURL set)
+	ProxyURL   string   // proxy mode: full proxy URL (supports auth)
+}
+
+// AWGEgressLookup resolves tunnel DNS for an AWG outbound tag.
+type AWGEgressLookup interface {
+	DNSForTag(ctx context.Context, tag string) []string
+}
+
+// TunnelListenPortLookup resolves a sing-box tunnel tag to its local mixed
+// inbound listen port (1080+).
+type TunnelListenPortLookup interface {
+	ListenPortByTag(ctx context.Context, tag string) (int, bool)
+}
+
+// SubscriptionListenPortLookup resolves a subscription selector tag to its
+// local mixed inbound listen port (11000+).
+type SubscriptionListenPortLookup interface {
+	ListenPortBySelectorTag(ctx context.Context, selectorTag string) (int, bool)
+}
+
+// SingboxRuntimeChecker reports whether sing-box is running. Proxy-based
+// routes require a live process listening on localhost.
+type SingboxRuntimeChecker interface {
+	IsRunning() bool
+}
+
+// TransportResolverDeps wires lookup helpers for compositeTransportResolver.
+type TransportResolverDeps struct {
+	Tunnels   TunnelListenPortLookup
+	Subs      SubscriptionListenPortLookup
+	Singbox   SingboxRuntimeChecker
+	AWGEgress AWGEgressLookup
+	// SysClassNet overrides /sys/class/net for tests.
+	SysClassNet string
+}
+
+// TransportResolver maps a catalog outbound to a concrete transport.
+type TransportResolver interface {
+	Resolve(ctx context.Context, ob Outbound) (TransportSpec, error)
+	IsAvailable(ctx context.Context, ob Outbound) bool
+}
+
+type compositeTransportResolver struct {
+	tunnels   TunnelListenPortLookup
+	subs      SubscriptionListenPortLookup
+	singbox   SingboxRuntimeChecker
+	awgEgress AWGEgressLookup
+	sysNet    string
+}
+
+func NewTransportResolver(d TransportResolverDeps) TransportResolver {
+	sysNet := strings.TrimSpace(d.SysClassNet)
+	if sysNet == "" {
+		sysNet = "/sys/class/net"
+	}
+	return &compositeTransportResolver{
+		tunnels:   d.Tunnels,
+		subs:      d.Subs,
+		singbox:   d.Singbox,
+		awgEgress: d.AWGEgress,
+		sysNet:    sysNet,
+	}
+}
+
+func (r *compositeTransportResolver) singboxRunning() bool {
+	return r.singbox != nil && r.singbox.IsRunning()
+}
+
+func (r *compositeTransportResolver) Resolve(ctx context.Context, ob Outbound) (TransportSpec, error) {
+	kind := strings.TrimSpace(ob.Kind)
+	tag := strings.TrimSpace(ob.Tag)
+	if tag == "" || tag == "direct" || kind == "" || kind == "direct" {
+		return TransportSpec{Mode: TransportModeDirect}, nil
+	}
+
+	switch kind {
+	case "awg":
+		iface := strings.TrimSpace(ob.Detail)
+		if iface == "" {
+			return TransportSpec{}, fmt.Errorf("outbound %q has no kernel interface", ob.Tag)
+		}
+		if !r.ifaceExists(iface) {
+			return TransportSpec{}, fmt.Errorf("outbound %q interface %q is not present", ob.Tag, iface)
+		}
+		spec := TransportSpec{Mode: TransportModeBind, Interface: iface}
+		if r.awgEgress != nil {
+			spec.DNSServers = r.awgEgress.DNSForTag(ctx, tag)
+		}
+		return spec, nil
+
+	case "singbox":
+		if !r.singboxRunning() {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box is not running", ob.Tag)
+		}
+		if r.tunnels == nil {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box tunnel lookup is not configured", ob.Tag)
+		}
+		port, ok := r.tunnels.ListenPortByTag(ctx, ob.Tag)
+		if !ok || port <= 0 {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: local sing-box proxy port not found", ob.Tag)
+		}
+		return TransportSpec{Mode: TransportModeProxy, ProxyPort: port}, nil
+
+	case "subscription":
+		if !r.singboxRunning() {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box is not running", ob.Tag)
+		}
+		if r.subs == nil {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: subscription lookup is not configured", ob.Tag)
+		}
+		port, ok := r.subs.ListenPortBySelectorTag(ctx, ob.Tag)
+		if !ok || port <= 0 {
+			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: local subscription proxy port not found", ob.Tag)
+		}
+		return TransportSpec{Mode: TransportModeProxy, ProxyPort: port}, nil
+
+	default:
+		return TransportSpec{}, fmt.Errorf("outbound %q kind %q is not supported for download transport", ob.Tag, ob.Kind)
+	}
+}
+
+func (r *compositeTransportResolver) IsAvailable(ctx context.Context, ob Outbound) bool {
+	spec, err := r.Resolve(ctx, ob)
+	if err != nil {
+		return false
+	}
+	_ = spec
+	return true
+}
+
+func (r *compositeTransportResolver) ifaceExists(name string) bool {
+	if name == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(r.sysNet, name))
+	return err == nil
+}
+
+func newHTTPClientFromSpec(spec TransportSpec) (*http.Client, error) {
+	cfg := httpclient.TransportConfig{}
+	switch spec.Mode {
+	case TransportModeDirect:
+		// zero cfg → default route
+	case TransportModeBind:
+		cfg.Interface = spec.Interface
+		cfg.DNSServers = spec.DNSServers
+	case TransportModeProxy:
+		if spec.ProxyURL != "" {
+			cfg.ProxyURL = spec.ProxyURL
+		} else if spec.ProxyPort > 0 {
+			cfg.ProxyURL = fmt.Sprintf("http://%s:%d", localProxyHost, spec.ProxyPort)
+		} else {
+			return nil, fmt.Errorf("proxy transport requires ProxyURL or ProxyPort")
+		}
+	default:
+		return nil, fmt.Errorf("unsupported transport mode %q", spec.Mode)
+	}
+
+	tr, err := httpclient.NewTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: tr}, nil
+}

--- a/internal/downloader/transport_test.go
+++ b/internal/downloader/transport_test.go
@@ -1,0 +1,129 @@
+package downloader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeTunnelPorts struct {
+	ports map[string]int
+}
+
+func (f *fakeTunnelPorts) ListenPortByTag(_ context.Context, tag string) (int, bool) {
+	p, ok := f.ports[tag]
+	return p, ok && p > 0
+}
+
+type fakeSubPorts struct {
+	ports map[string]int
+}
+
+func (f *fakeSubPorts) ListenPortBySelectorTag(_ context.Context, tag string) (int, bool) {
+	p, ok := f.ports[tag]
+	return p, ok && p > 0
+}
+
+type fakeSingboxRuntime struct {
+	running bool
+}
+
+func (f *fakeSingboxRuntime) IsRunning() bool { return f.running }
+
+type fakeAWGEgress struct {
+	dns map[string][]string
+}
+
+func (f *fakeAWGEgress) DNSForTag(_ context.Context, tag string) []string {
+	if f == nil || f.dns == nil {
+		return nil
+	}
+	return f.dns[tag]
+}
+
+func TestTransportResolver_AWG_Bind(t *testing.T) {
+	sysNet := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sysNet, "opkgtun1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := NewTransportResolver(TransportResolverDeps{
+		SysClassNet: sysNet,
+		AWGEgress: &fakeAWGEgress{dns: map[string][]string{
+			"awg-1": {"10.0.0.1", "1.1.1.1"},
+		}},
+	})
+
+	spec, err := r.Resolve(context.Background(), Outbound{
+		Tag: "awg-1", Kind: "awg", Detail: "opkgtun1",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if spec.Mode != TransportModeBind || spec.Interface != "opkgtun1" {
+		t.Fatalf("spec = %+v, want bind opkgtun1", spec)
+	}
+	if len(spec.DNSServers) != 2 || spec.DNSServers[0] != "10.0.0.1" {
+		t.Fatalf("DNSServers = %+v, want tunnel DNS", spec.DNSServers)
+	}
+}
+
+func TestTransportResolver_AWG_MissingIface(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{SysClassNet: t.TempDir()})
+	_, err := r.Resolve(context.Background(), Outbound{Tag: "awg-1", Kind: "awg", Detail: "missing0"})
+	if err == nil || !strings.Contains(err.Error(), "not present") {
+		t.Fatalf("expected missing iface error, got %v", err)
+	}
+}
+
+func TestTransportResolver_Singbox_ProxyPort(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{
+		Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+		Singbox: &fakeSingboxRuntime{running: true},
+	})
+	spec, err := r.Resolve(context.Background(), Outbound{Tag: "DE", Kind: "singbox"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if spec.Mode != TransportModeProxy || spec.ProxyPort != 1080 {
+		t.Fatalf("spec = %+v, want proxy :1080", spec)
+	}
+}
+
+func TestTransportResolver_Singbox_NotRunning(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{
+		Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+		Singbox: &fakeSingboxRuntime{running: false},
+	})
+	_, err := r.Resolve(context.Background(), Outbound{Tag: "DE", Kind: "singbox"})
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected not running error, got %v", err)
+	}
+}
+
+func TestTransportResolver_Subscription_ProxyPort(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{
+		Subs:    &fakeSubPorts{ports: map[string]int{"sub-abc": 11001}},
+		Singbox: &fakeSingboxRuntime{running: true},
+	})
+	spec, err := r.Resolve(context.Background(), Outbound{Tag: "sub-abc", Kind: "subscription"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if spec.Mode != TransportModeProxy || spec.ProxyPort != 11001 {
+		t.Fatalf("spec = %+v, want proxy :11001", spec)
+	}
+}
+
+func TestTransportResolver_AWG_AvailableWithoutSingbox(t *testing.T) {
+	sysNet := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sysNet, "nwg0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := NewTransportResolver(TransportResolverDeps{SysClassNet: sysNet})
+	ob := Outbound{Tag: "awg-sys-1", Kind: "awg", Detail: "nwg0"}
+	if !r.IsAvailable(context.Background(), ob) {
+		t.Fatal("AWG outbound should be available without sing-box")
+	}
+}

--- a/internal/downloader/types.go
+++ b/internal/downloader/types.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-
-	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
 
 type Route struct {
@@ -55,18 +53,6 @@ func (l *Lease) Close() {
 
 type OutboundsProvider interface {
 	ListDownloadOutbounds(ctx context.Context) []Outbound
-}
-
-type SingboxOperator interface {
-	IsRunning() (bool, int)
-	SetSelectorDefault(ctx context.Context, selectorTag, memberTag string) error
-	GetSelectorActive(ctx context.Context, selectorTag string) (string, error)
-}
-
-type SlotController interface {
-	SaveSilent(slot singboxorch.Slot, jsonBytes []byte) error
-	SetEnabledSilent(slot singboxorch.Slot, enabled bool) error
-	Reload() error
 }
 
 type RouteProvider interface {

--- a/internal/hydraroute/geodata.go
+++ b/internal/hydraroute/geodata.go
@@ -970,6 +970,7 @@ func downloadFileWithClient(ctx context.Context, client *http.Client, rawURL, de
 	if err != nil {
 		return 0, fmt.Errorf("build request: %w", err)
 	}
+	req.Header.Set("User-Agent", "curl/8.7.1")
 
 	if client == nil {
 		client = &http.Client{}

--- a/internal/sys/httpclient/client.go
+++ b/internal/sys/httpclient/client.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -40,6 +39,10 @@ type CallConfig struct {
 	// Interface binds the request to a kernel device (curl --interface).
 	// Implemented via SO_BINDTODEVICE on the dialer.
 	Interface string
+
+	// DNSServers are used for hostname resolution when Interface is set.
+	// Queries go over UDP bound to the same interface (tunnel DNS).
+	DNSServers []string
 
 	// ProxyURL routes through an HTTP/SOCKS proxy (curl -x / --proxy).
 	// Supports "http://", "socks5://", "socks5h://" schemes.
@@ -229,10 +232,7 @@ func (c *Client) buildTransport(cfg CallConfig, parsedProxy *url.URL) *http.Tran
 	if connectTimeout == 0 {
 		connectTimeout = 5 * time.Second
 	}
-	dialer := bindDialer(cfg.Interface, connectTimeout)
-	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return dialer.DialContext(ctx, network, addr)
-	}
+	t.DialContext = buildDialContext(cfg.Interface, cfg.DNSServers, connectTimeout)
 
 	// Set up proxy if specified.
 	if parsedProxy != nil {
@@ -242,6 +242,20 @@ func (c *Client) buildTransport(cfg CallConfig, parsedProxy *url.URL) *http.Tran
 	// Enforce ForceAttemptHTTP2 = false — some VPN endpoints behind
 	// restrictive firewalls choke on HTTP/2 ALPN negotiation.
 	t.ForceAttemptHTTP2 = false
+
+	// Pin ALPN to HTTP/1.1. ForceAttemptHTTP2=false alone is not enough:
+	// on Go 1.24+ the TLS layer still advertises "h2" in ALPN, so servers
+	// negotiate HTTP/2 while this transport only speaks HTTP/1.1. The result
+	// is a bare "EOF" on strict servers (Fastly / raw.githubusercontent.com)
+	// and a "malformed HTTP response \x00\x00\x12\x04…" (an h2 SETTINGS frame)
+	// on lenient ones (Cloudflare / cp.amnezia.org). Cloning is required so we
+	// never mutate the shared base transport's TLS config.
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	} else {
+		t.TLSClientConfig = t.TLSClientConfig.Clone()
+	}
+	t.TLSClientConfig.NextProtos = []string{"http/1.1"}
 
 	return t
 }

--- a/internal/sys/httpclient/client.go
+++ b/internal/sys/httpclient/client.go
@@ -234,9 +234,13 @@ func (c *Client) buildTransport(cfg CallConfig, parsedProxy *url.URL) *http.Tran
 	}
 	t.DialContext = buildDialContext(cfg.Interface, cfg.DNSServers, connectTimeout)
 
-	// Set up proxy if specified.
+	// Set up proxy. Explicit URL wins; otherwise honour HTTP_PROXY/HTTPS_PROXY
+	// for direct (unbound) egress. Bind mode must not use env proxy — traffic
+	// must stay on the tunnel interface.
 	if parsedProxy != nil {
 		t.Proxy = http.ProxyURL(parsedProxy)
+	} else if cfg.Interface == "" {
+		t.Proxy = http.ProxyFromEnvironment
 	}
 
 	// Enforce ForceAttemptHTTP2 = false — some VPN endpoints behind

--- a/internal/sys/httpclient/client_test.go
+++ b/internal/sys/httpclient/client_test.go
@@ -24,7 +24,7 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 
 func handler204(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) }
 func handler200(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "ok") }
-func handlerIP(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "203.0.113.1") }
+func handlerIP(w http.ResponseWriter, _ *http.Request)  { fmt.Fprint(w, "203.0.113.1") }
 
 // stubDoer implements HTTPDoer for tests that exercise the call site wrappers.
 type stubDoer struct {
@@ -284,6 +284,33 @@ func TestDo_URL_Missing(t *testing.T) {
 	_, err := c.Do(context.Background(), CallConfig{})
 	if err == nil {
 		t.Fatal("expected error for missing URL, got nil")
+	}
+}
+
+// TestBuildTransport_PinsHTTP1 guards against HTTP/2 ALPN regressions: the
+// transport must advertise only "http/1.1" and never enable h2. Without this,
+// servers negotiate HTTP/2 while the client speaks HTTP/1.1, producing EOF /
+// "malformed HTTP response" on real downloads (geo files, Amnezia Premium).
+func TestBuildTransport_PinsHTTP1(t *testing.T) {
+	tr, err := NewTransport(TransportConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be false")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig must be set so ALPN is pinned")
+	}
+	got := tr.TLSClientConfig.NextProtos
+	if len(got) != 1 || got[0] != "http/1.1" {
+		t.Fatalf("NextProtos = %v, want [http/1.1]", got)
+	}
+
+	// The shared base transport must not be mutated by per-call cloning.
+	c := New()
+	if c.baseTransport.TLSClientConfig != nil && len(c.baseTransport.TLSClientConfig.NextProtos) != 0 {
+		t.Errorf("base transport NextProtos leaked: %v", c.baseTransport.TLSClientConfig.NextProtos)
 	}
 }
 

--- a/internal/sys/httpclient/client_test.go
+++ b/internal/sys/httpclient/client_test.go
@@ -291,6 +291,26 @@ func TestDo_URL_Missing(t *testing.T) {
 // transport must advertise only "http/1.1" and never enable h2. Without this,
 // servers negotiate HTTP/2 while the client speaks HTTP/1.1, producing EOF /
 // "malformed HTTP response" on real downloads (geo files, Amnezia Premium).
+func TestBuildTransport_DirectUsesEnvProxy(t *testing.T) {
+	tr, err := NewTransport(TransportConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.Proxy == nil {
+		t.Fatal("direct transport must use ProxyFromEnvironment")
+	}
+}
+
+func TestBuildTransport_BindSkipsEnvProxy(t *testing.T) {
+	tr, err := NewTransport(TransportConfig{Interface: "wg0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.Proxy != nil {
+		t.Fatal("bind transport must not set Proxy")
+	}
+}
+
 func TestBuildTransport_PinsHTTP1(t *testing.T) {
 	tr, err := NewTransport(TransportConfig{})
 	if err != nil {

--- a/internal/sys/httpclient/dial_context.go
+++ b/internal/sys/httpclient/dial_context.go
@@ -1,0 +1,30 @@
+package httpclient
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+)
+
+func buildDialContext(bindIface string, dnsServers []string, connectTimeout time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	dialer := bindDialer(bindIface, connectTimeout)
+	bindIface = strings.TrimSpace(bindIface)
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if bindIface != "" {
+			network = "tcp4"
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			if net.ParseIP(host) == nil {
+				ip, err := LookupIPv4ForBind(ctx, host, dnsServers, bindIface)
+				if err != nil {
+					return nil, err
+				}
+				addr = net.JoinHostPort(ip, port)
+			}
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+}

--- a/internal/sys/httpclient/dialer_linux.go
+++ b/internal/sys/httpclient/dialer_linux.go
@@ -4,36 +4,55 @@ package httpclient
 
 import (
 	"net"
+	"strings"
 	"syscall"
 	"time"
 )
 
-// bindDialer returns a net.Dialer that binds to the given interface
-// using SO_BINDTODEVICE.
+// bindDialer returns a net.Dialer that binds outgoing sockets to the given
+// interface using SO_BINDTODEVICE, and clamps the advertised TCP MSS to the
+// interface MTU so large inbound segments fit inside tunnel devices.
 func bindDialer(iface string, connectTimeout time.Duration) *net.Dialer {
 	d := &net.Dialer{
 		Timeout: connectTimeout,
 	}
+	iface = strings.TrimSpace(iface)
 	if iface == "" {
 		return d
 	}
-	// Keep the *net.Dialer default but add control hook.
-	// SO_BINDTODEVICE is privileged; calling code must run as root
-	// or have CAP_NET_RAW on the Keenetic router.
-	ctrl := func(_, _ string, c syscall.RawConn) error {
+
+	// Resolve the MSS clamp once per dialer. 0 means "leave the kernel
+	// default" (unknown MTU or a full-size 1500-byte link).
+	mss := tunnelMSS(iface)
+
+	// SO_BINDTODEVICE is privileged; calling code must run as root or have
+	// CAP_NET_RAW on the Keenetic router. Dialer.Control covers both the TCP
+	// and UDP (tunnel-DNS) socket flavours.
+	d.Control = func(network, _ string, c syscall.RawConn) error {
 		var setErr error
-		err := c.Control(func(fd uintptr) {
-			setErr = syscall.SetsockoptString(
+		ctrlErr := c.Control(func(fd uintptr) {
+			if err := syscall.SetsockoptString(
 				int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, iface,
-			)
+			); err != nil {
+				setErr = err
+				return
+			}
+			// Clamp the advertised MSS for TCP only. The route the kernel
+			// picks for MSS is the WAN (1500), but SO_BINDTODEVICE forces
+			// egress through a smaller-MTU tunnel — without this the remote
+			// would send oversized segments that the tunnel black-holes,
+			// stalling TLS and surfacing as "EOF". Best-effort: the kernel
+			// enforces its own floor and ignores invalid values.
+			if mss > 0 && strings.HasPrefix(network, "tcp") {
+				_ = syscall.SetsockoptInt(
+					int(fd), syscall.IPPROTO_TCP, syscall.TCP_MAXSEG, mss,
+				)
+			}
 		})
-		if err != nil {
-			return err
+		if ctrlErr != nil {
+			return ctrlErr
 		}
 		return setErr
 	}
-	// Need to control both network flavours.
-	// On modern Go Dialer.Control covers both.
-	d.Control = ctrl
 	return d
 }

--- a/internal/sys/httpclient/dns.go
+++ b/internal/sys/httpclient/dns.go
@@ -1,0 +1,229 @@
+package httpclient
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// LookupIPv4ForBind resolves host to an IPv4 address. When dnsServers is
+// non-empty, queries are sent over UDP bound to bindIface (tunnel DNS).
+// Otherwise the system resolver is used (ip4 only).
+func LookupIPv4ForBind(ctx context.Context, host string, dnsServers []string, bindIface string) (string, error) {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return "", fmt.Errorf("httpclient: empty host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String(), nil
+		}
+		return "", fmt.Errorf("httpclient: non-IPv4 literal %q", host)
+	}
+
+	if len(dnsServers) > 0 {
+		var lastErr error
+		for _, srv := range dnsServers {
+			srv = strings.TrimSpace(srv)
+			if srv == "" {
+				continue
+			}
+			ip, err := lookupAViaDNS(ctx, host, srv, bindIface, 0)
+			if err == nil {
+				return ip, nil
+			}
+			lastErr = err
+		}
+		if lastErr != nil {
+			return "", fmt.Errorf("httpclient: tunnel DNS lookup %q: %w", host, lastErr)
+		}
+		return "", fmt.Errorf("httpclient: no DNS servers configured for %q", host)
+	}
+
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
+	if err != nil {
+		return "", fmt.Errorf("httpclient: system DNS lookup %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String(), nil
+		}
+	}
+	return "", fmt.Errorf("httpclient: no IPv4 address for %q", host)
+}
+
+func lookupAViaDNS(ctx context.Context, host, dnsServer, bindIface string, depth int) (string, error) {
+	if depth > 5 {
+		return "", fmt.Errorf("CNAME chain too deep for %q", host)
+	}
+	query, err := encodeDNSQuery(host)
+	if err != nil {
+		return "", err
+	}
+
+	d := bindDialer(bindIface, 5*time.Second)
+	conn, err := d.DialContext(ctx, "udp4", net.JoinHostPort(dnsServer, "53"))
+	if err != nil {
+		return "", fmt.Errorf("dial DNS %s: %w", dnsServer, err)
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	}
+
+	if _, err := conn.Write(query); err != nil {
+		return "", fmt.Errorf("write DNS query: %w", err)
+	}
+
+	buf := make([]byte, 1500)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return "", fmt.Errorf("read DNS response: %w", err)
+	}
+	return parseDNSARecord(ctx, buf[:n], dnsServer, bindIface, depth)
+}
+
+func encodeDNSQuery(host string) ([]byte, error) {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return nil, fmt.Errorf("empty DNS name")
+	}
+
+	var q []byte
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 {
+			return nil, fmt.Errorf("invalid DNS name %q", host)
+		}
+		q = append(q, byte(len(label)))
+		q = append(q, label...)
+	}
+	q = append(q, 0)
+
+	out := make([]byte, 12+len(q)+4)
+	out[0] = 0x12
+	out[1] = 0x34
+	out[2] = 0x01 // RD=1
+	copy(out[12:], q)
+	off := 12 + len(q)
+	binary.BigEndian.PutUint16(out[off:], 1)   // A
+	binary.BigEndian.PutUint16(out[off+2:], 1) // IN
+	return out, nil
+}
+
+func parseDNSARecord(ctx context.Context, pkt []byte, dnsServer, bindIface string, depth int) (string, error) {
+	if len(pkt) < 12 {
+		return "", fmt.Errorf("short DNS packet")
+	}
+	if pkt[3]&0x0f != 0 {
+		return "", fmt.Errorf("DNS error rcode %d", pkt[3]&0x0f)
+	}
+	ancount := int(binary.BigEndian.Uint16(pkt[6:8]))
+	off := 12
+	off, err := skipDNSName(pkt, off)
+	if err != nil {
+		return "", err
+	}
+	if off+4 > len(pkt) {
+		return "", fmt.Errorf("truncated DNS question")
+	}
+	off += 4
+
+	var cname string
+	for i := 0; i < ancount; i++ {
+		off, err = skipDNSName(pkt, off)
+		if err != nil {
+			return "", err
+		}
+		if off+10 > len(pkt) {
+			return "", fmt.Errorf("truncated DNS answer header")
+		}
+		rrType := binary.BigEndian.Uint16(pkt[off : off+2])
+		rdLen := int(binary.BigEndian.Uint16(pkt[off+8 : off+10]))
+		rdataOff := off + 10
+		off = rdataOff + rdLen
+		if off > len(pkt) {
+			return "", fmt.Errorf("truncated DNS rdata")
+		}
+		switch rrType {
+		case 1: // A
+			if rdLen == 4 {
+				return net.IP(pkt[rdataOff : rdataOff+4]).String(), nil
+			}
+		case 5: // CNAME
+			if cname == "" {
+				cname, err = decodeDNSName(pkt, rdataOff)
+			}
+		}
+	}
+	if cname != "" {
+		return lookupAViaDNS(ctx, cname, dnsServer, bindIface, depth+1)
+	}
+	return "", fmt.Errorf("no A record in DNS response")
+}
+
+func skipDNSName(pkt []byte, off int) (int, error) {
+	for jumps := 0; jumps < 128; jumps++ {
+		if off >= len(pkt) {
+			return 0, fmt.Errorf("truncated DNS name")
+		}
+		l := int(pkt[off])
+		if l == 0 {
+			return off + 1, nil
+		}
+		if l&0xc0 == 0xc0 {
+			if off+1 >= len(pkt) {
+				return 0, fmt.Errorf("truncated DNS compression pointer")
+			}
+			return off + 2, nil
+		}
+		off++
+		if off+l > len(pkt) {
+			return 0, fmt.Errorf("truncated DNS label")
+		}
+		off += l
+	}
+	return 0, fmt.Errorf("DNS name too long")
+}
+
+func decodeDNSName(pkt []byte, off int) (string, error) {
+	return decodeDNSNameFromWire(pkt, pkt, off)
+}
+
+func decodeDNSNameFromWire(pkt, wire []byte, off int) (string, error) {
+	var labels []string
+	jumps := 0
+	for {
+		if off >= len(wire) || jumps > 128 {
+			return "", fmt.Errorf("invalid DNS name")
+		}
+		l := int(wire[off])
+		if l == 0 {
+			break
+		}
+		if l&0xc0 == 0xc0 {
+			if off+1 >= len(wire) {
+				return "", fmt.Errorf("truncated DNS pointer")
+			}
+			ptr := int(binary.BigEndian.Uint16(wire[off:off+2]) & 0x3fff)
+			off = ptr
+			jumps++
+			continue
+		}
+		off++
+		if off+l > len(wire) {
+			return "", fmt.Errorf("truncated DNS label")
+		}
+		labels = append(labels, string(wire[off:off+l]))
+		off += l
+	}
+	if len(labels) == 0 {
+		return "", fmt.Errorf("empty DNS name")
+	}
+	return strings.Join(labels, "."), nil
+}

--- a/internal/sys/httpclient/dns_test.go
+++ b/internal/sys/httpclient/dns_test.go
@@ -1,0 +1,52 @@
+package httpclient
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func TestEncodeDNSQuery(t *testing.T) {
+	q, err := encodeDNSQuery("raw.githubusercontent.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(q) < 20 {
+		t.Fatalf("query too short: %d", len(q))
+	}
+}
+
+func TestParseDNSARecord_directA(t *testing.T) {
+	pkt := buildDNSResponse(1, net.IPv4(1, 2, 3, 4).To4())
+	ip, err := parseDNSARecord(t.Context(), pkt, "1.1.1.1", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ip != "1.2.3.4" {
+		t.Fatalf("ip = %q, want 1.2.3.4", ip)
+	}
+}
+
+func buildDNSResponse(rrType uint16, rdata []byte) []byte {
+	q := []byte{7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0}
+	ansName := []byte{0xc0, 0x0c}
+	ansTail := make([]byte, 10+len(rdata))
+	binary.BigEndian.PutUint16(ansTail[0:2], rrType)
+	binary.BigEndian.PutUint16(ansTail[2:4], 1)
+	binary.BigEndian.PutUint32(ansTail[4:8], 60)
+	binary.BigEndian.PutUint16(ansTail[8:10], uint16(len(rdata)))
+	copy(ansTail[10:], rdata)
+
+	out := make([]byte, 12+len(q)+4+len(ansName)+len(ansTail))
+	out[2] = 0x81
+	binary.BigEndian.PutUint16(out[6:8], 1)
+	copy(out[12:], q)
+	off := 12 + len(q)
+	binary.BigEndian.PutUint16(out[off:], 1)
+	binary.BigEndian.PutUint16(out[off+2:], 1)
+	off += 4
+	copy(out[off:], ansName)
+	off += len(ansName)
+	copy(out[off:], ansTail)
+	return out
+}

--- a/internal/sys/httpclient/mss.go
+++ b/internal/sys/httpclient/mss.go
@@ -1,0 +1,59 @@
+package httpclient
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ipv4TCPHeaderOverhead is the combined IPv4 (20) + TCP (20) header size that
+// is subtracted from a link MTU to derive the largest TCP payload (MSS).
+const ipv4TCPHeaderOverhead = 40
+
+// sysClassNet is the kernel directory exposing per-interface attributes.
+// Declared as a var so tests can point it at a fixture directory.
+var sysClassNet = "/sys/class/net" //nolint:gochecknoglobals
+
+// tunnelMSS returns the TCP MSS to advertise for a socket bound to iface, or
+// 0 when no clamping is needed.
+//
+// SO_BINDTODEVICE forces egress through a tunnel device, but the kernel still
+// derives the advertised MSS from the matching *route* — typically the
+// 1500-byte WAN — not from the bound device. A WireGuard / AmneziaWG interface
+// has a smaller MTU (e.g. 1280), so without clamping the remote peer sends
+// segments too large for the tunnel. Those oversized inbound packets are
+// silently dropped, stalling the TLS handshake and surfacing to callers as a
+// bare "EOF". Clamping the MSS to the tunnel MTU keeps every inbound segment
+// inside the tunnel.
+func tunnelMSS(iface string) int {
+	return mssFromMTU(readIfaceMTU(iface))
+}
+
+// mssFromMTU converts a link MTU into the MSS to advertise, or 0 when the MTU
+// is unknown or already at/above a standard 1500-byte link (where the
+// route-derived MSS already fits and no clamp is required).
+func mssFromMTU(mtu int) int {
+	if mtu <= ipv4TCPHeaderOverhead || mtu >= 1500 {
+		return 0
+	}
+	return mtu - ipv4TCPHeaderOverhead
+}
+
+// readIfaceMTU reads /sys/class/net/<iface>/mtu. Returns 0 on any error so
+// callers fall back to the kernel default (no clamp).
+func readIfaceMTU(iface string) int {
+	iface = strings.TrimSpace(iface)
+	if iface == "" {
+		return 0
+	}
+	data, err := os.ReadFile(filepath.Join(sysClassNet, iface, "mtu"))
+	if err != nil {
+		return 0
+	}
+	mtu, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return mtu
+}

--- a/internal/sys/httpclient/mss_test.go
+++ b/internal/sys/httpclient/mss_test.go
@@ -1,0 +1,56 @@
+package httpclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMSSFromMTU(t *testing.T) {
+	cases := []struct {
+		mtu  int
+		want int
+	}{
+		{mtu: 1280, want: 1240}, // AmneziaWG / WireGuard tunnel
+		{mtu: 1420, want: 1380}, // common WG default
+		{mtu: 1412, want: 1372},
+		{mtu: 1500, want: 0}, // full Ethernet link — no clamp needed
+		{mtu: 1600, want: 0}, // jumbo / above standard — no clamp
+		{mtu: 40, want: 0},   // degenerate
+		{mtu: 0, want: 0},    // unknown
+		{mtu: -1, want: 0},   // invalid
+	}
+	for _, tc := range cases {
+		if got := mssFromMTU(tc.mtu); got != tc.want {
+			t.Errorf("mssFromMTU(%d) = %d, want %d", tc.mtu, got, tc.want)
+		}
+	}
+}
+
+func TestReadIfaceMTU(t *testing.T) {
+	dir := t.TempDir()
+	ifaceDir := filepath.Join(dir, "nwg2")
+	if err := os.MkdirAll(ifaceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ifaceDir, "mtu"), []byte("1280\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := sysClassNet
+	sysClassNet = dir
+	t.Cleanup(func() { sysClassNet = orig })
+
+	if got := readIfaceMTU("nwg2"); got != 1280 {
+		t.Fatalf("readIfaceMTU(nwg2) = %d, want 1280", got)
+	}
+	if got := readIfaceMTU("does-not-exist"); got != 0 {
+		t.Fatalf("readIfaceMTU(missing) = %d, want 0", got)
+	}
+	if got := readIfaceMTU(""); got != 0 {
+		t.Fatalf("readIfaceMTU(empty) = %d, want 0", got)
+	}
+	if got := tunnelMSS("nwg2"); got != 1240 {
+		t.Fatalf("tunnelMSS(nwg2) = %d, want 1240", got)
+	}
+}

--- a/internal/sys/httpclient/transport.go
+++ b/internal/sys/httpclient/transport.go
@@ -1,0 +1,50 @@
+package httpclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// TransportConfig configures a reusable *http.Transport for http.Client.
+type TransportConfig struct {
+	// Interface binds outgoing sockets to a kernel device (SO_BINDTODEVICE).
+	Interface string
+
+	// ProxyURL routes through an HTTP proxy, e.g. "http://127.0.0.1:1080".
+	ProxyURL string
+
+	// DNSServers are used for hostname resolution when Interface is set.
+	DNSServers []string
+}
+
+// NewTransport returns an http.Transport with optional interface binding
+// and/or HTTP proxy. Caller owns the returned value; clone per-client if
+// needed.
+func NewTransport(cfg TransportConfig) (*http.Transport, error) {
+	var parsedProxy *url.URL
+	if cfg.ProxyURL != "" {
+		u, err := url.Parse(cfg.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("httpclient: invalid proxy URL %q: %w", cfg.ProxyURL, err)
+		}
+		parsedProxy = u
+	}
+
+	base := &http.Transport{
+		MaxIdleConns:          10,
+		IdleConnTimeout:       30 * time.Second,
+		DisableKeepAlives:     true,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     false,
+	}
+
+	c := &Client{baseTransport: base}
+	return c.buildTransport(CallConfig{
+		Interface:      cfg.Interface,
+		DNSServers:     cfg.DNSServers,
+		ConnectTimeout: 10 * time.Second,
+	}, parsedProxy), nil
+}


### PR DESCRIPTION
## Прямой egress служебных загрузок через туннель (без sing-box) + хайлайтер человеческих ошибок

### Проблема

«Скачивание через …» (geo.dat, обновления AWGM, sing-box binary, DNSRoute-листы, Amnezia Premium) было жёстко завязано на sing-box: любой нестандартный маршрут шёл через локальный прокси sing-box. Для AWG-туннеля это бессмысленно — AWG живёт в ядре и умеет egress сам. На практике обновление geo через AWG-туннель падало с `EOF`, а Amnezia Premium — с `malformed HTTP response "\x00\x00\x12\x04…"`. 

### Что сделали и почему именно так

**1. Прямой bind-транспорт для AWG (без sing-box).**
Добавлен режим транспорта `bind`: диалер вешает сокет на интерфейс туннеля через `SO_BINDTODEVICE` и резолвит DNS через этот же интерфейс. Это даёт egress строго через туннель без участия sing-box. Sing-box-туннели и подписки по-прежнему ходят через локальный прокси sing-box (иначе никак — это userspace-протоколы); подписки (fetch их содержимого) всегда идут напрямую через WAN.

**2. Настоящая причина `EOF` / `malformed HTTP response` — ALPN, а не MTU.**
Go 1.24+ даже при `ForceAttemptHTTP2=false` продолжает анонсировать `h2` в ALPN. Сервер договаривается на HTTP/2, а транспорт говорит только HTTP/1.1 → на строгих серверах (Fastly / raw.githubusercontent.com) это рвётся в голый `EOF`, на мягких (Cloudflare / cp.amnezia.org) приходит сырой HTTP/2 SETTINGS-фрейм, который HTTP/1.1-парсер видит как «malformed response». Фикс: жёстко пиним `TLSClientConfig.NextProtos = ["http/1.1"]`.
Тонкость: `TLSClientConfig` клонируется перед мутацией, чтобы не портить общий базовый transport.

**3. Премиум больше не утекает мимо туннеля.**
`configureAmneziaCPTransport` переписывал `DialContext` у транспорта, полученного от download-сервиса, и тем самым выключал bind на туннель. Разделили на `applyAmneziaCPTimeouts` (только таймауты — для арендованного транспорта маршрута, сохраняет bind-диалер и ALPN-пин) и `configureAmneziaCPTransport` (свежий прямой транспорт для фолбэка без маршрута).

### Побочные штуки, которые добавили заодно

- **MSS-clamp (защитно).** При `SO_BINDTODEVICE` ядро берёт MSS из маршрута (обычно WAN 1500), а не из MTU туннеля (1280/1420). Без клампа удалёнка шлёт слишком большие сегменты, которые туннель чёрной дырой глотает → стойл TLS → `EOF`. Клампим `TCP_MAXSEG` под MTU интерфейса. Не было первопричиной (ей был ALPN), но оставили как защиту от PMTU-блэкхолов на больших передачах. Linux-only, best-effort.
- `DisableKeepAlives=true` и `User-Agent: curl/8.7.1` на geo-загрузке — снимают часть капризов строгих CDN/файрволов.

### Фронт: понятные ошибки вместо сырого текста

Раньше каждое место показывало `e.message` как есть и не намекало на причину (sing-box выключен, туннель не поднят, таймаут).

- **`humanizeDownloadError(err)`** — единый классификатор: читает `code`+`message` (из API-ошибки, `Error`, строки, `UpdateInfo.error`, `sub.lastError`) и возвращает вид (`singbox-off / awg-down / timeout / network / route / generic`), понятный заголовок, подсказку-действие, флаг «нужны настройки загрузок» и `raw` (для деталей/лога). `downloadErrorToText()` — плоская строка для тостов.
- **`DownloadErrorNotice`** — инлайн-нотис: понятный текст + ссылка «Открыть Настройки → Загрузки» + сворачиваемые «Подробности» с сырой ошибкой. Проп `hideSettingsLink` отключает ссылку, когда нотис уже внутри страницы настроек (нет смысла ссылаться на самого себя).
- **Один тост вместо двух** в geo-обновлениях (раньше дублировались баннер ошибки и строка «Последняя операция»).

### Прочие правки UI

- **Подсветка всего блока** «Загрузки и обновления» через `?highlight=downloads#downloads` (раньше обводился только селектор); все ссылки из ошибок ведут туда.
- **Группированный дропдаун маршрутов** по образцу NDMS: *AWG-туннели / Sing-box туннели / Sing-box подписки*, Direct сверху. Неизвестные `kind` не показываются.

### Где это используется

- Geo `.dat` (`HrNeoGeoDataView`).
- Обновление и проверка обновлений AWGM (`UpdateSection`, `settings/+page`).
- DNSRoute URL-листы (тост рефреша + per-sub `lastError` в модалке).
- Amnezia Premium (логин, страны, конфиги).
- Список маршрутов и смена канала обновлений.

### Тонкости, на которые стоит смотреть при ревью

- `/system/update/check` отдаёт **200 с `data.error`**, а не error-envelope — гуманизатор читает оба варианта.
- ALPN-пин трогает только per-call клон транспорта; базовый не мутируется (есть тест).
- MSS-clamp читает MTU из `/sys/class/net/<iface>/mtu`, при ошибке — без клампа (фолбэк на дефолт ядра).

### Тест-кейсы

**Юнит:**
- `downloadError.test.ts` — классификация: `sing-box is not running` → `singbox-off`; `interface … is not present` → `awg-down`; `timed out`/`deadline exceeded` → `timeout`; `EOF`/`malformed HTTP response`/`connection reset` → `network`; envelope-код `*_ROUTE_ERROR` → `route`; неизвестное → `generic` (без ссылки на настройки); чтение `code`+`message` из тела API-ошибки; `null`/пустой ввод.
- `mss_test.go` — `mssFromMTU`: 1280→1240, 1420→1380, 1500→0 (без клампа), мусор→0; чтение MTU из фикстуры.
- `client_test.go` — `NextProtos == ["http/1.1"]`, `ForceAttemptHTTP2 == false`, базовый транспорт не мутируется.
- `dns_test.go` / `transport_test.go` / `adapters_test.go` — резолв bind-маршрута и недоступность outbound без sing-box.

**Ручные (через мок-инжектор фолтов):**
В mock-proxy на download-эндпоинтах рандомно возвращается успех или одна из ошибок (sing-box off / AWG iface down / timeout / network / generic) — можно прогнать все исходы в каждом месте. Управление: `MOCK_DOWNLOAD_FAULTS=0`, `MOCK_DOWNLOAD_FAULT_PROB`, рантайм `POST /__mock/download-faults {enabled, probability}`. Список маршрутов `/download/outbounds` намеренно **не** фолтится, чтобы дропдаун не пустел.
- Geo-обновление при sing-box-маршруте и выключенном sing-box → один понятный тост + ссылка в настройки.
- Проверка обновлений с инжектом → инлайн-нотис без ссылки (мы уже в настройках).
- Premium-логин с инжектом сети → человеческий текст вместо `malformed HTTP response`.
- На роутере: geo/премиум через AWG-туннель грузятся напрямую с выключенным sing-box; через sing-box-маршрут — требуют запущенный sing-box.

# Важно, после вливания #303 гарантированно возникнет конфликт по Settings Page, в этом плане 303 приоритетнее