### PR TITLE
fix(httpclient): DNS-запрос через туннель без QDCOUNT  (#239)

### DIFF
--- a/internal/sys/httpclient/dns.go
+++ b/internal/sys/httpclient/dns.go
@@ -109,6 +109,9 @@ func encodeDNSQuery(host string) ([]byte, error) {
 	out[0] = 0x12
 	out[1] = 0x34
 	out[2] = 0x01 // RD=1
+	// QDCOUNT=1 — the packet carries one question. Without it, strict resolvers
+	// reject the query with FORMERR/rcode 1 (#239: download-via-AWG-tunnel DNS).
+	binary.BigEndian.PutUint16(out[4:], 1)
 	copy(out[12:], q)
 	off := 12 + len(q)
 	binary.BigEndian.PutUint16(out[off:], 1)   // A

--- a/internal/sys/httpclient/dns_test.go
+++ b/internal/sys/httpclient/dns_test.go
@@ -14,6 +14,18 @@ func TestEncodeDNSQuery(t *testing.T) {
 	if len(q) < 20 {
 		t.Fatalf("query too short: %d", len(q))
 	}
+	// QDCOUNT must be 1 — the packet carries one question. A query that omits
+	// it (QDCOUNT=0 with a question present) is malformed and strict resolvers
+	// reject it with FORMERR/rcode 1 (#239: download-via-AWG-tunnel DNS).
+	if qd := binary.BigEndian.Uint16(q[4:6]); qd != 1 {
+		t.Errorf("QDCOUNT = %d, want 1", qd)
+	}
+	// Sanity: ANCOUNT/NSCOUNT/ARCOUNT are 0 in a query.
+	for name, off := range map[string]int{"ANCOUNT": 6, "NSCOUNT": 8, "ARCOUNT": 10} {
+		if v := binary.BigEndian.Uint16(q[off : off+2]); v != 0 {
+			t.Errorf("%s = %d, want 0", name, v)
+		}
+	}
 }
 
 func TestParseDNSARecord_directA(t *testing.T) {


### PR DESCRIPTION
encodeDNSQuery формировал пакет с вопросом, но QDCOUNT в заголовке оставался 0 (заголовок не заполнялся). DNS-сервер (rcode 1) → «httpclient: tunnel DNS lookup …: DNS error rcode 1» при загрузке через AWG/Amnezia-туннель (список серверов Amnezia, апдейт через repo.hoaxisr.ru). 

Ставим QDCOUNT=1. Тест расширен: проверяет QDCOUNT==1 и нулевые AN/NS/AR (был только len). 