### PR TITLE
feat(servers): control internal server with ui

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -2736,6 +2736,21 @@ function buildMockServersAllData() {
 	};
 }
 
+/** @type {Record<string, { natMode: 'full' | 'internet-only' | 'none', policy: string }>} */
+const mockSystemServerSettings = {
+	Wireguard0: { natMode: 'full', policy: 'none' },
+	Wireguard9: { natMode: 'none', policy: 'Policy0' },
+};
+
+/** @type {Map<string, { privateKey: string, presharedKey: string, description: string, tunnelIP: string }>} */
+const mockSystemPeerSecrets = new Map();
+mockSystemPeerSecrets.set(mockPubkey(50), {
+	privateKey: mockPubkey(150),
+	presharedKey: mockPubkey(250),
+	description: 'Phone',
+	tunnelIP: '10.0.14.2/32',
+});
+
 function mockSystemServerPeers() {
 	const now = Date.now();
 	return SYSTEM_SERVER_PEERS_FIXTURE.map((p, i) => {
@@ -2755,11 +2770,18 @@ function mockSystemServerPeers() {
 }
 
 function mockSystemServers() {
+	const builtinPeers = mockSystemServerPeers().map((p, i) => ({
+		...p,
+		confAvailable: i === 0 || mockSystemPeerSecrets.has(p.publicKey),
+	}));
+	const wg0 = mockSystemServerSettings.Wireguard0 ?? { natMode: 'full', policy: 'none' };
+	const wg9 = mockSystemServerSettings.Wireguard9 ?? { natMode: 'none', policy: 'none' };
 	return [
 		{
 			id: 'Wireguard0',
-			interfaceName: 'Wireguard0',
+			interfaceName: 'nwg0',
 			description: 'Wireguard VPN Server',
+			builtIn: true,
 			status: 'up',
 			connected: true,
 			mtu: 1420,
@@ -2767,11 +2789,15 @@ function mockSystemServers() {
 			mask: '255.255.255.0',
 			publicKey: mockPubkey(41),
 			listenPort: 8443,
-			peers: mockSystemServerPeers(),
+			natEnabled: wg0.natMode === 'full',
+			natMode: wg0.natMode,
+			policy: wg0.policy,
+			keenDnsDomain: 'demo.keenetic.pro',
+			peers: builtinPeers,
 		},
 		{
 			id: 'Wireguard9',
-			interfaceName: 'Wireguard9',
+			interfaceName: 'nwg9',
 			description: 'Branch Office WG',
 			status: 'down',
 			connected: false,
@@ -2780,6 +2806,9 @@ function mockSystemServers() {
 			mask: '255.255.255.0',
 			publicKey: mockPubkey(42),
 			listenPort: 53199,
+			natEnabled: wg9.natMode === 'full',
+			natMode: wg9.natMode,
+			policy: wg9.policy,
 			peers: [
 				{
 					publicKey: mockPubkey(60),
@@ -2791,6 +2820,7 @@ function mockSystemServers() {
 					lastHandshake: '',
 					online: false,
 					enabled: true,
+					confAvailable: false,
 				},
 			],
 		},
@@ -5090,6 +5120,111 @@ const server = http.createServer(async (req, res) => {
 	// IPs are intentionally not in monotonic order so that "По IP" can be
 	// visually distinguished from "in storage order" and from a naive
 	// lexicographic sort (which would put 10.0.0.10 before 10.0.0.2).
+	const serverNatMatch = path.match(/^\/servers\/([^/]+)\/nat$/);
+	if (serverNatMatch && req.method === 'POST') {
+		const serverId = decodeURIComponent(serverNatMatch[1]);
+		let raw = '';
+		req.on('data', (c) => (raw += c));
+		req.on('end', () => {
+			try {
+				const body = JSON.parse(raw || '{}');
+				const mode = body.mode ?? (body.enabled ? 'full' : 'none');
+				if (!['full', 'internet-only', 'none'].includes(mode)) {
+					sendInvalidRequest(res, 'invalid NAT mode');
+					return;
+				}
+				if (!mockSystemServerSettings[serverId]) {
+					mockSystemServerSettings[serverId] = { natMode: 'none', policy: 'none' };
+				}
+				mockSystemServerSettings[serverId].natMode = mode;
+				sendData(res, buildMockServersAllData());
+			} catch (e) {
+				sendInvalidRequest(res, String(e));
+			}
+		});
+		return;
+	}
+
+	const serverPolicyMatch = path.match(/^\/servers\/([^/]+)\/policy$/);
+	if (serverPolicyMatch && req.method === 'POST') {
+		const serverId = decodeURIComponent(serverPolicyMatch[1]);
+		let raw = '';
+		req.on('data', (c) => (raw += c));
+		req.on('end', () => {
+			try {
+				const body = JSON.parse(raw || '{}');
+				const policy = body.policy ?? 'none';
+				if (!mockSystemServerSettings[serverId]) {
+					mockSystemServerSettings[serverId] = { natMode: 'none', policy: 'none' };
+				}
+				mockSystemServerSettings[serverId].policy = policy;
+				sendData(res, buildMockServersAllData());
+			} catch (e) {
+				sendInvalidRequest(res, String(e));
+			}
+		});
+		return;
+	}
+
+	const serverPeerMatch = path.match(/^\/servers\/([^/]+)\/peers(?:\/([^/]+)(?:\/(toggle|conf))?)?$/);
+	if (serverPeerMatch) {
+		const serverId = decodeURIComponent(serverPeerMatch[1]);
+		const pubkey = serverPeerMatch[2] ? decodeURIComponent(serverPeerMatch[2]) : '';
+		const leaf = serverPeerMatch[3] ?? '';
+		const servers = mockSystemServers();
+		const server = servers.find((s) => s.id === serverId);
+		if (!server) {
+			send(res, 404, { success: false, error: { code: 'NOT_FOUND', message: 'server not found' } });
+			return;
+		}
+
+		if (req.method === 'POST' && !pubkey) {
+			let raw = '';
+			req.on('data', (c) => (raw += c));
+			req.on('end', () => {
+				try {
+					const body = JSON.parse(raw || '{}');
+					const newKey = mockPubkey(90 + server.peers.length);
+					mockSystemPeerSecrets.set(newKey, {
+						privateKey: mockPubkey(190 + server.peers.length),
+						presharedKey: mockPubkey(290 + server.peers.length),
+						description: body.description || 'New peer',
+						tunnelIP: body.tunnelIP || '10.0.0.99/32',
+					});
+					sendData(res, buildMockServersAllData());
+				} catch (e) {
+					sendInvalidRequest(res, String(e));
+				}
+			});
+			return;
+		}
+
+		if (pubkey && leaf === 'toggle' && req.method === 'POST') {
+			sendData(res, buildMockServersAllData());
+			return;
+		}
+
+		if (pubkey && leaf === 'conf' && req.method === 'GET') {
+			if (!mockSystemPeerSecrets.has(pubkey)) {
+				send(res, 400, { success: false, error: { code: 'CONF_UNAVAILABLE', message: 'ключ недоступен' } });
+				return;
+			}
+			sendData(res, { conf: '[Interface]\nPrivateKey = MOCK\n\n[Peer]\nPublicKey = MOCK\n' });
+			return;
+		}
+
+		if (pubkey && !leaf && req.method === 'DELETE') {
+			mockSystemPeerSecrets.delete(pubkey);
+			sendData(res, buildMockServersAllData());
+			return;
+		}
+
+		if (pubkey && !leaf && req.method === 'PUT') {
+			sendData(res, buildMockServersAllData());
+			return;
+		}
+	}
+
 	if (req.method === 'GET' && path === '/servers/all') {
 		fetchJSON('/servers/all').then(({ status, body }) => {
 			if (body && typeof body === 'object' && body.data && typeof body.data === 'object') {
@@ -5097,6 +5232,11 @@ const server = http.createServer(async (req, res) => {
 			}
 			send(res, status, body);
 		});
+		return;
+	}
+
+	if (req.method === 'GET' && path === '/servers/marked') {
+		sendData(res, ['Wireguard9']);
 		return;
 	}
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -861,6 +861,74 @@ class ApiClient {
 		});
 	}
 
+	async setWireguardServerNATMode(
+		name: string,
+		mode: 'full' | 'internet-only' | 'none'
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(name)}/nat`, {
+			method: 'POST',
+			body: JSON.stringify({ mode })
+		});
+	}
+
+	async setWireguardServerPolicy(
+		name: string,
+		policy: string
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(name)}/policy`, {
+			method: 'POST',
+			body: JSON.stringify({ policy })
+		});
+	}
+
+	async addSystemServerPeer(
+		serverId: string,
+		data: { description: string; tunnelIP: string }
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(serverId)}/peers`, {
+			method: 'POST',
+			body: JSON.stringify(data)
+		});
+	}
+
+	async updateSystemServerPeer(
+		serverId: string,
+		pubkey: string,
+		data: { description: string; tunnelIP: string }
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(serverId)}/peers/${encodeURIComponent(pubkey)}`, {
+			method: 'PUT',
+			body: JSON.stringify(data)
+		});
+	}
+
+	async deleteSystemServerPeer(
+		serverId: string,
+		pubkey: string
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(serverId)}/peers/${encodeURIComponent(pubkey)}`, {
+			method: 'DELETE'
+		});
+	}
+
+	async toggleSystemServerPeer(
+		serverId: string,
+		publicKey: string,
+		enabled: boolean
+	): Promise<import('$lib/stores/servers').ServersSnapshot> {
+		return this.request(`/servers/${encodeURIComponent(serverId)}/peers/${encodeURIComponent(publicKey)}/toggle`, {
+			method: 'POST',
+			body: JSON.stringify({ enabled })
+		});
+	}
+
+	async getSystemServerPeerConf(serverId: string, pubkey: string): Promise<string> {
+		const res = await this.request<{ conf: string }>(
+			`/servers/${encodeURIComponent(serverId)}/peers/${encodeURIComponent(pubkey)}/conf`
+		);
+		return res.conf;
+	}
+
 	// #endregion
 
 	// ─────────────────────────────────────────────

--- a/frontend/src/lib/components/servers/AddSystemPeerModal.svelte
+++ b/frontend/src/lib/components/servers/AddSystemPeerModal.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	import type { WireguardServer } from '$lib/types';
+	import { Modal, Button } from '$lib/components/ui';
+	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
+	import { servers } from '$lib/stores/servers';
+
+	interface Props {
+		open: boolean;
+		serverId: string;
+		server: WireguardServer;
+		onclose: () => void;
+		onAdded: () => void;
+	}
+
+	let { open = $bindable(false), serverId, server, onclose, onAdded }: Props = $props();
+
+	let description = $state('');
+	let tunnelIP = $state('');
+	let adding = $state(false);
+	let wasOpen = $state(false);
+
+	function peerHostIP(p: { allowedIPs?: string[] }): string {
+		const raw = p.allowedIPs?.find((ip) => ip.includes('/32')) || p.allowedIPs?.[0] || '';
+		return raw.replace(/\/(32|128)$/, '');
+	}
+
+	function suggestNextIP(): string {
+		const parts = server.address.split('.');
+		if (parts.length !== 4) return '';
+		const base = parts.slice(0, 3).join('.');
+		const usedIPs = new Set([server.address, ...(server.peers ?? []).map(peerHostIP)]);
+		for (let i = 2; i < 255; i++) {
+			const candidate = `${base}.${i}`;
+			if (!usedIPs.has(candidate)) return `${candidate}/32`;
+		}
+		return '';
+	}
+
+	$effect(() => {
+		if (open && !wasOpen) {
+			description = '';
+			tunnelIP = suggestNextIP();
+		}
+		wasOpen = open;
+	});
+
+	async function handleAdd() {
+		adding = true;
+		try {
+			const fresh = await api.addSystemServerPeer(serverId, { description, tunnelIP });
+			servers.applyMutationResponse(fresh);
+			notifications.success('Клиент добавлен');
+			onclose();
+			onAdded();
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка добавления');
+		} finally {
+			adding = false;
+		}
+	}
+</script>
+
+<Modal {open} title="Добавить клиента" size="sm" {onclose}>
+	<div class="form-fields">
+		<div class="form-group">
+			<label class="label" for="ssp-desc">Имя / описание</label>
+			<input type="text" id="ssp-desc" class="input" bind:value={description} placeholder="Телефон" />
+		</div>
+		<div class="form-group">
+			<label class="label" for="ssp-ip">Tunnel IP (CIDR)</label>
+			<input type="text" id="ssp-ip" class="input" bind:value={tunnelIP} placeholder="10.0.0.2/32" />
+		</div>
+	</div>
+
+	{#snippet actions()}
+		<Button variant="ghost" size="md" onclick={onclose}>Отмена</Button>
+		<Button variant="primary" size="md" onclick={handleAdd} loading={adding} disabled={!tunnelIP}>
+			Добавить
+		</Button>
+	{/snippet}
+</Modal>
+
+<style>
+	.form-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.label {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.input {
+		padding: 8px 12px;
+		font-size: 13px;
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		color: var(--text-primary);
+	}
+
+	.input:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+</style>

--- a/frontend/src/lib/components/servers/EditSystemPeerModal.svelte
+++ b/frontend/src/lib/components/servers/EditSystemPeerModal.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import type { WireguardServerPeer } from '$lib/types';
+	import { Modal, Button } from '$lib/components/ui';
+	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
+	import { servers } from '$lib/stores/servers';
+
+	interface Props {
+		open: boolean;
+		serverId: string;
+		peer: WireguardServerPeer;
+		onclose: () => void;
+		onUpdated: () => void;
+	}
+
+	let { open = $bindable(false), serverId, peer, onclose, onUpdated }: Props = $props();
+
+	let description = $state('');
+	let tunnelIP = $state('');
+	let saving = $state(false);
+	let wasOpen = $state(false);
+
+	function peerTunnelIP(p: WireguardServerPeer): string {
+		const raw = p.allowedIPs?.find((ip) => ip.includes('/32')) || p.allowedIPs?.[0] || '';
+		if (!raw) return '';
+		if (raw.includes('/')) return raw;
+		return `${raw}/32`;
+	}
+
+	$effect(() => {
+		if (open && !wasOpen) {
+			description = peer.description;
+			tunnelIP = peerTunnelIP(peer);
+		}
+		wasOpen = open;
+	});
+
+	async function handleSave() {
+		saving = true;
+		try {
+			const fresh = await api.updateSystemServerPeer(serverId, peer.publicKey, { description, tunnelIP });
+			servers.applyMutationResponse(fresh);
+			notifications.success('Клиент обновлён');
+			onclose();
+			onUpdated();
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка сохранения');
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<Modal {open} title="Редактировать клиента" size="sm" {onclose}>
+	<div class="form-fields">
+		<div class="form-group">
+			<label class="label" for="esp-desc">Имя / описание</label>
+			<input type="text" id="esp-desc" class="input" bind:value={description} />
+		</div>
+		<div class="form-group">
+			<label class="label" for="esp-ip">Tunnel IP (CIDR)</label>
+			<input type="text" id="esp-ip" class="input" bind:value={tunnelIP} />
+		</div>
+	</div>
+
+	{#snippet actions()}
+		<Button variant="ghost" size="md" onclick={onclose}>Отмена</Button>
+		<Button variant="primary" size="md" onclick={handleSave} loading={saving}>
+			Сохранить
+		</Button>
+	{/snippet}
+</Modal>
+
+<style>
+	.form-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.label {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	.input {
+		padding: 8px 12px;
+		font-size: 13px;
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		color: var(--text-primary);
+	}
+
+	.input:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+</style>

--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ManagedPeer, ManagedPeerStats } from '$lib/types';
 	import { Trash2 } from 'lucide-svelte';
-	import { Toggle } from '$lib/components/ui';
+	import { ConfirmModal, Toggle } from '$lib/components/ui';
 	import { formatBytes, formatRelativeTime } from '$lib/utils/format';
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
@@ -12,22 +12,48 @@
 	interface Props {
 		peers: ManagedPeer[];
 		getPeerStats: (publicKey: string) => ManagedPeerStats | undefined;
-		confirmDeletePeerKey: string | null;
+		showPeerActions?: boolean;
+		showPeerDownload?: boolean;
+		showPeerToggle?: boolean;
 		onTogglePeer: (peer: ManagedPeer) => void;
 		onOpenConf: (peer: ManagedPeer) => void;
 		onOpenEditPeer: (peer: ManagedPeer) => void;
-		onDeletePeerClick: (peer: ManagedPeer) => void;
+		onDeletePeer: (peer: ManagedPeer) => void | Promise<void>;
+		isPeerToggling?: (publicKey: string) => boolean;
 	}
 
 	let {
 		peers,
 		getPeerStats,
-		confirmDeletePeerKey,
+		showPeerActions = true,
+		showPeerDownload = true,
+		showPeerToggle = true,
 		onTogglePeer,
 		onOpenConf,
 		onOpenEditPeer,
-		onDeletePeerClick,
+		onDeletePeer,
+		isPeerToggling = () => false,
 	}: Props = $props();
+
+	let deletePeerTarget = $state<ManagedPeer | null>(null);
+	let deletingPeer = $state(false);
+
+	function requestDeletePeer(peer: ManagedPeer) {
+		deletePeerTarget = peer;
+	}
+
+	async function confirmDeletePeer() {
+		if (!deletePeerTarget || deletingPeer) return;
+		deletingPeer = true;
+		try {
+			await onDeletePeer(deletePeerTarget);
+			deletePeerTarget = null;
+		} catch {
+			// keep modal open on error
+		} finally {
+			deletingPeer = false;
+		}
+	}
 
 	function peerName(peer: ManagedPeer): string {
 		return peer.description || `${peer.publicKey.slice(0, 8)}...`;
@@ -98,7 +124,9 @@
 					<th class="col-handshake" aria-sort={peerAriaSort($peerSort, 'handshake')}>
 						<PeerTableSortHeader label="Handshake" sortKey="handshake" />
 					</th>
-					<th class="col-actions">Действия</th>
+					{#if showPeerDownload || showPeerActions}
+						<th class="col-actions">Действия</th>
+					{/if}
 				</tr>
 			</thead>
 			<tbody>
@@ -111,25 +139,42 @@
 					<tr class:peer-disabled={!peer.enabled}>
 						<td
 							class="peer-name-cell"
-							role="button"
-							tabindex="0"
-							title={peer.enabled ? `Отключить «${peerName(peer)}»` : `Включить «${peerName(peer)}»`}
-							onclick={(e) => {
-								if (isInsideInlineToggle(e)) return;
-								onTogglePeer(peer);
-							}}
-							onkeydown={(e) => {
-								if (isInsideInlineToggle(e)) return;
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.preventDefault();
-									onTogglePeer(peer);
-								}
-							}}
+							class:peer-name-cell-readonly={!showPeerToggle}
+							role={showPeerToggle ? 'button' : undefined}
+							tabindex={showPeerToggle ? 0 : undefined}
+							title={showPeerToggle
+								? peer.enabled
+									? `Отключить «${peerName(peer)}»`
+									: `Включить «${peerName(peer)}»`
+								: undefined}
+							onclick={showPeerToggle
+								? (e) => {
+										if (isInsideInlineToggle(e) || isPeerToggling(peer.publicKey)) return;
+										onTogglePeer(peer);
+									}
+								: undefined}
+							onkeydown={showPeerToggle
+								? (e) => {
+										if (isInsideInlineToggle(e) || isPeerToggling(peer.publicKey)) return;
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											onTogglePeer(peer);
+										}
+									}
+								: undefined}
 						>
 							<div class="peer-name-row">
-								<span class="peer-inline-toggle">
-									<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
-								</span>
+								{#if showPeerToggle}
+									<span class="peer-inline-toggle">
+										<Toggle
+											checked={peer.enabled}
+											onchange={() => onTogglePeer(peer)}
+											disabled={isPeerToggling(peer.publicKey)}
+											loading={isPeerToggling(peer.publicKey)}
+											size="sm"
+										/>
+									</span>
+								{/if}
 								<div class="peer-name-block">
 									<span class="peer-name">{peerName(peer)}</span>
 									<div class="peer-status-sub">
@@ -183,33 +228,36 @@
 								-
 							{/if}
 						</td>
-						<td class="col-actions">
-							<div class="peer-actions">
-								<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-									<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-										<polyline points="7 10 12 15 17 10" />
-										<line x1="12" y1="15" x2="12" y2="3" />
-									</svg>
-								</button>
-								<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-									<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-										<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-									</svg>
-								</button>
-								<button
-									class="peer-action-btn peer-action-btn-danger"
-									class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
-									onclick={() => onDeletePeerClick(peer)}
-									title={confirmDeletePeerKey === peer.publicKey
-										? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
-										: `Удалить «${peerName(peer)}»`}
-								>
-									<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
-								</button>
-							</div>
-						</td>
+						{#if showPeerDownload || showPeerActions}
+							<td class="col-actions">
+								<div class="peer-actions">
+									{#if showPeerDownload}
+										<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
+											<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+												<polyline points="7 10 12 15 17 10" />
+												<line x1="12" y1="15" x2="12" y2="3" />
+											</svg>
+										</button>
+									{/if}
+									{#if showPeerActions}
+									<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
+										<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+											<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+										</svg>
+									</button>
+									<button
+										class="peer-action-btn peer-action-btn-danger"
+										onclick={() => requestDeletePeer(peer)}
+										title={`Удалить «${peerName(peer)}»`}
+									>
+										<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
+									</button>
+									{/if}
+								</div>
+							</td>
+						{/if}
 					</tr>
 				{/each}
 			</tbody>
@@ -223,12 +271,20 @@
 		{@const status = peerStatus(peer, peerStats)}
 		{@const endpointValue = peerStats?.endpoint || '-'}
 		{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
-		<article class="mobile-peer-card" class:peer-disabled={!peer.enabled} class:has-actions={true}>
+		<article class="mobile-peer-card" class:peer-disabled={!peer.enabled} class:has-actions={showPeerDownload || showPeerActions}>
 			<div class="mobile-peer-card-top">
 				<div class="mobile-peer-title-row">
-					<span class="peer-inline-toggle">
-						<Toggle checked={peer.enabled} onchange={() => onTogglePeer(peer)} size="sm" />
-					</span>
+					{#if showPeerToggle}
+						<span class="peer-inline-toggle">
+							<Toggle
+								checked={peer.enabled}
+								onchange={() => onTogglePeer(peer)}
+								disabled={isPeerToggling(peer.publicKey)}
+								loading={isPeerToggling(peer.publicKey)}
+								size="sm"
+							/>
+						</span>
+					{/if}
 					<div class="peer-name-block">
 						<span class="mobile-peer-name">{peerName(peer)}</span>
 						<div class="peer-status-sub">
@@ -243,31 +299,34 @@
 					</div>
 				</div>
 
-				<div class="mobile-peer-actions">
-					<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-							<polyline points="7 10 12 15 17 10" />
-							<line x1="12" y1="15" x2="12" y2="3" />
-						</svg>
-					</button>
-					<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-							<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-							<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-						</svg>
-					</button>
-					<button
-						class="peer-action-btn peer-action-btn-danger"
-						class:peer-action-btn-confirm={confirmDeletePeerKey === peer.publicKey}
-						onclick={() => onDeletePeerClick(peer)}
-						title={confirmDeletePeerKey === peer.publicKey
-							? `Нажмите ещё раз, чтобы удалить «${peerName(peer)}»`
-							: `Удалить «${peerName(peer)}»`}
-					>
-						<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
-					</button>
-				</div>
+				{#if showPeerDownload || showPeerActions}
+					<div class="mobile-peer-actions">
+						{#if showPeerDownload}
+							<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
+								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+									<polyline points="7 10 12 15 17 10" />
+									<line x1="12" y1="15" x2="12" y2="3" />
+								</svg>
+							</button>
+						{/if}
+						{#if showPeerActions}
+						<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
+							<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+								<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+							</svg>
+						</button>
+						<button
+							class="peer-action-btn peer-action-btn-danger"
+							onclick={() => requestDeletePeer(peer)}
+							title={`Удалить «${peerName(peer)}»`}
+						>
+							<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
+						</button>
+						{/if}
+					</div>
+				{/if}
 			</div>
 
 			<div class="mobile-peer-card-middle">
@@ -312,6 +371,21 @@
 		</article>
 	{/each}
 </div>
+
+{#if deletePeerTarget}
+	<ConfirmModal
+		open={true}
+		title="Удаление клиента"
+		message={`Удалить клиента «${peerName(deletePeerTarget)}»?`}
+		secondary={`Туннельный IP: ${deletePeerTarget.tunnelIP}. Конфигурация и ключи будут удалены без возможности восстановления.`}
+		confirmLabel="Удалить"
+		busy={deletingPeer}
+		onConfirm={confirmDeletePeer}
+		onClose={() => {
+			if (!deletingPeer) deletePeerTarget = null;
+		}}
+	/>
+{/if}
 
 <style>
 	.table-wrap {
@@ -367,6 +441,10 @@
 		min-width: 140px;
 		text-align: left;
 		cursor: pointer;
+	}
+
+	td.peer-name-cell-readonly {
+		cursor: default;
 	}
 
 	.peer-name {
@@ -475,6 +553,7 @@
 	.traffic-cell {
 		display: flex;
 		flex-direction: column;
+		align-items: center;
 		gap: 0;
 		line-height: 1.05;
 		white-space: nowrap;
@@ -553,13 +632,14 @@
 	}
 
 	td.col-actions {
-		text-align: right;
+		text-align: center;
+		vertical-align: middle;
 	}
 
 	.peer-actions {
 		display: inline-flex;
 		align-items: center;
-		justify-content: flex-end;
+		justify-content: center;
 		width: 100%;
 		gap: 0.375rem;
 	}
@@ -584,17 +664,6 @@
 
 	.peer-action-btn-danger:hover {
 		color: var(--error, #ef4444);
-	}
-
-	.peer-action-btn-confirm {
-		background: var(--error, #ef4444);
-		color: white;
-	}
-
-	.peer-action-btn-confirm:hover {
-		background: var(--error, #ef4444);
-		color: white;
-		filter: brightness(1.1);
 	}
 
 	.cell-copy {

--- a/frontend/src/lib/components/servers/ManagedServerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedServerCard.svelte
@@ -14,11 +14,13 @@
 		PeerConfModal,
 		PeerSortControls,
 		ManagedPeerTable,
+		ServerAccessPolicyDropdown,
 	} from '$lib/components/servers';
 	import { comparePeerFieldsDirected } from '$lib/utils/peerSort';
 	import { peerSort } from '$lib/stores/peerSort';
-	import { isStandardAccessPolicyName } from '$lib/utils/accessPolicy';
 	import { classifyAwgVersionFromAsc } from '$lib/utils/classifyAwgVersion';
+	import { formatSubnetPlaceholder, maskToPrefix, resolveNatMode, type NatMode } from '$lib/utils/network';
+	import { countActiveManagedPeers } from '$lib/utils/serverPeerActivity';
 
 	interface Props {
 		server: ManagedServer;
@@ -47,7 +49,6 @@
 	let confPeerName = $state('');
 	let deleting = $state(false);
 	let confirmDelete = $state(false);
-	let confirmDeletePeerKey = $state<string | null>(null);
 
 	let searchQuery = $state('');
 
@@ -58,8 +59,7 @@
 	let sortedPeers = $derived.by(() => {
 		let peers = server.peers ?? [];
 
-		// Filter (only when search is rendered: 5+ peers)
-		if (searchQuery && peers.length >= 5) {
+		if (searchQuery) {
 			const q = searchQuery.toLowerCase();
 			peers = peers.filter(p =>
 				(p.description || '').toLowerCase().includes(q) ||
@@ -100,10 +100,12 @@
 		return sorted;
 	});
 
-	let onlineCount = $derived(stats?.peers?.filter(p => p.online).length ?? 0);
+	let onlineCount = $derived(countActiveManagedPeers(server.peers, stats?.peers));
+	let statusUnknown = $derived(stats === null);
 	let isUp = $derived(stats?.status === 'up');
 	let totalRx = $derived(stats?.peers?.reduce((sum, p) => sum + p.rxBytes, 0) ?? 0);
 	let totalTx = $derived(stats?.peers?.reduce((sum, p) => sum + p.txBytes, 0) ?? 0);
+	let togglingPeerKeys = $state(new Set<string>());
 
 	async function handleDeleteServer() {
 		if (!confirmDelete) {
@@ -126,69 +128,40 @@
 	}
 
 	async function handleTogglePeer(peer: ManagedPeer) {
+		if (togglingPeerKeys.has(peer.publicKey)) return;
+		togglingPeerKeys = new Set(togglingPeerKeys).add(peer.publicKey);
 		try {
 			const fresh = await api.toggleManagedPeer(serverId, peer.publicKey, !peer.enabled);
 			servers.applyMutationResponse(fresh);
 			onUpdated();
 		} catch (e) {
 			notifications.error(e instanceof Error ? e.message : 'Ошибка');
+		} finally {
+			const next = new Set(togglingPeerKeys);
+			next.delete(peer.publicKey);
+			togglingPeerKeys = next;
 		}
 	}
 
-	function handleDeletePeerClick(peer: ManagedPeer) {
-		if (confirmDeletePeerKey === peer.publicKey) {
-			doDeletePeer(peer);
-		} else {
-			confirmDeletePeerKey = peer.publicKey;
-			setTimeout(() => {
-				if (confirmDeletePeerKey === peer.publicKey) {
-					confirmDeletePeerKey = null;
-				}
-			}, 3000);
-		}
+	function isPeerToggling(publicKey: string): boolean {
+		return togglingPeerKeys.has(publicKey);
 	}
 
 	async function doDeletePeer(peer: ManagedPeer) {
 		try {
-			confirmDeletePeerKey = null;
 			const fresh = await api.deleteManagedPeer(serverId, peer.publicKey);
 			servers.applyMutationResponse(fresh);
 			notifications.success('Клиент удалён');
 			onUpdated();
 		} catch (e) {
 			notifications.error(e instanceof Error ? e.message : 'Ошибка удаления');
+			throw e;
 		}
 	}
 
 	function openEditPeer(peer: ManagedPeer) {
 		selectedPeer = peer;
 		editPeerOpen = true;
-	}
-
-	function maskToPrefix(mask: string): string {
-		if (/^\d+$/.test(mask)) return mask;
-		const parts = mask.split('.').map(Number);
-		let bits = 0;
-		for (const p of parts) {
-			bits += (p >>> 0).toString(2).split('1').length - 1;
-		}
-		return String(bits);
-	}
-
-	/** Подсеть вида 10.0.0.X/24 — host-октеты заменены на X по маске. */
-	function formatSubnetPlaceholder(address: string, mask: string): string {
-		const prefix = Number(maskToPrefix(mask));
-		const octets = address.split('.').map((p) => parseInt(p, 10));
-		if (octets.length !== 4 || octets.some((n) => Number.isNaN(n)) || Number.isNaN(prefix)) {
-			return `${address}/${maskToPrefix(mask)}`;
-		}
-		const parts = octets.map((value, i) => {
-			const bitsBefore = i * 8;
-			if (prefix <= bitsBefore) return 'X';
-			if (prefix >= bitsBefore + 8) return String(value);
-			return 'X';
-		});
-		return `${parts.join('.')}/${prefix}`;
 	}
 
 	const WAN_IP_MASKED = 'показать';
@@ -232,9 +205,7 @@
 	let togglingNAT = $state(false);
 	let togglingIngress = $state(false);
 
-	let natMode = $derived<'full' | 'internet-only' | 'none'>(
-		server.natMode ?? (server.natEnabled ? 'full' : 'none')
-	);
+	let natMode = $derived<NatMode>(resolveNatMode(server.natMode, server.natEnabled));
 
 	const natModeOptions: DropdownOption<'full' | 'internet-only' | 'none'>[] = [
 		{ value: 'full', label: 'Полный NAT' },
@@ -286,20 +257,9 @@
 		confModalOpen = true;
 	}
 
-	let policies = $state<{ id: string; description: string }[]>([]);
 	let policyChanging = $state(false);
-	// Local mirror of server.policy for the <select>. On error we reset
-	// it back to server.policy so the DOM reverts — without this the
-	// browser keeps the failed value because no fresh snapshot arrives.
-	// Empty initial value is overwritten by the $effect on mount before
-	// the select is interactive.
-	let selectedPolicy = $state('');
 	let ascParams = $state<ASCParams | null>(null);
 	let ascLoadedFor = $state('');
-
-	$effect(() => {
-		selectedPolicy = server.policy;
-	});
 
 	$effect(() => {
 		const id = server.interfaceName;
@@ -336,30 +296,7 @@
 
 	onMount(async () => {
 		void api.getWANIP().then((ip) => { wanIP = ip; }).catch(() => {});
-		try {
-			policies = await api.getManagedServerPolicies();
-		} catch {
-			policies = [];
-		}
 	});
-
-	let orphanedPolicy = $derived.by(() => {
-		const p = server.policy;
-		if (!p || p === 'none' || p === 'permit' || p === 'deny') return null;
-		if (policies.some(o => o.id === p)) return null;
-		return p;
-	});
-
-	let standardPolicies = $derived(policies.filter((p) => isStandardAccessPolicyName(p.id)));
-
-	let policyOptions = $derived<DropdownOption[]>([
-		{ value: 'none', label: 'Политика по умолчанию' },
-		...(orphanedPolicy ? [{ value: orphanedPolicy, label: `${orphanedPolicy} (отсутствует)` }] : []),
-		...standardPolicies.map((p) => ({
-			value: p.id,
-			label: p.description ? `${p.id} — ${p.description}` : p.id,
-		})),
-	]);
 
 	async function handlePolicyChange(newPolicy: string) {
 		if (newPolicy === server.policy) return;
@@ -370,14 +307,13 @@
 			notifications.success('Политика обновлена');
 		} catch (e) {
 			notifications.error(e instanceof Error ? e.message : 'Ошибка изменения политики');
-			selectedPolicy = server.policy;
 		} finally {
 			policyChanging = false;
 		}
 	}
 </script>
 
-<div class="card managed-card" class:status-up={isUp}>
+<div class="card server-detail-card managed-card" class:status-up={isUp}>
 	<!-- Header -->
 	<div class="card-header">
 		<div class="header-info">
@@ -386,9 +322,10 @@
 					<Toggle
 						checked={isUp}
 						onchange={handleToggleEnabled}
-						disabled={togglingEnabled || restartingServer}
+						disabled={togglingEnabled || restartingServer || statusUnknown}
+						loading={togglingEnabled}
+						label="Сервер включён"
 						size="sm"
-						spinner="none"
 					/>
 					<h3 class="card-title">{serverDisplayName}</h3>
 				</div>
@@ -414,20 +351,22 @@
 		<div class="header-right">
 			<div class="header-actions">
 			<Button
-				variant="ghost"
+				variant="secondary"
 				size="sm"
 				onclick={handleRestartOrStart}
 				disabled={restartingServer || togglingEnabled || deleting}
 				loading={restartingServer}
 				iconBefore={restartIcon}
-				title={isUp
-					? `Перезапустить сервер «${serverDisplayName}»`
-					: `Запустить сервер «${serverDisplayName}»`}
+				title={statusUnknown
+					? `Статус сервера «${serverDisplayName}» загружается`
+					: isUp
+						? `Перезапустить сервер «${serverDisplayName}»`
+						: `Запустить сервер «${serverDisplayName}»`}
 			>
-				{isUp ? 'Рестарт' : 'Запуск'}
+				{statusUnknown ? 'Рестарт' : isUp ? 'Рестарт' : 'Запуск'}
 			</Button>
 			<Button
-				variant="ghost"
+				variant="secondary"
 				size="sm"
 				onclick={onOpenASC}
 				iconBefore={ascIcon}
@@ -436,7 +375,7 @@
 				Обфускация
 			</Button>
 			<Button
-				variant="ghost"
+				variant="secondary"
 				size="sm"
 				onclick={() => editServerOpen = true}
 				iconBefore={settingsIcon}
@@ -504,7 +443,7 @@
 		<div class="setting-row">
 			<div class="setting-copy">
 				<span class="setting-title">Доступ в LAN</span>
-				<span class="setting-description">Сегменты LAN, доступные клиентам этого сервера</span>
+				<span class="setting-description">Сегменты LAN, доступные клиентам этого сервера.</span>
 			</div>
 			<div class="setting-control">
 				<ChipMultiSelect values={server.lanSegments ?? []} options={lanSegmentOptions} onchange={handleSetLANSegments} disabled={settingLAN} />
@@ -514,28 +453,18 @@
 		<div class="setting-row setting-row-toggle">
 			<div class="setting-copy">
 				<span class="setting-title">Маршрутизация через sing-box</span>
-				<span class="setting-description">Заворачивать интернет-трафик клиентов данного сервера в sing-box</span>
+				<span class="setting-description">Заворачивать интернет-трафик клиентов данного сервера в sing-box.</span>
 			</div>
 			<div class="setting-control setting-control-toggle">
-				<Toggle checked={ingressEnabled} onchange={handleToggleIngress} disabled={togglingIngress} spinner="after" />
+				<Toggle checked={ingressEnabled} onchange={handleToggleIngress} disabled={togglingIngress} spinner="before" />
 			</div>
 		</div>
 
-		<div class="setting-row">
-			<div class="setting-copy">
-				<span class="setting-title">Политика доступа</span>
-				<span class="setting-description">Регулирует выход в интернет для клиентов сервера. Применяется ко всем клиентам этого сервера.</span>
-			</div>
-			<div class="setting-control">
-				<Dropdown
-					value={selectedPolicy}
-					options={policyOptions}
-					disabled={policyChanging}
-					onchange={handlePolicyChange}
-					fullWidth
-				/>
-			</div>
-		</div>
+		<ServerAccessPolicyDropdown
+			policy={server.policy}
+			disabled={policyChanging}
+			onchange={handlePolicyChange}
+		/>
 	</div>
 
 	<!-- Peers -->
@@ -545,7 +474,7 @@
 			<div class="peers-controls">
 				<PeerSortControls
 					bind:searchQuery
-					showSearch={(server.peers ?? []).length >= 5}
+					showSearch={(server.peers ?? []).length > 0}
 					hideSortOnDesktop
 				/>
 				<Button variant="secondary" size="sm" onclick={() => addPeerOpen = true} iconBefore={addPeerIcon}>
@@ -560,11 +489,11 @@
 			<ManagedPeerTable
 				peers={sortedPeers}
 				{getPeerStats}
-				{confirmDeletePeerKey}
 				onTogglePeer={handleTogglePeer}
+				{isPeerToggling}
 				onOpenConf={openConf}
 				onOpenEditPeer={openEditPeer}
-				onDeletePeerClick={handleDeletePeerClick}
+				onDeletePeer={doDeletePeer}
 			/>
 		{/if}
 	</div>
@@ -642,72 +571,15 @@
 
 
 <style>
+	@import './serverCardShared.css';
+
 	.managed-card {
-		display: flex;
-		flex-direction: column;
-		--managed-section-gap: 0.625rem;
-		gap: var(--managed-section-gap);
 		border-color: var(--accent);
 	}
 
-	.card-header {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		align-items: flex-start;
-		gap: 1rem;
-		margin-bottom: 0;
-		padding-bottom: 0;
-		border-bottom: none;
-	}
-
-	.header-info {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		flex: 1 1 265px;
-		min-width: 265px;
-		max-width: 100%;
-	}
-
-	.title-row {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		column-gap: 0.5rem;
-		row-gap: 0.375rem;
-		min-width: 0;
-	}
-
-	.title-main {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		min-width: 0;
-		flex: 0 1 auto;
-		max-width: 100%;
-	}
-
-	.title-main :global(.toggle-container) {
-		flex-shrink: 0;
-		display: inline-flex;
-		align-items: center;
-		align-self: center;
-	}
-
 	.title-badges {
-		display: inline-flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0.375rem;
 		flex: 1 1 auto;
 		min-width: fit-content;
-	}
-
-	.card-title {
-		font-size: 1.125rem;
-		font-weight: 600;
-		min-width: 0;
 	}
 
 	.badge-managed {
@@ -719,75 +591,6 @@
 		border-radius: 10px;
 		background: rgba(59, 130, 246, 0.15);
 		color: var(--accent);
-	}
-
-	.server-meta {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.meta {
-		font-size: 0.75rem;
-		color: var(--text-muted);
-	}
-
-	.mono {
-		font-family: var(--font-mono, monospace);
-	}
-
-	.header-right {
-		display: flex;
-		flex-wrap: nowrap;
-		align-items: center;
-		justify-content: flex-end;
-		gap: 0.5rem;
-		flex: 0 0 auto;
-		margin-left: auto;
-	}
-
-	.header-actions {
-		display: flex;
-		flex-wrap: nowrap;
-		align-items: center;
-		justify-content: flex-end;
-		gap: 0.25rem;
-		flex: 0 0 auto;
-	}
-
-	.server-settings {
-		background: var(--color-bg-tertiary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-sm);
-		padding: 0 0.875rem;
-		margin-top: 0.5rem;
-		min-width: 0;
-	}
-
-	.server-settings .setting-row:first-child {
-		padding-top: 0.875rem;
-	}
-
-	.server-settings .setting-row:last-child {
-		padding-bottom: 0.875rem;
-	}
-
-	.setting-copy {
-		display: flex;
-		flex-direction: column;
-		gap: 0.125rem;
-		min-width: 0;
-	}
-
-	.setting-title {
-		font-size: 0.875rem;
-		font-weight: 500;
-		color: var(--text-primary);
-	}
-
-	.setting-description-warning {
-		color: var(--warning, #f59e0b);
 	}
 
 	.wan-ip-reveal {
@@ -810,51 +613,10 @@
 		color: var(--text-primary);
 	}
 
-	.wan-ip-reveal:focus,
 	.wan-ip-reveal:focus-visible {
-		outline: none;
-		box-shadow: none;
-	}
-
-	.setting-control {
-		width: 100%;
-		min-width: 0;
-		max-width: 280px;
-		justify-self: end;
-	}
-
-	.setting-control :global(.dropdown),
-	.setting-control :global(.field),
-	.setting-control :global(.picker) {
-		width: 100%;
-		min-width: 0;
-	}
-
-	.setting-control-toggle {
-		width: auto;
-		max-width: none;
-		justify-self: end;
-		align-self: center;
-	}
-
-	.setting-row-toggle {
-		display: grid;
-		grid-template-columns: minmax(0, 1fr) auto;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.setting-row-toggle .setting-copy {
-		min-width: 0;
-	}
-
-	.server-settings :global(.field .trigger) {
-		background: var(--color-settings-surface-bg);
-		border-color: var(--color-border);
-	}
-
-	.server-settings :global(.field .trigger:hover:not(:disabled)) {
-		background: var(--color-bg-hover);
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+		border-radius: 2px;
 	}
 
 	.server-settings :global(.picker .chips) {
@@ -863,101 +625,7 @@
 		border-radius: var(--radius-sm);
 	}
 
-	.server-settings :global(.toggle-container .toggle-slider) {
-		background: var(--color-settings-surface-bg);
-	}
-
-	.server-settings :global(.toggle-container:hover input:not(:checked) ~ .toggle-slider) {
-		background: var(--color-bg-hover);
-	}
-
-	@media (min-width: 641px) {
-		.server-settings .setting-row {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(12rem, 280px);
-			align-items: start;
-			gap: 0.75rem;
-		}
-
-		.server-settings .setting-row-toggle {
-			grid-template-columns: minmax(0, 1fr) auto;
-			align-items: center;
-		}
-
-		.setting-control {
-			max-width: none;
-		}
-	}
-
-	.peers-section {
-		--peers-divider-gap: 1rem;
-		border-top: 1px solid var(--border);
-		padding-top: var(--peers-divider-gap);
-		margin-top: calc(var(--peers-divider-gap) - var(--managed-section-gap));
-	}
-
-	.peers-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 0.75rem;
-	}
-
-	.peers-controls {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-	}
-
-	.peers-title {
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: var(--text-secondary);
-	}
-
-	.empty-peers {
-		padding: 1.5rem;
-		text-align: center;
-		font-size: 0.8125rem;
-		color: var(--text-muted);
-	}
-
 	@media (max-width: 640px) {
-		.peers-header {
-			flex-direction: column;
-			align-items: stretch;
-			gap: 0.5rem;
-		}
-
-		.peers-controls {
-			flex-wrap: wrap;
-		}
-
-		.peers-controls :global(.btn) {
-			width: 100%;
-		}
-
-		.card-header {
-			flex-direction: column;
-		}
-
-		.header-info {
-			flex: 1 1 auto;
-			min-width: 0;
-		}
-
-		.header-right {
-			width: 100%;
-			margin-left: 0;
-			flex-direction: column;
-			align-items: stretch;
-			gap: 0.5rem;
-		}
-
-		.setting-control {
-			max-width: none;
-		}
-
 		.header-actions {
 			align-self: stretch;
 			display: grid;
@@ -970,28 +638,6 @@
 			width: 100%;
 			min-width: 0;
 			justify-content: center;
-		}
-
-	}
-
-	@media (max-width: 640px) {
-		.managed-card {
-			overflow: hidden;
-		}
-
-		.peers-controls {
-			display: grid;
-			grid-template-columns: 1fr;
-			width: 100%;
-			gap: 0.4rem;
-		}
-
-		.peers-controls :global(.peer-sort-controls) {
-			width: 100%;
-		}
-
-		.peers-controls :global(.btn) {
-			width: 100%;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/PeerConfModal.svelte
+++ b/frontend/src/lib/components/servers/PeerConfModal.svelte
@@ -10,10 +10,11 @@
 		serverId: string;
 		pubkey: string;
 		peerName: string;
+		kind?: 'managed' | 'system';
 		onclose: () => void;
 	}
 
-	let { open = $bindable(false), serverId, pubkey, peerName, onclose }: Props = $props();
+	let { open = $bindable(false), serverId, pubkey, peerName, kind = 'managed', onclose }: Props = $props();
 
 	let conf = $state('');
 	let loading = $state(false);
@@ -32,7 +33,9 @@
 	async function loadConf() {
 		loading = true;
 		try {
-			conf = await api.getManagedPeerConf(serverId, pubkey);
+			conf = kind === 'system'
+				? await api.getSystemServerPeerConf(serverId, pubkey)
+				: await api.getManagedPeerConf(serverId, pubkey);
 		} catch (e) {
 			notifications.error(e instanceof Error ? e.message : 'Ошибка загрузки');
 			conf = '';

--- a/frontend/src/lib/components/servers/PeerSortControls.svelte
+++ b/frontend/src/lib/components/servers/PeerSortControls.svelte
@@ -125,7 +125,11 @@
 	}
 
 	@media (max-width: 640px) {
-		.peer-sort-controls {
+		.peer-sort-controls.hide-sort-on-desktop {
+			display: contents;
+		}
+
+		.peer-sort-controls:not(.hide-sort-on-desktop) {
 			display: grid;
 			grid-template-columns: minmax(0, 1fr) auto;
 			gap: 0.375rem;
@@ -133,7 +137,8 @@
 		}
 
 		.peer-search {
-			grid-column: 1 / -1;
+			grid-column: 1;
+			grid-row: 1;
 			width: 100%;
 			min-width: 0;
 		}
@@ -152,7 +157,12 @@
 		.peer-sort-controls.hide-sort-on-desktop .peer-sort-ui {
 			display: inline-flex;
 			grid-column: 1 / -1;
+			grid-row: 2;
 			width: 100%;
+		}
+
+		.peer-sort-controls:not(.hide-sort-on-desktop) .peer-search {
+			grid-column: 1 / -1;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/servers/PeerTable.svelte
+++ b/frontend/src/lib/components/servers/PeerTable.svelte
@@ -392,7 +392,7 @@
 	.traffic-cell {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
+		align-items: center;
 		gap: 0;
 		line-height: 1.05;
 		white-space: nowrap;

--- a/frontend/src/lib/components/servers/ServerAccessPolicyDropdown.svelte
+++ b/frontend/src/lib/components/servers/ServerAccessPolicyDropdown.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { Dropdown, type DropdownOption } from '$lib/components/ui';
+	import { isStandardAccessPolicyName } from '$lib/utils/accessPolicy';
+
+	interface Props {
+		policy: string;
+		disabled?: boolean;
+		onchange: (policy: string) => void | Promise<void>;
+	}
+
+	let { policy, disabled = false, onchange }: Props = $props();
+
+	let policies = $state<{ id: string; description: string }[]>([]);
+	let selectedPolicy = $state('');
+
+	$effect(() => {
+		selectedPolicy = policy;
+	});
+
+	let orphanedPolicy = $derived.by(() => {
+		const p = policy;
+		if (!p || p === 'none' || p === 'permit' || p === 'deny') return null;
+		if (policies.some((o) => o.id === p)) return null;
+		return p;
+	});
+
+	let standardPolicies = $derived(policies.filter((p) => isStandardAccessPolicyName(p.id)));
+
+	let policyOptions = $derived<DropdownOption[]>([
+		{ value: 'none', label: 'Политика по умолчанию' },
+		...(orphanedPolicy ? [{ value: orphanedPolicy, label: `${orphanedPolicy} (отсутствует)` }] : []),
+		...standardPolicies.map((p) => ({
+			value: p.id,
+			label: p.description ? `${p.id} — ${p.description}` : p.id,
+		})),
+	]);
+
+	onMount(async () => {
+		try {
+			policies = await api.getManagedServerPolicies();
+		} catch {
+			policies = [];
+		}
+	});
+</script>
+
+<div class="setting-row">
+	<div class="setting-copy">
+		<span class="setting-title">Политика доступа</span>
+		<span class="setting-description"
+			>Регулирует выход в интернет для клиентов сервера. Применяется ко всем клиентам этого сервера.</span
+		>
+	</div>
+	<div class="setting-control">
+		<Dropdown value={selectedPolicy} options={policyOptions} {disabled} {onchange} fullWidth />
+	</div>
+</div>

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -65,6 +65,11 @@
 	let togglingPeerKeys = $state(new Set<string>());
 
 	let natMode = $derived<NatMode>(resolveNatMode(server.natMode, server.natEnabled));
+	// When the backend couldn't read NAT/policy from NDMS, natMode/policy are a
+	// fabricated 'none' — surface "unknown" and block edits instead of letting
+	// the user act on it. Absent flags (legacy/managed) are treated as known.
+	let natModeKnown = $derived(server.natModeKnown ?? true);
+	let policyKnown = $derived(server.policyKnown ?? true);
 
 	const natModeOptions: DropdownOption<NatMode>[] = [
 		{ value: 'full', label: 'Полный NAT' },
@@ -378,14 +383,16 @@
 			<div class="setting-row">
 				<div class="setting-copy">
 					<span class="setting-title">NAT</span>
-					{#if natMode === 'full'}
+					{#if !natModeKnown}
+						<span class="setting-description setting-description-warning">Не удалось прочитать состояние NAT с роутера — обновите страницу.</span>
+					{:else if natMode === 'full'}
 						<span class="setting-description">Для доступа клиентов в интернет через NAT роутера.</span>
 					{:else if natMode === 'internet-only'}
 						<span class="setting-description">NAT только для интернет-трафика; в LAN клиент виден со своим VPN-адресом.</span>
 					{:else}
 						<span class="setting-description">Без NAT — клиенты не выходят в интернет напрямую.</span>
 					{/if}
-					{#if ingressEnabled && natMode === 'full'}
+					{#if natModeKnown && ingressEnabled && natMode === 'full'}
 						<span class="setting-description setting-description-warning">Интернет-трафик идёт через sing-box - NAT влияет только на видимость в LAN.</span>
 					{/if}
 				</div>
@@ -393,7 +400,7 @@
 					<Dropdown
 						value={natMode}
 						options={natModeOptions}
-						disabled={togglingNAT}
+						disabled={togglingNAT || !natModeKnown}
 						onchange={handleSetNATMode}
 						fullWidth
 					/>
@@ -417,9 +424,12 @@
 
 			<ServerAccessPolicyDropdown
 				policy={server.policy ?? 'none'}
-				disabled={policyChanging}
+				disabled={policyChanging || !policyKnown}
 				onchange={handlePolicyChange}
 			/>
+			{#if !policyKnown}
+				<span class="setting-description setting-description-warning">Не удалось прочитать политику доступа с роутера — обновите страницу.</span>
+			{/if}
 		</div>
 	{/if}
 

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -1,93 +1,177 @@
 <script lang="ts">
-	import type { WireguardServer, WireguardServerConfig, ASCParams, WireguardServerPeer } from '$lib/types';
+	import type {
+		ASCParams,
+		WireguardServer,
+		WireguardServerConfig,
+		WireguardServerPeer,
+		ManagedPeer,
+		ManagedPeerStats,
+	} from '$lib/types';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
 	import { servers } from '$lib/stores/servers';
 	import { formatBytes } from '$lib/utils/format';
 	import { comparePeerFieldsDirected } from '$lib/utils/peerSort';
 	import { peerSort } from '$lib/stores/peerSort';
-	import { PeerTable, ConfGeneratorModal, PeerSortControls } from '$lib/components/servers';
-	import { Button, IconButton } from '$lib/components/ui';
-
-	function peerIP(p: WireguardServerPeer): string {
-		return p.allowedIPs?.find(ip => ip.includes('/32'))
-			?? p.allowedIPs?.[0]
-			?? '';
-	}
+	import { maskToPrefix, resolveNatMode, type NatMode } from '$lib/utils/network';
+	import { countActiveSystemPeers } from '$lib/utils/serverPeerActivity';
+	import {
+		PeerSortControls,
+		ManagedPeerTable,
+		AddSystemPeerModal,
+		EditSystemPeerModal,
+		PeerConfModal,
+		ConfGeneratorModal,
+		ServerAccessPolicyDropdown,
+	} from '$lib/components/servers';
+	import { Toggle, Button, Dropdown, Stat, StatStrip, type DropdownOption } from '$lib/components/ui';
+	import { Plus, RefreshCw, ExternalLink } from 'lucide-svelte';
 
 	interface Props {
 		server: WireguardServer;
-		isBuiltIn: boolean;
+		isMarked?: boolean;
 		onUnmark?: (id: string) => void;
+		ingressEnabled?: boolean;
+		onToggleIngress?: (interfaceName: string, enabled: boolean) => Promise<void>;
 	}
 
-	let { server, isBuiltIn, onUnmark }: Props = $props();
+	let {
+		server,
+		isMarked = false,
+		onUnmark,
+		ingressEnabled = false,
+		onToggleIngress = async () => {},
+	}: Props = $props();
 
+	let isBuiltIn = $derived(server.builtIn ?? server.description === 'Wireguard VPN Server');
+
+	let addPeerOpen = $state(false);
+	let editPeerOpen = $state(false);
 	let confModalOpen = $state(false);
+	let confGeneratorOpen = $state(false);
+	let selectedPeer = $state<WireguardServerPeer | null>(null);
+	let confPubkey = $state('');
+	let confPeerName = $state('');
 	let confPeerKey = $state('');
 	let serverConfig = $state<WireguardServerConfig | null>(null);
 	let ascParams = $state<ASCParams | null>(null);
-	let loadingConfig = $state(false);
 	let wanIP = $state('');
-
 	let searchQuery = $state('');
+	let togglingEnabled = $state(false);
+	let restartingServer = $state(false);
+	let togglingIngress = $state(false);
+	let togglingNAT = $state(false);
+	let policyChanging = $state(false);
+	let togglingPeerKeys = $state(new Set<string>());
 
-	// Computed stats
-	let onlineCount = $derived((server.peers ?? []).filter(p => p.online && p.enabled).length);
+	let natMode = $derived<NatMode>(resolveNatMode(server.natMode, server.natEnabled));
+
+	const natModeOptions: DropdownOption<NatMode>[] = [
+		{ value: 'full', label: 'Полный NAT' },
+		{ value: 'internet-only', label: 'NAT только для интернета' },
+		{ value: 'none', label: 'Без NAT' },
+	];
+
+	let serverName = $derived(server.description || server.id);
+	let isUp = $derived(server.status === 'up' || server.connected);
+	let onlineCount = $derived(countActiveSystemPeers(server.peers));
 	let totalPeers = $derived((server.peers ?? []).length);
 	let totalRx = $derived((server.peers ?? []).reduce((sum, p) => sum + p.rxBytes, 0));
 	let totalTx = $derived((server.peers ?? []).reduce((sum, p) => sum + p.txBytes, 0));
-	let serverName = $derived(server.description || server.id);
-	let isUp = $derived(server.status === 'up' || server.connected);
 
-	let restartingServer = $state(false);
+	function peerTunnelIP(p: WireguardServerPeer): string {
+		const raw = p.allowedIPs?.find((ip) => ip.includes('/32')) || p.allowedIPs?.[0] || '';
+		if (!raw) return '';
+		return raw.includes('/') ? raw : `${raw}/32`;
+	}
+
+	function toManagedPeer(p: WireguardServerPeer): ManagedPeer {
+		return {
+			publicKey: p.publicKey,
+			privateKey: '',
+			presharedKey: '',
+			description: p.description,
+			tunnelIP: peerTunnelIP(p),
+			enabled: p.enabled,
+		};
+	}
+
+	function getPeerStats(publicKey: string): ManagedPeerStats | undefined {
+		const p = (server.peers ?? []).find((peer) => peer.publicKey === publicKey);
+		if (!p) return undefined;
+		return {
+			publicKey: p.publicKey,
+			endpoint: p.endpoint || '-',
+			rxBytes: p.rxBytes,
+			txBytes: p.txBytes,
+			lastHandshake: p.lastHandshake,
+			online: p.online,
+		};
+	}
 
 	let sortedPeers = $derived.by(() => {
-		let peers: WireguardServerPeer[] = server.peers ?? [];
-
-		if (searchQuery && peers.length >= 5) {
+		let peers = server.peers ?? [];
+		if (searchQuery) {
 			const q = searchQuery.toLowerCase();
-			peers = peers.filter(p =>
-				(p.description || '').toLowerCase().includes(q) ||
-				peerIP(p).toLowerCase().includes(q)
+			peers = peers.filter(
+				(p) =>
+					(p.description || '').toLowerCase().includes(q) ||
+					peerTunnelIP(p).toLowerCase().includes(q)
 			);
 		}
-
 		const sortBy = $peerSort.sortBy;
-		if (sortBy === null) return peers;
-
-		const sorted = [...peers].sort((a, b) => {
-			return comparePeerFieldsDirected(
-				{
-					name: a.description || a.publicKey,
-					ip: peerIP(a),
-					endpoint: a.endpoint || '-',
-					rxBytes: a.rxBytes,
-					txBytes: a.txBytes,
-					online: a.online,
-					lastHandshake: a.lastHandshake || null,
-				},
-				{
-					name: b.description || b.publicKey,
-					ip: peerIP(b),
-					endpoint: b.endpoint || '-',
-					rxBytes: b.rxBytes,
-					txBytes: b.txBytes,
-					online: b.online,
-					lastHandshake: b.lastHandshake || null,
-				},
-				sortBy,
-				$peerSort.sortAsc,
-			);
-		});
-
-		return sorted;
+		if (sortBy === null) return peers.map(toManagedPeer);
+		return [...peers]
+			.sort((a, b) => {
+				const sa = getPeerStats(a.publicKey);
+				const sb = getPeerStats(b.publicKey);
+				return comparePeerFieldsDirected(
+					{
+						name: a.description || a.publicKey,
+						ip: peerTunnelIP(a),
+						endpoint: sa?.endpoint || '-',
+						rxBytes: sa?.rxBytes ?? null,
+						txBytes: sa?.txBytes ?? null,
+						online: sa?.online ?? null,
+						lastHandshake: sa?.lastHandshake ?? null,
+					},
+					{
+						name: b.description || b.publicKey,
+						ip: peerTunnelIP(b),
+						endpoint: sb?.endpoint || '-',
+						rxBytes: sb?.rxBytes ?? null,
+						txBytes: sb?.txBytes ?? null,
+						online: sb?.online ?? null,
+						lastHandshake: sb?.lastHandshake ?? null,
+					},
+					sortBy,
+					$peerSort.sortAsc
+				);
+			})
+			.map(toManagedPeer);
 	});
+
+	let managedPeerMap = $derived.by(() => {
+		const map = new Map<string, WireguardServerPeer>();
+		for (const p of server.peers ?? []) map.set(p.publicKey, p);
+		return map;
+	});
+
+	async function handleToggleEnabled() {
+		togglingEnabled = true;
+		try {
+			const fresh = await api.setWireguardServerEnabled(server.id, !isUp);
+			servers.applyMutationResponse(fresh);
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка переключения');
+		} finally {
+			togglingEnabled = false;
+		}
+	}
 
 	async function handleRestartOrStart() {
 		if (restartingServer) return;
 		restartingServer = true;
-
 		try {
 			await api.restartWireguardServer(server.id);
 			notifications.success(isUp ? 'Команда рестарта отправлена' : 'Команда запуска отправлена');
@@ -99,9 +183,98 @@
 		}
 	}
 
-	async function openConfModal(publicKey: string) {
+	async function handleToggleIngress() {
+		togglingIngress = true;
+		try {
+			await onToggleIngress(server.interfaceName, !ingressEnabled);
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка переключения egress в sing-box');
+		} finally {
+			togglingIngress = false;
+		}
+	}
+
+	async function handleSetNATMode(mode: NatMode) {
+		if (mode === natMode) return;
+		togglingNAT = true;
+		try {
+			const fresh = await api.setWireguardServerNATMode(server.id, mode);
+			servers.applyMutationResponse(fresh);
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка изменения NAT');
+		} finally {
+			togglingNAT = false;
+		}
+	}
+
+	async function handlePolicyChange(newPolicy: string) {
+		if (newPolicy === (server.policy ?? 'none')) return;
+		policyChanging = true;
+		try {
+			const fresh = await api.setWireguardServerPolicy(server.id, newPolicy);
+			servers.applyMutationResponse(fresh);
+			notifications.success('Политика обновлена');
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка изменения политики');
+		} finally {
+			policyChanging = false;
+		}
+	}
+
+	function isPeerToggling(publicKey: string): boolean {
+		return togglingPeerKeys.has(publicKey);
+	}
+
+	async function handleTogglePeer(peer: ManagedPeer) {
+		if (togglingPeerKeys.has(peer.publicKey)) return;
+		togglingPeerKeys = new Set(togglingPeerKeys).add(peer.publicKey);
+		try {
+			const fresh = await api.toggleSystemServerPeer(server.id, peer.publicKey, !peer.enabled);
+			servers.applyMutationResponse(fresh);
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка');
+		} finally {
+			const next = new Set(togglingPeerKeys);
+			next.delete(peer.publicKey);
+			togglingPeerKeys = next;
+		}
+	}
+
+	async function doDeletePeer(peer: ManagedPeer) {
+		try {
+			const fresh = await api.deleteSystemServerPeer(server.id, peer.publicKey);
+			servers.applyMutationResponse(fresh);
+			notifications.success('Клиент удалён');
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Ошибка удаления');
+			throw e;
+		}
+	}
+
+	function openEditPeer(peer: ManagedPeer) {
+		const raw = managedPeerMap.get(peer.publicKey);
+		if (!raw) return;
+		selectedPeer = raw;
+		editPeerOpen = true;
+	}
+
+	function openConf(peer: ManagedPeer) {
+		if (isMarked) {
+			void openConfGenerator(peer.publicKey);
+			return;
+		}
+		const raw = managedPeerMap.get(peer.publicKey);
+		if (!raw?.confAvailable) {
+			notifications.warning('Конфиг недоступен — клиент создан вне AWG Manager или через KeenDNS');
+			return;
+		}
+		confPubkey = peer.publicKey;
+		confPeerName = peer.description || 'peer';
+		confModalOpen = true;
+	}
+
+	async function openConfGenerator(publicKey: string) {
 		confPeerKey = publicKey;
-		loadingConfig = true;
 		try {
 			const [config, asc, ip] = await Promise.all([
 				api.getServerConfig(server.id),
@@ -111,96 +284,180 @@
 			serverConfig = config;
 			ascParams = asc;
 			wanIP = ip;
-			confModalOpen = true;
-		} catch (e) {
+			confGeneratorOpen = true;
+		} catch {
 			notifications.error('Не удалось загрузить конфигурацию');
-		} finally {
-			loadingConfig = false;
 		}
 	}
 
-	let confPeer = $derived(
-		serverConfig?.peers.find(p => p.publicKey === confPeerKey) ?? null
+	let confGeneratorPeer = $derived(
+		serverConfig?.peers.find((p) => p.publicKey === confPeerKey) ?? null
+	);
+
+	let keenDnsHref = $derived(
+		server.keenDnsDomain ? `https://${server.keenDnsDomain}` : ''
 	);
 </script>
 
-<div class="card server-card" class:status-up={isUp} class:status-down={!isUp}>
-	<!-- Header -->
-	<div class="server-header">
-		<div class="server-info">
-			<div class="flex items-center gap-2">
-				<h3 class="server-name">{server.description || server.id}</h3>
-				{#if isBuiltIn}
-					<span class="badge badge-builtin">Встроенный</span>
-				{/if}
+<div class="card server-detail-card server-card" class:status-up={isUp}>
+	<div class="card-header">
+		<div class="header-info">
+			<div class="title-row">
+				<div class="title-main">
+					<Toggle
+						checked={isUp}
+						onchange={handleToggleEnabled}
+						disabled={togglingEnabled || restartingServer}
+						loading={togglingEnabled}
+						label="Сервер включён"
+						size="sm"
+					/>
+					<h3 class="card-title">{serverName}</h3>
+				</div>
+				<div class="title-badges">
+					{#if isBuiltIn}
+						<span class="badge badge-builtin">Встроенный</span>
+					{:else if isMarked}
+						<span class="badge badge-system">Системный</span>
+					{/if}
+				</div>
 			</div>
 			<div class="server-meta">
-				<span class="meta-item mono">{server.interfaceName}</span>
-				<span class="meta-item mono">{server.address}/{server.mask === '255.255.255.0' ? '24' : server.mask}</span>
-				<span class="meta-item mono">:{server.listenPort}</span>
+				<span class="meta mono">{server.interfaceName}</span>
+				<span class="meta mono">{server.address}/{maskToPrefix(server.mask)}</span>
+				<span class="meta mono">:{server.listenPort}</span>
+				{#if server.mtu}
+					<span class="meta mono">MTU {server.mtu}</span>
+				{/if}
+				{#if isBuiltIn && (totalRx > 0 || totalTx > 0)}
+					<span class="meta mono">↓{formatBytes(totalRx)} ↑{formatBytes(totalTx)}</span>
+				{/if}
 			</div>
+			{#if server.keenDnsDomain}
+				<div class="keendns-row">
+					<a class="keendns-link" href={keenDnsHref} target="_blank" rel="noopener noreferrer">
+						<ExternalLink size={13} strokeWidth={2} aria-hidden="true" />
+						<span>{server.keenDnsDomain}</span>
+					</a>
+				</div>
+			{/if}
 		</div>
-		<div class="server-header-right">
-			<div class="server-status">
-				<span class="led" class:led-up={isUp} class:led-down={!isUp}></span>
-				<span class="peer-count">{onlineCount}/{totalPeers}</span>
-			</div>
-
-			<div class="server-header-actions">
-				<IconButton
-					ariaLabel={isUp
-						? `Перезапустить сервер ${serverName}`
-						: `Запустить сервер ${serverName}`}
-					title={isUp
-						? `Перезапустить сервер «${serverName}»`
-						: `Запустить сервер «${serverName}»`}
+		<div class="header-right">
+			<div class="header-actions">
+				<Button
+					variant="secondary"
+					size="sm"
 					onclick={handleRestartOrStart}
-					disabled={restartingServer}
+					disabled={restartingServer || togglingEnabled}
+					loading={restartingServer}
+					iconBefore={restartIcon}
 				>
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M21 12a9 9 0 1 1-2.64-6.36" />
-						<path d="M21 3v6h-6" />
-					</svg>
-				</IconButton>
+					{isUp ? 'Рестарт' : 'Запуск'}
+				</Button>
 			</div>
 		</div>
 	</div>
 
-	<!-- Stats -->
-	<div class="server-stats">
-		<div class="stat">
-			<span class="stat-label">RX</span>
-			<span class="stat-value">{formatBytes(totalRx)}</span>
-		</div>
-		<div class="stat">
-			<span class="stat-label">TX</span>
-			<span class="stat-value">{formatBytes(totalTx)}</span>
-		</div>
-		<div class="stat">
-			<span class="stat-label">Пиры</span>
-			<span class="stat-value">{onlineCount} онлайн</span>
-		</div>
-	</div>
-
-	<!-- Peer table -->
-	{#if (server.peers ?? []).length > 0}
-		<div class="peers-section">
-			<div class="peers-header">
-				<span class="peers-title">Клиенты ({onlineCount}/{totalPeers} онлайн)</span>
-				<PeerSortControls
-					bind:searchQuery
-					showSearch={(server.peers ?? []).length >= 5}
-					hideSortOnDesktop
+	{#if isMarked}
+		<div class="kpi-rows">
+			<StatStrip>
+				<Stat value={formatBytes(totalRx)} label="принято" sub="суммарно по клиентам" />
+				<Stat value={formatBytes(totalTx)} label="отправлено" sub="суммарно по клиентам" />
+				<Stat
+					value={`${onlineCount}/${totalPeers}`}
+					label="Клиенты"
+					sub={onlineCount > 0 ? `${onlineCount} онлайн` : 'нет активных'}
 				/>
+				
+			</StatStrip>
+		</div>
+	{/if}
+
+	{#if isBuiltIn}
+		<div class="server-settings">
+			<div class="setting-row">
+				<div class="setting-copy">
+					<span class="setting-title">NAT</span>
+					{#if natMode === 'full'}
+						<span class="setting-description">Для доступа клиентов в интернет через NAT роутера.</span>
+					{:else if natMode === 'internet-only'}
+						<span class="setting-description">NAT только для интернет-трафика; в LAN клиент виден со своим VPN-адресом.</span>
+					{:else}
+						<span class="setting-description">Без NAT — клиенты не выходят в интернет напрямую.</span>
+					{/if}
+					{#if ingressEnabled && natMode === 'full'}
+						<span class="setting-description setting-description-warning">Интернет-трафик идёт через sing-box - NAT влияет только на видимость в LAN.</span>
+					{/if}
+				</div>
+				<div class="setting-control">
+					<Dropdown
+						value={natMode}
+						options={natModeOptions}
+						disabled={togglingNAT}
+						onchange={handleSetNATMode}
+						fullWidth
+					/>
+				</div>
 			</div>
-			<PeerTable
-				peers={sortedPeers}
-				onDownloadConf={isBuiltIn ? undefined : openConfModal}
+
+			<div class="setting-row setting-row-toggle">
+				<div class="setting-copy">
+					<span class="setting-title">Маршрутизация через sing-box</span>
+					<span class="setting-description">Заворачивать интернет-трафик клиентов данного сервера в sing-box.</span>
+				</div>
+				<div class="setting-control setting-control-toggle">
+					<Toggle
+						checked={ingressEnabled}
+						onchange={handleToggleIngress}
+						disabled={togglingIngress}
+						spinner="before"
+					/>
+				</div>
+			</div>
+
+			<ServerAccessPolicyDropdown
+				policy={server.policy ?? 'none'}
+				disabled={policyChanging}
+				onchange={handlePolicyChange}
 			/>
 		</div>
 	{/if}
 
-	<!-- Actions -->
+	<div class="peers-section">
+		<div class="peers-header">
+			<span class="peers-title">Клиенты ({onlineCount}/{totalPeers} онлайн)</span>
+			<div class="peers-controls">
+				<PeerSortControls
+					bind:searchQuery
+					showSearch={(server.peers ?? []).length > 0}
+					hideSortOnDesktop
+				/>
+				{#if isBuiltIn}
+					<Button variant="secondary" size="sm" onclick={() => (addPeerOpen = true)} iconBefore={addPeerIcon}>
+						Добавить клиента
+					</Button>
+				{/if}
+			</div>
+		</div>
+
+		{#if (server.peers ?? []).length === 0}
+			<div class="empty-peers">Нет клиентов. Добавьте первого.</div>
+		{:else}
+			<ManagedPeerTable
+				peers={sortedPeers}
+				{getPeerStats}
+				showPeerDownload={isBuiltIn || isMarked}
+				showPeerActions={isBuiltIn}
+				showPeerToggle={isBuiltIn}
+				onTogglePeer={handleTogglePeer}
+				{isPeerToggling}
+				onOpenConf={openConf}
+				onOpenEditPeer={openEditPeer}
+				onDeletePeer={doDeletePeer}
+			/>
+		{/if}
+	</div>
+
 	{#if !isBuiltIn && onUnmark}
 		<div class="server-actions">
 			<Button variant="ghost" size="sm" onclick={() => onUnmark?.(server.id)} {iconBefore}>
@@ -208,81 +465,70 @@
 			</Button>
 		</div>
 	{/if}
-
-	{#snippet iconBefore()}
-		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-			<polyline points="15,3 21,3 21,9"/>
-			<polyline points="9,21 3,21 3,15"/>
-			<line x1="21" y1="3" x2="14" y2="10"/>
-			<line x1="3" y1="21" x2="10" y2="14"/>
-		</svg>
-	{/snippet}
-
 </div>
 
-{#if confModalOpen && serverConfig && confPeer}
-	<ConfGeneratorModal
-		bind:open={confModalOpen}
-		{serverConfig}
-		peer={confPeer}
-		{ascParams}
-		{wanIP}
-		onclose={() => { confModalOpen = false; }}
+<AddSystemPeerModal
+	bind:open={addPeerOpen}
+	serverId={server.id}
+	{server}
+	onclose={() => (addPeerOpen = false)}
+	onAdded={() => servers.invalidate()}
+/>
+
+{#if selectedPeer}
+	<EditSystemPeerModal
+		bind:open={editPeerOpen}
+		serverId={server.id}
+		peer={selectedPeer}
+		onclose={() => { editPeerOpen = false; selectedPeer = null; }}
+		onUpdated={() => servers.invalidate()}
 	/>
 {/if}
 
+<PeerConfModal
+	bind:open={confModalOpen}
+	serverId={server.id}
+	pubkey={confPubkey}
+	peerName={confPeerName}
+	kind="system"
+	onclose={() => (confModalOpen = false)}
+/>
+
+{#if confGeneratorOpen && serverConfig && confGeneratorPeer}
+	<ConfGeneratorModal
+		bind:open={confGeneratorOpen}
+		{serverConfig}
+		peer={confGeneratorPeer}
+		{ascParams}
+		{wanIP}
+		onclose={() => {
+			confGeneratorOpen = false;
+		}}
+	/>
+{/if}
+
+{#snippet iconBefore()}
+	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+		<polyline points="15,3 21,3 21,9"/>
+		<polyline points="9,21 3,21 3,15"/>
+		<line x1="21" y1="3" x2="14" y2="10"/>
+		<line x1="3" y1="21" x2="10" y2="14"/>
+	</svg>
+{/snippet}
+
+{#snippet addPeerIcon()}
+	<Plus size={14} strokeWidth={2} aria-hidden="true" />
+{/snippet}
+
+{#snippet restartIcon()}
+	<RefreshCw size={14} strokeWidth={2} aria-hidden="true" />
+{/snippet}
+
 <style>
+	@import './serverCardShared.css';
+
 	.server-card {
-		display: flex;
-		flex-direction: column;
-		gap: 0.625rem;
 		transition: border-color 0.2s;
-	}
-
-	.status-up {
-		border-color: var(--success);
-	}
-
-	.status-down {
-		border-color: var(--text-muted, #6b7280);
-	}
-
-	.server-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
-		gap: 1rem;
-	}
-
-	.server-info {
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		min-width: 0;
-	}
-
-	.server-name {
-		font-size: 1.125rem;
-		font-weight: 600;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.server-meta {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.meta-item {
-		font-size: 0.75rem;
-		color: var(--text-muted);
-	}
-
-	.mono {
-		font-family: var(--font-mono, monospace);
 	}
 
 	.badge {
@@ -299,80 +545,32 @@
 		color: var(--accent);
 	}
 
-	.server-header-right {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex-shrink: 0;
-	}
-
-	.server-header-actions {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.server-status {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		flex-shrink: 0;
-	}
-
-	.led {
-		width: 8px;
-		height: 8px;
-		border-radius: 50%;
-		transition: background 0.3s ease, box-shadow 0.3s ease;
-	}
-
-	.led-up {
-		background: var(--success, #10b981);
-		box-shadow: 0 0 6px var(--success, #10b981);
-	}
-
-	.led-down {
-		background: var(--text-muted, #6b7280);
-	}
-
-	.peer-count {
-		font-size: 0.875rem;
-		font-weight: 500;
-		font-variant-numeric: tabular-nums;
+	.badge-system {
+		background: rgba(107, 114, 128, 0.15);
 		color: var(--text-secondary);
 	}
 
-	.server-stats {
-		display: grid;
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-		gap: 0.5rem;
-		padding: 0.625rem 0;
-		border-top: 1px dashed var(--border);
-		border-bottom: 1px solid var(--border);
+	.keendns-row {
+		margin-top: 0.125rem;
 	}
 
-	.stat {
-		min-width: 0;
+	.keendns-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 0.8125rem;
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.keendns-link:hover {
+		text-decoration: underline;
+	}
+
+	.kpi-rows {
 		display: flex;
 		flex-direction: column;
-		gap: 0.125rem;
-		padding: 0.5rem;
-		border: 1px solid var(--border);
-		border-radius: var(--radius-sm);
-		background: var(--bg-primary);
-	}
-
-	.stat-label {
-		font-size: 0.6875rem;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--text-muted);
-	}
-
-	.stat-value {
-		font-size: 0.8125rem;
-		font-family: var(--font-mono, monospace);
-		color: var(--text-secondary);
+		gap: 0.625rem;
 	}
 
 	.server-actions {
@@ -380,44 +578,19 @@
 		gap: 0.5rem;
 	}
 
-	.peers-section {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.peers-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.peers-title {
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: var(--text-secondary);
-	}
-
 	@media (max-width: 640px) {
-		.server-header {
-			flex-direction: column;
-		}
-
-		.server-header-right {
+		.header-actions {
+			align-self: stretch;
+			display: grid;
+			grid-template-columns: 1fr;
+			gap: 0.5rem;
 			width: 100%;
-			justify-content: space-between;
 		}
 
-		.peers-header {
-			flex-direction: column;
-			align-items: stretch;
-		}
-
-		.peers-header :global(.peer-sort-controls) {
+		.header-actions :global(.btn) {
 			width: 100%;
+			min-width: 0;
+			justify-content: center;
 		}
 	}
-
 </style>

--- a/frontend/src/lib/components/servers/index.ts
+++ b/frontend/src/lib/components/servers/index.ts
@@ -10,9 +10,12 @@ export { default as CreateManagedServerModal } from './CreateManagedServerModal.
 export { default as EditManagedServerModal } from './EditManagedServerModal.svelte';
 export { default as AddManagedPeerModal } from './AddManagedPeerModal.svelte';
 export { default as EditManagedPeerModal } from './EditManagedPeerModal.svelte';
+export { default as AddSystemPeerModal } from './AddSystemPeerModal.svelte';
+export { default as EditSystemPeerModal } from './EditSystemPeerModal.svelte';
 export { default as PeerConfModal } from './PeerConfModal.svelte';
 export { default as ServerRail } from './ServerRail.svelte';
 export type { RailItem } from './ServerRail.svelte';
 export { default as ManagedServerBackupToolbar } from './ManagedServerBackupToolbar.svelte';
 export { default as ManagedServerImportModal } from './ManagedServerImportModal.svelte';
 export { default as ManagedServerDriftBanner } from './ManagedServerDriftBanner.svelte';
+export { default as ServerAccessPolicyDropdown } from './ServerAccessPolicyDropdown.svelte';

--- a/frontend/src/lib/components/servers/serverCardShared.css
+++ b/frontend/src/lib/components/servers/serverCardShared.css
@@ -1,0 +1,290 @@
+/* Shared layout/styles for ServerCard and ManagedServerCard. Import from both cards. */
+
+.server-detail-card {
+	display: flex;
+	flex-direction: column;
+	--managed-section-gap: 0.625rem;
+	gap: var(--managed-section-gap);
+}
+
+.server-detail-card.status-up {
+	border-color: var(--success);
+}
+
+.server-detail-card .card-header {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: 1rem;
+	margin-bottom: 0;
+	padding-bottom: 0;
+	border-bottom: none;
+}
+
+.server-detail-card .header-info {
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+	flex: 1 1 265px;
+	min-width: 265px;
+	max-width: 100%;
+}
+
+.server-detail-card .title-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	column-gap: 0.5rem;
+	row-gap: 0.375rem;
+	min-width: 0;
+}
+
+.server-detail-card .title-main {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	min-width: 0;
+	flex: 0 1 auto;
+	max-width: 100%;
+}
+
+.server-detail-card .title-main :global(.toggle-container) {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	align-self: center;
+}
+
+.server-detail-card .title-badges {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.375rem;
+}
+
+.server-detail-card .card-title {
+	font-size: 1.125rem;
+	font-weight: 600;
+	min-width: 0;
+}
+
+.server-detail-card .server-meta {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+}
+
+.server-detail-card .meta {
+	font-size: 0.75rem;
+	color: var(--text-muted);
+}
+
+.server-detail-card .mono {
+	font-family: var(--font-mono, monospace);
+}
+
+.server-detail-card .header-right {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	flex: 0 0 auto;
+	margin-left: auto;
+}
+
+.server-detail-card .header-actions {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.25rem;
+	flex: 0 0 auto;
+}
+
+.server-detail-card .server-settings {
+	background: var(--color-bg-tertiary);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	padding: 0 0.875rem;
+	margin-top: 0.5rem;
+	min-width: 0;
+}
+
+.server-detail-card .server-settings .setting-row:first-child {
+	padding-top: 0.875rem;
+}
+
+.server-detail-card .server-settings .setting-row:last-child {
+	padding-bottom: 0.875rem;
+}
+
+.server-detail-card .setting-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+}
+
+.server-detail-card .setting-title {
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--text-primary);
+}
+
+.server-detail-card .setting-description-warning {
+	color: var(--warning, #f59e0b);
+}
+
+.server-detail-card .setting-control {
+	width: 100%;
+	min-width: 0;
+	max-width: 280px;
+	justify-self: end;
+}
+
+.server-detail-card .setting-control :global(.dropdown),
+.server-detail-card .setting-control :global(.field),
+.server-detail-card .setting-control :global(.picker) {
+	width: 100%;
+	min-width: 0;
+}
+
+.server-detail-card .setting-control-toggle {
+	width: auto;
+	max-width: none;
+	justify-self: end;
+	align-self: center;
+}
+
+.server-detail-card .setting-row-toggle {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.server-detail-card .setting-row-toggle .setting-copy {
+	min-width: 0;
+}
+
+.server-detail-card .server-settings :global(.field .trigger) {
+	background: var(--color-settings-surface-bg);
+	border-color: var(--color-border);
+}
+
+.server-detail-card .server-settings :global(.field .trigger:hover:not(:disabled)) {
+	background: var(--color-bg-hover);
+}
+
+.server-detail-card .server-settings :global(.toggle-container .toggle-slider) {
+	background: var(--color-settings-surface-bg);
+}
+
+.server-detail-card .server-settings :global(.toggle-container:hover input:not(:checked) ~ .toggle-slider) {
+	background: var(--color-bg-hover);
+}
+
+@media (min-width: 641px) {
+	.server-detail-card .server-settings .setting-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(12rem, 280px);
+		align-items: start;
+		gap: 0.75rem;
+	}
+
+	.server-detail-card .server-settings .setting-row-toggle {
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+	}
+
+	.server-detail-card .setting-control {
+		max-width: none;
+	}
+}
+
+.server-detail-card .peers-section {
+	--peers-divider-gap: 1rem;
+	border-top: 1px solid var(--border);
+	padding-top: var(--peers-divider-gap);
+	margin-top: calc(var(--peers-divider-gap) - var(--managed-section-gap));
+}
+
+.server-detail-card .peers-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 0.75rem;
+}
+
+.server-detail-card .peers-controls {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+}
+
+.server-detail-card .peers-title {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--text-secondary);
+}
+
+.server-detail-card .empty-peers {
+	padding: 1.5rem;
+	text-align: center;
+	font-size: 0.8125rem;
+	color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+	.server-detail-card {
+		overflow: hidden;
+	}
+
+	.server-detail-card .card-header {
+		flex-direction: column;
+	}
+
+	.server-detail-card .header-info {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	.server-detail-card .header-right {
+		width: 100%;
+		margin-left: 0;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
+	}
+
+	.server-detail-card .setting-control {
+		max-width: none;
+	}
+
+	.server-detail-card .peers-header {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
+	}
+
+	.server-detail-card .peers-controls {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		width: 100%;
+		gap: 0.4rem;
+	}
+
+	.server-detail-card .peers-controls :global(.btn) {
+		grid-column: 2;
+		grid-row: 1;
+		width: 100%;
+		min-width: 0;
+	}
+
+	.server-detail-card .peers-controls:not(:has(:global(.btn))) :global(.peer-search) {
+		grid-column: 1 / -1;
+	}
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -320,6 +320,14 @@ export interface WireguardServer {
 	policy?: string;
 	keenDnsDomain?: string;
 	builtIn?: boolean;
+	/**
+	 * False when the backend failed to read NAT mode / policy from NDMS
+	 * (e.g. transient router error). When false, natMode/policy are NOT
+	 * trustworthy and the UI must show an "unknown" state rather than the
+	 * zero-valued 'none'. Absent (legacy/managed) is treated as known.
+	 */
+	natModeKnown?: boolean;
+	policyKnown?: boolean;
 }
 
 export interface WireguardServerPeer {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -315,6 +315,11 @@ export interface WireguardServer {
 	publicKey: string;
 	listenPort: number;
 	peers: WireguardServerPeer[];
+	natEnabled?: boolean;
+	natMode?: 'full' | 'internet-only' | 'none';
+	policy?: string;
+	keenDnsDomain?: string;
+	builtIn?: boolean;
 }
 
 export interface WireguardServerPeer {
@@ -327,6 +332,7 @@ export interface WireguardServerPeer {
 	lastHandshake: string;
 	online: boolean;
 	enabled: boolean;
+	confAvailable?: boolean;
 }
 
 export interface WireguardServerConfig {

--- a/frontend/src/lib/utils/ingressMutation.test.ts
+++ b/frontend/src/lib/utils/ingressMutation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createIngressMutationLock } from './ingressMutation';
+
+describe('createIngressMutationLock', () => {
+	it('runs mutations sequentially', async () => {
+		const withLock = createIngressMutationLock();
+		const order: number[] = [];
+
+		const first = withLock(async () => {
+			order.push(1);
+			await new Promise((r) => setTimeout(r, 20));
+			order.push(2);
+		});
+
+		const second = withLock(async () => {
+			order.push(3);
+		});
+
+		await Promise.all([first, second]);
+		expect(order).toEqual([1, 2, 3]);
+	});
+
+	it('continues chain after failure', async () => {
+		const withLock = createIngressMutationLock();
+
+		await expect(
+			withLock(async () => {
+				throw new Error('fail');
+			}),
+		).rejects.toThrow('fail');
+
+		await expect(withLock(async () => 'ok')).resolves.toBe('ok');
+	});
+});

--- a/frontend/src/lib/utils/ingressMutation.ts
+++ b/frontend/src/lib/utils/ingressMutation.ts
@@ -1,0 +1,13 @@
+/** Serializes async read-modify-write ingress settings updates to prevent lost writes. */
+export function createIngressMutationLock() {
+	let chain: Promise<unknown> = Promise.resolve();
+
+	return function withIngressLock<T>(fn: () => Promise<T>): Promise<T> {
+		const run = chain.then(fn, fn);
+		chain = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	};
+}

--- a/frontend/src/lib/utils/network.test.ts
+++ b/frontend/src/lib/utils/network.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatSubnetPlaceholder, maskToPrefix, resolveNatMode } from './network';
+
+describe('resolveNatMode', () => {
+	it('prefers explicit natMode', () => {
+		expect(resolveNatMode('internet-only', true)).toBe('internet-only');
+		expect(resolveNatMode('none', true)).toBe('none');
+	});
+
+	it('falls back to natEnabled when natMode absent', () => {
+		expect(resolveNatMode(undefined, true)).toBe('full');
+		expect(resolveNatMode(undefined, false)).toBe('none');
+	});
+
+	it('does not treat false natEnabled as missing', () => {
+		expect(resolveNatMode('internet-only', false)).toBe('internet-only');
+	});
+});
+
+describe('maskToPrefix', () => {
+	it('passes numeric prefix through', () => {
+		expect(maskToPrefix('24')).toBe('24');
+	});
+
+	it('converts dotted mask', () => {
+		expect(maskToPrefix('255.255.255.0')).toBe('24');
+	});
+});
+
+describe('formatSubnetPlaceholder', () => {
+	it('masks host bits in /24', () => {
+		expect(formatSubnetPlaceholder('10.0.0.1', '255.255.255.0')).toBe('10.0.0.X/24');
+	});
+});

--- a/frontend/src/lib/utils/network.ts
+++ b/frontend/src/lib/utils/network.ts
@@ -1,0 +1,33 @@
+export type NatMode = 'full' | 'internet-only' | 'none';
+
+/** Resolve tri-state NAT from API fields (natMode wins over legacy natEnabled). */
+export function resolveNatMode(natMode?: NatMode, natEnabled?: boolean): NatMode {
+	if (natMode === 'full' || natMode === 'internet-only' || natMode === 'none') {
+		return natMode;
+	}
+	return natEnabled ? 'full' : 'none';
+}
+
+export function maskToPrefix(mask: string): string {
+	if (/^\d+$/.test(mask)) return mask;
+	const parts = mask.split('.').map(Number);
+	let bits = 0;
+	for (const p of parts) bits += (p >>> 0).toString(2).split('1').length - 1;
+	return String(bits);
+}
+
+/** Subnet like 10.0.0.X/24 — host octets replaced with X per mask. */
+export function formatSubnetPlaceholder(address: string, mask: string): string {
+	const prefix = Number(maskToPrefix(mask));
+	const octets = address.split('.').map((p) => parseInt(p, 10));
+	if (octets.length !== 4 || octets.some((n) => Number.isNaN(n)) || Number.isNaN(prefix)) {
+		return `${address}/${maskToPrefix(mask)}`;
+	}
+	const parts = octets.map((value, i) => {
+		const bitsBefore = i * 8;
+		if (prefix <= bitsBefore) return 'X';
+		if (prefix >= bitsBefore + 8) return String(value);
+		return 'X';
+	});
+	return `${parts.join('.')}/${prefix}`;
+}

--- a/frontend/src/lib/utils/serverPeerActivity.test.ts
+++ b/frontend/src/lib/utils/serverPeerActivity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+	countActiveManagedPeers,
+	countActiveSystemPeers,
+	isSystemPeerActive,
+} from './serverPeerActivity';
+
+describe('isSystemPeerActive', () => {
+	it('requires online and enabled', () => {
+		expect(isSystemPeerActive({ online: true, enabled: true } as never)).toBe(true);
+		expect(isSystemPeerActive({ online: true, enabled: false } as never)).toBe(false);
+		expect(isSystemPeerActive({ online: false, enabled: true } as never)).toBe(false);
+	});
+});
+
+describe('countActiveSystemPeers', () => {
+	it('counts only active peers', () => {
+		const peers = [
+			{ online: true, enabled: true },
+			{ online: true, enabled: false },
+			{ online: false, enabled: true },
+		] as never[];
+		expect(countActiveSystemPeers(peers)).toBe(1);
+	});
+});
+
+describe('countActiveManagedPeers', () => {
+	it('joins stats online with config enabled', () => {
+		const peers = [
+			{ publicKey: 'a', enabled: true },
+			{ publicKey: 'b', enabled: false },
+		] as never[];
+		const statsPeers = [
+			{ publicKey: 'a', online: true },
+			{ publicKey: 'b', online: true },
+		] as never[];
+		expect(countActiveManagedPeers(peers, statsPeers)).toBe(1);
+	});
+
+	it('returns 0 without stats', () => {
+		expect(countActiveManagedPeers([{ publicKey: 'a', enabled: true }] as never[], undefined)).toBe(
+			0,
+		);
+	});
+});

--- a/frontend/src/lib/utils/serverPeerActivity.ts
+++ b/frontend/src/lib/utils/serverPeerActivity.ts
@@ -1,0 +1,21 @@
+import type { ManagedPeer, ManagedPeerStats, WireguardServerPeer } from '$lib/types';
+
+/** Active = online and not administratively disabled. */
+export function isSystemPeerActive(peer: WireguardServerPeer): boolean {
+	return peer.online && peer.enabled;
+}
+
+export function countActiveSystemPeers(peers: WireguardServerPeer[] | undefined): number {
+	return (peers ?? []).filter(isSystemPeerActive).length;
+}
+
+/** Uses stats for online signal and peer config for enabled flag. */
+export function countActiveManagedPeers(
+	peers: ManagedPeer[] | undefined,
+	statsPeers: ManagedPeerStats[] | undefined,
+): number {
+	const config = peers ?? [];
+	if (!statsPeers?.length) return 0;
+	const enabledByKey = new Map(config.map((p) => [p.publicKey, p.enabled]));
+	return statsPeers.filter((p) => p.online && enabledByKey.get(p.publicKey) !== false).length;
+}

--- a/frontend/src/routes/servers/+page.svelte
+++ b/frontend/src/routes/servers/+page.svelte
@@ -20,6 +20,10 @@
 		type RailItem,
 	} from '$lib/components/servers';
 	import { dedupBy } from '$lib/utils/dedupBy';
+	import { createIngressMutationLock } from '$lib/utils/ingressMutation';
+	import { countActiveManagedPeers, countActiveSystemPeers } from '$lib/utils/serverPeerActivity';
+
+	const withIngressLock = createIngressMutationLock();
 
 	let unsub: (() => void) | undefined;
 	onMount(() => {
@@ -58,14 +62,30 @@
 		}
 	}
 
-	async function handleToggleIngress(interfaceName: string, enabled: boolean) {
-		const s = await api.singboxRouterGetSettings();
-		const set = new Set(s.ingressInterfaces ?? []);
-		const ref = `managed:${interfaceName}`;
-		if (enabled) set.add(ref); else set.delete(ref);
-		const next = [...set];
-		await api.singboxRouterPutSettings({ ...s, ingressInterfaces: next });
-		ingressRefs = next;
+	async function handleToggleManagedIngress(interfaceName: string, enabled: boolean) {
+		await withIngressLock(async () => {
+			const s = await api.singboxRouterGetSettings();
+			const set = new Set(s.ingressInterfaces ?? []);
+			const ref = `managed:${interfaceName}`;
+			if (enabled) set.add(ref);
+			else set.delete(ref);
+			const next = [...set];
+			await api.singboxRouterPutSettings({ ...s, ingressInterfaces: next });
+			ingressRefs = next;
+		});
+	}
+
+	async function handleToggleSystemIngress(interfaceName: string, enabled: boolean) {
+		await withIngressLock(async () => {
+			const s = await api.singboxRouterGetSettings();
+			const set = new Set(s.ingressInterfaces ?? []);
+			const ref = `iface:${interfaceName}`;
+			if (enabled) set.add(ref);
+			else set.delete(ref);
+			const next = [...set];
+			await api.singboxRouterPutSettings({ ...s, ingressInterfaces: next });
+			ingressRefs = next;
+		});
 	}
 
 	// ─── Rail item ids for managed servers ─────────────────────────
@@ -119,7 +139,7 @@
 				// hooks emit. Comparing against "running" never matched and
 				// flagged the rail item as stopped even on healthy servers.
 				status: stats?.status === 'up' ? 'running' : 'stopped',
-				peerActive: statsPeers.filter((p) => p.online).length,
+				peerActive: countActiveManagedPeers(mPeers, statsPeers),
 				peerCount: mPeers.length,
 				kind: 'managed',
 			});
@@ -133,7 +153,7 @@
 				listenPort: s.listenPort,
 				status: s.status === 'up' ? 'running' : 'stopped',
 				peerCount: sPeers.length,
-				peerActive: sPeers.filter((p) => p.rxBytes > 0 || p.txBytes > 0).length,
+				peerActive: countActiveSystemPeers(sPeers),
 				kind: 'system',
 			});
 		}
@@ -196,6 +216,20 @@
 	let activeServer = $derived(
 		activeItem?.kind === 'system' ? serverList.find((s) => s.id === activeId) : null,
 	);
+
+	let markedServerIds = $state<string[]>([]);
+
+	async function loadMarkedServers() {
+		try {
+			markedServerIds = await api.getMarkedServerInterfaces();
+		} catch {
+			markedServerIds = [];
+		}
+	}
+
+	$effect(() => {
+		if (snap.data) void loadMarkedServers();
+	});
 
 	async function unmarkServer(id: string) {
 		try {
@@ -272,14 +306,16 @@
 						{routerIP}
 						onOpenASC={() => openManagedASC(activeManaged!.interfaceName)}
 						ingressEnabled={ingressRefs.includes(`managed:${activeManaged.interfaceName}`)}
-						onToggleIngress={handleToggleIngress}
+						onToggleIngress={handleToggleManagedIngress}
 						{lanSegmentOptions}
 					/>
 				{:else if activeItem?.kind === 'system' && activeServer}
 				<ServerCard
 					server={activeServer}
-					isBuiltIn={activeServer.description === 'Wireguard VPN Server'}
+					isMarked={markedServerIds.includes(activeServer.id)}
 					onUnmark={unmarkServer}
+					ingressEnabled={ingressRefs.includes(`iface:${activeServer.interfaceName}`)}
+					onToggleIngress={handleToggleSystemIngress}
 				/>
 				{/if}
 			</main>

--- a/internal/api/server_peers.go
+++ b/internal/api/server_peers.go
@@ -124,6 +124,21 @@ func (h *ServersHandler) requireWGCommands(w http.ResponseWriter) bool {
 	return true
 }
 
+// AddServerPeer adds a peer to a built-in/marked WireGuard server.
+// POST /api/servers/{name}/peers
+//
+//	@Summary		Add server peer
+//	@Description	Generates a keypair and registers a new peer on the named WireGuard server. Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string						true	"Interface name (e.g. Wireguard0)"
+//	@Param			body	body		ServerAddPeerRequestDTO	true	"Peer description and tunnel IP"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/peers [post]
 func (h *ServersHandler) AddServerPeer(w http.ResponseWriter, r *http.Request, name string) {
 	req, ok := parseJSON[ServerAddPeerRequestDTO](w, r, http.MethodPost)
 	if !ok {
@@ -140,13 +155,9 @@ func (h *ServersHandler) AddServerPeer(w http.ResponseWriter, r *http.Request, n
 		response.Error(w, err.Error(), "INVALID_TUNNEL_IP")
 		return
 	}
-	for _, p := range server.Peers {
-		for _, allowed := range p.AllowedIPs {
-			if strings.HasPrefix(allowed, strings.TrimSuffix(req.TunnelIP, "/32")) {
-				response.Error(w, "tunnel IP already in use", "TUNNEL_IP_IN_USE")
-				return
-			}
-		}
+	if peerTunnelIPInUse(server, req.TunnelIP) {
+		response.Error(w, "tunnel IP already in use", "TUNNEL_IP_IN_USE")
+		return
 	}
 
 	privKey, pubKey, err := managed.GenerateKeyPair(r.Context())
@@ -165,10 +176,12 @@ func (h *ServersHandler) AddServerPeer(w http.ResponseWriter, r *http.Request, n
 		return
 	}
 
-	if err := h.commands.Wireguard.AddPeer(r.Context(), name, pubKey, psk, strings.TrimSpace(req.Description), ip.String(), true); err != nil {
-		response.Error(w, err.Error(), "ADD_PEER_FAILED")
-		return
-	}
+	// Persist the secret BEFORE the router add. If the order were reversed and
+	// the save failed, the peer would exist on the router with its private key
+	// lost forever — .conf could never be regenerated and the IP would stay
+	// occupied. A stranded secret (save ok, router add fails) is harmless: it
+	// is keyed by a pubkey that never reaches the router peer list, and we roll
+	// it back below anyway.
 	if err := h.settings.SetServerPeerSecret(name, pubKey, storage.ServerPeerSecret{
 		PrivateKey:   privKey,
 		PresharedKey: psk,
@@ -178,10 +191,32 @@ func (h *ServersHandler) AddServerPeer(w http.ResponseWriter, r *http.Request, n
 		response.Error(w, err.Error(), "SAVE_FAILED")
 		return
 	}
+	if err := h.commands.Wireguard.AddPeer(r.Context(), name, pubKey, psk, strings.TrimSpace(req.Description), ip.String(), true); err != nil {
+		_ = h.settings.DeleteServerPeerSecret(name, pubKey)
+		response.Error(w, err.Error(), "ADD_PEER_FAILED")
+		return
+	}
 	publishInvalidated(h.bus, ResourceServers, "server-peer-added")
 	h.writeAll(w, r)
 }
 
+// UpdateServerPeer updates a peer's tunnel IP and/or description.
+// PUT /api/servers/{name}/peers/{pubkey}
+//
+//	@Summary		Update server peer
+//	@Description	Changes a peer's allowed-IP and/or description on the named WireGuard server. Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string							true	"Interface name (e.g. Wireguard0)"
+//	@Param			pubkey	path		string							true	"Peer public key"
+//	@Param			body	body		ServerUpdatePeerRequestDTO	true	"New description and tunnel IP"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/peers/{pubkey} [put]
 func (h *ServersHandler) UpdateServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
 	req, ok := parseJSON[ServerUpdatePeerRequestDTO](w, r, http.MethodPut)
 	if !ok {
@@ -216,25 +251,53 @@ func (h *ServersHandler) UpdateServerPeer(w http.ResponseWriter, r *http.Request
 			response.Error(w, err.Error(), "UPDATE_PEER_FAILED")
 			return
 		}
-		if sec, ok := h.settings.GetServerPeerSecret(name, pubkey); ok {
-			sec.TunnelIP = req.TunnelIP
-			_ = h.settings.SetServerPeerSecret(name, pubkey, sec)
-		}
 	}
 	if req.Description != peer.Description {
 		if err := h.commands.Wireguard.SetPeerComment(r.Context(), name, pubkey, strings.TrimSpace(req.Description)); err != nil {
 			response.Error(w, err.Error(), "UPDATE_PEER_FAILED")
 			return
 		}
-		if sec, ok := h.settings.GetServerPeerSecret(name, pubkey); ok {
+	}
+	// Keep the stored secret (source of truth for .conf regen) in sync with
+	// the router change. Runs unconditionally so a retry after a prior save
+	// failure still reconciles even when the router side is now a no-op. The
+	// error is surfaced, not swallowed: a stale stored IP would hand out a
+	// wrong .conf after reboot.
+	if sec, ok := h.settings.GetServerPeerSecret(name, pubkey); ok {
+		changed := false
+		if req.TunnelIP != "" && sec.TunnelIP != req.TunnelIP {
+			sec.TunnelIP = req.TunnelIP
+			changed = true
+		}
+		if sec.Description != req.Description {
 			sec.Description = req.Description
-			_ = h.settings.SetServerPeerSecret(name, pubkey, sec)
+			changed = true
+		}
+		if changed {
+			if err := h.settings.SetServerPeerSecret(name, pubkey, sec); err != nil {
+				response.Error(w, err.Error(), "SAVE_FAILED")
+				return
+			}
 		}
 	}
 	publishInvalidated(h.bus, ResourceServers, "server-peer-updated")
 	h.writeAll(w, r)
 }
 
+// DeleteServerPeer removes a peer from a WireGuard server.
+// DELETE /api/servers/{name}/peers/{pubkey}
+//
+//	@Summary		Delete server peer
+//	@Description	Removes the peer with the given public key from the named WireGuard server. Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string	true	"Interface name (e.g. Wireguard0)"
+//	@Param			pubkey	path		string	true	"Peer public key"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/peers/{pubkey} [delete]
 func (h *ServersHandler) DeleteServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
 	if !h.requireWGCommands(w) {
 		return
@@ -256,6 +319,22 @@ func (h *ServersHandler) DeleteServerPeer(w http.ResponseWriter, r *http.Request
 	h.writeAll(w, r)
 }
 
+// ToggleServerPeer enables or disables a peer.
+// POST /api/servers/{name}/peers/{pubkey}/toggle
+//
+//	@Summary		Toggle server peer
+//	@Description	Enables or disables (connect on/off) the peer on the named WireGuard server. Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string					true	"Interface name (e.g. Wireguard0)"
+//	@Param			pubkey	path		string					true	"Peer public key"
+//	@Param			body	body		EnabledToggleRequest	true	"Enabled flag"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/peers/{pubkey}/toggle [post]
 func (h *ServersHandler) ToggleServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
 	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
 	if !ok {
@@ -280,6 +359,20 @@ func (h *ServersHandler) ToggleServerPeer(w http.ResponseWriter, r *http.Request
 	h.writeAll(w, r)
 }
 
+// ServerPeerConf returns the downloadable WireGuard .conf for a peer.
+// GET /api/servers/{name}/peers/{pubkey}/conf
+//
+//	@Summary		Get server peer config
+//	@Description	Generates the WireGuard client .conf for the peer. Only available when the peer's private key was created via AWG Manager and is stored locally.
+//	@Tags			servers
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string	true	"Interface name (e.g. Wireguard0)"
+//	@Param			pubkey	path		string	true	"Peer public key"
+//	@Success		200		{object}	map[string]string
+//	@Failure		404		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/peers/{pubkey}/conf [get]
 func (h *ServersHandler) ServerPeerConf(w http.ResponseWriter, r *http.Request, name, pubkey string) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -408,6 +501,24 @@ func peerTunnelHostIP(peer *ndms.WireguardServerPeer) string {
 	return ""
 }
 
+// peerTunnelIPInUse reports whether tunnelIP's host address is already
+// assigned to an existing peer. Compares parsed host IPs for equality —
+// a string prefix check (e.g. "10.0.0.2" vs "10.0.0.20") gives false
+// positives and must not be used here.
+func peerTunnelIPInUse(server *ndms.WireguardServer, tunnelIP string) bool {
+	host, _, err := net.ParseCIDR(tunnelIP)
+	if err != nil {
+		return false
+	}
+	for i := range server.Peers {
+		existing := peerTunnelHostIP(&server.Peers[i])
+		if existing != "" && net.ParseIP(existing).Equal(host) {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *ServersHandler) validateServerPeerTunnelIP(server *ndms.WireguardServer, tunnelIP string) error {
 	ip, ipNet, err := net.ParseCIDR(tunnelIP)
 	if err != nil {
@@ -450,9 +561,11 @@ func (h *ServersHandler) enrichServerDTO(ctx context.Context, srv ndms.Wireguard
 	if _, mode, err := h.readSystemServerNATMode(ctx, srv.ID); err == nil {
 		dto.NATEnabled = mode == "full"
 		dto.NATMode = mode
+		dto.NATModeKnown = true
 	}
 	if policy, err := h.readSystemServerPolicy(ctx, srv.ID); err == nil {
 		dto.Policy = policy
+		dto.PolicyKnown = true
 	}
 	if h.queries != nil && h.queries.KeenDNS != nil {
 		if info, err := h.queries.KeenDNS.Get(ctx); err == nil && info != nil {

--- a/internal/api/server_peers.go
+++ b/internal/api/server_peers.go
@@ -1,0 +1,502 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/managed"
+	"github.com/hoaxisr/awg-manager/internal/ndms"
+	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/testing"
+)
+
+// ServerAddPeerRequestDTO is the body for POST /servers/{name}/peers.
+type ServerAddPeerRequestDTO struct {
+	Description string `json:"description" example:"My Phone"`
+	TunnelIP    string `json:"tunnelIP" example:"10.0.14.2/32"`
+}
+
+// ServerUpdatePeerRequestDTO is the body for PUT /servers/{name}/peers/{pubkey}.
+type ServerUpdatePeerRequestDTO struct {
+	Description string `json:"description" example:"My Phone"`
+	TunnelIP    string `json:"tunnelIP" example:"10.0.14.2/32"`
+}
+
+// Subtree dispatches /api/servers/{name}/... operations.
+func (h *ServersHandler) Subtree(w http.ResponseWriter, r *http.Request) {
+	parts, ok := splitPath(r.URL.EscapedPath(), "/api/servers/")
+	if !ok || len(parts) < 2 {
+		response.Error(w, "unknown path", "UNKNOWN_PATH")
+		return
+	}
+	name := parts[0]
+	if !h.validateName(w, name) {
+		return
+	}
+	switch parts[1] {
+	case "nat":
+		if len(parts) != 2 {
+			response.Error(w, "unknown path", "UNKNOWN_PATH")
+			return
+		}
+		h.SetNAT(w, r, name)
+		return
+	case "policy":
+		if len(parts) != 2 {
+			response.Error(w, "unknown path", "UNKNOWN_PATH")
+			return
+		}
+		h.SetPolicy(w, r, name)
+		return
+	case "peers":
+	default:
+		response.Error(w, "unknown path", "UNKNOWN_PATH")
+		return
+	}
+	switch len(parts) {
+	case 2:
+		if r.Method != http.MethodPost {
+			response.MethodNotAllowed(w)
+			return
+		}
+		h.AddServerPeer(w, r, name)
+	case 3:
+		pubkey, err := url.PathUnescape(parts[2])
+		if err != nil || !validateWireguardPubkey(pubkey) {
+			response.Error(w, "invalid public key", "INVALID_PUBKEY")
+			return
+		}
+		switch r.Method {
+		case http.MethodPut:
+			h.UpdateServerPeer(w, r, name, pubkey)
+		case http.MethodDelete:
+			h.DeleteServerPeer(w, r, name, pubkey)
+		default:
+			response.MethodNotAllowed(w)
+		}
+	case 4:
+		pubkey, err := url.PathUnescape(parts[2])
+		if err != nil || !validateWireguardPubkey(pubkey) {
+			response.Error(w, "invalid public key", "INVALID_PUBKEY")
+			return
+		}
+		switch parts[3] {
+		case "toggle":
+			h.ToggleServerPeer(w, r, name, pubkey)
+		case "conf":
+			h.ServerPeerConf(w, r, name, pubkey)
+		default:
+			response.Error(w, "unknown path", "UNKNOWN_PATH")
+		}
+	default:
+		response.Error(w, "unknown path", "UNKNOWN_PATH")
+	}
+}
+
+func validateWireguardPubkey(pubkey string) bool {
+	return len(pubkey) == 44 && strings.HasSuffix(pubkey, "=")
+}
+
+func (h *ServersHandler) requireListedServer(ctx context.Context, w http.ResponseWriter, name string) (*ndms.WireguardServer, bool) {
+	server, err := h.getListedServer(ctx, name)
+	if err != nil {
+		response.Error(w, err.Error(), "GET_FAILED")
+		return nil, false
+	}
+	if server == nil {
+		response.Error(w, "server not found", "NOT_FOUND")
+		return nil, false
+	}
+	return server, true
+}
+
+func (h *ServersHandler) requireWGCommands(w http.ResponseWriter) bool {
+	if h.commands == nil || h.commands.Wireguard == nil {
+		response.Error(w, "ndms commands not initialized", "INTERNAL_ERROR")
+		return false
+	}
+	return true
+}
+
+func (h *ServersHandler) AddServerPeer(w http.ResponseWriter, r *http.Request, name string) {
+	req, ok := parseJSON[ServerAddPeerRequestDTO](w, r, http.MethodPost)
+	if !ok {
+		return
+	}
+	if !h.requireWGCommands(w) {
+		return
+	}
+	server, ok := h.requireListedServer(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	if err := h.validateServerPeerTunnelIP(server, req.TunnelIP); err != nil {
+		response.Error(w, err.Error(), "INVALID_TUNNEL_IP")
+		return
+	}
+	for _, p := range server.Peers {
+		for _, allowed := range p.AllowedIPs {
+			if strings.HasPrefix(allowed, strings.TrimSuffix(req.TunnelIP, "/32")) {
+				response.Error(w, "tunnel IP already in use", "TUNNEL_IP_IN_USE")
+				return
+			}
+		}
+	}
+
+	privKey, pubKey, err := managed.GenerateKeyPair(r.Context())
+	if err != nil {
+		response.Error(w, err.Error(), "KEYGEN_FAILED")
+		return
+	}
+	psk, err := managed.GeneratePresharedKey(r.Context())
+	if err != nil {
+		response.Error(w, err.Error(), "KEYGEN_FAILED")
+		return
+	}
+	ip, _, err := net.ParseCIDR(req.TunnelIP)
+	if err != nil {
+		response.Error(w, "invalid tunnel IP", "INVALID_TUNNEL_IP")
+		return
+	}
+
+	if err := h.commands.Wireguard.AddPeer(r.Context(), name, pubKey, psk, strings.TrimSpace(req.Description), ip.String(), true); err != nil {
+		response.Error(w, err.Error(), "ADD_PEER_FAILED")
+		return
+	}
+	if err := h.settings.SetServerPeerSecret(name, pubKey, storage.ServerPeerSecret{
+		PrivateKey:   privKey,
+		PresharedKey: psk,
+		Description:  req.Description,
+		TunnelIP:     req.TunnelIP,
+	}); err != nil {
+		response.Error(w, err.Error(), "SAVE_FAILED")
+		return
+	}
+	publishInvalidated(h.bus, ResourceServers, "server-peer-added")
+	h.writeAll(w, r)
+}
+
+func (h *ServersHandler) UpdateServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
+	req, ok := parseJSON[ServerUpdatePeerRequestDTO](w, r, http.MethodPut)
+	if !ok {
+		return
+	}
+	if !h.requireWGCommands(w) {
+		return
+	}
+	server, ok := h.requireListedServer(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	peer := findServerPeer(server, pubkey)
+	if peer == nil {
+		response.Error(w, "peer not found", "NOT_FOUND")
+		return
+	}
+
+	oldIP := peerTunnelHostIP(peer)
+	wantIPChange := req.TunnelIP != "" && req.TunnelIP != oldIP+"/32" && req.TunnelIP != oldIP
+	if wantIPChange {
+		if err := h.validateServerPeerTunnelIP(server, req.TunnelIP); err != nil {
+			response.Error(w, err.Error(), "INVALID_TUNNEL_IP")
+			return
+		}
+		newHost, _, _ := net.ParseCIDR(req.TunnelIP)
+		if newHost == nil {
+			response.Error(w, "invalid tunnel IP", "INVALID_TUNNEL_IP")
+			return
+		}
+		if err := h.commands.Wireguard.UpdatePeerAllowIPs(r.Context(), name, pubkey, oldIP, newHost.String()); err != nil {
+			response.Error(w, err.Error(), "UPDATE_PEER_FAILED")
+			return
+		}
+		if sec, ok := h.settings.GetServerPeerSecret(name, pubkey); ok {
+			sec.TunnelIP = req.TunnelIP
+			_ = h.settings.SetServerPeerSecret(name, pubkey, sec)
+		}
+	}
+	if req.Description != peer.Description {
+		if err := h.commands.Wireguard.SetPeerComment(r.Context(), name, pubkey, strings.TrimSpace(req.Description)); err != nil {
+			response.Error(w, err.Error(), "UPDATE_PEER_FAILED")
+			return
+		}
+		if sec, ok := h.settings.GetServerPeerSecret(name, pubkey); ok {
+			sec.Description = req.Description
+			_ = h.settings.SetServerPeerSecret(name, pubkey, sec)
+		}
+	}
+	publishInvalidated(h.bus, ResourceServers, "server-peer-updated")
+	h.writeAll(w, r)
+}
+
+func (h *ServersHandler) DeleteServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
+	if !h.requireWGCommands(w) {
+		return
+	}
+	server, ok := h.requireListedServer(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	if findServerPeer(server, pubkey) == nil {
+		response.Error(w, "peer not found", "NOT_FOUND")
+		return
+	}
+	if err := h.commands.Wireguard.RemovePeer(r.Context(), name, pubkey); err != nil {
+		response.Error(w, err.Error(), "DELETE_PEER_FAILED")
+		return
+	}
+	_ = h.settings.DeleteServerPeerSecret(name, pubkey)
+	publishInvalidated(h.bus, ResourceServers, "server-peer-deleted")
+	h.writeAll(w, r)
+}
+
+func (h *ServersHandler) ToggleServerPeer(w http.ResponseWriter, r *http.Request, name, pubkey string) {
+	req, ok := parseJSON[EnabledToggleRequest](w, r, http.MethodPost)
+	if !ok {
+		return
+	}
+	if !h.requireWGCommands(w) {
+		return
+	}
+	server, ok := h.requireListedServer(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	if findServerPeer(server, pubkey) == nil {
+		response.Error(w, "peer not found", "NOT_FOUND")
+		return
+	}
+	if err := h.commands.Wireguard.SetPeerConnect(r.Context(), name, pubkey, req.Enabled); err != nil {
+		response.Error(w, err.Error(), "TOGGLE_FAILED")
+		return
+	}
+	publishInvalidated(h.bus, ResourceServers, "server-peer-toggled")
+	h.writeAll(w, r)
+}
+
+func (h *ServersHandler) ServerPeerConf(w http.ResponseWriter, r *http.Request, name, pubkey string) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	server, ok := h.requireListedServer(r.Context(), w, name)
+	if !ok {
+		return
+	}
+	if findServerPeer(server, pubkey) == nil {
+		response.Error(w, "peer not found", "NOT_FOUND")
+		return
+	}
+	sec, ok := h.settings.GetServerPeerSecret(name, pubkey)
+	if !ok || sec.PrivateKey == "" {
+		response.Error(w, "ключ клиента недоступен (создан вне AWG Manager или через KeenDNS)", "CONF_UNAVAILABLE")
+		return
+	}
+	conf, err := h.generateServerPeerConf(r.Context(), server, pubkey, sec)
+	if err != nil {
+		response.Error(w, err.Error(), "CONF_FAILED")
+		return
+	}
+	response.Success(w, map[string]string{"conf": conf})
+}
+
+func (h *ServersHandler) generateServerPeerConf(ctx context.Context, server *ndms.WireguardServer, pubkey string, sec storage.ServerPeerSecret) (string, error) {
+	endpoint, err := h.resolveServerEndpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	tunnelIP := sec.TunnelIP
+	if tunnelIP == "" {
+		if peer := findServerPeer(server, pubkey); peer != nil {
+			host := peerTunnelHostIP(peer)
+			if host != "" {
+				tunnelIP = host + "/32"
+			}
+		}
+	}
+	if tunnelIP == "" {
+		return "", fmt.Errorf("peer tunnel IP unknown")
+	}
+	mtu := server.MTU
+	if mtu == 0 {
+		mtu = 1420
+	}
+
+	var b strings.Builder
+	b.WriteString("[Interface]\n")
+	b.WriteString(fmt.Sprintf("PrivateKey = %s\n", sec.PrivateKey))
+	b.WriteString(fmt.Sprintf("Address = %s\n", tunnelIP))
+	b.WriteString("DNS = 1.1.1.1, 8.8.8.8\n")
+	b.WriteString(fmt.Sprintf("MTU = %d\n", mtu))
+
+	if h.queries != nil && h.queries.WGServers != nil {
+		if ascRaw, err := h.queries.WGServers.GetASCParams(ctx, server.ID, true); err == nil && ascRaw != nil {
+			writeServerASCParams(&b, ascRaw)
+		}
+	}
+
+	b.WriteString("\n[Peer]\n")
+	b.WriteString(fmt.Sprintf("PublicKey = %s\n", server.PublicKey))
+	if sec.PresharedKey != "" {
+		b.WriteString(fmt.Sprintf("PresharedKey = %s\n", sec.PresharedKey))
+	}
+	b.WriteString(fmt.Sprintf("Endpoint = %s:%d\n", endpoint, server.ListenPort))
+	b.WriteString("AllowedIPs = 0.0.0.0/0, ::/0\n")
+	b.WriteString("PersistentKeepalive = 25\n")
+	return b.String(), nil
+}
+
+func (h *ServersHandler) resolveServerEndpoint(ctx context.Context) (string, error) {
+	if h.queries != nil && h.queries.KeenDNS != nil {
+		if info, err := h.queries.KeenDNS.Get(ctx); err == nil && info != nil && info.Domain != "" {
+			return info.Domain, nil
+		}
+	}
+	return testing.GetWANIPWithFallback(ctx, h.queries.WANInterfaceAddress)
+}
+
+func writeServerASCParams(b *strings.Builder, raw json.RawMessage) {
+	var ext ndms.ASCParamsExtended
+	if err := json.Unmarshal(raw, &ext); err != nil || ext.Jc == 0 {
+		return
+	}
+	b.WriteString(fmt.Sprintf("Jc = %d\n", ext.Jc))
+	b.WriteString(fmt.Sprintf("Jmin = %d\n", ext.Jmin))
+	b.WriteString(fmt.Sprintf("Jmax = %d\n", ext.Jmax))
+	b.WriteString(fmt.Sprintf("S1 = %d\n", ext.S1))
+	b.WriteString(fmt.Sprintf("S2 = %d\n", ext.S2))
+	b.WriteString(fmt.Sprintf("H1 = %s\n", ext.H1))
+	b.WriteString(fmt.Sprintf("H2 = %s\n", ext.H2))
+	b.WriteString(fmt.Sprintf("H3 = %s\n", ext.H3))
+	b.WriteString(fmt.Sprintf("H4 = %s\n", ext.H4))
+	if ext.S3 > 0 || ext.S4 > 0 {
+		b.WriteString(fmt.Sprintf("S3 = %d\n", ext.S3))
+		b.WriteString(fmt.Sprintf("S4 = %d\n", ext.S4))
+	}
+}
+
+func findServerPeer(server *ndms.WireguardServer, pubkey string) *ndms.WireguardServerPeer {
+	for i := range server.Peers {
+		if server.Peers[i].PublicKey == pubkey {
+			return &server.Peers[i]
+		}
+	}
+	return nil
+}
+
+func peerTunnelHostIP(peer *ndms.WireguardServerPeer) string {
+	for _, allowed := range peer.AllowedIPs {
+		if strings.Contains(allowed, "/32") {
+			host, _, err := net.ParseCIDR(allowed)
+			if err == nil && host != nil {
+				return host.String()
+			}
+		}
+	}
+	if len(peer.AllowedIPs) > 0 {
+		host, _, err := net.ParseCIDR(peer.AllowedIPs[0])
+		if err == nil && host != nil {
+			return host.String()
+		}
+	}
+	return ""
+}
+
+func (h *ServersHandler) validateServerPeerTunnelIP(server *ndms.WireguardServer, tunnelIP string) error {
+	ip, ipNet, err := net.ParseCIDR(tunnelIP)
+	if err != nil {
+		return fmt.Errorf("invalid tunnel IP (must be CIDR, e.g. 10.0.0.2/32): %w", err)
+	}
+	serverIP := net.ParseIP(server.Address)
+	serverMask := net.IPMask(net.ParseIP(server.Mask).To4())
+	if serverIP == nil || serverMask == nil {
+		return nil
+	}
+	serverNet := &net.IPNet{IP: serverIP.Mask(serverMask), Mask: serverMask}
+	if !serverNet.Contains(ip) {
+		return fmt.Errorf("tunnel IP %s is not in server subnet %s", ip, serverNet)
+	}
+	if ip.Equal(serverIP) {
+		return fmt.Errorf("tunnel IP %s is the server's own address", ip)
+	}
+	ones, bits := serverNet.Mask.Size()
+	if ones < bits-1 {
+		if ip.Equal(serverNet.IP) {
+			return fmt.Errorf("tunnel IP %s is the network address", ip)
+		}
+		broadcast := make(net.IP, len(serverNet.IP))
+		for i := range serverNet.IP {
+			broadcast[i] = serverNet.IP[i] | ^serverNet.Mask[i]
+		}
+		if ip.Equal(broadcast) {
+			return fmt.Errorf("tunnel IP %s is the broadcast address", ip)
+		}
+	}
+	_ = ipNet
+	return nil
+}
+
+const builtInVPNServerDescription = "Wireguard VPN Server"
+
+func (h *ServersHandler) enrichServerDTO(ctx context.Context, srv ndms.WireguardServer) WireguardServerDTO {
+	dto := toWireguardServerDTO(srv)
+	dto.BuiltIn = srv.Description == builtInVPNServerDescription
+	if _, mode, err := h.readSystemServerNATMode(ctx, srv.ID); err == nil {
+		dto.NATEnabled = mode == "full"
+		dto.NATMode = mode
+	}
+	if policy, err := h.readSystemServerPolicy(ctx, srv.ID); err == nil {
+		dto.Policy = policy
+	}
+	if h.queries != nil && h.queries.KeenDNS != nil {
+		if info, err := h.queries.KeenDNS.Get(ctx); err == nil && info != nil {
+			dto.KeenDNSDomain = info.Domain
+		}
+	}
+	for i := range dto.Peers {
+		sec, ok := h.settings.GetServerPeerSecret(srv.ID, dto.Peers[i].PublicKey)
+		if ok {
+			dto.Peers[i].ConfAvailable = true
+			if dto.Peers[i].Description == "" && sec.Description != "" {
+				dto.Peers[i].Description = sec.Description
+			}
+		}
+	}
+	return dto
+}
+
+func toWireguardServerDTO(srv ndms.WireguardServer) WireguardServerDTO {
+	peers := make([]WireguardServerPeerDTO, len(srv.Peers))
+	for i, p := range srv.Peers {
+		peers[i] = WireguardServerPeerDTO{
+			PublicKey:     p.PublicKey,
+			Description:   p.Description,
+			Endpoint:      p.Endpoint,
+			AllowedIPs:    p.AllowedIPs,
+			RxBytes:       p.RxBytes,
+			TxBytes:       p.TxBytes,
+			LastHandshake: p.LastHandshake,
+			Online:        p.Online,
+			Enabled:       p.Enabled,
+		}
+	}
+	return WireguardServerDTO{
+		ID:            srv.ID,
+		InterfaceName: srv.InterfaceName,
+		Description:   srv.Description,
+		Status:        srv.Status,
+		Connected:     srv.Connected,
+		MTU:           srv.MTU,
+		Address:       srv.Address,
+		Mask:          srv.Mask,
+		PublicKey:     srv.PublicKey,
+		ListenPort:    srv.ListenPort,
+		Peers:         peers,
+	}
+}

--- a/internal/api/server_peers_test.go
+++ b/internal/api/server_peers_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms"
+)
+
+func TestPeerTunnelIPInUse(t *testing.T) {
+	server := &ndms.WireguardServer{
+		Peers: []ndms.WireguardServerPeer{
+			{PublicKey: "A=", AllowedIPs: []string{"10.0.0.20/32"}},
+			{PublicKey: "B=", AllowedIPs: []string{"10.0.0.3/32"}},
+		},
+	}
+	tests := []struct {
+		name     string
+		tunnelIP string
+		want     bool
+	}{
+		// Regression: "10.0.0.2" is a string prefix of "10.0.0.20" but a
+		// distinct host — the old HasPrefix check wrongly reported it in use.
+		{"prefix-overlap is free", "10.0.0.2/32", false},
+		{"exact match is in use", "10.0.0.20/32", true},
+		{"other exact match in use", "10.0.0.3/32", true},
+		{"unrelated free", "10.0.0.99/32", false},
+		{"invalid input is not in use", "garbage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerTunnelIPInUse(server, tt.tunnelIP); got != tt.want {
+				t.Errorf("peerTunnelIPInUse(%q) = %v, want %v", tt.tunnelIP, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -56,6 +56,12 @@ type WireguardServerDTO struct {
 	Policy        string                   `json:"policy,omitempty" example:"Policy0"`
 	KeenDNSDomain string                   `json:"keenDnsDomain,omitempty" example:"home.keenetic.pro"`
 	BuiltIn       bool                     `json:"builtIn,omitempty" example:"true"`
+	// NATModeKnown/PolicyKnown are false when the corresponding NDMS read
+	// failed (e.g. transient router error). The frontend must render an
+	// "unknown" state instead of trusting the zero-valued NATMode/Policy,
+	// which would otherwise read as a fabricated "none".
+	NATModeKnown bool `json:"natModeKnown" example:"true"`
+	PolicyKnown  bool `json:"policyKnown" example:"true"`
 }
 
 // ManagedPeerStatsDTO mirrors frontend ManagedPeerStats.

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -35,6 +35,7 @@ type WireguardServerPeerDTO struct {
 	LastHandshake string   `json:"lastHandshake" example:"2024-01-15T10:30:00Z"`
 	Online        bool     `json:"online" example:"true"`
 	Enabled       bool     `json:"enabled" example:"true"`
+	ConfAvailable bool     `json:"confAvailable,omitempty" example:"true"`
 }
 
 // WireguardServerDTO mirrors frontend WireguardServer.
@@ -50,6 +51,11 @@ type WireguardServerDTO struct {
 	PublicKey     string                   `json:"publicKey" example:"EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE="`
 	ListenPort    int                      `json:"listenPort" example:"51820"`
 	Peers         []WireguardServerPeerDTO `json:"peers"`
+	NATEnabled    bool                     `json:"natEnabled,omitempty" example:"true"`
+	NATMode       string                   `json:"natMode,omitempty" example:"full"`
+	Policy        string                   `json:"policy,omitempty" example:"Policy0"`
+	KeenDNSDomain string                   `json:"keenDnsDomain,omitempty" example:"home.keenetic.pro"`
+	BuiltIn       bool                     `json:"builtIn,omitempty" example:"true"`
 }
 
 // ManagedPeerStatsDTO mirrors frontend ManagedPeerStats.
@@ -127,12 +133,13 @@ func isValidWireguardName(name string) bool {
 // resource:invalidated hints on mark/unmark and poller metrics ticks so
 // subscribers refetch immediately instead of waiting for the next poll.
 type ServersHandler struct {
-	queries  *query.Queries
-	commands *ndmscommand.Commands
-	settings *storage.SettingsStore
-	awgStore *storage.AWGTunnelStore
-	bus      *events.Bus
-	managed  *ManagedServerHandler
+	queries     *query.Queries
+	commands    *ndmscommand.Commands
+	settings    *storage.SettingsStore
+	awgStore    *storage.AWGTunnelStore
+	bus         *events.Bus
+	managed     *ManagedServerHandler
+	managedSvc  *managed.Service
 }
 
 // SetEventBus sets the event bus used for SSE publishing.
@@ -142,6 +149,9 @@ func (h *ServersHandler) SetEventBus(bus *events.Bus) {
 
 // SetManagedHandler sets the managed server handler for shared publishing.
 func (h *ServersHandler) SetManagedHandler(m *ManagedServerHandler) { h.managed = m }
+
+// SetManagedService wires managed.Service for system-server NAT/policy RCI.
+func (h *ServersHandler) SetManagedService(svc *managed.Service) { h.managedSvc = svc }
 
 // SetCommands wires NDMS interface commands used by server up/down/restart
 // controls. Kept as a setter so tests using NewServersHandler do not need to
@@ -281,6 +291,10 @@ func (h *ServersHandler) writeAll(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, err.Error(), "LIST_FAILED")
 		return
 	}
+	enriched := make([]WireguardServerDTO, len(list))
+	for i, srv := range list {
+		enriched[i] = h.enrichServerDTO(ctx, srv)
+	}
 	managedList := []*managedServerResponse{}
 	managedStats := map[string]*managed.ManagedServerStats{}
 	if h.managed != nil {
@@ -288,7 +302,7 @@ func (h *ServersHandler) writeAll(w http.ResponseWriter, r *http.Request) {
 		managedStats = h.managed.getManagedStatsMap(ctx)
 	}
 	payload := map[string]any{
-		"servers":      list,
+		"servers":      enriched,
 		"managed":      managedList,
 		"managedStats": managedStats,
 	}

--- a/internal/api/servers_settings.go
+++ b/internal/api/servers_settings.go
@@ -74,6 +74,19 @@ func (h *ServersHandler) invalidateSystemServerCaches(iface string) {
 
 // SetNAT sets the NAT mode on a built-in/marked WireGuard server.
 // POST /api/servers/{name}/nat
+//
+//	@Summary		Set server NAT mode
+//	@Description	Sets the NAT mode (full / internet-only / none) on the named WireGuard server via NDMS. Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string				true	"Interface name (e.g. Wireguard0)"
+//	@Param			body	body		SetNATModeRequest	true	"NAT mode"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/nat [post]
 func (h *ServersHandler) SetNAT(w http.ResponseWriter, r *http.Request, name string) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)
@@ -136,6 +149,19 @@ func (h *ServersHandler) SetNAT(w http.ResponseWriter, r *http.Request, name str
 
 // SetPolicy sets the ip hotspot policy on a built-in/marked WireGuard server.
 // POST /api/servers/{name}/policy
+//
+//	@Summary		Set server access policy
+//	@Description	Binds the named WireGuard server interface to an NDMS hotspot access policy (or "none"). Returns the fresh servers snapshot.
+//	@Tags			servers
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			name	path		string					true	"Interface name (e.g. Wireguard0)"
+//	@Param			body	body		SetServerPolicyRequest	true	"Policy id (router-side) or 'none'"
+//	@Success		200		{object}	ServersAllResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/servers/{name}/policy [post]
 func (h *ServersHandler) SetPolicy(w http.ResponseWriter, r *http.Request, name string) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/servers_settings.go
+++ b/internal/api/servers_settings.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+func detectSystemServerNATMode(natEnabled, hasStatic bool) string {
+	switch {
+	case hasStatic && !natEnabled:
+		return "internet-only"
+	case natEnabled:
+		return "full"
+	default:
+		return "none"
+	}
+}
+
+func (h *ServersHandler) readSystemServerNATMode(ctx context.Context, iface string) (natEnabled bool, natMode string, err error) {
+	if h.queries == nil || h.queries.NAT == nil {
+		return false, "none", nil
+	}
+	natEnabled, err = h.queries.NAT.HasInterface(ctx, iface)
+	if err != nil {
+		return false, "", err
+	}
+	hasStatic := false
+	if h.queries.StaticNAT != nil {
+		hasStatic, _, err = h.queries.StaticNAT.ForInterface(ctx, iface)
+		if err != nil {
+			return false, "", err
+		}
+	}
+	return natEnabled, detectSystemServerNATMode(natEnabled, hasStatic), nil
+}
+
+func (h *ServersHandler) readSystemServerPolicy(ctx context.Context, iface string) (string, error) {
+	if h.queries == nil || h.queries.RunningConfig == nil {
+		return "none", nil
+	}
+	policy, err := h.queries.RunningConfig.GetInterfaceHotspotPolicy(ctx, iface)
+	if err != nil {
+		return "", err
+	}
+	if policy == "" {
+		return "none", nil
+	}
+	return policy, nil
+}
+
+func (h *ServersHandler) invalidateSystemServerCaches(iface string) {
+	if h.queries == nil {
+		return
+	}
+	if h.queries.NAT != nil {
+		h.queries.NAT.InvalidateAll()
+	}
+	if h.queries.StaticNAT != nil {
+		h.queries.StaticNAT.InvalidateAll()
+	}
+	if h.queries.RunningConfig != nil {
+		h.queries.RunningConfig.InvalidateAll()
+	}
+	if h.queries.WGServers != nil {
+		h.queries.WGServers.Invalidate(iface)
+	}
+	if h.managedSvc != nil {
+		h.managedSvc.InvalidateCache(iface)
+	}
+}
+
+// SetNAT sets the NAT mode on a built-in/marked WireGuard server.
+// POST /api/servers/{name}/nat
+func (h *ServersHandler) SetNAT(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.managedSvc == nil {
+		response.Error(w, "managed service not initialized", "INTERNAL_ERROR")
+		return
+	}
+	if _, ok := h.requireListedServer(r.Context(), w, name); !ok {
+		return
+	}
+
+	req, ok := parseJSON[SetNATModeRequest](w, r, http.MethodPost)
+	if !ok {
+		return
+	}
+	mode := req.Mode
+	if mode == "" && req.Enabled != nil {
+		if *req.Enabled {
+			mode = "full"
+		} else {
+			mode = "none"
+		}
+	}
+	if mode == "" {
+		response.BadRequest(w, "NAT mode required")
+		return
+	}
+	switch mode {
+	case "full", "internet-only", "none":
+	default:
+		response.BadRequest(w, "invalid NAT mode: "+mode)
+		return
+	}
+
+	meta, _ := h.settings.GetServerInterfaceMeta(name)
+	wan, err := h.managedSvc.ApplyNATModeToInterface(r.Context(), name, mode, meta.NATStaticWAN)
+	if err != nil {
+		response.Error(w, err.Error(), "NAT_FAILED")
+		return
+	}
+	if err := h.settings.UpdateServerInterfaceMeta(name, func(m *storage.ServerInterfaceMeta) error {
+		m.NATMode = mode
+		if mode == "internet-only" {
+			m.NATStaticWAN = wan
+		} else {
+			m.NATStaticWAN = ""
+		}
+		return nil
+	}); err != nil {
+		response.Error(w, err.Error(), "SAVE_FAILED")
+		return
+	}
+
+	h.invalidateSystemServerCaches(name)
+	publishInvalidated(h.bus, ResourceServers, "server-nat-changed")
+	h.writeAll(w, r)
+}
+
+// SetPolicy sets the ip hotspot policy on a built-in/marked WireGuard server.
+// POST /api/servers/{name}/policy
+func (h *ServersHandler) SetPolicy(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.managedSvc == nil {
+		response.Error(w, "managed service not initialized", "INTERNAL_ERROR")
+		return
+	}
+	if _, ok := h.requireListedServer(r.Context(), w, name); !ok {
+		return
+	}
+
+	req, ok := parseJSON[SetServerPolicyRequest](w, r, http.MethodPost)
+	if !ok {
+		return
+	}
+	current, err := h.readSystemServerPolicy(r.Context(), name)
+	if err != nil {
+		response.Error(w, err.Error(), "POLICY_READ_FAILED")
+		return
+	}
+	if req.Policy == current {
+		h.writeAll(w, r)
+		return
+	}
+
+	if err := h.managedSvc.ApplyPolicyToInterface(r.Context(), name, req.Policy); err != nil {
+		response.Error(w, err.Error(), "POLICY_FAILED")
+		return
+	}
+
+	h.invalidateSystemServerCaches(name)
+	publishInvalidated(h.bus, ResourceServers, "server-policy-changed")
+	h.writeAll(w, r)
+}

--- a/internal/api/servers_settings_test.go
+++ b/internal/api/servers_settings_test.go
@@ -1,0 +1,20 @@
+package api
+
+import "testing"
+
+func TestDetectSystemServerNATMode(t *testing.T) {
+	cases := []struct {
+		nat, static bool
+		want        string
+	}{
+		{true, false, "full"},
+		{false, true, "internet-only"},
+		{false, false, "none"},
+		{true, true, "full"},
+	}
+	for _, c := range cases {
+		if got := detectSystemServerNATMode(c.nat, c.static); got != c.want {
+			t.Fatalf("detect(%v,%v) = %q, want %q", c.nat, c.static, got, c.want)
+		}
+	}
+}

--- a/internal/managed/service_iface.go
+++ b/internal/managed/service_iface.go
@@ -1,0 +1,52 @@
+package managed
+
+import (
+	"context"
+	"fmt"
+)
+
+// ApplyNATModeToInterface applies a NAT mode to any NDMS WireGuard interface.
+// prevWAN is the stored WAN iface for tearing down internet-only static NAT.
+func (s *Service) ApplyNATModeToInterface(ctx context.Context, ifaceName, mode, prevWAN string) (string, error) {
+	switch mode {
+	case "full", "internet-only", "none":
+	default:
+		return "", fmt.Errorf("неизвестный NAT-режим: %q", mode)
+	}
+	return s.applyNATModeRaw(ctx, ifaceName, mode, prevWAN)
+}
+
+// ApplyPolicyToInterface sets or clears the ip hotspot policy on an interface.
+func (s *Service) ApplyPolicyToInterface(ctx context.Context, ifaceName, policy string) error {
+	if policy == "" {
+		return fmt.Errorf("policy must not be empty")
+	}
+	if policy != "none" {
+		opts, err := s.ListPolicies(ctx)
+		if err != nil {
+			return fmt.Errorf("list policies: %w", err)
+		}
+		known := false
+		for _, o := range opts {
+			if o.ID == policy {
+				known = true
+				break
+			}
+		}
+		if !known {
+			return fmt.Errorf("unknown policy: %s", policy)
+		}
+	}
+	if policy == "none" {
+		if err := s.rciClearHotspotPolicy(ctx, ifaceName); err != nil {
+			return fmt.Errorf("clear policy: %w", err)
+		}
+	} else {
+		if err := s.rciSetHotspotPolicy(ctx, ifaceName, policy); err != nil {
+			return fmt.Errorf("set policy: %w", err)
+		}
+	}
+	s.log.Info("interface policy changed", "interface", ifaceName, "policy", policy)
+	s.appLog.Info("policy", ifaceName, fmt.Sprintf("Policy set to %s", policy))
+	return nil
+}

--- a/internal/ndms/command/mutation.go
+++ b/internal/ndms/command/mutation.go
@@ -2,7 +2,9 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // postMutation is the common post-then-invalidate pattern shared by most
@@ -32,4 +34,78 @@ func postMutation(
 		inv()
 	}
 	return nil
+}
+
+// postMutationChecked is postMutation plus a nested-status check. Some NDMS
+// mutations (notably interface.<name>.wireguard.peer ops) answer HTTP 200 with
+// a benign top-level envelope while reporting the real failure inside a nested
+// status[] array — which the transport-level error check does not inspect, so
+// postMutation would treat the call as success. This variant scans the
+// response for any explicit status:"error" entry and fails closed when found,
+// without requesting a save or invalidating caches.
+//
+// It is deliberately additive: a normal success response contains no
+// status:"error" entry, so behaviour is unchanged for those. NOTE: the exact
+// nested shape for peer ops is modelled on the import path and should be
+// confirmed against a live router (e.g. a deliberately-invalid peer add)
+// before relying on it as the sole guard.
+func postMutationChecked(
+	ctx context.Context,
+	poster Poster,
+	save *SaveCoordinator,
+	payload any,
+	opDesc string,
+	invalidators ...func(),
+) error {
+	resp, err := poster.Post(ctx, payload)
+	if err != nil {
+		return fmt.Errorf("%s: %w", opDesc, err)
+	}
+	if msgs := ndmsStatusErrors(resp); len(msgs) > 0 {
+		return fmt.Errorf("%s: router reported error: %s", opDesc, strings.Join(msgs, "; "))
+	}
+	save.Request()
+	for _, inv := range invalidators {
+		inv()
+	}
+	return nil
+}
+
+// ndmsStatusErrors recursively walks a decoded NDMS response and returns the
+// messages of every object carrying status:"error" (case-insensitive),
+// regardless of where it sits — scalar `"status":"error"` or a nested
+// `"status":[{"status":"error",...}]` array. Returns nil on unparseable input
+// (the transport layer already validated the top-level envelope).
+func ndmsStatusErrors(resp []byte) []string {
+	var root any
+	if err := json.Unmarshal(resp, &root); err != nil {
+		return nil
+	}
+	return walkNDMSStatusErrors(root)
+}
+
+func walkNDMSStatusErrors(v any) []string {
+	switch t := v.(type) {
+	case map[string]any:
+		var msgs []string
+		if s, ok := t["status"].(string); ok && strings.EqualFold(s, "error") {
+			if m, ok := t["message"].(string); ok && m != "" {
+				msgs = append(msgs, m)
+			} else {
+				msgs = append(msgs, "error")
+			}
+		}
+		for _, val := range t {
+			msgs = append(msgs, walkNDMSStatusErrors(val)...)
+		}
+		return msgs
+	case []any:
+		var msgs []string
+		for _, val := range t {
+			msgs = append(msgs, walkNDMSStatusErrors(val)...)
+		}
+		return msgs
+	default:
+		return nil
+	}
 }

--- a/internal/ndms/command/mutation_test.go
+++ b/internal/ndms/command/mutation_test.go
@@ -1,0 +1,49 @@
+package command
+
+import "testing"
+
+func TestNDMSStatusErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    string
+		wantErr bool
+	}{
+		{
+			name: "clean peer add success — no status error",
+			resp: `{"interface":{"Wireguard0":{"wireguard":{"peer":[{"key":"K="}]}}}}`,
+		},
+		{
+			name: "nested status array with error",
+			resp: `{"interface":{"Wireguard0":{"wireguard":{"peer":{"status":[` +
+				`{"status":"message","message":"ok"},` +
+				`{"status":"error","message":"allow-ips already in use"}]}}}}}`,
+			wantErr: true,
+		},
+		{
+			name:    "scalar status error",
+			resp:    `{"status":"error","message":"no such interface"}`,
+			wantErr: true,
+		},
+		{
+			name: "only message-level status — not an error",
+			resp: `{"status":[{"status":"message","message":"peer added"}]}`,
+		},
+		{
+			name: "unparseable response — treated as no error",
+			resp: `not json`,
+		},
+		{
+			name:    "error status without message still flagged",
+			resp:    `{"status":[{"status":"error"}]}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs := ndmsStatusErrors([]byte(tt.resp))
+			if got := len(msgs) > 0; got != tt.wantErr {
+				t.Errorf("ndmsStatusErrors() error=%v (msgs=%v), want error=%v", got, msgs, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ndms/command/wireguard.go
+++ b/internal/ndms/command/wireguard.go
@@ -157,7 +157,7 @@ func (c *WireguardCommands) AddPeer(ctx context.Context, ifaceName, pubKey, psk,
 			},
 		},
 	}
-	return postMutation(ctx, c.poster, c.save, payload, "add peer "+ifaceName,
+	return postMutationChecked(ctx, c.poster, c.save, payload, "add peer "+ifaceName,
 		func() { c.invalidateServer(ifaceName) })
 }
 
@@ -174,7 +174,7 @@ func (c *WireguardCommands) RemovePeer(ctx context.Context, ifaceName, pubKey st
 			},
 		},
 	}
-	return postMutation(ctx, c.poster, c.save, payload, "remove peer "+ifaceName,
+	return postMutationChecked(ctx, c.poster, c.save, payload, "remove peer "+ifaceName,
 		func() { c.invalidateServer(ifaceName) })
 }
 
@@ -191,7 +191,7 @@ func (c *WireguardCommands) SetPeerConnect(ctx context.Context, ifaceName, pubKe
 			},
 		},
 	}
-	return postMutation(ctx, c.poster, c.save, payload, "toggle peer "+ifaceName,
+	return postMutationChecked(ctx, c.poster, c.save, payload, "toggle peer "+ifaceName,
 		func() { c.invalidateServer(ifaceName) })
 }
 
@@ -208,7 +208,7 @@ func (c *WireguardCommands) SetPeerComment(ctx context.Context, ifaceName, pubKe
 			},
 		},
 	}
-	return postMutation(ctx, c.poster, c.save, payload, "rename peer "+ifaceName,
+	return postMutationChecked(ctx, c.poster, c.save, payload, "rename peer "+ifaceName,
 		func() { c.invalidateServer(ifaceName) })
 }
 
@@ -231,7 +231,7 @@ func (c *WireguardCommands) UpdatePeerAllowIPs(ctx context.Context, ifaceName, p
 				},
 			},
 		}
-		if err := postMutation(ctx, c.poster, c.save, payload, "remove peer allow-ips "+ifaceName,
+		if err := postMutationChecked(ctx, c.poster, c.save, payload, "remove peer allow-ips "+ifaceName,
 			func() { c.invalidateServer(ifaceName) }); err != nil {
 			return fmt.Errorf("remove old allow-ips: %w", err)
 		}
@@ -252,6 +252,6 @@ func (c *WireguardCommands) UpdatePeerAllowIPs(ctx context.Context, ifaceName, p
 			},
 		},
 	}
-	return postMutation(ctx, c.poster, c.save, payload, "set peer allow-ips "+ifaceName,
+	return postMutationChecked(ctx, c.poster, c.save, payload, "set peer allow-ips "+ifaceName,
 		func() { c.invalidateServer(ifaceName) })
 }

--- a/internal/ndms/command/wireguard.go
+++ b/internal/ndms/command/wireguard.go
@@ -119,3 +119,139 @@ func (c *WireguardCommands) ImportWireguardConfig(ctx context.Context, confData 
 	}
 	return ImportResult{Created: imp.Created, Intersects: imp.Intersects, Messages: msgs}, nil
 }
+
+func (c *WireguardCommands) invalidateServer(name string) {
+	if c.queries == nil {
+		return
+	}
+	if c.queries.Interfaces != nil {
+		c.queries.Interfaces.Invalidate(name)
+	}
+	if c.queries.WGServers != nil {
+		c.queries.WGServers.Invalidate(name)
+	}
+	if c.queries.RunningConfig != nil {
+		c.queries.RunningConfig.InvalidateAll()
+	}
+}
+
+// AddPeer adds a peer to a WireGuard server interface.
+func (c *WireguardCommands) AddPeer(ctx context.Context, ifaceName, pubKey, psk, comment, peerIP string, enabled bool) error {
+	peer := map[string]any{
+		"key":           pubKey,
+		"preshared-key": psk,
+		"connect":       enabled,
+		"allow-ips": []map[string]any{
+			{"address": peerIP, "mask": "255.255.255.255"},
+		},
+	}
+	if comment != "" {
+		peer["comment"] = comment
+	}
+	payload := map[string]any{
+		"interface": map[string]any{
+			ifaceName: map[string]any{
+				"wireguard": map[string]any{
+					"peer": []map[string]any{peer},
+				},
+			},
+		},
+	}
+	return postMutation(ctx, c.poster, c.save, payload, "add peer "+ifaceName,
+		func() { c.invalidateServer(ifaceName) })
+}
+
+// RemovePeer removes a peer by public key.
+func (c *WireguardCommands) RemovePeer(ctx context.Context, ifaceName, pubKey string) error {
+	payload := map[string]any{
+		"interface": map[string]any{
+			ifaceName: map[string]any{
+				"wireguard": map[string]any{
+					"peer": []map[string]any{
+						{"no": true, "key": pubKey},
+					},
+				},
+			},
+		},
+	}
+	return postMutation(ctx, c.poster, c.save, payload, "remove peer "+ifaceName,
+		func() { c.invalidateServer(ifaceName) })
+}
+
+// SetPeerConnect enables or disables a peer.
+func (c *WireguardCommands) SetPeerConnect(ctx context.Context, ifaceName, pubKey string, connect bool) error {
+	payload := map[string]any{
+		"interface": map[string]any{
+			ifaceName: map[string]any{
+				"wireguard": map[string]any{
+					"peer": []map[string]any{
+						{"key": pubKey, "connect": connect},
+					},
+				},
+			},
+		},
+	}
+	return postMutation(ctx, c.poster, c.save, payload, "toggle peer "+ifaceName,
+		func() { c.invalidateServer(ifaceName) })
+}
+
+// SetPeerComment sets the description/comment for a peer.
+func (c *WireguardCommands) SetPeerComment(ctx context.Context, ifaceName, pubKey, comment string) error {
+	payload := map[string]any{
+		"interface": map[string]any{
+			ifaceName: map[string]any{
+				"wireguard": map[string]any{
+					"peer": []map[string]any{
+						{"key": pubKey, "comment": comment},
+					},
+				},
+			},
+		},
+	}
+	return postMutation(ctx, c.poster, c.save, payload, "rename peer "+ifaceName,
+		func() { c.invalidateServer(ifaceName) })
+}
+
+// UpdatePeerAllowIPs removes old /32 and sets a new one.
+func (c *WireguardCommands) UpdatePeerAllowIPs(ctx context.Context, ifaceName, pubKey, oldIP, newIP string) error {
+	if oldIP != "" {
+		payload := map[string]any{
+			"interface": map[string]any{
+				ifaceName: map[string]any{
+					"wireguard": map[string]any{
+						"peer": []map[string]any{
+							{
+								"key": pubKey,
+								"allow-ips": []map[string]any{
+									{"no": true, "address": oldIP, "mask": "255.255.255.255"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if err := postMutation(ctx, c.poster, c.save, payload, "remove peer allow-ips "+ifaceName,
+			func() { c.invalidateServer(ifaceName) }); err != nil {
+			return fmt.Errorf("remove old allow-ips: %w", err)
+		}
+	}
+	payload := map[string]any{
+		"interface": map[string]any{
+			ifaceName: map[string]any{
+				"wireguard": map[string]any{
+					"peer": []map[string]any{
+						{
+							"key": pubKey,
+							"allow-ips": []map[string]any{
+								{"address": newIP, "mask": "255.255.255.255"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return postMutation(ctx, c.poster, c.save, payload, "set peer allow-ips "+ifaceName,
+		func() { c.invalidateServer(ifaceName) })
+}

--- a/internal/ndms/query/hotspot_iface_policy.go
+++ b/internal/ndms/query/hotspot_iface_policy.go
@@ -1,0 +1,39 @@
+package query
+
+import (
+	"context"
+	"strings"
+)
+
+// GetInterfaceHotspotPolicy returns the ip hotspot policy bound to iface.
+// "none" when the interface uses default-permit (no explicit policy line).
+func (s *RunningConfigStore) GetInterfaceHotspotPolicy(ctx context.Context, iface string) (string, error) {
+	lines, err := s.Lines(ctx)
+	if err != nil {
+		return "", err
+	}
+	inHotspot := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "ip hotspot" {
+			inHotspot = true
+			continue
+		}
+		if !inHotspot {
+			continue
+		}
+		if trimmed == "!" {
+			break
+		}
+		if !strings.HasPrefix(trimmed, "policy ") {
+			continue
+		}
+		parts := strings.Fields(trimmed)
+		// policy <interface> <access|policyName>
+		if len(parts) < 3 || parts[1] != iface {
+			continue
+		}
+		return parts[2], nil
+	}
+	return "none", nil
+}

--- a/internal/ndms/query/hotspot_iface_policy_test.go
+++ b/internal/ndms/query/hotspot_iface_policy_test.go
@@ -1,0 +1,34 @@
+package query
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunningConfigStore_GetInterfaceHotspotPolicy(t *testing.T) {
+	fg := newFakeGetter()
+	fg.SetRaw("/show/running-config", []byte(`{"message":[
+		"!",
+		"ip hotspot",
+		" policy Home Policy0",
+		" policy Wireguard0 Policy1",
+		"!"
+	]}`))
+	s := NewRunningConfigStore(fg, NopLogger())
+
+	policy, err := s.GetInterfaceHotspotPolicy(context.Background(), "Wireguard0")
+	if err != nil {
+		t.Fatalf("GetInterfaceHotspotPolicy: %v", err)
+	}
+	if policy != "Policy1" {
+		t.Fatalf("policy = %q, want Policy1", policy)
+	}
+
+	none, err := s.GetInterfaceHotspotPolicy(context.Background(), "Wireguard9")
+	if err != nil {
+		t.Fatalf("GetInterfaceHotspotPolicy missing: %v", err)
+	}
+	if none != "none" {
+		t.Fatalf("missing policy = %q, want none", none)
+	}
+}

--- a/internal/ndms/query/keendns.go
+++ b/internal/ndms/query/keendns.go
@@ -1,0 +1,117 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms/cache"
+)
+
+const keenDNSTTL = 60 * time.Second
+
+// KeenDNSInfo holds the router's KeenDNS domain registration, if any.
+type KeenDNSInfo struct {
+	Domain  string `json:"domain"`
+	Enabled bool   `json:"enabled"`
+}
+
+// KeenDNSStore caches KeenDNS status from NDMS.
+type KeenDNSStore struct {
+	*cache.KeyedStore[string, *KeenDNSInfo]
+	getter Getter
+	log    Logger
+}
+
+func NewKeenDNSStore(g Getter, log Logger) *KeenDNSStore {
+	s := &KeenDNSStore{getter: g, log: log}
+	s.KeyedStore = cache.NewKeyedStore(keenDNSTTL, log, "keendns", s.fetch)
+	return s
+}
+
+// Get returns the current KeenDNS registration. Missing/unconfigured → nil, nil.
+func (s *KeenDNSStore) Get(ctx context.Context) (*KeenDNSInfo, error) {
+	return s.KeyedStore.Get(ctx, "status")
+}
+
+func (s *KeenDNSStore) fetch(ctx context.Context, _ string) (*KeenDNSInfo, error) {
+	for _, path := range []string{"/show/ndns", "/show/sc/ndns", "/show/ip/dns/domain"} {
+		info, err := s.fetchFromPath(ctx, path)
+		if err != nil {
+			s.log.Warnf("keendns: %s: %v", path, err)
+			continue
+		}
+		if info != nil && info.Domain != "" {
+			return info, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *KeenDNSStore) fetchFromPath(ctx context.Context, path string) (*KeenDNSInfo, error) {
+	raw, err := s.getter.GetRaw(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("{}")) {
+		return nil, nil
+	}
+	return parseKeenDNSJSON(trimmed), nil
+}
+
+func parseKeenDNSJSON(raw []byte) *KeenDNSInfo {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	domain := findKeenDNSDomain(v)
+	if domain == "" {
+		return nil
+	}
+	return &KeenDNSInfo{Domain: domain, Enabled: true}
+}
+
+func findKeenDNSDomain(v any) string {
+	switch t := v.(type) {
+	case string:
+		s := strings.TrimSpace(t)
+		if looksLikeKeenDNSDomain(s) {
+			return s
+		}
+	case map[string]any:
+		for _, key := range []string{"domain", "name", "hostname", "fqdn", "address"} {
+			if raw, ok := t[key]; ok {
+				if d := findKeenDNSDomain(raw); d != "" {
+					return d
+				}
+			}
+		}
+		for _, child := range t {
+			if d := findKeenDNSDomain(child); d != "" {
+				return d
+			}
+		}
+	case []any:
+		for _, item := range t {
+			if d := findKeenDNSDomain(item); d != "" {
+				return d
+			}
+		}
+	}
+	return ""
+}
+
+func looksLikeKeenDNSDomain(s string) bool {
+	if s == "" || strings.Contains(s, " ") {
+		return false
+	}
+	lower := strings.ToLower(s)
+	return strings.HasSuffix(lower, ".keenetic.pro") ||
+		strings.HasSuffix(lower, ".keenetic.name") ||
+		strings.HasSuffix(lower, ".keenetic.link") ||
+		strings.HasSuffix(lower, ".netcraze.pro") ||
+		strings.HasSuffix(lower, ".netcraze.link")
+}

--- a/internal/ndms/query/nat.go
+++ b/internal/ndms/query/nat.go
@@ -1,0 +1,66 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms/cache"
+)
+
+// NATEntry is one row from /show/rc/ip/nat.
+type NATEntry struct {
+	Interface string `json:"interface"`
+}
+
+const natTTL = 30 * time.Second
+
+// NATStore caches /show/rc/ip/nat.
+type NATStore struct {
+	*cache.ListStore[[]NATEntry]
+	getter Getter
+}
+
+func NewNATStore(g Getter, log Logger) *NATStore {
+	s := &NATStore{getter: g}
+	s.ListStore = cache.NewListStore(natTTL, log, "ip-nat", s.fetch)
+	return s
+}
+
+// HasInterface reports whether NAT is enabled for the given NDMS interface name.
+func (s *NATStore) HasInterface(ctx context.Context, iface string) (bool, error) {
+	entries, err := s.List(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		if e.Interface == iface {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *NATStore) fetch(ctx context.Context) ([]NATEntry, error) {
+	raw, err := s.getter.GetRaw(ctx, "/show/rc/ip/nat")
+	if err != nil {
+		return nil, fmt.Errorf("fetch ip nat: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var entries []NATEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		// Some firmware returns a single object instead of an array.
+		var single NATEntry
+		if err2 := json.Unmarshal(raw, &single); err2 != nil {
+			return nil, fmt.Errorf("decode ip nat: %w", err)
+		}
+		if single.Interface != "" {
+			return []NATEntry{single}, nil
+		}
+		return nil, nil
+	}
+	return entries, nil
+}

--- a/internal/ndms/query/nat_test.go
+++ b/internal/ndms/query/nat_test.go
@@ -1,0 +1,31 @@
+package query
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNATStore_HasInterface(t *testing.T) {
+	fg := newFakeGetter()
+	fg.SetJSON("/show/rc/ip/nat", `[
+		{"interface":"Wireguard0"},
+		{"interface":"Home"}
+	]`)
+	s := NewNATStore(fg, nopLogger{})
+
+	ok, err := s.HasInterface(context.Background(), "Wireguard0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected NAT on Wireguard0")
+	}
+
+	ok, err = s.HasInterface(context.Background(), "Wireguard9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected no NAT on Wireguard9")
+	}
+}

--- a/internal/ndms/query/registry.go
+++ b/internal/ndms/query/registry.go
@@ -22,6 +22,9 @@ type Queries struct {
 	RunningConfig    *RunningConfigStore
 	SystemInfo       *SystemInfoStore
 	WGServers        *WGServerStore
+	NAT              *NATStore
+	StaticNAT        *StaticNATStore
+	KeenDNS          *KeenDNSStore
 }
 
 // Deps groups the non-Store dependencies NewQueries needs.
@@ -79,5 +82,8 @@ func NewQueries(d Deps) *Queries {
 		RunningConfig:    NewRunningConfigStore(d.Getter, d.Logger),
 		SystemInfo:       NewSystemInfoStore(d.Getter, d.Logger),
 		WGServers:        NewWGServerStore(d.Getter, d.Logger, ifaces),
+		NAT:              NewNATStore(d.Getter, d.Logger),
+		StaticNAT:        NewStaticNATStore(d.Getter, d.Logger),
+		KeenDNS:          NewKeenDNSStore(d.Getter, d.Logger),
 	}
 }

--- a/internal/ndms/query/static_nat.go
+++ b/internal/ndms/query/static_nat.go
@@ -1,0 +1,66 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms/cache"
+)
+
+// StaticNATEntry is one row from /show/rc/ip/static.
+type StaticNATEntry struct {
+	Interface    string `json:"interface"`
+	ToInterface  string `json:"to-interface"`
+}
+
+const staticNATTTL = 30 * time.Second
+
+// StaticNATStore caches /show/rc/ip/static.
+type StaticNATStore struct {
+	*cache.ListStore[[]StaticNATEntry]
+	getter Getter
+}
+
+func NewStaticNATStore(g Getter, log Logger) *StaticNATStore {
+	s := &StaticNATStore{getter: g}
+	s.ListStore = cache.NewListStore(staticNATTTL, log, "ip-static", s.fetch)
+	return s
+}
+
+// ForInterface reports whether static NAT is configured for iface and the WAN target.
+func (s *StaticNATStore) ForInterface(ctx context.Context, iface string) (bool, string, error) {
+	entries, err := s.List(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	for _, e := range entries {
+		if e.Interface == iface {
+			return true, e.ToInterface, nil
+		}
+	}
+	return false, "", nil
+}
+
+func (s *StaticNATStore) fetch(ctx context.Context) ([]StaticNATEntry, error) {
+	raw, err := s.getter.GetRaw(ctx, "/show/rc/ip/static")
+	if err != nil {
+		return nil, fmt.Errorf("fetch ip static: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var entries []StaticNATEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		var single StaticNATEntry
+		if err2 := json.Unmarshal(raw, &single); err2 != nil {
+			return nil, fmt.Errorf("decode ip static: %w", err)
+		}
+		if single.Interface != "" {
+			return []StaticNATEntry{single}, nil
+		}
+		return nil, nil
+	}
+	return entries, nil
+}

--- a/internal/ndms/query/wireguard.go
+++ b/internal/ndms/query/wireguard.go
@@ -89,6 +89,7 @@ type rciWireguardDetail struct {
 type rciWireguardPeer struct {
 	PublicKey             string `json:"public-key"`
 	Description           string `json:"description"`
+	Comment               string `json:"comment"`
 	RemoteEndpointAddress string `json:"remote-endpoint-address"`
 	RemotePort            int    `json:"remote-port"`
 	Via                   string `json:"via"`
@@ -328,13 +329,13 @@ func (s *WGServerStore) fetchAll(ctx context.Context) ([]ndms.WireguardServer, e
 	}
 	sort.Slice(servers, func(i, j int) bool { return servers[i].ID < servers[j].ID })
 
-	// Enrich peers with AllowedIPs from RC in parallel. Transport-layer
-	// semaphore bounds concurrency; we only coordinate completion.
+	// Enrich peers with RC fields (allowed-ips, comment) in parallel.
+	// Transport-layer semaphore bounds concurrency; we only coordinate completion.
 	if len(servers) > 0 {
 		var wg sync.WaitGroup
 		type enrichResult struct {
 			idx int
-			m   map[string][]string
+			m   map[string]peerRCFields
 			err error
 		}
 		results := make(chan enrichResult, len(servers))
@@ -342,7 +343,7 @@ func (s *WGServerStore) fetchAll(ctx context.Context) ([]ndms.WireguardServer, e
 			wg.Add(1)
 			go func(idx int, name string) {
 				defer wg.Done()
-				allowedByKey, err := s.fetchPeerAllowedIPsByKey(ctx, name)
+				allowedByKey, err := s.fetchPeerRCByKey(ctx, name)
 				results <- enrichResult{idx: idx, m: allowedByKey, err: err}
 			}(i, servers[i].ID)
 		}
@@ -352,8 +353,8 @@ func (s *WGServerStore) fetchAll(ctx context.Context) ([]ndms.WireguardServer, e
 				continue
 			}
 			for j := range servers[r.idx].Peers {
-				if ips, ok := r.m[servers[r.idx].Peers[j].PublicKey]; ok {
-					servers[r.idx].Peers[j].AllowedIPs = ips
+				if rc, ok := r.m[servers[r.idx].Peers[j].PublicKey]; ok {
+					applyPeerRCFields(&servers[r.idx].Peers[j], rc)
 				}
 			}
 		}
@@ -369,22 +370,36 @@ func (s *WGServerStore) fetchItem(ctx context.Context, name string) (*ndms.Wireg
 	srv := rciToWireguardServer(detail)
 	srv.ID = name
 	srv.InterfaceName = s.resolveSystemName(ctx, name)
-	if allowedByKey, err := s.fetchPeerAllowedIPsByKey(ctx, name); err == nil {
+	if rcByKey, err := s.fetchPeerRCByKey(ctx, name); err == nil {
 		for j := range srv.Peers {
-			if ips, ok := allowedByKey[srv.Peers[j].PublicKey]; ok {
-				srv.Peers[j].AllowedIPs = ips
+			if rc, ok := rcByKey[srv.Peers[j].PublicKey]; ok {
+				applyPeerRCFields(&srv.Peers[j], rc)
 			}
 		}
 	}
 	return &srv, nil
 }
 
-func (s *WGServerStore) fetchPeerAllowedIPsByKey(ctx context.Context, name string) (map[string][]string, error) {
+type peerRCFields struct {
+	allowedIPs []string
+	comment    string
+}
+
+func applyPeerRCFields(peer *ndms.WireguardServerPeer, rc peerRCFields) {
+	if len(rc.allowedIPs) > 0 {
+		peer.AllowedIPs = rc.allowedIPs
+	}
+	if peer.Description == "" && rc.comment != "" {
+		peer.Description = rc.comment
+	}
+}
+
+func (s *WGServerStore) fetchPeerRCByKey(ctx context.Context, name string) (map[string]peerRCFields, error) {
 	var rc rciRCInterface
 	if err := s.getter.Get(ctx, "/show/rc/interface/"+name, &rc); err != nil {
 		return nil, err
 	}
-	out := make(map[string][]string)
+	out := make(map[string]peerRCFields)
 	if rc.Wireguard == nil {
 		return out, nil
 	}
@@ -398,7 +413,7 @@ func (s *WGServerStore) fetchPeerAllowedIPsByKey(ctx context.Context, name strin
 			}
 			ips = append(ips, fmt.Sprintf("%s/%d", a.Address, ones))
 		}
-		out[rp.Key] = ips
+		out[rp.Key] = peerRCFields{allowedIPs: ips, comment: rp.Comment}
 	}
 	return out, nil
 }
@@ -492,6 +507,13 @@ func (s *WGServerStore) resolveSystemName(ctx context.Context, ndmsID string) st
 // callers can detect empty decodes without reaching into the embedded struct.
 func (d rciWireguardDetail) ID() string { return d.InterfaceName }
 
+func peerRuntimeDescription(p rciWireguardPeer) string {
+	if p.Description != "" {
+		return p.Description
+	}
+	return p.Comment
+}
+
 func formatPeerEndpoint(p rciWireguardPeer) string {
 	if p.RemoteEndpointAddress == "" && p.RemotePort == 0 {
 		return ""
@@ -550,7 +572,7 @@ func rciToWireguardServer(iface rciWireguardDetail) ndms.WireguardServer {
 		for _, p := range iface.Wireguard.Peer {
 			server.Peers = append(server.Peers, ndms.WireguardServerPeer{
 				PublicKey:     p.PublicKey,
-				Description:   p.Description,
+				Description:   peerRuntimeDescription(p),
 				Endpoint:      formatPeerEndpoint(p),
 				RxBytes:       p.RxBytes,
 				TxBytes:       p.TxBytes,

--- a/internal/ndms/query/wireguard_test.go
+++ b/internal/ndms/query/wireguard_test.go
@@ -226,6 +226,51 @@ func TestWGServerStore_GetAll_ParsesRuntime(t *testing.T) {
 	}
 }
 
+func TestWGServerStore_PeerDescription_FromRCCommentWhenRuntimeEmpty(t *testing.T) {
+	fg := newFakeGetter()
+	const ifaceList = `{
+		"Wireguard1": {
+			"id": "Wireguard1",
+			"interface-name": "nwg1",
+			"type": "Wireguard",
+			"description": "ourserver",
+			"state": "up",
+			"connected": "yes",
+			"address": "10.0.1.1",
+			"mask": "255.255.255.0",
+			"mtu": 1420,
+			"wireguard": {
+				"public-key": "SRVKEY1=",
+				"listen-port": 51821,
+				"peer": [
+					{
+						"public-key": "PEERB=",
+						"remote-endpoint-address": "5.6.7.8",
+						"remote-port": 51820,
+						"enabled": false
+					}
+				]
+			}
+		}
+	}`
+	fg.SetJSON("/show/interface/", ifaceList)
+	fg.SetPostInterface("Wireguard1", wrapShowInterface(sampleWGSingleInterfaceJSON))
+	fg.SetJSON("/show/rc/interface/Wireguard1", sampleWGRCInterfaceJSON)
+	fg.SetJSON("/show/interface/system-name?name=Wireguard1", `"nwg1"`)
+
+	s := NewWGServerStore(fg, NopLogger(), NewInterfaceStore(fg, NopLogger()))
+	servers, err := s.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(servers) != 1 || len(servers[0].Peers) != 1 {
+		t.Fatalf("unexpected servers: %+v", servers)
+	}
+	if got := servers[0].Peers[0].Description; got != "bob" {
+		t.Fatalf("Description = %q, want bob from RC comment", got)
+	}
+}
+
 func TestWGServerStore_GetAll_CacheHitSkipsFetch(t *testing.T) {
 	fg := newFakeGetter()
 	primeWGFakeGetter(fg)

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -2497,6 +2497,15 @@ definitions:
       state:
         type: string
     type: object
+  api.ServerAddPeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      tunnelIP:
+        example: 10.0.14.2/32
+        type: string
+    type: object
   api.ServerSettingsDTO:
     properties:
       interface:
@@ -2505,6 +2514,15 @@ definitions:
       port:
         example: 8080
         type: integer
+    type: object
+  api.ServerUpdatePeerRequestDTO:
+    properties:
+      description:
+        example: My Phone
+        type: string
+      tunnelIP:
+        example: 10.0.14.2/32
+        type: string
     type: object
   api.ServersAllData:
     properties:
@@ -4786,6 +4804,9 @@ definitions:
       address:
         example: 10.0.1.1
         type: string
+      builtIn:
+        example: true
+        type: boolean
       connected:
         example: true
         type: boolean
@@ -4798,6 +4819,9 @@ definitions:
       interfaceName:
         example: Wireguard0
         type: string
+      keenDnsDomain:
+        example: home.keenetic.pro
+        type: string
       listenPort:
         example: 51820
         type: integer
@@ -4807,10 +4831,30 @@ definitions:
       mtu:
         example: 1420
         type: integer
+      natEnabled:
+        example: true
+        type: boolean
+      natMode:
+        example: full
+        type: string
+      natModeKnown:
+        description: |-
+          NATModeKnown/PolicyKnown are false when the corresponding NDMS read
+          failed (e.g. transient router error). The frontend must render an
+          "unknown" state instead of trusting the zero-valued NATMode/Policy,
+          which would otherwise read as a fabricated "none".
+        example: true
+        type: boolean
       peers:
         items:
           $ref: '#/definitions/api.WireguardServerPeerDTO'
         type: array
+      policy:
+        example: Policy0
+        type: string
+      policyKnown:
+        example: true
+        type: boolean
       publicKey:
         example: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE=
         type: string
@@ -4826,6 +4870,9 @@ definitions:
         items:
           type: string
         type: array
+      confAvailable:
+        example: true
+        type: boolean
       description:
         example: Phone
         type: string
@@ -8581,6 +8628,281 @@ paths:
       summary: Routing tunnel catalog
       tags:
       - routing
+  /servers/{name}/nat:
+    post:
+      consumes:
+      - application/json
+      description: Sets the NAT mode (full / internet-only / none) on the named WireGuard
+        server via NDMS. Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: NAT mode
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.SetNATModeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Set server NAT mode
+      tags:
+      - servers
+  /servers/{name}/peers:
+    post:
+      consumes:
+      - application/json
+      description: Generates a keypair and registers a new peer on the named WireGuard
+        server. Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Peer description and tunnel IP
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.ServerAddPeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Add server peer
+      tags:
+      - servers
+  /servers/{name}/peers/{pubkey}:
+    delete:
+      description: Removes the peer with the given public key from the named WireGuard
+        server. Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Peer public key
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Delete server peer
+      tags:
+      - servers
+    put:
+      consumes:
+      - application/json
+      description: Changes a peer's allowed-IP and/or description on the named WireGuard
+        server. Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Peer public key
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: New description and tunnel IP
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.ServerUpdatePeerRequestDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Update server peer
+      tags:
+      - servers
+  /servers/{name}/peers/{pubkey}/conf:
+    get:
+      description: Generates the WireGuard client .conf for the peer. Only available
+        when the peer's private key was created via AWG Manager and is stored locally.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Peer public key
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get server peer config
+      tags:
+      - servers
+  /servers/{name}/peers/{pubkey}/toggle:
+    post:
+      consumes:
+      - application/json
+      description: Enables or disables (connect on/off) the peer on the named WireGuard
+        server. Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Peer public key
+        in: path
+        name: pubkey
+        required: true
+        type: string
+      - description: Enabled flag
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.EnabledToggleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Toggle server peer
+      tags:
+      - servers
+  /servers/{name}/policy:
+    post:
+      consumes:
+      - application/json
+      description: Binds the named WireGuard server interface to an NDMS hotspot access
+        policy (or "none"). Returns the fresh servers snapshot.
+      parameters:
+      - description: Interface name (e.g. Wireguard0)
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Policy id (router-side) or 'none'
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.SetServerPolicyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServersAllResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Set server access policy
+      tags:
+      - servers
   /servers/all:
     get:
       description: 'Returns the composite servers snapshot: WireGuard servers list,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -881,6 +881,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/servers/enabled", guarded(serverHandler.SetEnabled))
 	mux.HandleFunc("/api/servers/restart", guarded(serverHandler.Restart))
 	mux.HandleFunc("/api/servers/wan-ip", guarded(serverHandler.WANIP))
+	mux.HandleFunc("/api/servers/", guarded(serverHandler.Subtree))
 
 	// Managed WireGuard Servers (protected + boot guarded). The new
 	// route table is id-keyed: see ManagedServerHandler.Subtree for the
@@ -888,6 +889,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	managedHandler := api.NewManagedServerHandler(s.managedService)
 	managedHandler.SetServersHandler(serverHandler)
 	serverHandler.SetManagedHandler(managedHandler)
+	if s.managedServiceImpl != nil {
+		serverHandler.SetManagedService(s.managedServiceImpl)
+	}
 	mux.HandleFunc("/api/managed-servers", guarded(managedHandler.Collection))
 	mux.HandleFunc("/api/managed-servers/", guarded(managedHandler.Subtree))
 
@@ -1006,6 +1010,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Cross-wire servers <-> managed for unified server:updated event
 	serverHandler.SetManagedHandler(managedHandler)
 	managedHandler.SetServersHandler(serverHandler)
+	if s.managedServiceImpl != nil {
+		serverHandler.SetManagedService(s.managedServiceImpl)
+	}
 
 	// Plug MetricsPoller into the handler now that ServersHandler is fully
 	// wired (bus + managed). The poller re-broadcasts the full server snapshot

--- a/internal/storage/patch_test.go
+++ b/internal/storage/patch_test.go
@@ -320,10 +320,38 @@ func containsSubstr(s, sub string) bool {
 	return false
 }
 
+// nonPatchableSettings are Settings fields intentionally kept OUT of the
+// SettingsPatch wire surface. They are server-internal bookkeeping written
+// only through dedicated atomic store methods (UpdateServerInterfaceMeta,
+// SetServerPeerSecret), never through /settings/update. serverPeerSecrets in
+// particular holds client WireGuard private keys, so exposing it on the
+// generic PATCH would let an authenticated caller overwrite or wipe key
+// material — see TestSettingsPatch_ExcludesServerSecrets.
+var nonPatchableSettings = map[string]struct{}{
+	"serverInterfaceMeta": {},
+	"serverPeerSecrets":   {},
+}
+
+// TestSettingsPatch_ExcludesServerSecrets pins the intentional exclusion: a
+// future change that "mirrors" these fields into SettingsPatch (the obvious
+// way to green the mirror test) would be a security regression, so assert
+// they are absent from the patch DTO.
+func TestSettingsPatch_ExcludesServerSecrets(t *testing.T) {
+	patchT := reflect.TypeOf(SettingsPatch{})
+	for tag := range nonPatchableSettings {
+		for i := 0; i < patchT.NumField(); i++ {
+			if strings.Split(patchT.Field(i).Tag.Get("json"), ",")[0] == tag {
+				t.Errorf("SettingsPatch must not expose %q (server-internal secret/bookkeeping)", tag)
+			}
+		}
+	}
+}
+
 // TestSettingsPatchMirrorsSettings enforces that every exported field in
 // Settings has a matching pointer field in SettingsPatch with the same
-// json tag. Catches drift at test time when a new Settings field lands
-// without a corresponding SettingsPatch entry.
+// json tag (except deliberately nonPatchableSettings). Catches drift at test
+// time when a new Settings field lands without a corresponding SettingsPatch
+// entry.
 func TestSettingsPatchMirrorsSettings(t *testing.T) {
 	settingsT := reflect.TypeOf(Settings{})
 	patchT := reflect.TypeOf(SettingsPatch{})
@@ -345,6 +373,11 @@ func TestSettingsPatchMirrorsSettings(t *testing.T) {
 		}
 		tag := strings.Split(f.Tag.Get("json"), ",")[0]
 		if tag == "" || tag == "-" {
+			continue
+		}
+		if _, skip := nonPatchableSettings[tag]; skip {
+			// Deliberately excluded from the wire PATCH surface — see
+			// nonPatchableSettings and TestSettingsPatch_ExcludesServerSecrets.
 			continue
 		}
 		patchF, ok := patchByTag[tag]

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -723,6 +723,83 @@ func (s *SettingsStore) IsServerInterface(id string) bool {
 	return contains(settings.ServerInterfaces, id)
 }
 
+// GetServerInterfaceMeta returns AWG Manager metadata for a system server.
+func (s *SettingsStore) GetServerInterfaceMeta(serverID string) (ServerInterfaceMeta, bool) {
+	settings, err := s.Get()
+	if err != nil || settings.ServerInterfaceMeta == nil {
+		return ServerInterfaceMeta{}, false
+	}
+	meta, ok := settings.ServerInterfaceMeta[serverID]
+	return meta, ok
+}
+
+// UpdateServerInterfaceMeta updates metadata for a system server.
+func (s *SettingsStore) UpdateServerInterfaceMeta(serverID string, fn func(*ServerInterfaceMeta) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settings == nil {
+		return fmt.Errorf("settings not loaded")
+	}
+	if s.settings.ServerInterfaceMeta == nil {
+		s.settings.ServerInterfaceMeta = map[string]ServerInterfaceMeta{}
+	}
+	meta := s.settings.ServerInterfaceMeta[serverID]
+	if err := fn(&meta); err != nil {
+		return err
+	}
+	s.settings.ServerInterfaceMeta[serverID] = meta
+	return s.saveUnlocked(s.settings)
+}
+
+// GetServerPeerSecret returns stored key material for a system-server peer.
+func (s *SettingsStore) GetServerPeerSecret(serverID, pubkey string) (ServerPeerSecret, bool) {
+	settings, err := s.Get()
+	if err != nil || settings.ServerPeerSecrets == nil {
+		return ServerPeerSecret{}, false
+	}
+	peers, ok := settings.ServerPeerSecrets[serverID]
+	if !ok {
+		return ServerPeerSecret{}, false
+	}
+	sec, ok := peers[pubkey]
+	return sec, ok
+}
+
+// SetServerPeerSecret stores key material for a system-server peer.
+func (s *SettingsStore) SetServerPeerSecret(serverID, pubkey string, sec ServerPeerSecret) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settings == nil {
+		return fmt.Errorf("settings not loaded")
+	}
+	if s.settings.ServerPeerSecrets == nil {
+		s.settings.ServerPeerSecrets = map[string]map[string]ServerPeerSecret{}
+	}
+	if s.settings.ServerPeerSecrets[serverID] == nil {
+		s.settings.ServerPeerSecrets[serverID] = map[string]ServerPeerSecret{}
+	}
+	s.settings.ServerPeerSecrets[serverID][pubkey] = sec
+	return s.saveUnlocked(s.settings)
+}
+
+// DeleteServerPeerSecret removes stored key material for a system-server peer.
+func (s *SettingsStore) DeleteServerPeerSecret(serverID, pubkey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.settings == nil {
+		return fmt.Errorf("settings not loaded")
+	}
+	peers, ok := s.settings.ServerPeerSecrets[serverID]
+	if !ok {
+		return nil
+	}
+	delete(peers, pubkey)
+	if len(peers) == 0 {
+		delete(s.settings.ServerPeerSecrets, serverID)
+	}
+	return s.saveUnlocked(s.settings)
+}
+
 // migratePortFile reads port from old port file and removes it.
 func (s *SettingsStore) migratePortFile(settings *Settings) {
 	portFile := filepath.Join(filepath.Dir(s.path), "port")

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -21,6 +21,13 @@ type Settings struct {
 	ConnectivityCheckURL string            `json:"connectivityCheckUrl"`
 	UsageLevel           string            `json:"usageLevel"`
 	ServerInterfaces     []string          `json:"serverInterfaces,omitempty"`
+	// ServerInterfaceMeta stores AWG Manager bookkeeping for built-in/marked
+	// servers (NAT static-WAN for internet-only teardown). map[serverID].
+	ServerInterfaceMeta map[string]ServerInterfaceMeta `json:"serverInterfaceMeta,omitempty"`
+	// ServerPeerSecrets stores private keys for peers created via AWG Manager
+	// on built-in/marked NDMS servers (NDMS itself does not retain client keys).
+	// map[serverID]map[publicKey]ServerPeerSecret
+	ServerPeerSecrets  map[string]map[string]ServerPeerSecret `json:"serverPeerSecrets,omitempty"`
 	ManagedServers       []ManagedServer   `json:"managedServers,omitempty"`
 	// ManagedServer is retained for one release as the migration source.
 	// migrateManagedServers() moves it into ManagedServers[0] on first read
@@ -133,6 +140,20 @@ type ManagedServer struct {
 	// params (jc/jmin/jmax/s1/s2/s3/s4/h1/h2/h3/h4). Not persisted in
 	// settings.json — NDMS remains source-of-truth for these fields.
 	ASC json.RawMessage `json:"-"`
+}
+
+// ServerInterfaceMeta tracks NAT teardown metadata for system servers.
+type ServerInterfaceMeta struct {
+	NATMode      string `json:"natMode,omitempty"`      // full | internet-only | none
+	NATStaticWAN string `json:"natStaticWan,omitempty"` // WAN iface used by ip static
+}
+
+// ServerPeerSecret holds key material for a peer on a built-in/marked server.
+type ServerPeerSecret struct {
+	PrivateKey   string `json:"privateKey"`
+	PresharedKey string `json:"presharedKey,omitempty"`
+	Description  string `json:"description,omitempty"`
+	TunnelIP     string `json:"tunnelIP,omitempty"`
 }
 
 // ManagedPeer represents a client peer on the managed server.


### PR DESCRIPTION
## Управление встроенным WireGuard-сервером из UI

Раньше полноценно управлять можно было только managed-серверами (AmneziaWG). Встроенный WG на роутере в UI был по сути read-only — пиры, NAT и политики доступа трогать нельзя.

Теперь для системных серверов тот же набор действий, что и у managed: пиры, NAT, политика доступа.

### Что сделано

**Backend**
- Новые эндпоинты под `/api/servers/{name}/...`: пиры (CRUD, toggle, conf), NAT (`full` / `internet-only` / `none`), политика доступа
- Состояние NAT и policy читается из NDMS (NAT, StaticNAT, hotspot policy)
- Секреты пиров (ключи, IP) хранятся в settings — чтобы можно было отдавать `.conf` после перезагрузки
- В ответе списка серверов: `builtIn`, `natMode`, `policy`, `keenDnsDomain`

**Frontend**
- `ServerCard` приведён к уровню `ManagedServerCard`: NAT, policy, таблица пиров, добавление/редактирование
- Общие куски вынесены: `ServerAccessPolicyDropdown`, `serverCardShared.css`, `ManagedPeerTable`
- API-клиент и mock-proxy обновлены под новые ручки

### Зачем так

Один UX для двух типов серверов — не нужно лезть в CLI/конфиг роутера для базовых операций. Логика NAT/policy переиспользуется между system и managed, без дублирования в карточках.

### Test plan

- [ ] Открыть встроенный WG-сервер на `/servers` — видны NAT, policy, список пиров
- [ ] Добавить / отредактировать / удалить пира, скачать `.conf`
- [ ] Переключить NAT: full → internet-only → none, убедиться что состояние сохраняется после refresh
- [ ] Сменить политику доступа
- [ ] Проверить что managed-серверы не сломались (регрессия после рефакторинга карточек)
- [ ] Прогнать mock-proxy в dev-режиме