### PR TITLE
fix(sb-router): не допускать self-reference/циклы в composite outbound

### DIFF
--- a/frontend/src/lib/components/routing/singboxRouter/CompositeOutboundEditModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/CompositeOutboundEditModal.svelte
@@ -102,14 +102,28 @@
 	});
 
 	// Flat options with group labels for the Dropdown native grouping.
-	// Filter out tags already added so the user can't pick duplicates.
+	// Filter out tags already added so the user can't pick duplicates, and
+	// the group's own tag so it can't reference itself (self-reference
+	// FATALs sing-box with a circular-dependency error).
 	const memberDropdownOptions = $derived<DropdownOption[]>(
 		outboundOptions.flatMap((g) =>
 			g.items
-				.filter((i) => !members.includes(i.value))
+				.filter((i) => !members.includes(i.value) && i.value !== tag.trim())
 				.map((i) => ({ value: i.value, label: i.label, group: g.group }))
 		)
 	);
+
+	// Advisory: warn when the group's tag matches an existing outbound's
+	// display name (e.g. a composite named "DE" like the AWG tunnel "DE").
+	// Tags are the real identifier, so this is not an error — but the name
+	// clash is exactly what leads users to add the wrong "DE" as a member.
+	const tagCollision = $derived.by(() => {
+		const t = tag.trim();
+		if (!t) return false;
+		return outboundOptions.some((g) =>
+			g.items.some((i) => i.value !== t && i.label.replace(/\s*\(.*\)\s*$/, '') === t)
+		);
+	});
 
 	// Default-picker options: only members already chosen. Подписочные
 	// тэги (sub-XXX-YYY) и awg-XXX тэги резолвим в человеческие labels —
@@ -209,6 +223,9 @@
 		<label class="field">
 			<div class="lbl">Tag (имя)</div>
 			<input bind:value={tag} placeholder="fast-de" />
+			{#if tagCollision}
+				<div class="tag-warn">⚠ Имя совпадает с именем существующего туннеля — их легко перепутать в списке участников. Лучше дать группе отличающееся имя.</div>
+			{/if}
 		</label>
 
 		{#if type !== 'direct'}
@@ -318,6 +335,13 @@
 		padding: 0.5rem 0.75rem;
 		border-radius: 4px;
 		line-height: 1.5;
+	}
+
+	.tag-warn {
+		margin-top: 0.35rem;
+		font-size: 0.75rem;
+		line-height: 1.4;
+		color: var(--warning, #d97706);
 	}
 	.field {
 		display: grid;

--- a/frontend/src/lib/components/routing/singboxRouter/outboundOptions.test.ts
+++ b/frontend/src/lib/components/routing/singboxRouter/outboundOptions.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildOutboundOptions } from './outboundOptions';
+import type { AWGTagInfo, SingboxRouterOutbound } from '$lib/types';
+
+const awg: AWGTagInfo[] = [{ tag: 'awg-awg10', label: 'DE', kind: 'managed', iface: 'opkgtun10' }];
+const composites: SingboxRouterOutbound[] = [
+	{ type: 'urltest', tag: 'DE', outbounds: ['awg-awg10'], source: 'router' },
+	{ type: 'selector', tag: 'other', outbounds: ['awg-awg10'], source: 'router' },
+];
+
+function values(groups: ReturnType<typeof buildOutboundOptions>): string[] {
+	return groups.flatMap((g) => g.items.map((i) => i.value));
+}
+
+describe('buildOutboundOptions', () => {
+	it('lists the composite among candidates without excludeTag', () => {
+		const got = values(buildOutboundOptions(awg, null, composites, false));
+		expect(got).toContain('DE');
+	});
+
+	it('excludes the edited tag so a composite cannot reference itself', () => {
+		const got = values(buildOutboundOptions(awg, null, composites, false, null, 'DE'));
+		expect(got).not.toContain('DE');
+		// other outbounds remain selectable
+		expect(got).toContain('awg-awg10');
+		expect(got).toContain('other');
+	});
+
+	it('drops a group that becomes empty after exclusion', () => {
+		const onlySelf: SingboxRouterOutbound[] = [
+			{ type: 'urltest', tag: 'DE', outbounds: ['awg-awg10'], source: 'router' },
+		];
+		const groups = buildOutboundOptions(null, null, onlySelf, false, null, 'DE');
+		expect(groups.some((g) => g.group === 'Composite outbounds')).toBe(false);
+	});
+});

--- a/frontend/src/lib/components/routing/singboxRouter/outboundOptions.ts
+++ b/frontend/src/lib/components/routing/singboxRouter/outboundOptions.ts
@@ -11,6 +11,7 @@ export function buildOutboundOptions(
 	composite: SingboxRouterOutbound[] | undefined | null,
 	includeSpecial = true,
 	subscriptions: Subscription[] | undefined | null = null,
+	excludeTag: string | null = null,
 ): OutboundGroup[] {
 	// Stores may yield undefined before initial load completes; treat as empty
 	// to avoid breaking the dropdown render. Same pattern as defensive `?? []`
@@ -75,6 +76,16 @@ export function buildOutboundOptions(
 				return { value: o.tag, label: `${o.tag} (${o.type})` };
 			}),
 		});
