### PR TITLE
fix(accesspolicy): туннели не показываются down в политиках

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -647,6 +647,11 @@ func main() {
 	sysfsTrafficPoller.Start()
 
 	orch.SetEventBus(eventBus)
+	// Refresh the NDMS interface cache when a kernel tunnel is confirmed up:
+	// OpkgTun iflayerchanged hooks are unreliable, so the cache otherwise keeps
+	// a frozen "down" snapshot and policy/WAN/all-interface lists misreport the
+	// tunnel as down (#328). Async — Invalidate does a blocking HTTP.
+	orch.SetInterfaceInvalidator(func(name string) { go ndmsQueries.Interfaces.Invalidate(name) })
 	loggingService.SetEventBus(eventBus)
 	tunnelService.SetEventBus(eventBus)
 	pingCheckFacade.SetEventBus(eventBus)

--- a/internal/orchestrator/interface_refresh_test.go
+++ b/internal/orchestrator/interface_refresh_test.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/tunnel"
+)
+
+// On a kernel tunnel's confirmed "running" transition, the orchestrator must
+// refresh the NDMS interface cache (issue #328): NDMS iflayerchanged hooks are
+// unreliable for OpkgTun, so without a proactive invalidate the cached
+// State/IPv4 stays frozen and policy/WAN/all-interface lists show the tunnel
+// down forever despite it being up.
+func TestUpdateState_RunningKernel_InvalidatesInterfaceCache(t *testing.T) {
+	const id = "abc42"
+	o := &Orchestrator{state: newState(), bus: events.NewBus(), store: storage.NewAWGTunnelStore(t.TempDir())}
+	o.state.tunnels[id] = &tunnelState{ID: id, Name: "vpn", Backend: "kernel", Running: true}
+
+	var got []string
+	o.SetInterfaceInvalidator(func(name string) { got = append(got, name) })
+
+	o.updateState(Action{Type: ActionColdStartKernel, Tunnel: id})
+
+	want := tunnel.NewNames(id).NDMSName // "OpkgTun42"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("invalidator calls = %v, want exactly [%q]", got, want)
+	}
+}
+
+// NativeWG self-invalidates on its own create/start path (and uses a different
+// NDMS name), so the orchestrator must NOT invalidate an "OpkgTunN" name for it.
+func TestUpdateState_RunningNativeWG_DoesNotInvalidate(t *testing.T) {
+	const id = "abc43"
+	o := &Orchestrator{state: newState(), bus: events.NewBus(), store: storage.NewAWGTunnelStore(t.TempDir())}
+	o.state.tunnels[id] = &tunnelState{ID: id, Name: "vpn", Backend: "nativewg", Running: true}
+
+	var got []string
+	o.SetInterfaceInvalidator(func(name string) { got = append(got, name) })
+
+	o.updateState(Action{Type: ActionStartNativeWG, Tunnel: id})
+
+	if len(got) != 0 {
+		t.Fatalf("nativewg must not trigger OpkgTun invalidation, got %v", got)
+	}
+}
+
+// A stop transition must not invalidate (nothing to refresh as up).
+func TestUpdateState_StoppedKernel_DoesNotInvalidate(t *testing.T) {
+	const id = "abc44"
+	o := &Orchestrator{state: newState(), bus: events.NewBus(), store: storage.NewAWGTunnelStore(t.TempDir())}
+	o.state.tunnels[id] = &tunnelState{ID: id, Name: "vpn", Backend: "kernel", Running: false}
+
+	var got []string
+	o.SetInterfaceInvalidator(func(name string) { got = append(got, name) })
+
+	o.updateState(Action{Type: ActionStopKernel, Tunnel: id})
+
+	if len(got) != 0 {
+		t.Fatalf("stop must not invalidate, got %v", got)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -89,6 +89,12 @@ type Orchestrator struct {
 
 	// clock returns current time; injectable for tests. nil → time.Now.
 	clock func() time.Time
+
+	// ifaceInvalidator, when set, refreshes the NDMS interface cache for a
+	// kernel tunnel's NDMS name on its confirmed "running" transition (#328).
+	// nil-safe. Production wires an async closure; the orchestrator calls it
+	// synchronously so async-ness stays a wiring detail (and tests deterministic).
+	ifaceInvalidator func(name string)
 }
 
 // New creates a new Orchestrator.
@@ -126,6 +132,10 @@ func (o *Orchestrator) SetClientRoute(cr ClientRouteExecutor) { o.clientRoute = 
 
 // SetEventBus sets the event bus for SSE publishing.
 func (o *Orchestrator) SetEventBus(bus *events.Bus) { o.bus = bus }
+
+// SetInterfaceInvalidator wires the NDMS interface-cache refresh invoked on a
+// kernel tunnel's confirmed "running" transition. nil-safe. See issue #328.
+func (o *Orchestrator) SetInterfaceInvalidator(fn func(name string)) { o.ifaceInvalidator = fn }
 
 // SetSupportsASC sets the ASC support flag.
 func (o *Orchestrator) SetSupportsASC(fn func() bool) {
@@ -433,6 +443,18 @@ func (o *Orchestrator) updateState(action Action) {
 				ID: t.ID, Name: t.Name, State: "running", Backend: t.Backend,
 			})
 			publishInvalidatedBus(o.bus, "tunnels", "state-running")
+			// Kernel tunnels: NDMS iflayerchanged hooks are unreliable for
+			// OpkgTun, so the cache invalidate done at InterfaceUp can snapshot
+			// a pre-"running" layer and then never get corrected — leaving
+			// List* readers (policies/WAN/all) with a frozen "down" (#328).
+			// Re-refresh now that the start sequence is fully complete and the
+			// layer has had time to settle. nwg self-invalidates on its own
+			// path (and uses a different NDMS name), so skip it.
+			if o.ifaceInvalidator != nil && t.Backend == "kernel" {
+				if ndmsName := tunnel.NewNames(t.ID).NDMSName; ndmsName != "" {
+					o.ifaceInvalidator(ndmsName)
+				}
+			}
 		case ActionStopKernel, ActionStopNativeWG, ActionSuspendProxy, ActionSuspendKernel:
 			o.bus.Publish("tunnel:state", events.TunnelStateEvent{
 				ID: t.ID, Name: t.Name, State: "stopped", Backend: t.Backend,


### PR DESCRIPTION
(#328)

Для OpkgTun NDMS iflayerchanged-хуки ненадёжны: InterfaceUp инвалидирует кэш интерфейсов сразу после подъёма, снимая «не-running» снимок, а поздней коррекции не приходит — кэш застывает в down. ListGlobalInterfaces (политики), ListWAN, ListAll читают этот кэш → туннели выключены, хотя реально up (state.Manager верен, т.к. читает живой /summary+sysfs).

Оркестратор по подтверждённому переходу в running (после полного start- экшена, когда слой устаканился) проактивно рефрешит кэш интерфейса для kernel-туннеля: SetInterfaceInvalidator + вызов в updateState (гейт Backend==kernel, nwg инвалидируется сам). Проводка в main: async go-Invalidate.

Тест: kernel-running → Invalidate(OpkgTunN); nativewg/stop → нет.