### PR TITLE
Typed ошибки sing-box и humanization egress-сбоев

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -2660,14 +2660,37 @@ const DOWNLOAD_FAULT_ROUTES = [
 	{ method: 'GET', path: '/system/update/check', style: 'updateInfo' },
 ];
 
-// One realistic message per humanized failure kind (see downloadError.ts):
-// sing-box off, AWG interface down, timeout, network drop, generic.
-const DOWNLOAD_FAULT_MESSAGES = [
-	'outbound "sb-subscription-1" is unavailable: sing-box is not running',
-	'outbound "awg-de-frankfurt" interface "awg0" is not present',
-	'download via DE Frankfurt: request failed: context deadline exceeded (timed out)',
-	'download via Direct (WAN): request failed: http get: EOF',
-	'remote returned HTTP 500: internal server error',
+// One realistic message + code per humanized failure kind (see downloadError.ts).
+const DOWNLOAD_FAULTS = [
+	{
+		message: 'outbound "sb-subscription-1" is unavailable: sing-box is not running',
+		code: 'DOWNLOAD_SINGBOX_NOT_RUNNING',
+	},
+	{
+		message: 'outbound "DE" is unavailable: sing-box proxy port not listening',
+		code: 'DOWNLOAD_SINGBOX_NOT_READY',
+	},
+	{
+		message: 'outbound "awg-de-frankfurt" interface "awg0" is not present',
+		code: 'DOWNLOAD_AWG_DOWN',
+	},
+	{
+		message: 'download via RelayCH (singbox): request failed: context deadline exceeded',
+		code: 'DOWNLOAD_TIMEOUT',
+	},
+	{
+		message:
+			'download via RelayCH (singbox): request failed: Get "https://github.com/foo/VERSION": EOF',
+		code: 'DOWNLOAD_SINGBOX_EGRESS_FAILED',
+	},
+	{
+		message: 'download via Direct (WAN): request failed: connection reset by peer',
+		code: 'DOWNLOAD_NETWORK',
+	},
+	{
+		message: 'remote returned HTTP 500: internal server error',
+		code: 'GEO_DOWNLOAD_ERROR',
+	},
 ];
 
 // Randomly short-circuit a service-download endpoint with a failure so the UI
@@ -2682,7 +2705,9 @@ function maybeInjectDownloadFault(req, res, path) {
 	// Drain any request body so keep-alive sockets don't stall.
 	if (req.method !== 'GET' && req.method !== 'HEAD') req.resume();
 
-	const message = DOWNLOAD_FAULT_MESSAGES[Math.floor(Math.random() * DOWNLOAD_FAULT_MESSAGES.length)];
+	const fault = DOWNLOAD_FAULTS[Math.floor(Math.random() * DOWNLOAD_FAULTS.length)];
+	const message = fault.message;
+	const faultCode = fault.code;
 	if (route.style === 'updateInfo') {
 		send(res, 200, {
 			success: true,
@@ -2692,12 +2717,13 @@ function maybeInjectDownloadFault(req, res, path) {
 				available: false,
 				channel: updateChannel,
 				error: message,
+				errorCode: faultCode,
 			},
 		});
 	} else {
-		send(res, 400, { error: true, message, code: route.code });
+		send(res, 400, { error: true, message, code: faultCode || route.code });
 	}
-	console.log(`[mock-proxy] injected download fault on ${req.method} ${path}: ${message}`);
+	console.log(`[mock-proxy] injected download fault on ${req.method} ${path}: ${message} (${faultCode})`);
 	return true;
 }
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -487,7 +487,7 @@ class ApiClient {
 		await this.request(`/hydraroute/geo-files/delete?path=${encodeURIComponent(path)}`, { method: 'DELETE' });
 	}
 
-	async updateGeoFile(path?: string, route?: DownloadRoute): Promise<{ updated: number; partial?: boolean; error?: string }> {
+	async updateGeoFile(path?: string, route?: DownloadRoute): Promise<{ updated: number; partial?: boolean; error?: string; errorCode?: string }> {
 		return this.request('/hydraroute/geo-files/update', {
 			method: 'POST',
 			body: JSON.stringify({ path: path || '', route }),

--- a/frontend/src/lib/components/dnsroutes/DnsRouteEditModal.svelte
+++ b/frontend/src/lib/components/dnsroutes/DnsRouteEditModal.svelte
@@ -11,7 +11,7 @@
 		findRoutingTunnelLabel,
 	} from '$lib/utils/routingTunnelOptions';
 	import DownloadRouteNote from '$lib/components/downloads/DownloadRouteNote.svelte';
-	import { humanizeDownloadError } from '$lib/utils/downloadError';
+	import { humanizeDownloadError, downloadRouteError } from '$lib/utils/downloadError';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
 
 	interface Props {
@@ -490,7 +490,7 @@
 							<span class="sub-meta">
 								{#if sub.lastError}
 									<span class="sub-error" title={sub.lastError}>
-										{humanizeDownloadError(sub.lastError).title}
+										{humanizeDownloadError(downloadRouteError(sub.lastError, sub.lastErrorCode)).title}
 									</span>
 								{:else if sub.lastCount !== undefined && sub.lastCount > 0}
 									<span class="sub-ok">{sub.lastCount} доменов</span>

--- a/frontend/src/lib/components/downloads/DownloadErrorNotice.svelte
+++ b/frontend/src/lib/components/downloads/DownloadErrorNotice.svelte
@@ -22,7 +22,7 @@
 	const showSettingsLink = $derived(info.needsDownloadSettings && !hideSettingsLink);
 </script>
 
-<div class="dl-error" class:dl-error-singbox={info.kind === 'singbox-off'}>
+<div class="dl-error" class:dl-error-singbox={info.kind === 'singbox-off' || info.kind === 'singbox-route'}>
 	<span class="dl-error-title">{info.title}</span>
 	{#if info.detail}
 		<span class="dl-error-detail">{info.detail}</span>

--- a/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoGeoDataView.svelte
@@ -16,6 +16,7 @@
 	import { geoDownloadProgress } from '$lib/stores/geoDownload';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
 	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
+	import { downloadRouteError } from '$lib/utils/downloadError';
 
 	interface Props {
 		files: GeoFileEntry[];
@@ -231,6 +232,7 @@
 		lastDownload = null;
 		activeDownload = op;
 		const notes: string[] = [];
+		let syncErrorCode = '';
 		try {
 			try {
 				await api.rescanGeoFiles();
@@ -250,10 +252,15 @@
 							? `Обновлено ${upd.updated}, ошибки: ${upd.error}`
 							: upd.error,
 					);
+					if (upd.errorCode) syncErrorCode = upd.errorCode;
 				}
 			} catch (e: unknown) {
 				await onrefresh();
 				notes.push(e instanceof Error ? e.message : String(e));
+				if (typeof e === 'object' && e !== null && 'body' in e) {
+					const code = (e as { body?: { code?: string } }).body?.code;
+					if (code) syncErrorCode = code;
+				}
 			}
 
 			if (notes.length > 0) {
@@ -261,7 +268,7 @@
 					ok: false,
 					action: 'Синхронизация geo-файлов',
 					routeLabel: op.routeLabel,
-					error: notes.join('; '),
+					error: downloadRouteError(notes.join('; '), syncErrorCode || undefined),
 				};
 			} else {
 				lastDownload = {

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -5,6 +5,8 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { singboxInstallProgress } from '$lib/stores/singboxInstall';
 	import { formatBytes } from '$lib/utils/format';
+	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
+	import { humanizeDownloadError } from '$lib/utils/downloadError';
 	import { stripAnsi } from '$lib/utils/ansi';
 	import { Blocks } from 'lucide-svelte';
 
@@ -16,8 +18,8 @@
 		hydraStatusError?: string | null;
 		singboxInstalling: boolean;
 		singboxUpdating?: boolean;
-		singboxInstallError: string | null;
-		singboxUpdateError?: string | null;
+		singboxInstallError: unknown;
+		singboxUpdateError?: unknown;
 		oninstallSingbox: () => void;
 		onupdateSingbox?: () => void;
 		showSingbox?: boolean;
@@ -83,7 +85,7 @@
 			case 'done':
 				return 'Готово';
 			case 'error':
-				return p.error ? `Ошибка: ${p.error}` : 'Ошибка';
+				return p.error ? humanizeDownloadError(p.error).title : 'Ошибка';
 			default:
 				return '';
 		}
@@ -103,14 +105,14 @@
 
 	async function copyError() {
 		const err = singboxInstallError ?? singboxUpdateError;
-		if (err) {
-			await copyToClipboard(err);
+		if (err != null) {
+			await copyToClipboard(humanizeDownloadError(err).raw);
 		}
 	}
 
 	// Auto-close modal when the upstream error is cleared (e.g. successful retry).
 	$effect(() => {
-		if (singboxInstallError === null && singboxUpdateError === null) {
+		if (singboxInstallError == null && singboxUpdateError == null) {
 			errorModalOpen = false;
 		}
 	});
@@ -269,7 +271,10 @@
 	size="lg"
 	onclose={() => (errorModalOpen = false)}
 >
-	<pre class="error-pre">{singboxInstallError ?? singboxUpdateError ?? ''}</pre>
+	<DownloadErrorNotice
+		error={singboxInstallError ?? singboxUpdateError}
+		hideSettingsLink
+	/>
 	{#snippet actions()}
 		<Button variant="ghost" size="sm" onclick={copyError}>Скопировать</Button>
 		<Button variant="primary" size="sm" onclick={() => (errorModalOpen = false)}>
@@ -329,18 +334,6 @@
 	.install-error-label {
 		color: var(--color-error);
 		font-size: 0.8125rem;
-	}
-	.error-pre {
-		margin: 0;
-		padding: 0.75rem;
-		background: var(--color-settings-control-bg);
-		border-radius: var(--radius-sm);
-		font-family: var(--font-mono);
-		font-size: 0.75rem;
-		white-space: pre-wrap;
-		word-break: break-word;
-		max-height: 50vh;
-		overflow: auto;
 	}
 
 	.progress-widget {

--- a/frontend/src/lib/components/settings/UpdateSection.svelte
+++ b/frontend/src/lib/components/settings/UpdateSection.svelte
@@ -4,7 +4,7 @@
 	import { Modal, Button } from '$lib/components/ui';
 	import ChangelogModal from './ChangelogModal.svelte';
 	import DownloadErrorNotice from '$lib/components/downloads/DownloadErrorNotice.svelte';
-	import { downloadErrorToText } from '$lib/utils/downloadError';
+	import { downloadErrorToText, downloadRouteError } from '$lib/utils/downloadError';
 	import type { UpdateInfo } from '$lib/types';
 
 	interface Props {
@@ -31,7 +31,9 @@
 		try {
 			updateInfo = await api.checkUpdate(true);
 			if (updateInfo.error) {
-				notifications.error(`Проверка обновлений: ${downloadErrorToText(updateInfo.error)}`);
+				notifications.error(
+					`Проверка обновлений: ${downloadErrorToText(downloadRouteError(updateInfo.error, updateInfo.errorCode))}`,
+				);
 			} else if (updateInfo.available) {
 				notifications.success(`Доступна версия ${updateInfo.latestVersion}`);
 			} else {
@@ -106,7 +108,10 @@
 			</span>
 		{:else if updateInfo?.error}
 			<div class="update-error-notice">
-				<DownloadErrorNotice error={updateInfo.error} hideSettingsLink />
+				<DownloadErrorNotice
+					error={downloadRouteError(updateInfo.error, updateInfo.errorCode)}
+					hideSettingsLink
+				/>
 			</div>
 		{:else}
 			<span class="setting-description">

--- a/frontend/src/lib/components/singbox/SingboxInstallBanner.svelte
+++ b/frontend/src/lib/components/singbox/SingboxInstallBanner.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api/client';
 	import { Button, IconButton } from '$lib/components/ui';
 	import { formatBytes } from '$lib/utils/format';
+	import { humanizeDownloadError } from '$lib/utils/downloadError';
 
 	let installing = $state(false);
 	let updating = $state(false);
@@ -30,7 +31,7 @@
 			case 'done':
 				return 'Готово';
 			case 'error':
-				return p.error ? `Ошибка: ${p.error}` : 'Ошибка';
+				return p.error ? humanizeDownloadError(p.error).title : 'Ошибка';
 			default:
 				return '';
 		}

--- a/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionActiveCard.svelte
@@ -23,6 +23,7 @@
     import { notifications } from '$lib/stores/notifications';
     import type { Subscription, SubscriptionMember } from '$lib/types';
     import { formatBitRate, formatBytes, formatRelativeTime } from '$lib/utils/format';
+    import { humanizeDownloadError } from '$lib/utils/downloadError';
     import SubscriptionMemberPicker from './SubscriptionMemberPicker.svelte';
     import type { SingboxLayoutMode } from '$lib/constants/singboxLayout';
     import TunnelDiagnosticsModal from '$lib/components/testing/TunnelDiagnosticsModal.svelte';
@@ -123,6 +124,9 @@
     const lastFetchedHuman = $derived(
         subscription.lastFetched ? formatRelativeTime(subscription.lastFetched) : '—',
     );
+    const lastErrorInfo = $derived(
+        subscription.lastError ? humanizeDownloadError(subscription.lastError) : null,
+    );
 
     const cardState = $derived(delayPresentation.state);
     const latText = $derived(delayPresentation.label);
@@ -215,8 +219,8 @@
     >
             <td class="tunnel-list-cell tunnel-list-cell--delay lc lc-delay" data-label="Delay">
                 {#if subscription.lastError}
-                    <span class="delay-inline-err mono" title={subscription.lastError}>
-                        {subscription.lastError}
+                    <span class="delay-inline-err mono" title={lastErrorInfo?.raw}>
+                        {lastErrorInfo?.title ?? subscription.lastError}
                     </span>
                 {:else}
                     <TunnelSingboxPingButton
@@ -379,7 +383,7 @@
     {#if renderMode !== 'list-card'}
     <div class="details">
     {#if subscription.lastError}
-        <div class="sub-error mono">{subscription.lastError}</div>
+        <div class="sub-error mono" title={lastErrorInfo?.raw}>{lastErrorInfo?.title ?? subscription.lastError}</div>
     {/if}
 
     <div class="details-dense-cols">
@@ -541,7 +545,7 @@
     </div>
 
     {#if subscription.lastError}
-        <div class="sub-error mono">{subscription.lastError}</div>
+        <div class="sub-error mono" title={lastErrorInfo?.raw}>{lastErrorInfo?.title ?? subscription.lastError}</div>
     {/if}
 
     <div class="server-section">

--- a/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionCard.svelte
@@ -17,6 +17,7 @@
 	import { singboxDelayFromHistory } from '$lib/utils/singboxDelay';
 	import { singboxDelayStatusDot } from '$lib/utils/statusDot';
 	import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
+	import { humanizeDownloadError } from '$lib/utils/downloadError';
 	import TunnelDiagnosticsModal from '$lib/components/testing/TunnelDiagnosticsModal.svelte';
 
 	interface Props {
@@ -37,6 +38,9 @@
 	}: Props = $props();
 
 	const resolvedMemberTag = $derived(resolveSubscriptionMemberTag(subscription, liveActiveMember));
+	const lastErrorInfo = $derived(
+		subscription.lastError ? humanizeDownloadError(subscription.lastError) : null,
+	);
 
 	const history = $derived(
 		resolvedMemberTag ? ($singboxDelayHistory.get(resolvedMemberTag) ?? []) : [],
@@ -180,8 +184,8 @@
 	>
 			<td class="tunnel-list-cell tunnel-list-cell--delay lc lc-delay" data-label="Delay">
 				{#if subscription.lastError}
-					<span class="delay-inline-err mono" title={subscription.lastError}>
-						{subscription.lastError}
+					<span class="delay-inline-err mono" title={lastErrorInfo?.raw}>
+						{lastErrorInfo?.title ?? subscription.lastError}
 					</span>
 				{:else if !subscription.enabled}
 					<span class="delay-dash">—</span>
@@ -366,7 +370,7 @@
 		{/if}
 	</div>
 	{#if subscription.lastError}
-		<div class="inactive-err mono" title={subscription.lastError}>{subscription.lastError}</div>
+		<div class="inactive-err mono" title={lastErrorInfo?.raw}>{lastErrorInfo?.title ?? subscription.lastError}</div>
 	{/if}
 	{/if}
 	{#if renderMode === 'list-card'}
@@ -443,7 +447,7 @@
 		{#if subscription.lastError}
 			<div class="detail-row detail-row-err">
 				<span class="detail-label">Ошибка</span>
-				<span class="detail-value mono" title={subscription.lastError}>{subscription.lastError}</span>
+				<span class="detail-value mono" title={lastErrorInfo?.raw}>{lastErrorInfo?.title ?? subscription.lastError}</span>
 			</div>
 		{/if}
 	</div>

--- a/frontend/src/lib/components/tunnels/VpnLinkPasteImport.svelte
+++ b/frontend/src/lib/components/tunnels/VpnLinkPasteImport.svelte
@@ -66,7 +66,7 @@
 	let premiumBusy = $state(false);
 	let premiumBusyDepth = 0;
 	let premiumPickBusy = $state('');
-	let premiumError = $state('');
+	let premiumError = $state<unknown>(null);
 	let premiumReissueConfirm = $state<{ code: string; label: string } | null>(null);
 	let premiumConfirmBusy = $state(false);
 	let hasStoredPremiumKey = $state(false);
@@ -139,7 +139,7 @@
 		linkError = '';
 		linkPreview = '';
 		configContent = '';
-		premiumError = '';
+		premiumError = null;
 		premiumBusyDepth = 0;
 		premiumBusy = false;
 		resetPremiumCatalogState();
@@ -166,7 +166,7 @@
 		if (classifyVpnLink(key) === 'regular') return;
 
 		beginPremiumBusy();
-		premiumError = '';
+		premiumError = null;
 		try {
 			const { sid } = await api.amneziaPremiumLogin(key);
 			if (gen !== vpnAnalysisGen) return;
@@ -182,8 +182,7 @@
 			if (gen !== vpnAnalysisGen) return;
 			if (e instanceof DOMException && e.name === 'AbortError') return;
 			resetPremiumCatalogState();
-			const msg = e instanceof Error ? e.message : 'Ошибка запроса к cp.amnezia.org';
-			premiumError = msg;
+			premiumError = e;
 			notifications.error(downloadErrorToText(e));
 		} finally {
 			endPremiumBusy();
@@ -210,7 +209,7 @@
 		if (!raw) {
 			resetPremiumCatalogState();
 			configContent = '';
-			premiumError = '';
+			premiumError = null;
 			premiumBusyDepth = 0;
 			premiumBusy = false;
 			return;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -213,6 +213,7 @@ export interface DnsRouteSubscription {
 	lastFetched?: string;
 	lastCount?: number;
 	lastError?: string;
+	lastErrorCode?: string;
 }
 
 export interface DnsRouteTarget {
@@ -748,6 +749,7 @@ export interface UpdateInfo {
 	checkedAt: string;
 	checking: boolean;
 	error?: string;
+	errorCode?: string;
 	warning?: string;
 }
 

--- a/frontend/src/lib/utils/downloadError.test.ts
+++ b/frontend/src/lib/utils/downloadError.test.ts
@@ -1,58 +1,111 @@
 import { describe, expect, it } from 'vitest';
-import { downloadErrorToText, humanizeDownloadError } from './downloadError';
+import {
+	DOWNLOAD_ERROR_CODES,
+	downloadErrorToText,
+	downloadRouteError,
+	humanizeDownloadError,
+} from './downloadError';
 
 describe('humanizeDownloadError', () => {
-	it('classifies sing-box-off from outbound-unavailable message', () => {
+	it('classifies singbox-off from backend code', () => {
+		const h = humanizeDownloadError({
+			message: 'outbound "DE" is unavailable: sing-box is not running',
+			code: DOWNLOAD_ERROR_CODES.SINGBOX_NOT_RUNNING,
+		});
+		expect(h.kind).toBe('singbox-off');
+		expect(h.title).toMatch(/sing-box/i);
+	});
+
+	it('classifies singbox-off when local proxy is not ready', () => {
+		const h = humanizeDownloadError({
+			message: 'outbound "DE" is unavailable: sing-box proxy port not listening',
+			code: DOWNLOAD_ERROR_CODES.SINGBOX_NOT_READY,
+		});
+		expect(h.kind).toBe('singbox-off');
+		expect(h.title).toMatch(/запускается/i);
+	});
+
+	it('classifies singbox-route from egress failure code', () => {
+		const h = humanizeDownloadError({
+			message:
+				'download via RelayCH (singbox): request failed: Get "https://github.com/foo/VERSION": EOF',
+			code: DOWNLOAD_ERROR_CODES.SINGBOX_EGRESS_FAILED,
+		});
+		expect(h.kind).toBe('singbox-route');
+		expect(h.detail).toMatch(/туннель/i);
+		expect(h.detail).not.toMatch(/запускается/i);
+	});
+
+	it('classifies awg-down from backend code', () => {
+		const h = humanizeDownloadError({
+			message: 'outbound "awg-de" interface "awg0" is not present',
+			code: DOWNLOAD_ERROR_CODES.AWG_DOWN,
+		});
+		expect(h.kind).toBe('awg-down');
+	});
+
+	it('classifies timeout from backend code', () => {
+		const h = humanizeDownloadError({
+			message: 'download timed out',
+			code: DOWNLOAD_ERROR_CODES.TIMEOUT,
+		});
+		expect(h.kind).toBe('timeout');
+	});
+
+	it('classifies network from backend code', () => {
+		const h = humanizeDownloadError({
+			message: 'connection reset by peer',
+			code: DOWNLOAD_ERROR_CODES.NETWORK,
+		});
+		expect(h.kind).toBe('network');
+	});
+
+	it('falls back to string patterns when code is missing (legacy)', () => {
 		const h = humanizeDownloadError(
 			new Error('outbound "sub-14ddb10d" is unavailable: sing-box is not running'),
 		);
 		expect(h.kind).toBe('singbox-off');
-		expect(h.needsDownloadSettings).toBe(true);
-		expect(h.title).toMatch(/sing-box/i);
 	});
 
-	it('classifies awg-down from missing interface', () => {
-		const h = humanizeDownloadError('outbound "awg-de" interface "awg0" is not present');
-		expect(h.kind).toBe('awg-down');
-		expect(h.needsDownloadSettings).toBe(true);
+	it('legacy EOF on singbox route without code maps to singbox-route', () => {
+		const h = humanizeDownloadError(
+			'download via RelayCH (singbox): request failed: Get "https://github.com/foo/VERSION": EOF',
+		);
+		expect(h.kind).toBe('singbox-route');
+		expect(h.detail).toMatch(/перезапустите sing-box/i);
 	});
 
-	it('classifies timeout', () => {
-		const h = humanizeDownloadError('download timed out after 15m0s');
-		expect(h.kind).toBe('timeout');
+	it('legacy connection refused on singbox route maps to singbox-off (starting)', () => {
+		const h = humanizeDownloadError(
+			'download via RelayCH (singbox): request failed: dial tcp 127.0.0.1:1080: connect: connection refused',
+		);
+		expect(h.kind).toBe('singbox-off');
+		expect(h.title).toMatch(/запускается/i);
 	});
 
-	it('classifies network drops (EOF / malformed HTTP / reset)', () => {
+	it('legacy EOF without code stays network (not singbox-route)', () => {
 		expect(humanizeDownloadError('http get: EOF').kind).toBe('network');
-		expect(
-			humanizeDownloadError('malformed HTTP response "\\x00\\x00"').kind,
-		).toBe('network');
-		expect(humanizeDownloadError('connection reset by peer').kind).toBe('network');
-	});
-
-	it('classifies generic route errors via envelope code', () => {
-		const err = Object.assign(new Error('selected outbound is unavailable for download transport'), {
-			body: { code: 'GEO_DOWNLOAD_ROUTE_ERROR' },
-		});
-		const h = humanizeDownloadError(err);
-		expect(h.kind).toBe('route');
-		expect(h.code).toBe('GEO_DOWNLOAD_ROUTE_ERROR');
 	});
 
 	it('reads message + code from API client error body', () => {
 		const err = Object.assign(new Error('top'), {
-			body: { code: 'X', message: 'sing-box is not running' },
+			body: { code: DOWNLOAD_ERROR_CODES.SINGBOX_NOT_RUNNING, message: 'sing-box is not running' },
 		});
 		const h = humanizeDownloadError(err);
 		expect(h.kind).toBe('singbox-off');
-		expect(h.raw).toBe('sing-box is not running');
-		expect(h.code).toBe('X');
+		expect(h.code).toBe(DOWNLOAD_ERROR_CODES.SINGBOX_NOT_RUNNING);
+	});
+
+	it('reads errorCode from UpdateInfo-shaped objects', () => {
+		const h = humanizeDownloadError(
+			downloadRouteError('download via RelayCH (singbox): EOF', DOWNLOAD_ERROR_CODES.SINGBOX_EGRESS_FAILED),
+		);
+		expect(h.kind).toBe('singbox-route');
 	});
 
 	it('falls back to raw message for unknown errors', () => {
 		const h = humanizeDownloadError('repository quota exceeded');
 		expect(h.kind).toBe('generic');
-		expect(h.needsDownloadSettings).toBe(false);
 		expect(h.title).toBe('repository quota exceeded');
 	});
 
@@ -65,18 +118,18 @@ describe('humanizeDownloadError', () => {
 
 describe('downloadErrorToText', () => {
 	it('joins title + detail for toast contexts', () => {
-		const text = downloadErrorToText('sing-box is not running');
+		const text = downloadErrorToText(
+			downloadRouteError('sing-box is not running', DOWNLOAD_ERROR_CODES.SINGBOX_NOT_RUNNING),
+		);
 		expect(text).toMatch(/sing-box/i);
 		expect(text).toMatch(/Direct|AWG/);
 	});
 
-	it('appends settings cue when no detail but route-related', () => {
-		// generic has no settings cue
-		expect(downloadErrorToText('weird error')).toBe('weird error');
-	});
-
 	it('accepts an already-humanized error', () => {
-		const h = humanizeDownloadError('download timed out');
-		expect(downloadErrorToText(h)).toBe(downloadErrorToText('download timed out'));
+		const h = humanizeDownloadError({
+			message: 'download timed out',
+			code: DOWNLOAD_ERROR_CODES.TIMEOUT,
+		});
+		expect(downloadErrorToText(h)).toBe(downloadErrorToText(h));
 	});
 });

--- a/frontend/src/lib/utils/downloadError.ts
+++ b/frontend/src/lib/utils/downloadError.ts
@@ -5,14 +5,14 @@
  * download route (Direct / AWG-bind / sing-box / subscription), so they
  * share the same failure modes.
  *
- * The backend emits a heterogeneous mix of RU/EN strings and an envelope
- * `code`. Instead of every call site re-implementing regexes, this module
- * classifies the error once and returns a friendly user-facing message plus
- * the raw text (kept for logs / "details"). See humanizeDownloadError().
+ * The backend emits stable `DOWNLOAD_*` codes via RouteError. This module
+ * maps codes to friendly UI text and keeps string fallbacks only for legacy
+ * cached errors without a code.
  */
 
 export type DownloadErrorKind =
 	| 'singbox-off'
+	| 'singbox-route'
 	| 'awg-down'
 	| 'timeout'
 	| 'network'
@@ -29,16 +29,34 @@ export interface HumanizedDownloadError {
 	needsDownloadSettings: boolean;
 	/** Original backend message — keep for logs / collapsible details. */
 	raw: string;
-	/** Backend envelope code, when present (e.g. GEO_DOWNLOAD_ROUTE_ERROR). */
+	/** Backend envelope code, when present (e.g. DOWNLOAD_SINGBOX_EGRESS_FAILED). */
 	code?: string;
 }
 
 /** Deep-link that scrolls to and glows the "Загрузки и обновления" card. */
 export const DOWNLOAD_SETTINGS_HREF = '/settings?highlight=downloads#downloads';
 
+/** Stable download error codes emitted by internal/downloader. */
+export const DOWNLOAD_ERROR_CODES = {
+	SINGBOX_NOT_RUNNING: 'DOWNLOAD_SINGBOX_NOT_RUNNING',
+	SINGBOX_NOT_READY: 'DOWNLOAD_SINGBOX_NOT_READY',
+	SINGBOX_EGRESS_FAILED: 'DOWNLOAD_SINGBOX_EGRESS_FAILED',
+	AWG_DOWN: 'DOWNLOAD_AWG_DOWN',
+	TIMEOUT: 'DOWNLOAD_TIMEOUT',
+	NETWORK: 'DOWNLOAD_NETWORK',
+	ROUTE: 'DOWNLOAD_ROUTE',
+} as const;
+
 interface ExtractedError {
 	raw: string;
 	code: string;
+}
+
+/** Build input for humanizeDownloadError from message + optional backend code. */
+export function downloadRouteError(message?: string, code?: string): unknown {
+	if (!message) return null;
+	if (code) return { message, code };
+	return message;
 }
 
 /**
@@ -53,29 +71,55 @@ function extractError(err: unknown): ExtractedError {
 		const e = err as {
 			message?: string;
 			code?: string;
+			error?: string;
+			errorCode?: string;
 			body?: { code?: string; message?: string };
 		};
-		const code = e.body?.code || e.code || '';
-		const raw = e.body?.message || e.message || String(err);
+		const code = e.body?.code || e.code || e.errorCode || '';
+		const raw = e.body?.message || e.message || e.error || String(err);
 		return { raw, code };
 	}
 	return { raw: String(err), code: '' };
 }
 
+function kindFromCode(code: string): DownloadErrorKind | null {
+	switch (code) {
+		case DOWNLOAD_ERROR_CODES.SINGBOX_NOT_RUNNING:
+		case DOWNLOAD_ERROR_CODES.SINGBOX_NOT_READY:
+			return 'singbox-off';
+		case DOWNLOAD_ERROR_CODES.SINGBOX_EGRESS_FAILED:
+			return 'singbox-route';
+		case DOWNLOAD_ERROR_CODES.AWG_DOWN:
+			return 'awg-down';
+		case DOWNLOAD_ERROR_CODES.TIMEOUT:
+			return 'timeout';
+		case DOWNLOAD_ERROR_CODES.NETWORK:
+			return 'network';
+		case DOWNLOAD_ERROR_CODES.ROUTE:
+			return 'route';
+		default:
+			return null;
+	}
+}
+
 function classify(raw: string, code: string): DownloadErrorKind {
+	const fromCode = kindFromCode(code);
+	if (fromCode) return fromCode;
+
+	// Legacy fallback for cached/plain-string errors without a backend code.
 	const text = `${raw} ${code}`.toLowerCase();
 
-	// sing-box-backed route (sing-box tunnel or subscription) but the daemon
-	// is down / its local proxy port is not yet listening.
 	if (
 		text.includes('sing-box is not running') ||
+		text.includes('sing-box is not ready') ||
 		text.includes('sing-box proxy port') ||
-		text.includes('proxy port not found')
+		text.includes('subscription proxy port') ||
+		text.includes('proxy port not found') ||
+		text.includes('proxy port not listening')
 	) {
 		return 'singbox-off';
 	}
 
-	// AWG bind route but the kernel interface is missing / link is down.
 	if (
 		text.includes('is not present') ||
 		text.includes('no such device') ||
@@ -94,6 +138,29 @@ function classify(raw: string, code: string): DownloadErrorKind {
 	}
 
 	if (
+		text.includes('download via') &&
+		(text.includes('(singbox)') || text.includes('(subscription)'))
+	) {
+		if (
+			text.includes('connection refused') ||
+			text.includes('proxy port not listening') ||
+			text.includes('sing-box is not ready')
+		) {
+			return 'singbox-off';
+		}
+		if (
+			text.includes('eof') ||
+			text.includes('connection reset') ||
+			text.includes('connection broken') ||
+			text.includes('broken pipe') ||
+			text.includes('malformed http response') ||
+			text.includes('ошибка сети')
+		) {
+			return 'singbox-route';
+		}
+	}
+
+	if (
 		text.includes('eof') ||
 		text.includes('connection reset') ||
 		text.includes('connection broken') ||
@@ -105,7 +172,6 @@ function classify(raw: string, code: string): DownloadErrorKind {
 		return 'network';
 	}
 
-	// Generic "route is unavailable / ambiguous" without a more specific cause.
 	if (
 		text.includes('is unavailable') ||
 		text.includes('unavailable for download transport') ||
@@ -120,26 +186,43 @@ function classify(raw: string, code: string): DownloadErrorKind {
 
 /**
  * Classify a caught download error into a friendly, actionable message.
- *
- * Usage:
- *   const h = humanizeDownloadError(e);
- *   notifications.error(downloadErrorToText(h));   // toast (no link)
- *   <DownloadErrorNotice error={e} />              // inline (with link)
  */
 export function humanizeDownloadError(err: unknown): HumanizedDownloadError {
 	const { raw, code } = extractError(err);
 	const kind = classify(raw, code);
 
 	switch (kind) {
-		case 'singbox-off':
+		case 'singbox-off': {
+			const starting =
+				code === DOWNLOAD_ERROR_CODES.SINGBOX_NOT_READY ||
+				raw.toLowerCase().includes('not ready') ||
+				raw.toLowerCase().includes('proxy port not listening') ||
+				(raw.toLowerCase().includes('connection refused') &&
+					raw.toLowerCase().includes('download via') &&
+					(raw.toLowerCase().includes('(singbox)') ||
+						raw.toLowerCase().includes('(subscription)')));
 			return {
 				kind,
 				code,
 				raw,
 				needsDownloadSettings: true,
-				title: 'Маршрут загрузки требует запущенный sing-box.',
+				title: starting
+					? 'Sing-box ещё запускается.'
+					: 'Маршрут загрузки требует запущенный sing-box.',
+				detail: starting
+					? 'Локальный прокси sing-box пока недоступен. Подождите несколько секунд и повторите либо выберите другой маршрут.'
+					: 'Включите sing-box или выберите другой маршрут (Direct или AWG-туннель).',
+			};
+		}
+		case 'singbox-route':
+			return {
+				kind,
+				code,
+				raw,
+				needsDownloadSettings: true,
+				title: 'Не удалось загрузить через sing-box-маршрут.',
 				detail:
-					'Включите sing-box или выберите другой маршрут (Direct или AWG-туннель).',
+					'Туннель маршрута не смог установить соединение с сервером. Проверьте его состояние, перезапустите sing-box или выберите другой маршрут загрузок.',
 			};
 		case 'awg-down':
 			return {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -82,9 +82,9 @@
 	let restartConfirmOpen = $state(false);
 	let hydraBusy = $state(false);
 	let singboxInstalling = $state(false);
-	let singboxInstallError = $state<string | null>(null);
+	let singboxInstallError = $state<unknown>(null);
 	let singboxUpdating = $state(false);
-	let singboxUpdateError = $state<string | null>(null);
+	let singboxUpdateError = $state<unknown>(null);
 	let singboxBusy = $state(false);
 	let ndmsProxyBusy = $state(false);
 	let ndmsProxyConfirmOpen = $state(false);
@@ -185,7 +185,7 @@
 			singboxStatus.applyMutationResponse(fresh);
 			notifications.success("Sing-box установлен");
 		} catch (e) {
-			singboxInstallError = e instanceof Error ? e.message : String(e);
+			singboxInstallError = e;
 		} finally {
 			singboxInstalling = false;
 		}
@@ -199,7 +199,7 @@
 			singboxStatus.applyMutationResponse(fresh);
 			notifications.success("Sing-box обновлён");
 		} catch (e) {
-			singboxUpdateError = e instanceof Error ? e.message : String(e);
+			singboxUpdateError = e;
 		} finally {
 			singboxUpdating = false;
 		}

--- a/internal/api/amnezia_cp.go
+++ b/internal/api/amnezia_cp.go
@@ -209,7 +209,7 @@ func (h *AmneziaCPHandler) Login(w http.ResponseWriter, r *http.Request) {
 	lease, client, route, err := h.downloadClient(r.Context())
 	if err != nil {
 		h.log.Warn("amnezia-premium-cp", "route", "login: "+err.Error())
-		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), "AMNEZIA_CP_ROUTE_ERROR")
+		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), downloader.APIErrorCode(err, "AMNEZIA_CP_ROUTE_ERROR"))
 		return
 	}
 	if lease != nil {
@@ -226,8 +226,9 @@ func (h *AmneziaCPHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		reqErr := downloader.WrapRequestError(route, err)
 		h.log.Warn("amnezia-premium-cp", "login", fmt.Sprintf("network route=%s kind=%s: %v", routeDisplayName(route), route.Kind, err))
-		response.Error(w, fmt.Sprintf("Не удалось связаться с cp.amnezia.org через %s: %v", routeDisplayName(route), err), "AMNEZIA_CP_NETWORK")
+		response.Error(w, reqErr.Error(), downloader.APIErrorCode(reqErr, "AMNEZIA_CP_NETWORK"))
 		return
 	}
 	defer resp.Body.Close()
@@ -307,7 +308,7 @@ func (h *AmneziaCPHandler) AccountInfo(w http.ResponseWriter, r *http.Request) {
 	lease, client, route, err := h.downloadClient(r.Context())
 	if err != nil {
 		h.log.Warn("amnezia-premium-cp", "route", "account-info: "+err.Error())
-		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), "AMNEZIA_CP_ROUTE_ERROR")
+		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), downloader.APIErrorCode(err, "AMNEZIA_CP_ROUTE_ERROR"))
 		return
 	}
 	if lease != nil {
@@ -323,8 +324,9 @@ func (h *AmneziaCPHandler) AccountInfo(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		reqErr := downloader.WrapRequestError(route, err)
 		h.log.Warn("amnezia-premium-cp", "account-info", fmt.Sprintf("network route=%s kind=%s: %v", routeDisplayName(route), route.Kind, err))
-		response.Error(w, fmt.Sprintf("Не удалось связаться с cp.amnezia.org через %s: %v", routeDisplayName(route), err), "AMNEZIA_CP_NETWORK")
+		response.Error(w, reqErr.Error(), downloader.APIErrorCode(reqErr, "AMNEZIA_CP_NETWORK"))
 		return
 	}
 	defer resp.Body.Close()
@@ -422,7 +424,7 @@ func (h *AmneziaCPHandler) DownloadConfig(w http.ResponseWriter, r *http.Request
 	lease, client, route, err := h.downloadClient(r.Context())
 	if err != nil {
 		h.log.Warn("amnezia-premium-cp", "route", "download-config: "+err.Error())
-		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), "AMNEZIA_CP_ROUTE_ERROR")
+		response.Error(w, "Маршрут загрузки Amnezia Premium недоступен: "+err.Error(), downloader.APIErrorCode(err, "AMNEZIA_CP_ROUTE_ERROR"))
 		return
 	}
 	if lease != nil {
@@ -439,8 +441,9 @@ func (h *AmneziaCPHandler) DownloadConfig(w http.ResponseWriter, r *http.Request
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		reqErr := downloader.WrapRequestError(route, err)
 		h.log.Warn("amnezia-premium-cp", "download-config", fmt.Sprintf("network route=%s kind=%s: %v", routeDisplayName(route), route.Kind, err))
-		response.Error(w, fmt.Sprintf("Не удалось связаться с cp.amnezia.org через %s: %v", routeDisplayName(route), err), "AMNEZIA_CP_NETWORK")
+		response.Error(w, reqErr.Error(), downloader.APIErrorCode(reqErr, "AMNEZIA_CP_NETWORK"))
 		return
 	}
 	defer resp.Body.Close()

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/hoaxisr/awg-manager/internal/dnsroute"
+	"github.com/hoaxisr/awg-manager/internal/downloader"
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
@@ -493,13 +494,13 @@ func (h *DNSRouteHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 
 	if id != "" {
 		if err := h.svc.RefreshSubscriptions(r.Context(), id); err != nil {
-			response.Error(w, err.Error(), "DNS_ROUTE_REFRESH_ERROR")
+			response.Error(w, err.Error(), downloader.APIErrorCode(err, "DNS_ROUTE_REFRESH_ERROR"))
 			return
 		}
 		h.log.Info("dns-route-refresh", id, "DNS route subscriptions refreshed")
 	} else {
 		if err := h.svc.RefreshAllSubscriptions(r.Context()); err != nil {
-			response.Error(w, err.Error(), "DNS_ROUTE_REFRESH_ALL_ERROR")
+			response.Error(w, err.Error(), downloader.APIErrorCode(err, "DNS_ROUTE_REFRESH_ALL_ERROR"))
 			return
 		}
 		h.log.Info("dns-route-refresh-all", "", "All DNS route subscriptions refreshed")

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/hoaxisr/awg-manager/internal/downloader"
@@ -84,9 +83,10 @@ type GeoFileResponse struct {
 // POST /hydraroute/geo-files/update. The shape is the same whether the
 // caller targeted one path or all paths.
 type GeoFileUpdatedData struct {
-	Updated int    `json:"updated" example:"1"`
-	Partial bool   `json:"partial,omitempty" example:"true"`
-	Error   string `json:"error,omitempty"`
+	Updated       int    `json:"updated" example:"1"`
+	Partial       bool   `json:"partial,omitempty" example:"true"`
+	Error         string `json:"error,omitempty"`
+	ErrorCode     string `json:"errorCode,omitempty"`
 }
 
 // GeoFileUpdatedResponse is the envelope for POST /hydraroute/geo-files/update.
@@ -326,7 +326,7 @@ func (h *HydraRouteHandler) AddGeoFile(w http.ResponseWriter, r *http.Request) {
 	}
 	lease, err := h.downloadSvc.ResolveClient(r.Context(), toDownloaderRoute(req.Route))
 	if err != nil {
-		response.Error(w, err.Error(), "GEO_DOWNLOAD_ROUTE_ERROR")
+		response.Error(w, err.Error(), downloader.APIErrorCode(err, "GEO_DOWNLOAD_ROUTE_ERROR"))
 		return
 	}
 	defer lease.Close()
@@ -335,7 +335,8 @@ func (h *HydraRouteHandler) AddGeoFile(w http.ResponseWriter, r *http.Request) {
 
 	entry, err := gds.DownloadWithClientVia(r.Context(), req.Type, req.URL, lease.Client, routeLabel)
 	if err != nil {
-		response.Error(w, fmt.Sprintf("download via %s: %v", routeLabel, err), "GEO_DOWNLOAD_ERROR")
+		msg, code := wrapGeoDownloadError(lease.Route, err, "GEO_DOWNLOAD_ERROR")
+		response.Error(w, msg, code)
 		return
 	}
 
@@ -494,7 +495,7 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 	}
 	lease, err := h.downloadSvc.ResolveClient(r.Context(), toDownloaderRoute(req.Route))
 	if err != nil {
-		response.Error(w, err.Error(), "GEO_DOWNLOAD_ROUTE_ERROR")
+		response.Error(w, err.Error(), downloader.APIErrorCode(err, "GEO_DOWNLOAD_ROUTE_ERROR"))
 		return
 	}
 	defer lease.Close()
@@ -507,15 +508,18 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 		out.Updated = count
 		if err != nil {
 			out.Partial = count > 0
-			out.Error = fmt.Sprintf("update via %s: %v", routeLabel, err)
+			msg, code := wrapGeoDownloadError(lease.Route, err, "GEO_UPDATE_ERROR")
+			out.Error = msg
+			out.ErrorCode = code
 			if count == 0 {
-				response.Error(w, fmt.Sprintf("update via %s: %v", routeLabel, err), "GEO_UPDATE_ERROR")
+				response.Error(w, msg, code)
 				return
 			}
 		}
 	} else {
 		if _, err := gds.UpdateWithClientVia(r.Context(), req.Path, lease.Client, routeLabel); err != nil {
-			response.Error(w, fmt.Sprintf("update via %s: %v", routeLabel, err), "GEO_UPDATE_ERROR")
+			msg, code := wrapGeoDownloadError(lease.Route, err, "GEO_UPDATE_ERROR")
+			response.Error(w, msg, code)
 			return
 		}
 		out.Updated = 1
@@ -719,4 +723,12 @@ func (h *HydraRouteHandler) GetOversizedTags(w http.ResponseWriter, r *http.Requ
 		"maxelem":   cfg.EffectiveMaxElem(),
 		"tags":      response.MustNotNil(tags),
 	})
+}
+
+func wrapGeoDownloadError(route downloader.RouteInfo, err error, fallback string) (string, string) {
+	if err == nil {
+		return "", fallback
+	}
+	reqErr := downloader.WrapRequestError(route, err)
+	return reqErr.Error(), downloader.APIErrorCode(reqErr, fallback)
 }

--- a/internal/api/hydraroute_test.go
+++ b/internal/api/hydraroute_test.go
@@ -2,11 +2,26 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/hoaxisr/awg-manager/internal/downloader"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
+
+func TestWrapGeoDownloadError_SingboxEOF(t *testing.T) {
+	msg, code := wrapGeoDownloadError(
+		downloader.RouteInfo{Tag: "RelayCH", Kind: "singbox"},
+		errors.New(`Get "https://example.com": EOF`),
+		"GEO_DOWNLOAD_ERROR",
+	)
+	if code != string(downloader.ErrCodeSingboxEgressFailed) {
+		t.Fatalf("code = %q, want %q", code, downloader.ErrCodeSingboxEgressFailed)
+	}
+	if msg == "" {
+		t.Fatal("expected non-empty message")
+	}
+}
 
 func TestToDownloaderRoute(t *testing.T) {
 	if got := toDownloaderRoute(nil); got != nil {

--- a/internal/api/singbox.go
+++ b/internal/api/singbox.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hoaxisr/awg-manager/internal/downloader"
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
@@ -289,7 +290,7 @@ func (h *SingboxHandler) Install(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.op.Install(r.Context()); err != nil {
-		response.InternalError(w, err.Error())
+		response.ErrorWithStatus(w, http.StatusInternalServerError, err.Error(), downloader.APIErrorCode(err, "SINGBOX_INSTALL_ERROR"))
 		return
 	}
 	s := h.op.GetStatus(r.Context())
@@ -322,7 +323,7 @@ func (h *SingboxHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.op.Update(r.Context()); err != nil {
-		response.InternalError(w, err.Error())
+		response.ErrorWithStatus(w, http.StatusInternalServerError, err.Error(), downloader.APIErrorCode(err, "SINGBOX_UPDATE_ERROR"))
 		return
 	}
 	s := h.op.GetStatus(r.Context())

--- a/internal/dnsroute/impl.go
+++ b/internal/dnsroute/impl.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hoaxisr/awg-manager/internal/downloader"
 	"github.com/hoaxisr/awg-manager/internal/hydraroute"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/ndms/command"
@@ -791,12 +792,14 @@ func (s *ServiceImpl) refreshSubscriptions(ctx context.Context, id string) error
 		sub.LastFetched = now
 		if err != nil {
 			sub.LastError = err.Error()
+			sub.LastErrorCode = string(downloader.RouteErrorCode(err))
 			sub.LastCount = 0
 			s.appLog.Warn("subscription-fetch", id, fmt.Sprintf("url=%s err=%s", sub.URL, err.Error()))
 			// Keep going — one failed subscription shouldn't block others
 			continue
 		}
 		sub.LastError = ""
+		sub.LastErrorCode = ""
 		sub.LastCount = len(domains)
 		allSubDomains = append(allSubDomains, domains)
 	}

--- a/internal/dnsroute/types.go
+++ b/internal/dnsroute/types.go
@@ -46,7 +46,8 @@ type Subscription struct {
 	Name        string `json:"name"`
 	LastFetched string `json:"lastFetched,omitempty"`
 	LastCount   int    `json:"lastCount,omitempty"`
-	LastError   string `json:"lastError,omitempty"`
+	LastError     string `json:"lastError,omitempty"`
+	LastErrorCode string `json:"lastErrorCode,omitempty"`
 }
 
 // RouteTarget specifies which tunnel interface to route matched domains through.

--- a/internal/downloader/adapters.go
+++ b/internal/downloader/adapters.go
@@ -179,6 +179,21 @@ func (a *singboxRuntimeAdapter) IsRunning() bool {
 	return running
 }
 
+func (a *singboxRuntimeAdapter) IsReady() bool {
+	if a == nil || a.op == nil {
+		return false
+	}
+	running, _ := a.op.IsRunningPublic()
+	if !running {
+		return false
+	}
+	clash := a.op.Clash()
+	if clash == nil {
+		return false
+	}
+	return clash.IsHealthy()
+}
+
 func (p *settingsRouteProvider) GetDownloadRoute(ctx context.Context) (*Route, error) {
 	if p == nil || p.store == nil {
 		return &Route{Tag: "direct"}, nil

--- a/internal/downloader/errors.go
+++ b/internal/downloader/errors.go
@@ -1,0 +1,131 @@
+package downloader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ErrorCode classifies download-route failures for API envelopes and UI
+// humanization. Prefer reading codes via RouteErrorCode(err) instead of parsing
+// error strings on the frontend.
+type ErrorCode string
+
+const (
+	ErrCodeSingboxNotRunning   ErrorCode = "DOWNLOAD_SINGBOX_NOT_RUNNING"
+	ErrCodeSingboxNotReady     ErrorCode = "DOWNLOAD_SINGBOX_NOT_READY"
+	ErrCodeSingboxEgressFailed ErrorCode = "DOWNLOAD_SINGBOX_EGRESS_FAILED"
+	ErrCodeAWGDown             ErrorCode = "DOWNLOAD_AWG_DOWN"
+	ErrCodeTimeout             ErrorCode = "DOWNLOAD_TIMEOUT"
+	ErrCodeNetwork             ErrorCode = "DOWNLOAD_NETWORK"
+	ErrCodeRoute               ErrorCode = "DOWNLOAD_ROUTE"
+)
+
+// RouteError is a typed download failure with a stable machine code.
+type RouteError struct {
+	Code ErrorCode
+	msg  string
+	err  error
+}
+
+func newRouteError(code ErrorCode, msg string, err error) *RouteError {
+	return &RouteError{Code: code, msg: msg, err: err}
+}
+
+func (e *RouteError) Error() string { return e.msg }
+func (e *RouteError) Unwrap() error { return e.err }
+
+// RouteErrorCode walks err (including wrapped errors) and returns the first
+// RouteError code found, or "" when none is present.
+func RouteErrorCode(err error) ErrorCode {
+	for err != nil {
+		var re *RouteError
+		if errors.As(err, &re) {
+			return re.Code
+		}
+		err = errors.Unwrap(err)
+	}
+	return ""
+}
+
+// APIErrorCode returns the envelope code for err. Falls back to fallback when
+// err is not a RouteError.
+func APIErrorCode(err error, fallback string) string {
+	if code := RouteErrorCode(err); code != "" {
+		return string(code)
+	}
+	return fallback
+}
+
+func wrapRequestError(route RouteInfo, err error) error {
+	if err == nil {
+		return nil
+	}
+	display := route.DisplayName()
+	msg := fmt.Sprintf("download via %s: request failed: %v", display, err)
+	return newRouteError(classifyRequestError(route, err), msg, err)
+}
+
+// WrapRequestError classifies an HTTP client failure for the given route.
+func WrapRequestError(route RouteInfo, err error) error {
+	return wrapRequestError(route, err)
+}
+
+func classifyRequestError(route RouteInfo, err error) ErrorCode {
+	if isTimeout(err) {
+		return ErrCodeTimeout
+	}
+	kind := strings.TrimSpace(route.Kind)
+	switch kind {
+	case "singbox", "subscription":
+		if isLocalProxyDialError(err) {
+			return ErrCodeSingboxNotReady
+		}
+		if isTransportDrop(err) {
+			return ErrCodeSingboxEgressFailed
+		}
+	case "awg":
+		if isTransportDrop(err) {
+			return ErrCodeNetwork
+		}
+	}
+	if isTransportDrop(err) {
+		return ErrCodeNetwork
+	}
+	return ErrCodeNetwork
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timed out") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded")
+}
+
+func isTransportDrop(err error) bool {
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "eof") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection broken") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "malformed http response") ||
+		strings.Contains(msg, "ошибка сети")
+}
+
+func isLocalProxyDialError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "connection refused") {
+		return false
+	}
+	return strings.Contains(msg, localProxyHost) ||
+		strings.Contains(msg, "127.0.0.1") ||
+		strings.Contains(msg, "localhost")
+}

--- a/internal/downloader/errors_test.go
+++ b/internal/downloader/errors_test.go
@@ -1,0 +1,57 @@
+package downloader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestRouteErrorCode_RouteError(t *testing.T) {
+	inner := errors.New("EOF")
+	err := newRouteError(ErrCodeSingboxEgressFailed, "download via RelayCH (singbox): request failed: EOF", inner)
+	if got := RouteErrorCode(err); got != ErrCodeSingboxEgressFailed {
+		t.Fatalf("RouteErrorCode = %q, want %q", got, ErrCodeSingboxEgressFailed)
+	}
+	if got := RouteErrorCode(fmt.Errorf("wrap: %w", err)); got != ErrCodeSingboxEgressFailed {
+		t.Fatalf("wrapped RouteErrorCode = %q", got)
+	}
+}
+
+func TestClassifyRequestError_SingboxEgress(t *testing.T) {
+	err := classifyRequestError(RouteInfo{Tag: "RelayCH", Kind: "singbox"}, errors.New("Get \"https://example.com\": EOF"))
+	if err != ErrCodeSingboxEgressFailed {
+		t.Fatalf("code = %q, want %q", err, ErrCodeSingboxEgressFailed)
+	}
+}
+
+func TestClassifyRequestError_SingboxProxyNotReady(t *testing.T) {
+	err := classifyRequestError(
+		RouteInfo{Tag: "DE", Kind: "singbox"},
+		errors.New(`Get "https://example.com": dial tcp 127.0.0.1:1080: connect: connection refused`),
+	)
+	if err != ErrCodeSingboxNotReady {
+		t.Fatalf("code = %q, want %q", err, ErrCodeSingboxNotReady)
+	}
+}
+
+func TestClassifyRequestError_DirectNetwork(t *testing.T) {
+	err := classifyRequestError(RouteInfo{Tag: "direct", Kind: "direct"}, errors.New("connection reset by peer"))
+	if err != ErrCodeNetwork {
+		t.Fatalf("code = %q, want %q", err, ErrCodeNetwork)
+	}
+}
+
+func TestClassifyRequestError_Timeout(t *testing.T) {
+	err := classifyRequestError(RouteInfo{Tag: "DE", Kind: "singbox"}, context.DeadlineExceeded)
+	if err != ErrCodeTimeout {
+		t.Fatalf("code = %q, want %q", err, ErrCodeTimeout)
+	}
+}
+
+func TestIsTransportDrop_EOF(t *testing.T) {
+	if !isTransportDrop(net.ErrClosed) {
+		t.Fatal("expected net.ErrClosed to be a transport drop")
+	}
+}

--- a/internal/downloader/helpers.go
+++ b/internal/downloader/helpers.go
@@ -107,7 +107,7 @@ func (s *Service) ReadAll(ctx context.Context, req Request) ([]byte, ResponseMet
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return nil, meta, fmt.Errorf("download via %s: request failed: %w", lease.Route.DisplayName(), err)
+		return nil, meta, wrapRequestError(lease.Route, err)
 	}
 	defer resp.Body.Close()
 	meta.StatusCode = resp.StatusCode
@@ -189,7 +189,7 @@ func (s *Service) DownloadFile(ctx context.Context, req FileRequest) (FileResult
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return result, fmt.Errorf("download via %s: request failed: %w", lease.Route.DisplayName(), err)
+		return result, wrapRequestError(lease.Route, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/downloader/service_test.go
+++ b/internal/downloader/service_test.go
@@ -169,8 +169,9 @@ func TestResolveClient_AWGBind(t *testing.T) {
 
 func TestResolveClient_SingboxProxy(t *testing.T) {
 	resolver := NewTransportResolver(TransportResolverDeps{
-		Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1081}},
-		Singbox: &fakeSingboxRuntime{running: true},
+		Tunnels:       &fakeTunnelPorts{ports: map[string]int{"DE": 1081}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: true},
+		ProxyPortOpen: proxyPortAlwaysOpen,
 	})
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{
@@ -241,8 +242,9 @@ func TestListOutbounds_SingboxUnavailableWhenDown(t *testing.T) {
 			},
 		},
 		TransportResolver: NewTransportResolver(TransportResolverDeps{
-			Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
-			Singbox: &fakeSingboxRuntime{running: false},
+			Tunnels:       &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+			Singbox:       &fakeSingboxRuntime{running: false},
+			ProxyPortOpen: proxyPortAlwaysOpen,
 		}),
 	})
 	got := svc.ListOutbounds(context.Background())
@@ -559,8 +561,9 @@ func TestDescribeRoute_RespectsKind(t *testing.T) {
 
 func TestResolveClient_RespectsKind(t *testing.T) {
 	resolver := NewTransportResolver(TransportResolverDeps{
-		Subs:    &fakeSubPorts{ports: map[string]int{"same-tag": 11002}},
-		Singbox: &fakeSingboxRuntime{running: true},
+		Subs:          &fakeSubPorts{ports: map[string]int{"same-tag": 11002}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: true},
+		ProxyPortOpen: proxyPortAlwaysOpen,
 	})
 	svc := NewService(Deps{
 		Outbounds: &fakeOutboundsProvider{

--- a/internal/downloader/transport.go
+++ b/internal/downloader/transport.go
@@ -3,15 +3,24 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
 )
 
-const localProxyHost = "127.0.0.1"
+const (
+	localProxyHost         = "127.0.0.1"
+	proxyPortProbeTimeout  = 2 * time.Second
+)
+
+// ProxyPortOpen probes whether a local sing-box mixed inbound accepts TCP.
+// Nil in TransportResolverDeps uses a real dial to 127.0.0.1:<port>.
+type ProxyPortOpen func(host string, port int) bool
 
 // TransportMode selects how an HTTP client reaches the destination.
 type TransportMode string
@@ -54,10 +63,11 @@ type SubscriptionListenPortLookup interface {
 	ListenPortBySelectorTag(ctx context.Context, selectorTag string) (int, bool)
 }
 
-// SingboxRuntimeChecker reports whether sing-box is running. Proxy-based
-// routes require a live process listening on localhost.
+// SingboxRuntimeChecker reports sing-box daemon state for proxy-based routes.
 type SingboxRuntimeChecker interface {
 	IsRunning() bool
+	// IsReady reports whether the Clash API is healthy (sing-box finished boot).
+	IsReady() bool
 }
 
 // TransportResolverDeps wires lookup helpers for compositeTransportResolver.
@@ -68,6 +78,8 @@ type TransportResolverDeps struct {
 	AWGEgress AWGEgressLookup
 	// SysClassNet overrides /sys/class/net for tests.
 	SysClassNet string
+	// ProxyPortOpen overrides the local mixed-inbound TCP probe (tests).
+	ProxyPortOpen ProxyPortOpen
 }
 
 // TransportResolver maps a catalog outbound to a concrete transport.
@@ -82,6 +94,7 @@ type compositeTransportResolver struct {
 	singbox   SingboxRuntimeChecker
 	awgEgress AWGEgressLookup
 	sysNet    string
+	proxyOpen ProxyPortOpen
 }
 
 func NewTransportResolver(d TransportResolverDeps) TransportResolver {
@@ -95,11 +108,16 @@ func NewTransportResolver(d TransportResolverDeps) TransportResolver {
 		singbox:   d.Singbox,
 		awgEgress: d.AWGEgress,
 		sysNet:    sysNet,
+		proxyOpen: d.ProxyPortOpen,
 	}
 }
 
 func (r *compositeTransportResolver) singboxRunning() bool {
 	return r.singbox != nil && r.singbox.IsRunning()
+}
+
+func (r *compositeTransportResolver) singboxReady() bool {
+	return r.singbox != nil && r.singbox.IsReady()
 }
 
 func (r *compositeTransportResolver) Resolve(ctx context.Context, ob Outbound) (TransportSpec, error) {
@@ -116,7 +134,11 @@ func (r *compositeTransportResolver) Resolve(ctx context.Context, ob Outbound) (
 			return TransportSpec{}, fmt.Errorf("outbound %q has no kernel interface", ob.Tag)
 		}
 		if !r.ifaceExists(iface) {
-			return TransportSpec{}, fmt.Errorf("outbound %q interface %q is not present", ob.Tag, iface)
+			return TransportSpec{}, newRouteError(
+				ErrCodeAWGDown,
+				fmt.Sprintf("outbound %q interface %q is not present", ob.Tag, iface),
+				nil,
+			)
 		}
 		spec := TransportSpec{Mode: TransportModeBind, Interface: iface}
 		if r.awgEgress != nil {
@@ -126,27 +148,79 @@ func (r *compositeTransportResolver) Resolve(ctx context.Context, ob Outbound) (
 
 	case "singbox":
 		if !r.singboxRunning() {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box is not running", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotRunning,
+				fmt.Sprintf("outbound %q is unavailable: sing-box is not running", ob.Tag),
+				nil,
+			)
+		}
+		if !r.singboxReady() {
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotReady,
+				fmt.Sprintf("outbound %q is unavailable: sing-box is not ready", ob.Tag),
+				nil,
+			)
 		}
 		if r.tunnels == nil {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box tunnel lookup is not configured", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeRoute,
+				fmt.Sprintf("outbound %q is unavailable: sing-box tunnel lookup is not configured", ob.Tag),
+				nil,
+			)
 		}
 		port, ok := r.tunnels.ListenPortByTag(ctx, ob.Tag)
 		if !ok || port <= 0 {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: local sing-box proxy port not found", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeRoute,
+				fmt.Sprintf("outbound %q is unavailable: local sing-box proxy port not found", ob.Tag),
+				nil,
+			)
+		}
+		if !r.proxyPortListening(port) {
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotReady,
+				fmt.Sprintf("outbound %q is unavailable: sing-box proxy port not listening", ob.Tag),
+				nil,
+			)
 		}
 		return TransportSpec{Mode: TransportModeProxy, ProxyPort: port}, nil
 
 	case "subscription":
 		if !r.singboxRunning() {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: sing-box is not running", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotRunning,
+				fmt.Sprintf("outbound %q is unavailable: sing-box is not running", ob.Tag),
+				nil,
+			)
+		}
+		if !r.singboxReady() {
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotReady,
+				fmt.Sprintf("outbound %q is unavailable: sing-box is not ready", ob.Tag),
+				nil,
+			)
 		}
 		if r.subs == nil {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: subscription lookup is not configured", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeRoute,
+				fmt.Sprintf("outbound %q is unavailable: subscription lookup is not configured", ob.Tag),
+				nil,
+			)
 		}
 		port, ok := r.subs.ListenPortBySelectorTag(ctx, ob.Tag)
 		if !ok || port <= 0 {
-			return TransportSpec{}, fmt.Errorf("outbound %q is unavailable: local subscription proxy port not found", ob.Tag)
+			return TransportSpec{}, newRouteError(
+				ErrCodeRoute,
+				fmt.Sprintf("outbound %q is unavailable: local subscription proxy port not found", ob.Tag),
+				nil,
+			)
+		}
+		if !r.proxyPortListening(port) {
+			return TransportSpec{}, newRouteError(
+				ErrCodeSingboxNotReady,
+				fmt.Sprintf("outbound %q is unavailable: subscription proxy port not listening", ob.Tag),
+				nil,
+			)
 		}
 		return TransportSpec{Mode: TransportModeProxy, ProxyPort: port}, nil
 
@@ -170,6 +244,26 @@ func (r *compositeTransportResolver) ifaceExists(name string) bool {
 	}
 	_, err := os.Stat(filepath.Join(r.sysNet, name))
 	return err == nil
+}
+
+func (r *compositeTransportResolver) proxyPortListening(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	check := r.proxyOpen
+	if check == nil {
+		check = defaultProxyPortOpen
+	}
+	return check(localProxyHost, port)
+}
+
+func defaultProxyPortOpen(host string, port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), proxyPortProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func newHTTPClientFromSpec(spec TransportSpec) (*http.Client, error) {

--- a/internal/downloader/transport_test.go
+++ b/internal/downloader/transport_test.go
@@ -28,9 +28,11 @@ func (f *fakeSubPorts) ListenPortBySelectorTag(_ context.Context, tag string) (i
 
 type fakeSingboxRuntime struct {
 	running bool
+	ready   bool
 }
 
 func (f *fakeSingboxRuntime) IsRunning() bool { return f.running }
+func (f *fakeSingboxRuntime) IsReady() bool  { return f.running && f.ready }
 
 type fakeAWGEgress struct {
 	dns map[string][]string
@@ -42,6 +44,10 @@ func (f *fakeAWGEgress) DNSForTag(_ context.Context, tag string) []string {
 	}
 	return f.dns[tag]
 }
+
+func proxyPortAlwaysOpen(_ string, _ int) bool { return true }
+
+func proxyPortAlwaysClosed(_ string, _ int) bool { return false }
 
 func TestTransportResolver_AWG_Bind(t *testing.T) {
 	sysNet := t.TempDir()
@@ -75,12 +81,16 @@ func TestTransportResolver_AWG_MissingIface(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "not present") {
 		t.Fatalf("expected missing iface error, got %v", err)
 	}
+	if RouteErrorCode(err) != ErrCodeAWGDown {
+		t.Fatalf("RouteErrorCode = %q, want %q", RouteErrorCode(err), ErrCodeAWGDown)
+	}
 }
 
 func TestTransportResolver_Singbox_ProxyPort(t *testing.T) {
 	r := NewTransportResolver(TransportResolverDeps{
-		Tunnels: &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
-		Singbox: &fakeSingboxRuntime{running: true},
+		Tunnels:       &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: true},
+		ProxyPortOpen: proxyPortAlwaysOpen,
 	})
 	spec, err := r.Resolve(context.Background(), Outbound{Tag: "DE", Kind: "singbox"})
 	if err != nil {
@@ -88,6 +98,33 @@ func TestTransportResolver_Singbox_ProxyPort(t *testing.T) {
 	}
 	if spec.Mode != TransportModeProxy || spec.ProxyPort != 1080 {
 		t.Fatalf("spec = %+v, want proxy :1080", spec)
+	}
+}
+
+func TestTransportResolver_Singbox_ProxyPortNotListening(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{
+		Tunnels:       &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: true},
+		ProxyPortOpen: proxyPortAlwaysClosed,
+	})
+	_, err := r.Resolve(context.Background(), Outbound{Tag: "DE", Kind: "singbox"})
+	if err == nil || !strings.Contains(err.Error(), "proxy port not listening") {
+		t.Fatalf("expected proxy port not listening error, got %v", err)
+	}
+	if RouteErrorCode(err) != ErrCodeSingboxNotReady {
+		t.Fatalf("RouteErrorCode = %q, want %q", RouteErrorCode(err), ErrCodeSingboxNotReady)
+	}
+}
+
+func TestTransportResolver_Singbox_NotReady(t *testing.T) {
+	r := NewTransportResolver(TransportResolverDeps{
+		Tunnels:       &fakeTunnelPorts{ports: map[string]int{"DE": 1080}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: false},
+		ProxyPortOpen: proxyPortAlwaysOpen,
+	})
+	_, err := r.Resolve(context.Background(), Outbound{Tag: "DE", Kind: "singbox"})
+	if err == nil || RouteErrorCode(err) != ErrCodeSingboxNotReady {
+		t.Fatalf("expected not ready error, got %v", err)
 	}
 }
 
@@ -100,12 +137,16 @@ func TestTransportResolver_Singbox_NotRunning(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "not running") {
 		t.Fatalf("expected not running error, got %v", err)
 	}
+	if RouteErrorCode(err) != ErrCodeSingboxNotRunning {
+		t.Fatalf("RouteErrorCode = %q, want %q", RouteErrorCode(err), ErrCodeSingboxNotRunning)
+	}
 }
 
 func TestTransportResolver_Subscription_ProxyPort(t *testing.T) {
 	r := NewTransportResolver(TransportResolverDeps{
-		Subs:    &fakeSubPorts{ports: map[string]int{"sub-abc": 11001}},
-		Singbox: &fakeSingboxRuntime{running: true},
+		Subs:          &fakeSubPorts{ports: map[string]int{"sub-abc": 11001}},
+		Singbox:       &fakeSingboxRuntime{running: true, ready: true},
+		ProxyPortOpen: proxyPortAlwaysOpen,
 	})
 	spec, err := r.Resolve(context.Background(), Outbound{Tag: "sub-abc", Kind: "subscription"})
 	if err != nil {

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1198,6 +1198,8 @@ definitions:
     properties:
       error:
         type: string
+      errorCode:
+        type: string
       partial:
         example: true
         type: boolean

--- a/internal/updater/checker.go
+++ b/internal/updater/checker.go
@@ -70,7 +70,8 @@ func checkWithDownloader(ctx context.Context, currentVersion, channel string, dl
 
 	pkg, err := fetchLatestPackageWithDownloader(ctx, dl, pkgsURL, pkgName, cmp)
 	if err != nil {
-		info.Error = fmt.Sprintf("entware repo: %s", err)
+		info.Error = err.Error()
+		info.ErrorCode = string(downloader.RouteErrorCode(err))
 		return info
 	}
 

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -14,6 +14,7 @@ type UpdateInfo struct {
 	CheckedAt      time.Time `json:"checkedAt"`
 	Checking       bool      `json:"checking"`
 	Error          string    `json:"error,omitempty"`
+	ErrorCode      string    `json:"errorCode,omitempty"`
 	Warning        string    `json:"warning,omitempty"`
 }
 


### PR DESCRIPTION
# Зависит от #306 в плане UI, целевую ветку поменять на develop, лучше без squash

### Проблема

После #305 egress и humanization появились, но half-started sing-box всё ещё давал ложный `network`:

```
Не удалось установить соединение.
Соединение оборвалось — возможно, маршрут блокируется…
• download via RelayCH (singbox): request failed: Get "…/VERSION": EOF
```

Процесс жив, Clash отвечает, локальный прокси принимает TCP — resolve проходит, запрос уходит, туннель рвётся → EOF. На #305 это классифицировалось как generic `network`, хотя sing-box **намеренно выключенный** уже показывал правильный `singbox-off`.

Нужно: стабильные коды с бэка, ранняя детекция «ещё не готов», отдельный UX для «прокси есть, egress не встал».

### Что сделали

**1. Typed `RouteError` на бэке (`internal/downloader/errors.go`).**

Стабильные `DOWNLOAD_*` коды вместо regex на фронте. `WrapRequestError` классифицирует сбои HTTP-клиента по kind маршрута:

| Код | Когда |
|---|---|
| `DOWNLOAD_SINGBOX_NOT_RUNNING` | процесс не запущен |
| `DOWNLOAD_SINGBOX_NOT_READY` | Clash не healthy / порт не слушает / `connection refused` на localhost |
| `DOWNLOAD_SINGBOX_EGRESS_FAILED` | EOF/reset/malformed HTTP на singbox/subscription маршруте |
| `DOWNLOAD_AWG_DOWN` | интерфейс AWG не поднят |
| `DOWNLOAD_TIMEOUT` / `DOWNLOAD_NETWORK` | как раньше, но явно |

**2. Превентивные проверки до HTTP (`transport.go`).**

Перед resolve singbox/subscription маршрута:
- `IsReady()` — Clash `/version` отвечает 200
- `proxyPortListening()` — TCP dial на `127.0.0.1:<port>` (2s timeout)

«Ещё запускается» ловится **до** запроса, а не через EOF.

**3. Прокидывание `errorCode` в API.**

`errorCode` добавлен в `UpdateInfo`, geo update response, DNSRoute `lastErrorCode`, Amnezia CP, singbox install/update. `APIErrorCode(err, fallback)` — envelope code из `RouteError`, иначе legacy fallback.

**4. Фронт: kind `singbox-route`.**

- `singbox-off` — не запущен / ещё стартует (`NOT_READY` → «Sing-box ещё запускается»)
- `singbox-route` — egress через туннель не встал (`EGRESS_FAILED` → «перезапустите sing-box»)
- `network` — остаётся для Direct/AWG и прочего

`downloadRouteError(msg, code)` на call sites с persisted кодом. Legacy string fallback для старых `lastError` без кода — EOF + `download via … (singbox)` → `singbox-route`.

**5. Mock-proxy** — фолты с парой message+code для ручной прогонки всех исходов.

### Где затронуто

- Проверка/обновление AWGM (`UpdateSection`)
- Geo sync (`HrNeoGeoDataView`)
- DNSRoute refresh + per-sub `lastError` в модалке
- Amnezia Premium (`VpnLinkPasteImport`)
- Singbox install/update (`IntegrationsCard`, баннер)
- Подписки — humanize по `lastError` (код пока не persist'ится, работает fallback)

### Тонкости для ревью

- **Case D остаётся:** Clash healthy + порт слушает, outbound ещё не встал → `SINGBOX_EGRESS_FAILED`, не «ещё запускается». Честнее, чем generic network; идеального детекта outbound readiness нет.
- **Дублирование:** классификация в Go + TS — намеренно: код первичен, строки — fallback для cached errors.
- **Подписки sing-box** — `lastErrorCode` не добавляли; для них regex-fallback.
- `/system/update/check` по-прежнему 200 с `data.error` + теперь `data.errorCode`.

### Тест-кейсы

**Юнит:**
- `errors_test.go` — классификация EOF/refused/timeout
- `transport_test.go` — not running / not ready / port not listening
- `hydraroute_test.go` — singbox EOF → `SINGBOX_EGRESS_FAILED`
- `downloadError.test.ts` — все kinds + legacy fallback

**Ручные (mock-proxy, `MOCK_DOWNLOAD_FAULTS=1`):**
- sing-box выключен → `singbox-off`, ссылка в настройки
- proxy port not listening → «ещё запускается»
- EOF на singbox маршруте → `singbox-route`, не «блокируется маршрут»
- Direct EOF → по-прежнему `network`
- Проверка обновлений с инжектом → inline-нотис с `errorCode`