+	}
+
+	// Exclude one tag (the outbound being edited) so a composite can never
+	// be offered as a member of itself — a self-reference FATALs sing-box
+	// with a circular-dependency error. Empty groups are dropped.
+	const exclude = excludeTag?.trim();
+	if (exclude) {
+		return groups
+			.map((g) => ({ ...g, items: g.items.filter((i) => i.value !== exclude) }))
+			.filter((g) => g.items.length > 0);
 	}
 
 	return groups;

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -1448,7 +1448,8 @@ func (h *SingboxRouterHandler) handleErr(w http.ResponseWriter, action string, e
 	case errors.Is(err, router.ErrRuleIndexOutOfRange),
 		errors.Is(err, router.ErrDNSRuleIndexOutOfRange),
 		errors.Is(err, router.ErrDNSServerNotFound),
-		errors.Is(err, router.ErrRuleSetNotFound):
+		errors.Is(err, router.ErrRuleSetNotFound),
+		errors.Is(err, router.ErrOutboundNotFound):
 		response.Error(w, err.Error(), "NOT_FOUND")
 	case errors.Is(err, router.ErrInvalidMatchers),
 		errors.Is(err, router.ErrDNSInvalidServer):

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -434,7 +434,11 @@ func (c *RouterConfig) AddCompositeOutbound(o Outbound) error {
 			return fmt.Errorf("%w: %q", ErrOutboundTagConflict, o.Tag)
 		}
 	}
-	c.Outbounds = append(c.Outbounds, o)
+	next := append(append([]Outbound(nil), c.Outbounds...), o)
+	if err := validateNoCompositeCycles(next); err != nil {
+		return err
+	}
+	c.Outbounds = next
 	return nil
 }
 
@@ -453,9 +457,14 @@ func (c *RouterConfig) UpdateCompositeOutbound(tag string, o Outbound) error {
 		}
 	}
 	if idx < 0 {
-		return fmt.Errorf("%w: %q not found", ErrOutboundTagConflict, tag)
+		return fmt.Errorf("%w: %q", ErrOutboundNotFound, tag)
 	}
-	c.Outbounds[idx] = o
+	next := append([]Outbound(nil), c.Outbounds...)
+	next[idx] = o
+	if err := validateNoCompositeCycles(next); err != nil {
+		return err
+	}
+	c.Outbounds = next
 	if tag != o.Tag {
 		c.renameOutboundReferences(tag, o.Tag)
 	}
