### PR TITLE
fix(singbox): подписки не создают NDMS Proxy при выключенном тумблере

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -778,10 +778,18 @@ func main() {
 	}
 	subSvc := subscription.NewService(subStore, subAdapter)
 	subSvc.SetAppLogger(loggingService)
+	// Gate subscription ProxyN creation on the global toggle (same flag the
+	// Operator uses for tunnels) so disabling it stops subscriptions from
+	// creating NDMS Proxy interfaces too.
+	subSvc.SetNDMSProxyEnabled(settingsStore.IsSingboxNDMSProxyEnabled)
 
 	// Let NDMS-proxy enable/disable + orphan cleanup manage subscription
 	// composite proxies (a set separate from Tunnels()).
 	singboxOp.SetSubscriptionProxySet(subProxySet{store: subStore})
+	// On MigrateOn, reconcile subscription proxies through the service so
+	// subscriptions created while the toggle was off get a freshly allocated
+	// ProxyN (not just the already-indexed ones).
+	singboxOp.SetSubscriptionProxySync(subSvc.SyncProxies)
 
 	// Wire orchestrator into Operator so ApplyConfig writes 10-tunnels.json
 	// through SlotTunnels rather than an in-place write that bypasses

--- a/internal/singbox/migrate_ndms_proxy.go
+++ b/internal/singbox/migrate_ndms_proxy.go
@@ -112,11 +112,20 @@ func (m *Migrator) MigrateOn(ctx context.Context) error {
 	}
 
 	// Recreate subscription composite proxies symmetrically (SyncProxies only
