### PR TITLE
fix(ui): починить модалку «удаление невозможно» и человеческие причины

### DIFF
--- a/frontend/src/lib/components/tunnels/TunnelReferencedModal.svelte
+++ b/frontend/src/lib/components/tunnels/TunnelReferencedModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Modal, Button } from '$lib/components/ui';
 	import type { TunnelReferencedError } from '$lib/types';
+	import { describeRouterReference } from '$lib/utils/tunnelRefs';
 
 	interface Props {
 		open: boolean;
@@ -21,7 +22,7 @@
 			{#if details.deviceProxy}
 				<li>Активен в селекторе device-proxy (выбран как маршрут по умолчанию)</li>
 			{/if}
-			{#if details.routerRules.length > 0}
+			{#if details.routerRules && details.routerRules.length > 0}
 				<li>
 					Используется в правилах sing-box router:
 					<span class="rule-indices">
@@ -29,15 +30,11 @@
 					</span>
 				</li>
 			{/if}
-			{#if details.routerOther && details.routerOther.length > 0}
-				<li>
-					Используется в конфигурации sing-box router:
-					<ul class="ref-locations">
-						{#each details.routerOther as loc}
-							<li><code>{loc}</code></li>
-						{/each}
-					</ul>
-				</li>
+			{#if details.routerOther}
+				{#each details.routerOther as loc}
+					{@const ref = describeRouterReference(loc)}
+					<li>{#if ref.known}{ref.text}{:else}<code>{ref.text}</code>{/if}</li>
+				{/each}
 			{/if}
 		</ul>
 		<p class="hint">Удалите ссылки и попробуйте снова.</p>
@@ -54,6 +51,7 @@
 	.ref-list {
 		margin: 0.5rem 0 0.75rem;
 		padding-left: 1.25rem;
+		list-style: disc;
 	}
 	.ref-list li {
 		margin: 0.25rem 0;
@@ -62,18 +60,14 @@
 		font-family: var(--font-mono);
 		color: var(--color-text-muted);
 	}
+	.ref-list code {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
 	.hint {
 		color: var(--color-text-muted);
 		font-size: 0.875rem;
 		margin: 0;
-	}
-	.ref-locations {
-		margin: 0.25rem 0 0;
-		padding-left: 1rem;
-	}
-	.ref-locations code {
-		font-family: var(--font-mono);
-		font-size: 0.8125rem;
-		color: var(--color-text-muted);
 	}
 </style>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1587,8 +1587,9 @@ export interface AWGTagInfo {
 export interface TunnelReferencedError {
 	tunnelId: string;
 	deviceProxy: boolean;
-	routerRules: number[];
-	routerOther: string[];
+	// Go marshals empty (nil) slices as null, so these arrive null when empty.
+	routerRules: number[] | null;
+	routerOther: string[] | null;
 }
 
 // #endregion

--- a/frontend/src/lib/utils/tunnelRefs.test.ts
+++ b/frontend/src/lib/utils/tunnelRefs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { describeRouterReference } from './tunnelRefs';
+
+describe('describeRouterReference', () => {
+	it('describes route.final', () => {
+		expect(describeRouterReference('route.final')).toEqual({
+			text: 'Назначен маршрутом по умолчанию',
+			known: true
+		});
+	});
+
+	it('describes a composite member', () => {
+		expect(describeRouterReference('outbounds[0="vpn-default"].outbounds[3]')).toEqual({
+			text: 'Входит в группу маршрутов «vpn-default»',
+			known: true
+		});
+	});
+
+	it('describes a composite default', () => {
+		expect(describeRouterReference('outbounds[2="grp"].default')).toEqual({
+			text: 'Выбран по умолчанию в группе «grp»',
+			known: true
+		});
+	});
+
+	it('describes a dns detour', () => {
+		expect(describeRouterReference('dns.servers[1="my-dns"].detour')).toEqual({
+			text: 'Используется DNS-сервером «my-dns»',
+			known: true
+		});
+	});
+
+	it('describes a rule_set download_detour', () => {
+		expect(describeRouterReference('route.rule_set[0="geoip-ru"].download_detour')).toEqual({
+			text: 'Через него скачивается список «geoip-ru»',
+			known: true
+		});
+	});
+
+	it('handles names with special characters', () => {
+		expect(describeRouterReference('outbounds[0="vpn [eu] #1"].outbounds[0]')).toEqual({
+			text: 'Входит в группу маршрутов «vpn [eu] #1»',
+			known: true
+		});
+	});
+
+	it('falls back to the raw path for unknown formats', () => {
+		expect(describeRouterReference('something.unexpected[5]')).toEqual({
+			text: 'something.unexpected[5]',
+			known: false
+		});
+	});
+});

--- a/frontend/src/lib/utils/tunnelRefs.ts
+++ b/frontend/src/lib/utils/tunnelRefs.ts
@@ -1,0 +1,33 @@
+/**
+ * Translates the machine-readable router reference paths returned by the
+ * backend (`ErrTunnelReferenced.RouterOther`, formatted in
+ * internal/singbox/router/config.go) into human-readable Russian text for
+ * TunnelReferencedModal. Unknown formats fall back to the raw path so the
+ * user still sees something if the backend format changes.
+ */
+export interface RouterReference {
+	/** Human-readable description, or the raw location for unknown formats. */
+	text: string;
+	/** false when the location did not match a known format (render raw). */
+	known: boolean;
+}
+
+const PATTERNS: Array<{ re: RegExp; label: (name: string) => string }> = [
+	{ re: /^outbounds\[\d+="(.*)"\]\.outbounds\[\d+\]$/, label: (n) => `Входит в группу маршрутов «${n}»` },
+	{ re: /^outbounds\[\d+="(.*)"\]\.default$/, label: (n) => `Выбран по умолчанию в группе «${n}»` },
+	{ re: /^dns\.servers\[\d+="(.*)"\]\.detour$/, label: (n) => `Используется DNS-сервером «${n}»` },
+	{ re: /^route\.rule_set\[\d+="(.*)"\]\.download_detour$/, label: (n) => `Через него скачивается список «${n}»` }
+];
+
+export function describeRouterReference(loc: string): RouterReference {
+	if (loc === 'route.final') {
+		return { text: 'Назначен маршрутом по умолчанию', known: true };
+	}
+	for (const { re, label } of PATTERNS) {
+		const m = loc.match(re);
+		if (m) {
+			return { text: label(m[1]), known: true };
+		}
+	}
+	return { text: loc, known: false };
+}


### PR DESCRIPTION
Модалка падала на routerRules=null (Go отдаёт пустой slice как null) — пользователь видел только 409 без сообщения. Добавлен null-guard, тип routerRules/routerOther помечен nullable.

Машинные пути ссылок (outbounds[..], route.final, dns detour) переведены в понятный текст; список выровнен в один уровень с маркерами.