@@ -477,6 +486,11 @@ func validateCompositeOutbound(o Outbound) error {
 	for _, m := range o.Outbounds {
 		if strings.EqualFold(strings.TrimSpace(m), "direct") {
 			return fmt.Errorf("outbound %q: member %q is not allowed in composite groups (would bypass proxy silently)", o.Tag, m)
+		}
+		// Exact match (not EqualFold): sing-box outbound tags are
+		// case-sensitive keys, so "DE" and "de" are distinct outbounds.
+		if strings.TrimSpace(m) == strings.TrimSpace(o.Tag) {
+			return fmt.Errorf("outbound %q: member %q references itself (would create a circular dependency and crash sing-box)", o.Tag, m)
 		}
 	}
 	if strings.EqualFold(strings.TrimSpace(o.Default), "direct") {
@@ -507,6 +521,68 @@ func validateInterfaceOutbound(o Outbound) error {
 	}
 	if len(o.Outbounds) > 0 || o.URL != "" || o.Interval != "" || o.Tolerance != 0 || o.Default != "" || o.Strategy != "" {
 		return fmt.Errorf("outbound %q: direct outbound must not set composite fields (members/url/interval/tolerance/default/strategy)", o.Tag)
+	}
+	return nil
+}
+
+// validateNoCompositeCycles rejects a set of outbounds that contains a
+// circular dependency between composite groups (e.g. DE -> DE, or A -> B
+// -> A). sing-box only detects this at "start service" time — `sing-box
+// check` passes — so without this guard a cyclic config persists and the
+// process FATAL-loops on every start. Only composite->composite edges can
+// form a cycle; leaf outbounds (awg/sub/sb tunnels, direct) are ignored.
+//
+// Scope is the passed slice (router composites from 20-router.json).
+// Subscription-slot composites are not passed here, so they count as leaf
+// members — which is sound: their members are subscription servers, never
+// router composites, so no subscription->router edge (and thus no
+// cross-slot cycle) can be formed through the UI.
+func validateNoCompositeCycles(outbounds []Outbound) error {
+	isComposite := make(map[string]bool, len(outbounds))
+	for _, o := range outbounds {
+		isComposite[o.Tag] = true
+	}
+	edges := make(map[string][]string, len(outbounds))
+	for _, o := range outbounds {
+		for _, m := range o.Outbounds {
+			if isComposite[m] {
+				edges[o.Tag] = append(edges[o.Tag], m)
+			}
+		}
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(outbounds))
+	var path []string
+	var visit func(tag string) error
+	visit = func(tag string) error {
+		color[tag] = gray
+		path = append(path, tag)
+		for _, next := range edges[tag] {
+			switch color[next] {
+			case gray:
+				return fmt.Errorf("circular outbound dependency: %s -> %s",
+					strings.Join(path, " -> "), next)
+			case white:
+				if err := visit(next); err != nil {
+					return err
+				}
+			}
+		}
+		path = path[:len(path)-1]
+		color[tag] = black
+		return nil
+	}
+	for _, o := range outbounds {
+		if color[o.Tag] == white {
+			if err := visit(o.Tag); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/internal/singbox/router/config_test.go
+++ b/internal/singbox/router/config_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -334,5 +335,94 @@ func TestValidateOutbound_CompositeStillWorks(t *testing.T) {
 	}
 	if err := validateOutbound(Outbound{Type: "urltest", Tag: "g"}); err == nil {
 		t.Error("composite without members should fail")
+	}
+}
+
+func TestValidateOutbound_RejectsSelfReference(t *testing.T) {
+	o := Outbound{Type: "urltest", Tag: "DE", Outbounds: []string{"awg-awg10", "DE"}}
+	if err := validateOutbound(o); err == nil {
+		t.Error("composite listing its own tag as a member must be rejected")
+	}
+}
+
+func TestValidateNoCompositeCycles(t *testing.T) {
+	cases := []struct {
+		name      string
+		outbounds []Outbound
+		wantErr   bool
+	}{
+		{
+			name:      "self reference",
+			outbounds: []Outbound{{Type: "urltest", Tag: "DE", Outbounds: []string{"awg-awg10", "DE"}}},
+			wantErr:   true,
+		},
+		{
+			name: "two node cycle",
+			outbounds: []Outbound{
+				{Type: "selector", Tag: "A", Outbounds: []string{"B"}},
+				{Type: "selector", Tag: "B", Outbounds: []string{"A"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid dag",
+			outbounds: []Outbound{
+				{Type: "selector", Tag: "A", Outbounds: []string{"B", "awg-x"}},
+				{Type: "urltest", Tag: "B", Outbounds: []string{"awg-y"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "leaf members only",
+			outbounds: []Outbound{
+				{Type: "urltest", Tag: "DE", Outbounds: []string{"awg-awg10", "sub-9a40a86d"}},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNoCompositeCycles(tc.outbounds)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected cycle error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestAddCompositeOutbound_RejectsSelfReference(t *testing.T) {
+	cfg := &RouterConfig{Outbounds: []Outbound{}}
+	err := cfg.AddCompositeOutbound(Outbound{Type: "urltest", Tag: "DE", Outbounds: []string{"awg-awg10", "DE"}})
+	if err == nil {
+		t.Fatal("self-referential composite must be rejected")
+	}
+	if len(cfg.Outbounds) != 0 {
+		t.Errorf("rejected outbound must not be persisted, got %d", len(cfg.Outbounds))
+	}
+}
+
+func TestUpdateCompositeOutbound_MissingTagReturnsNotFound(t *testing.T) {
+	cfg := &RouterConfig{Outbounds: []Outbound{}}
+	err := cfg.UpdateCompositeOutbound("nope", Outbound{Type: "selector", Tag: "nope", Outbounds: []string{"a", "b"}})
+	if !errors.Is(err, ErrOutboundNotFound) {
+		t.Fatalf("expected ErrOutboundNotFound, got %v", err)
+	}
+	if errors.Is(err, ErrOutboundTagConflict) {
+		t.Error("missing-tag update must not surface as a tag conflict")
+	}
+}
+
+func TestUpdateCompositeOutbound_RejectsCycle(t *testing.T) {
+	cfg := &RouterConfig{Outbounds: []Outbound{
+		{Type: "selector", Tag: "A", Outbounds: []string{"awg-x"}},
+		{Type: "selector", Tag: "B", Outbounds: []string{"A"}},
+	}}
+	// Updating A to point back at B closes an A->B->A cycle.
+	err := cfg.UpdateCompositeOutbound("A", Outbound{Type: "selector", Tag: "A", Outbounds: []string{"B"}})
+	if err == nil {
+		t.Fatal("update closing a cycle must be rejected")
 	}
 }

--- a/internal/singbox/router/errors.go
+++ b/internal/singbox/router/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrRuleSetNotFound           = errors.New("rule set not found")
 	ErrDatRuleSetForbidden       = errors.New("dat rule set token is invalid")
 	ErrOutboundTagConflict       = errors.New("outbound with this tag already exists")
+	ErrOutboundNotFound          = errors.New("outbound not found")
 	ErrDNSServerTagConflict      = errors.New("dns server with this tag already exists")
 	ErrDNSServerReferenced       = errors.New("dns server is referenced by one or more dns rules or used as final/default")
 	ErrDNSServerNotFound         = errors.New("dns server not found")

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -539,6 +539,13 @@ func (s *ServiceImpl) persistConfig(ctx context.Context, cfg *RouterConfig) erro
 	if err != nil {
 		return err
 	}
+	// sing-box only reports circular outbound dependencies at "start
+	// service" (not via `sing-box check`), so a cyclic config would persist
+	// and FATAL-loop. Catch it here before writing, regardless of source
+	// (UI, subscription refresh, import, migration).
+	if err := validateNoCompositeCycles(materialized.Outbounds); err != nil {
+		return err
+	}
 	if s.deps.Orch != nil {
 		// Orchestrator path — write to pending/ (staging). The draft will
 		// be applied explicitly via ApplyStaging. No SIGHUP is triggered


### PR DESCRIPTION
Composite-группа, ссылающаяся на себя (DE -> DE) или образующая цикл (A -> B -> A), роняла sing-box на старте: FATAL "circular outbound dependency". sing-box check этого не ловит (ошибка только на start service), поэтому битый конфиг сохранялся и процесс уходил в FATAL-луп.

Бэк (config.go):
- validateCompositeOutbound отвергает член == собственный тег;
- validateNoCompositeCycles — детект циклов по графу композитов, вызывается в AddCompositeOutbound/UpdateCompositeOutbound до коммита;
- persistConfig прогоняет cycle-check перед записью (backstop для любого источника: подписки, импорт, миграция).

Фронт:
- buildOutboundOptions: параметр excludeTag (+vitest);
- CompositeOutboundEditModal: группа не предлагается в свои же члены; предупреждение при совпадении имени группы с именем туннеля.

