### PR TITLE
fix(managed): починить назначение ip hotspot policy серверу

### DIFF
--- a/internal/managed/rci.go
+++ b/internal/managed/rci.go
@@ -318,21 +318,22 @@ func (s *Service) rciClearASCParams(ctx context.Context, ifaceName string) error
 }
 
 // rciSetHotspotPolicy applies an ip hotspot policy to the interface.
-// policy is "permit", "deny", or an IP Policy profile name. For "none"
-// use rciClearHotspotPolicy.
+// policy is an IP Policy profile name. For "none" use
+// rciClearHotspotPolicy.
 //
-// JSON shape verified against /show/rc/ip/hotspot on a live router:
+// Write form verified on a live router. NB: the /show/rc/ip/hotspot read
+// form is an array keyed by "access"; the write command is a single
+// object keyed by "policy" (router replies "policy ... applied to
+// interface ..."):
 //
-//	"policy": [{"interface":"Bridge0","access":"permit"}, ...]
-//
-// access carries the literal value, including a profile name when the
-// chosen policy is a named IP Policy profile.
+//	{"ip":{"hotspot":{"policy":{"interface":"Wireguard0","policy":"Policy0"}}}}
 func (s *Service) rciSetHotspotPolicy(ctx context.Context, ifaceName, policy string) error {
 	return s.rciPost(ctx, map[string]interface{}{
 		"ip": map[string]interface{}{
 			"hotspot": map[string]interface{}{
-				"policy": []map[string]interface{}{
-					{"interface": ifaceName, "access": policy},
+				"policy": map[string]interface{}{
+					"interface": ifaceName,
+					"policy":    policy,
 				},
 			},
 		},
@@ -341,12 +342,18 @@ func (s *Service) rciSetHotspotPolicy(ctx context.Context, ifaceName, policy str
 
 // rciClearHotspotPolicy removes the ip hotspot policy from the interface
 // (default-permit). Mirrors `no policy <iface>` in (config-hotspot) mode.
+//
+// Write form verified on a live router (router replies "interface ...
+// policy cleared."):
+//
+//	{"ip":{"hotspot":{"policy":{"interface":"Wireguard0","no":true}}}}
 func (s *Service) rciClearHotspotPolicy(ctx context.Context, ifaceName string) error {
 	return s.rciPost(ctx, map[string]interface{}{
 		"ip": map[string]interface{}{
 			"hotspot": map[string]interface{}{
-				"policy": []map[string]interface{}{
-					{"no": true, "interface": ifaceName},
+				"policy": map[string]interface{}{
+					"interface": ifaceName,
+					"no":        true,
 				},
 			},
 		},

--- a/internal/managed/service_policy.go
+++ b/internal/managed/service_policy.go
@@ -11,7 +11,6 @@ import (
 // SetPolicy applies an ip hotspot policy to the managed server's
 // interface and persists the choice to storage. Accepted values:
 //   - "none"  → clears the policy via RCI (no policy <iface>)
-//   - "permit" / "deny" → literal RCI policy values
 //   - "<PolicyName>" → must match an existing IP Policy profile name
 //     from the router (queries.Policies.List)
 //
@@ -32,7 +31,7 @@ func (s *Service) SetPolicy(ctx context.Context, id, policy string) error {
 		return nil
 	}
 
-	if policy != "none" && policy != "permit" && policy != "deny" {
+	if policy != "none" {
 		opts, err := s.ListPolicies(ctx)
 		if err != nil {
 			return fmt.Errorf("list policies: %w", err)

--- a/internal/managed/service_policy_test.go
+++ b/internal/managed/service_policy_test.go
@@ -88,7 +88,7 @@ func TestSetPolicy_RejectsEmpty(t *testing.T) {
 
 func TestSetPolicy_RejectsMissingServer(t *testing.T) {
 	svc, _, _ := newTestService(t, nil, nil, `{}`)
-	if err := svc.SetPolicy(context.Background(), "Wireguard0", "permit"); err == nil {
+	if err := svc.SetPolicy(context.Background(), "Wireguard0", "Policy0"); err == nil {
 		t.Fatal("expected error when no managed server exists")
 	}
 }
@@ -100,30 +100,17 @@ func TestSetPolicy_RejectsUnknownPolicy(t *testing.T) {
 	}
 }
 
-func TestSetPolicy_AcceptsLiterals(t *testing.T) {
-	for _, lit := range []string{"permit", "deny", "none"} {
-		t.Run(lit, func(t *testing.T) {
-			svc, poster, store := newTestService(t, &storage.ManagedServer{InterfaceName: "Wireguard0", Policy: "none"}, nil, `{}`)
-			if lit == "none" {
-				if err := svc.SetPolicy(context.Background(), "Wireguard0", lit); err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(poster.posts) != 0 {
-					t.Fatalf("expected 0 RCI calls for no-op, got %d", len(poster.posts))
-				}
-				return
-			}
-			if err := svc.SetPolicy(context.Background(), "Wireguard0", lit); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if len(poster.posts) != 1 {
-				t.Fatalf("expected 1 RCI call, got %d", len(poster.posts))
-			}
-			persisted, ok := store.GetManagedServerByID("Wireguard0")
-			if !ok || persisted.Policy != lit {
-				t.Fatalf("policy not persisted: got %+v", persisted)
-			}
-		})
+func TestSetPolicy_NoneClearsExisting(t *testing.T) {
+	svc, poster, store := newTestService(t, &storage.ManagedServer{InterfaceName: "Wireguard0", Policy: "Policy0"}, nil, `{"Policy0":{"description":"NL"}}`)
+	if err := svc.SetPolicy(context.Background(), "Wireguard0", "none"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(poster.posts) != 1 {
+		t.Fatalf("expected 1 RCI clear call, got %d", len(poster.posts))
+	}
+	persisted, ok := store.GetManagedServerByID("Wireguard0")
+	if !ok || persisted.Policy != "none" {
+		t.Fatalf("policy not persisted: got %+v", persisted)
 	}
 }
 
@@ -142,8 +129,8 @@ func TestSetPolicy_AcceptsKnownProfile(t *testing.T) {
 }
 
 func TestSetPolicy_NoopWhenSame(t *testing.T) {
-	svc, poster, _ := newTestService(t, &storage.ManagedServer{InterfaceName: "Wireguard0", Policy: "permit"}, nil, `{}`)
-	if err := svc.SetPolicy(context.Background(), "Wireguard0", "permit"); err != nil {
+	svc, poster, _ := newTestService(t, &storage.ManagedServer{InterfaceName: "Wireguard0", Policy: "Policy0"}, nil, `{}`)
+	if err := svc.SetPolicy(context.Background(), "Wireguard0", "Policy0"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(poster.posts) != 0 {

--- a/internal/managed/service_restore_test.go
+++ b/internal/managed/service_restore_test.go
@@ -574,14 +574,12 @@ func TestRestore_PolicyNoneDoesNotEmitClearOnCreate(t *testing.T) {
 		if !ok {
 			continue
 		}
-		pol, ok := hotspot["policy"].([]map[string]interface{})
+		pol, ok := hotspot["policy"].(map[string]interface{})
 		if !ok {
 			continue
 		}
-		for _, p := range pol {
-			if no, ok := p["no"].(bool); ok && no {
-				t.Fatalf("unexpected clear policy payload on create: %+v", post)
-			}
+		if no, ok := pol["no"].(bool); ok && no {
+			t.Fatalf("unexpected clear policy payload on create: %+v", post)
 		}
 	}
 }
@@ -604,7 +602,7 @@ func TestRestore_PolicyProfileEmitsSetOnCreate(t *testing.T) {
 		Mask:          "255.255.255.0",
 		ListenPort:    51871,
 		PrivateKey:    validPrivateKey(7),
-		Policy:        "deny",
+		Policy:        "Policy0",
 	}}, RestoreOptions{})
 	if len(out) != 1 || out[0].Action != "created" {
 		t.Fatalf("outcomes: %+v", out)
@@ -619,11 +617,11 @@ func TestRestore_PolicyProfileEmitsSetOnCreate(t *testing.T) {
 		if !ok {
 			continue
 		}
-		pol, ok := hotspot["policy"].([]map[string]interface{})
-		if !ok || len(pol) == 0 {
+		pol, ok := hotspot["policy"].(map[string]interface{})
+		if !ok {
 			continue
 		}
-		if access, ok := pol[0]["access"].(string); ok && access == "deny" {
+		if access, ok := pol["policy"].(string); ok && access == "Policy0" {
 			foundSetPolicy = true
 			break
 		}


### PR DESCRIPTION
Форма RCI-payload была скопирована с read-шейпа /show/rc/ip/hotspot (массив, ключ "access") и роутер отвечал "no input". Write-команда ждёт объект с ключом "policy" — проверено на живом роутере.

Заодно убрана мёртвая ветка permit/deny: UI её не вызывает (dropdown отдаёт только none + PolicyN), концепт остался от того же неверного прочтения read-шейпа.