### PR TITLE
chore(httpclient): t.Context() → context.Background() в тесте 

### DIFF
--- a/internal/sys/httpclient/dns_test.go
+++ b/internal/sys/httpclient/dns_test.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
 	"testing"
@@ -30,7 +31,7 @@ func TestEncodeDNSQuery(t *testing.T) {
 
 func TestParseDNSARecord_directA(t *testing.T) {
 	pkt := buildDNSResponse(1, net.IPv4(1, 2, 3, 4).To4())
-	ip, err := parseDNSARecord(t.Context(), pkt, "1.1.1.1", "", 0)
+	ip, err := parseDNSARecord(context.Background(), pkt, "1.1.1.1", "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION


dns_test.go использовал t.Context() (go1.24+) при go.mod go 1.23 — go vet ругался «testing.Context requires go1.24». Единственное вхождение в репо; проект намеренно на 1.23, поэтому не бампаем версию, а используем context.Background() в тесте