### PR TITLE
Fix/331 delete last subscription

### DIFF
--- a/internal/singbox/subscription/batch_flush_test.go
+++ b/internal/singbox/subscription/batch_flush_test.go
@@ -85,3 +85,38 @@ func TestOperatorAdapter_RollbackRestoresCommitted(t *testing.T) {
 		t.Errorf("after rollback want 1 (committed), got %d", got)
 	}
 }
+
+// #331 regression: deleting the last subscription removes every outbound,
+// emptying the slot. Committing that teardown must SUCCEED — the "no valid
+// outbounds left" guard is for an additive Create/Refresh where every server
+// was dropped as invalid, NOT for a deliberate emptying. If commit errors,
+// deleteLocked's Reload-error check blocks store.Delete AND Reload restores the
+// just-deleted config, making the last subscription undeletable.
+func TestOperatorAdapter_CommitEmptySlotOnDelete(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	orch.SetValidator(&countingValidator{})
+	adapter := NewOperatorAdapter(orch, nil, nil)
+
+	// Materialise the only subscription member and commit it.
+	if err := adapter.AddOutbound("sub-x-0", validVlessJSON("10.0.0.1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Reload(context.Background()); err != nil {
+		t.Fatalf("initial commit: %v", err)
+	}
+
+	// Delete it: remove the only outbound, then commit the teardown.
+	if err := adapter.RemoveOutbound("sub-x-0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Reload(context.Background()); err != nil {
+		t.Fatalf("delete-to-empty commit must succeed, got: %v", err)
+	}
+	if got := len(adapter.DeclaredOutboundTags()); got != 0 {
+		t.Errorf("slot must be empty after delete, got %d outbound(s) (config resurrected?)", got)
+	}
+}

--- a/internal/singbox/subscription/operator_adapter.go
+++ b/internal/singbox/subscription/operator_adapter.go
@@ -565,11 +565,17 @@ func (a *OperatorAdapter) flush() error {
 		dropped = append(dropped, DropReason{Tag: tag, Reason: reason})
 	}
 
-	if len(a.cfg.Outbounds) == 0 {
+	// An empty slot is fatal only for an additive op (Create/Refresh) where
+	// every server was dropped as invalid (dropped > 0). A deliberate teardown
+	// — deleting the last subscription / member, nothing dropped — commits an
+	// empty slot and disables it below. Erroring here would block deleteLocked's
+	// store.Delete and Reload would restore the just-removed config, leaving the
+	// subscription undeletable (#331 regression).
+	if len(a.cfg.Outbounds) == 0 && len(dropped) > 0 {
 		return fmt.Errorf("%w: no valid outbounds left after filtering (dropped: %s)", ErrValidation, formatDropList(dropped))
 	}
 
-	// All outbounds clean — commit and enable.
+	// Commit; enable a populated slot, disable an emptied one.
 	data, err := json.MarshalIndent(a.cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("subscription adapter: marshal slot: %w", err)
@@ -577,7 +583,7 @@ func (a *OperatorAdapter) flush() error {
 	if err := a.orch.Save(orchestrator.SlotSubscriptions, data); err != nil {
 		return fmt.Errorf("subscription adapter: save slot: %w", err)
 	}
-	_ = a.orch.SetEnabled(orchestrator.SlotSubscriptions, true)
+	_ = a.orch.SetEnabled(orchestrator.SlotSubscriptions, len(a.cfg.Outbounds) > 0)
 
 	a.lastDropped = dropped
 	return nil

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -717,25 +717,18 @@ func (s *Service) SetActiveMember(ctx context.Context, id, memberTag string) err
 		return fmt.Errorf("member %q not in subscription", memberTag)
 	}
 
-	// 1. Update config slot's selector.default for restart persistence.
-	//    NOT followed by Reload — clash API handles the runtime switch.
-	//    For urltest mode: BuildURLTest ignores defaultTag (urltest has
-	//    no `default` field). The Clash API call below still pins the
-	//    chosen member as a temporary override until sing-box's next
-	//    auto-test interval, matching mihomo/sing-box semantics.
-	s.mutator.RemoveOutbound(sub.SelectorTag)
-	if err := s.mutator.AddOutbound(sub.SelectorTag, BuildGroupOutbound(*sub, sub.MemberTags, memberTag)); err != nil {
-		return err
-	}
-
-	// 2. Persist active member in store.
+	// Persist the choice in the store — the source of truth for the active
+	// member. The config slot is deliberately NOT rewritten: selector.default
+	// is rebuilt as first-member on every refresh, so persisting it here buys
+	// nothing, and a slot write without Reload would only leave an uncommitted
+	// batch open in the adapter.
 	if err := s.store.SetActiveMember(id, memberTag); err != nil {
 		return err
 	}
 
-	// 3. Hit Clash API for instant runtime switch — no SIGHUP, no connection
-	//    drop. If clash is unreachable (sing-box not running), return error but
-	//    config is already updated so a future restart will use the new default.
+	// Switch the live selector via the Clash API — instant, no SIGHUP, no
+	// connection drop. If clash is unreachable (sing-box not running) we return
+	// the error, but the store already holds the new active member.
 	if err := s.mutator.SelectClashProxy(sub.SelectorTag, memberTag); err != nil {
 		s.logWarn("subscription-active-member", id, "clash switch failed: "+err.Error())
 		return fmt.Errorf("subscription: clash select: %w", err)

--- a/internal/singbox/subscription/service_test.go
+++ b/internal/singbox/subscription/service_test.go
@@ -583,6 +583,11 @@ func TestService_SetActiveMember_UsesClashAPI(t *testing.T) {
 	}
 
 	secondMember := sub.MemberTags[1]
+	// Snapshot slot-mutation counts after Create; switching the active member
+	// must not touch the config slot at all (Clash + store only).
+	addedAfterCreate := len(mutator.addedOutbounds)
+	removedAfterCreate := len(mutator.removedOutbounds)
+
 	if err := svc.SetActiveMember(context.Background(), sub.ID, secondMember); err != nil {
 		t.Fatalf("SetActiveMember: %v", err)
 	}
@@ -596,9 +601,16 @@ func TestService_SetActiveMember_UsesClashAPI(t *testing.T) {
 		t.Errorf("clash select args wrong: got %q want %q", mutator.selectedSelector[0], expected)
 	}
 
-	// Verify Reload was NOT called for SetActiveMember (no connection-dropping SIGHUP).
-	// We verify this indirectly: the mutator's Reload is a no-op and SelectClashProxy
-	// is recorded; the key invariant is the config update + clash call both happen.
+	// Switching the active member is runtime-only: no selector Remove/Add, so
+	// no open batch and no SIGHUP. The slot's selector.default is rebuilt as
+	// first-member on every refresh anyway, so persisting it here is pointless;
+	// the choice lives in store.ActiveMember + the live Clash selector.
+	if len(mutator.addedOutbounds) != addedAfterCreate {
+		t.Errorf("SetActiveMember must not add outbounds, got %d new", len(mutator.addedOutbounds)-addedAfterCreate)
+	}
+	if len(mutator.removedOutbounds) != removedAfterCreate {
+		t.Errorf("SetActiveMember must not remove outbounds, got %d new", len(mutator.removedOutbounds)-removedAfterCreate)
+	}
 	stored, _ := store.Get(sub.ID)
 	if stored.ActiveMember != secondMember {
 		t.Errorf("store.ActiveMember=%q want %q", stored.ActiveMember, secondMember)


### PR DESCRIPTION
#331 инвертировал контракт: Reload стал точкой коммита flush(). Удаление налетало на guard пустого слота; SetActiveMember мутировал слот без Reload.