-	// covers Tunnels()). EnsureProxy is idempotent.
-	for _, sp := range m.op.subscriptionProxies() {
-		if eerr := m.op.proxyMgr.EnsureProxy(ctx, sp.Index, sp.Port, sp.Label); eerr != nil {
-			m.log.Warn("MigrateOn: EnsureProxy (subscription) failed",
-				"label", sp.Label, "idx", sp.Index, "err", eerr)
+	// covers Tunnels()). When the subscription reconciler is wired it also
+	// allocates fresh ProxyN for subscriptions created while the toggle was
+	// off (ProxyIndex=-1) — which subscriptionProxies() (filtered to >=0)
+	// cannot see. Fall back to the enumerator-only path when not wired.
+	if m.op.subProxySync != nil {
+		if serr := m.op.subProxySync(ctx); serr != nil {
+			m.log.Warn("MigrateOn: subscription proxy sync failed", "err", serr)
+		}
+	} else {
+		for _, sp := range m.op.subscriptionProxies() {
+			if eerr := m.op.proxyMgr.EnsureProxy(ctx, sp.Index, sp.Port, sp.Label); eerr != nil {
+				m.log.Warn("MigrateOn: EnsureProxy (subscription) failed",
+					"label", sp.Label, "idx", sp.Index, "err", eerr)
+			}
 		}
 	}
 

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -145,6 +145,13 @@ type Operator struct {
 	// removed/recreated symmetrically with tunnel proxies. nil-safe.
 	subProxies SubscriptionProxySet
 
+	// subProxySync, when wired, (re)creates subscription composite proxies on
+	// MigrateOn — including allocating fresh ProxyN for subscriptions created
+	// while the toggle was off (which subProxies, filtered to ProxyIndex>=0,
+	// cannot enumerate). nil-safe: when nil, MigrateOn falls back to the
+	// subProxies enumerator only.
+	subProxySync func(context.Context) error
+
 	// processLogger forwards sing-box stdout/stderr lines into the app
 	// log under singbox/process so users can see daemon output at
 	// /diagnostics?tab=logs without ssh'ing in. nil-safe (ScopedLogger
@@ -451,6 +458,11 @@ func (o *Operator) SetOrch(orch *orchestrator.Orchestrator) { o.orch = orch }
 // proxies, so NDMS-proxy enable/disable and orphan cleanup manage them
 // alongside tunnel proxies. nil-safe.
 func (o *Operator) SetSubscriptionProxySet(s SubscriptionProxySet) { o.subProxies = s }
+
+// SetSubscriptionProxySync wires the subscription-service proxy reconciler
+// invoked by MigrateOn to (re)create subscription proxies, including those
+// for subscriptions created while the toggle was off. nil-safe.
+func (o *Operator) SetSubscriptionProxySync(fn func(context.Context) error) { o.subProxySync = fn }
 
 // subscriptionProxies returns the current subscription composite proxies, or
 // nil when no enumerator is wired.

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -61,10 +61,74 @@ type Service struct {
 	fetchOpts FetchOpts
 	log       *logging.ScopedLogger // nil-safe; sing-box journal (runtime)
 	appLog    *logging.ScopedLogger // nil-safe; app journal (subscription partition)
+	// ndmsProxyEnabled mirrors Settings.CreateNDMSProxyForSingbox. When the
+	// closure is nil the service behaves as if enabled (back-compat for
+	// tests / legacy bootstrap), mirroring OperatorDeps.IsNDMSProxyEnabled.
+	ndmsProxyEnabled func() bool
 }
 
 func NewService(store *Store, mutator ConfigMutator) *Service {
 	return &Service{store: store, mutator: mutator}
+}
+
+// SetNDMSProxyEnabled wires the global "Create NDMS Proxy for sing-box"
+// toggle. When off, Create/Update do not register a ProxyN interface for
+// the subscription (ProxyIndex stays -1); SyncProxies (re-)creates them
+// when the toggle is turned back on.
+func (s *Service) SetNDMSProxyEnabled(fn func() bool) { s.ndmsProxyEnabled = fn }
+
+func (s *Service) proxyEnabled() bool {
+	if s.ndmsProxyEnabled == nil {
+		return true
+	}
+	return s.ndmsProxyEnabled()
+}
+
+// SyncProxies ensures every subscription has its NDMS ProxyN interface when
+// the global toggle is on. It is the toggle-ON counterpart to the gated
+// Create: subscriptions created while the toggle was off carry ProxyIndex=-1
+// and get a freshly allocated proxy here; subscriptions that already had one
+// (index retained across a toggle-off) are re-registered idempotently.
+//
+// Allocation is serialized (createMu) against Create, and each proxy is
+// registered via EnsureProxy — which makes the router slot occupied —
+// before the next index is allocated. AllocProxyIndex scans the live router
+// without a reserved set, so allocating a batch without committing each
+// first would hand out the same index twice.
+func (s *Service) SyncProxies(ctx context.Context) error {
+	if !s.proxyEnabled() {
+		return nil
+	}
+	s.createMu.Lock()
+	defer s.createMu.Unlock()
+	for _, sub := range s.store.List() {
+		if sub.ListenPort == 0 {
+			continue // no data path yet; nothing to wrap
+		}
+		mu := s.lockSub(sub.ID)
+		mu.Lock()
+		idx := sub.ProxyIndex
+		if idx < 0 {
+			alloc, err := s.mutator.AllocProxyIndex(ctx)
+			if err != nil {
+				mu.Unlock()
+				return fmt.Errorf("subscription %s: alloc proxy index: %w", sub.ID, err)
+			}
+			idx = alloc
+		}
+		if err := s.mutator.EnsureProxy(ctx, idx, int(sub.ListenPort), sub.Label); err != nil {
+			mu.Unlock()
+			return fmt.Errorf("subscription %s: ensure proxy: %w", sub.ID, err)
+		}
+		if sub.ProxyIndex < 0 {
+			if err := s.store.SetProxyIndex(sub.ID, idx); err != nil {
+				mu.Unlock()
+				return fmt.Errorf("subscription %s: persist proxy index: %w", sub.ID, err)
+			}
+		}
+		mu.Unlock()
+	}
+	return nil
 }
 
 // SetAppLogger wires UI-visible logging for events outside of the
@@ -152,23 +216,31 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Subscription, er
 		return nil, err
 	}
 
-	proxyIdx, err := s.mutator.AllocProxyIndex(ctx)
-	if err != nil {
-		s.store.Delete(sub.ID)
-		s.logWarn("subscription-create", sub.ID, "failed to allocate proxy index: "+err.Error())
-		return nil, fmt.Errorf("subscription: alloc proxy index: %w", err)
-	}
-	if err := s.store.SetProxyIndex(sub.ID, proxyIdx); err != nil {
-		s.store.Delete(sub.ID)
-		return nil, err
-	}
-	if err := s.mutator.EnsureProxy(ctx, proxyIdx, int(port), sub.Label); err != nil {
-		// Best-effort cleanup: EnsureProxy may have partially registered
-		// the interface before failing. RemoveProxy is idempotent.
-		_ = s.mutator.RemoveProxy(ctx, proxyIdx)
-		s.store.Delete(sub.ID)
-		s.logWarn("subscription-create", sub.ID, "failed to ensure NDMS proxy: "+err.Error())
-		return nil, fmt.Errorf("subscription: register NDMS proxy: %w", err)
+	// NDMS Proxy is only created when the global toggle is on. When off, the
+	// subscription stays proxy-less (ProxyIndex=-1) and routes via its mixed
+	// inbound + selector through the internal sing-box router; SyncProxies
+	// allocates the ProxyN later if the toggle is turned back on.
+	proxyIdx := -1
+	if s.proxyEnabled() {
+		idx, err := s.mutator.AllocProxyIndex(ctx)
+		if err != nil {
+			s.store.Delete(sub.ID)
+			s.logWarn("subscription-create", sub.ID, "failed to allocate proxy index: "+err.Error())
+			return nil, fmt.Errorf("subscription: alloc proxy index: %w", err)
+		}
+		if err := s.store.SetProxyIndex(sub.ID, idx); err != nil {
+			s.store.Delete(sub.ID)
+			return nil, err
+		}
+		proxyIdx = idx
+		if err := s.mutator.EnsureProxy(ctx, idx, int(port), sub.Label); err != nil {
+			// Best-effort cleanup: EnsureProxy may have partially registered
+			// the interface before failing. RemoveProxy is idempotent.
+			_ = s.mutator.RemoveProxy(ctx, idx)
+			s.store.Delete(sub.ID)
+			s.logWarn("subscription-create", sub.ID, "failed to ensure NDMS proxy: "+err.Error())
+			return nil, fmt.Errorf("subscription: register NDMS proxy: %w", err)
+		}
 	}
 
 	if _, err := s.refreshLocked(ctx, sub.ID); err != nil {
@@ -187,7 +259,9 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Subscription, er
 		// only the startup cleanup sweep would eventually reap. Swallow
 		// the RemoveProxy error: the storage row is going away regardless,
 		// and a stranded ProxyN is recoverable via Settings → cleanup.
-		_ = s.mutator.RemoveProxy(ctx, proxyIdx)
+		if proxyIdx >= 0 {
+			_ = s.mutator.RemoveProxy(ctx, proxyIdx)
+		}
 		_ = s.mutator.Reload(ctx)
 		s.store.Delete(sub.ID)
 		s.logWarn("subscription-create", sub.ID, "initial refresh failed: "+err.Error())
@@ -587,11 +661,13 @@ func (s *Service) Update(id string, patch UpdatePatch) (*Subscription, error) {
 			return sub, fmt.Errorf("reload after mode change: %w", err)
 		}
 	}
-	if patch.Label != nil {
+	if patch.Label != nil && s.proxyEnabled() && sub.ProxyIndex >= 0 {
 		// EnsureProxy is idempotent — re-running with new description updates
 		// NDMS Proxy.description in place. Best-effort: on failure the store
 		// already has the new label, the proxy description stays stale until
 		// next refresh; we surface the error so the UI can show a warning.
+		// Skipped when the toggle is off or the subscription has no ProxyN
+		// (created while off): there is no interface to relabel.
 		if err := s.mutator.EnsureProxy(context.Background(), sub.ProxyIndex, int(sub.ListenPort), sub.Label); err != nil {
 			return sub, fmt.Errorf("sync proxy description: %w", err)
 		}

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -90,43 +90,65 @@ func (s *Service) proxyEnabled() bool {
 // and get a freshly allocated proxy here; subscriptions that already had one
 // (index retained across a toggle-off) are re-registered idempotently.
 //
-// Allocation is serialized (createMu) against Create, and each proxy is
-// registered via EnsureProxy — which makes the router slot occupied —
-// before the next index is allocated. AllocProxyIndex scans the live router
-// without a reserved set, so allocating a batch without committing each
-// first would hand out the same index twice.
+// Allocation is serialized (createMu) against Create. AllocProxyIndex scans
+// the live router without a reserved set, so two passes are required: first
+// re-register every subscription that already holds an index (occupying its
+// router slot), then allocate fresh indices for the proxy-less ones. Without
+// pass 1 a fresh allocation could land on a slot a retained subscription still
+// owns in the store but hasn't re-registered yet — store.List() order is
+// non-deterministic, so the proxy-less subscription is not reliably processed
+// last. Within pass 2 each proxy is committed via EnsureProxy before the next
+// index is allocated, for the same reason.
 func (s *Service) SyncProxies(ctx context.Context) error {
 	if !s.proxyEnabled() {
 		return nil
 	}
 	s.createMu.Lock()
 	defer s.createMu.Unlock()
-	for _, sub := range s.store.List() {
-		if sub.ListenPort == 0 {
-			continue // no data path yet; nothing to wrap
+
+	subs := s.store.List()
+	// Pass 1: re-register retained indices so their router slots are occupied
+	// before pass 2 allocates.
+	for _, sub := range subs {
+		if sub.ListenPort == 0 || sub.ProxyIndex < 0 {
+			continue
 		}
 		mu := s.lockSub(sub.ID)
-		mu.Lock()
-		idx := sub.ProxyIndex
-		if idx < 0 {
-			alloc, err := s.mutator.AllocProxyIndex(ctx)
-			if err != nil {
-				mu.Unlock()
-				return fmt.Errorf("subscription %s: alloc proxy index: %w", sub.ID, err)
-			}
-			idx = alloc
-		}
-		if err := s.mutator.EnsureProxy(ctx, idx, int(sub.ListenPort), sub.Label); err != nil {
-			mu.Unlock()
+		err := func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			return s.mutator.EnsureProxy(ctx, sub.ProxyIndex, int(sub.ListenPort), sub.Label)
+		}()
+		if err != nil {
 			return fmt.Errorf("subscription %s: ensure proxy: %w", sub.ID, err)
 		}
-		if sub.ProxyIndex < 0 {
-			if err := s.store.SetProxyIndex(sub.ID, idx); err != nil {
-				mu.Unlock()
-				return fmt.Errorf("subscription %s: persist proxy index: %w", sub.ID, err)
-			}
+	}
+	// Pass 2: allocate a fresh ProxyN for subscriptions created while the
+	// toggle was off (ProxyIndex=-1). The live-router scan now sees the pass-1
+	// slots as taken, so no collision with a retained index.
+	for _, sub := range subs {
+		if sub.ListenPort == 0 || sub.ProxyIndex >= 0 {
+			continue
 		}
-		mu.Unlock()
+		mu := s.lockSub(sub.ID)
+		err := func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			idx, err := s.mutator.AllocProxyIndex(ctx)
+			if err != nil {
+				return fmt.Errorf("alloc proxy index: %w", err)
+			}
+			if err := s.mutator.EnsureProxy(ctx, idx, int(sub.ListenPort), sub.Label); err != nil {
+				return fmt.Errorf("ensure proxy: %w", err)
+			}
+			if err := s.store.SetProxyIndex(sub.ID, idx); err != nil {
+				return fmt.Errorf("persist proxy index: %w", err)
+			}
+			return nil
+		}()
+		if err != nil {
+			return fmt.Errorf("subscription %s: %w", sub.ID, err)
+		}
 	}
 	return nil
 }

--- a/internal/singbox/subscription/service_test.go
+++ b/internal/singbox/subscription/service_test.go
@@ -228,6 +228,41 @@ func TestService_SyncProxies_AllocatesForProxylessSequentially(t *testing.T) {
 	}
 }
 
+// SyncProxies must not hand a freshly-allocated index to a proxy-less
+// subscription that another subscription still retains in the store. A
+// subscription created while the toggle was on keeps its ProxyIndex across a
+// toggle-off (MigrateOff removes the router interface but not the stored
+// index); a subscription created while off carries ProxyIndex=-1. On toggle-on
+// SyncProxies must re-register the retained one and allocate a *distinct* index
+// for the proxy-less one. store.List() order is non-deterministic, so the loop
+// exercises both orderings.
+func TestService_SyncProxies_RetainedIndexNotReused(t *testing.T) {
+	for run := 0; run < 300; run++ {
+		store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+		mutator := &scanMutator{}
+		svc := NewService(store, mutator)
+		svc.SetNDMSProxyEnabled(func() bool { return true })
+
+		// A: created while on — retains ProxyIndex=0, but its router Proxy0 was
+		// torn down by MigrateOff (scanMutator.live starts empty).
+		a, _ := store.Create(CreateInput{Label: "a", URL: "http://x", Enabled: true})
+		_ = store.SetListenPort(a.ID, 11001)
+		_ = store.SetProxyIndex(a.ID, 0)
+		// B: created while off — ProxyIndex stays -1.
+		b, _ := store.Create(CreateInput{Label: "b", URL: "http://y", Enabled: true})
+		_ = store.SetListenPort(b.ID, 11002)
+
+		if err := svc.SyncProxies(context.Background()); err != nil {
+			t.Fatalf("run %d: SyncProxies: %v", run, err)
+		}
+		ga, _ := store.Get(a.ID)
+		gb, _ := store.Get(b.ID)
+		if ga.ProxyIndex == gb.ProxyIndex {
+			t.Fatalf("run %d: A and B share ProxyIndex %d (retained index reused by fresh alloc)", run, ga.ProxyIndex)
+		}
+	}
+}
+
 func TestService_Update_LabelOff_SkipsEnsureProxy(t *testing.T) {
 	store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
 	mutator := &fakeMutator{}

--- a/internal/singbox/subscription/service_test.go
+++ b/internal/singbox/subscription/service_test.go
@@ -127,6 +127,126 @@ func TestService_Create_FetchAndMaterialize(t *testing.T) {
 	}
 }
 
+// scanMutator simulates NextFreeIndex's real behaviour: AllocProxyIndex
+// returns the lowest index not yet registered via EnsureProxy. It exposes
+// whether a batch allocated collision-free (each EnsureProxy committed
+// before the next Alloc).
+type scanMutator struct {
+	fakeMutator
+	live map[int]bool
+}
+
+func (m *scanMutator) AllocProxyIndex(_ context.Context) (int, error) {
+	for i := 0; ; i++ {
+		if !m.live[i] {
+			return i, nil
+		}
+	}
+}
+func (m *scanMutator) EnsureProxy(_ context.Context, idx, port int, description string) error {
+	if m.live == nil {
+		m.live = map[int]bool{}
+	}
+	m.live[idx] = true
+	m.ensuredProxies = append(m.ensuredProxies, ensuredProxyCall{idx: idx, port: port, description: description})
+	return nil
+}
+
+func TestService_Create_NDMSProxyOff_SkipsProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@example.com:443?security=tls&sni=h\n"))
+	}))
+	defer srv.Close()
+
+	store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	mutator := &fakeMutator{}
+	svc := NewService(store, mutator)
+	svc.SetNDMSProxyEnabled(func() bool { return false })
+
+	sub, err := svc.Create(context.Background(), CreateInput{Label: "off", URL: srv.URL, Enabled: true})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mutator.ensuredProxies) != 0 {
+		t.Errorf("EnsureProxy must not be called when toggle is off, got %d calls", len(mutator.ensuredProxies))
+	}
+	if mutator.proxyIndex != 0 {
+		t.Errorf("AllocProxyIndex must not be called when toggle is off")
+	}
+	if sub.ProxyIndex != -1 {
+		t.Errorf("ProxyIndex = %d, want -1 (no proxy in off mode)", sub.ProxyIndex)
+	}
+	if sub.ListenPort == 0 {
+		t.Error("listen port must still be allocated in off mode (data path)")
+	}
+}
+
+func TestService_SyncProxies_OffIsNoop(t *testing.T) {
+	store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	mutator := &fakeMutator{}
+	svc := NewService(store, mutator)
+	svc.SetNDMSProxyEnabled(func() bool { return false })
+
+	sub, _ := store.Create(CreateInput{Label: "a", URL: "http://x", Enabled: true})
+	_ = store.SetListenPort(sub.ID, 11001)
+
+	if err := svc.SyncProxies(context.Background()); err != nil {
+		t.Fatalf("SyncProxies: %v", err)
+	}
+	if len(mutator.ensuredProxies) != 0 {
+		t.Errorf("SyncProxies must be a no-op when toggle is off, got %d EnsureProxy", len(mutator.ensuredProxies))
+	}
+}
+
+func TestService_SyncProxies_AllocatesForProxylessSequentially(t *testing.T) {
+	store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	mutator := &scanMutator{}
+	svc := NewService(store, mutator)
+	svc.SetNDMSProxyEnabled(func() bool { return true })
+
+	// Two subscriptions created while the toggle was off → ProxyIndex=-1.
+	a, _ := store.Create(CreateInput{Label: "a", URL: "http://x", Enabled: true})
+	_ = store.SetListenPort(a.ID, 11001)
+	b, _ := store.Create(CreateInput{Label: "b", URL: "http://y", Enabled: true})
+	_ = store.SetListenPort(b.ID, 11002)
+
+	if err := svc.SyncProxies(context.Background()); err != nil {
+		t.Fatalf("SyncProxies: %v", err)
+	}
+	if len(mutator.ensuredProxies) != 2 {
+		t.Fatalf("expected 2 EnsureProxy, got %d", len(mutator.ensuredProxies))
+	}
+	// Collision-safety: sequential allocation must yield distinct indexes.
+	if mutator.ensuredProxies[0].idx == mutator.ensuredProxies[1].idx {
+		t.Errorf("two proxy-less subs got the same index %d (allocation not committed before next)", mutator.ensuredProxies[0].idx)
+	}
+	for _, id := range []string{a.ID, b.ID} {
+		got, _ := store.Get(id)
+		if got.ProxyIndex < 0 {
+			t.Errorf("sub %s ProxyIndex not persisted: %d", id, got.ProxyIndex)
+		}
+	}
+}
+
+func TestService_Update_LabelOff_SkipsEnsureProxy(t *testing.T) {
+	store, _ := NewStore(filepath.Join(t.TempDir(), "sub.json"))
+	mutator := &fakeMutator{}
+	svc := NewService(store, mutator)
+	svc.SetNDMSProxyEnabled(func() bool { return false })
+
+	// Subscription created while off: ProxyIndex stays -1.
+	sub, _ := store.Create(CreateInput{Label: "a", URL: "http://x", Enabled: true})
+	_ = store.SetListenPort(sub.ID, 11001)
+
+	newLabel := "renamed"
+	if _, err := svc.Update(sub.ID, UpdatePatch{Label: &newLabel}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mutator.ensuredProxies) != 0 {
+		t.Errorf("relabel must not call EnsureProxy when off / ProxyIndex<0, got %d", len(mutator.ensuredProxies))
+	}
+}
+
 func TestService_Create_FailsOnZeroOutbounds_ClashYAML(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-yaml")


### PR DESCRIPTION
Тумблер CreateNDMSProxyForSingbox гейтил только путь обычных туннелей (operator.go); подписки создавали ProxyN безусловно — subscription.Service не знал про флаг, а API лишь маскировал ProxyIndex в DTO. При OFF подписка плодила ProxyX в роутере.


Тесты: Create-OFF (нет alloc/ensure, idx=-1), Update-label-OFF, SyncProxies (ON последовательно, OFF no-op). go test ./... зелёный.