### PR TITLE
Feature/frontend cold load

### DIFF
--- a/frontend/src/lib/components/hrneo/HrNeoTab.svelte
+++ b/frontend/src/lib/components/hrneo/HrNeoTab.svelte
@@ -73,8 +73,8 @@
 	});
 
 	let hrNeoDataReady = $derived(
-		($dnsRoutesStore.lastFetchedAt > 0 || $dnsRoutesStore.status === 'error') &&
-			($routingTunnelsStore.lastFetchedAt > 0 || $routingTunnelsStore.status === 'error'),
+		($dnsRoutesStore.data !== null || $dnsRoutesStore.lastFetchedAt > 0 || $dnsRoutesStore.status === 'error') &&
+			($routingTunnelsStore.data !== null || $routingTunnelsStore.lastFetchedAt > 0 || $routingTunnelsStore.status === 'error'),
 	);
 
 	let editOpen = $state(false);

--- a/frontend/src/lib/stores/auth.ts
+++ b/frontend/src/lib/stores/auth.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import { api } from '$lib/api/client';
+import { clearClientCaches } from './detailCache';
 
 interface AuthState {
 	authenticated: boolean;
@@ -26,6 +27,7 @@ function createAuthStore() {
 				// Only show "session expired" if user was previously authenticated.
 				// If not authenticated yet (e.g. on login page), just ignore the 401.
 				if (!s.authenticated) return s;
+				clearClientCaches();
 				return {
 					authenticated: false,
 					authDisabled: false,
@@ -107,6 +109,7 @@ function createAuthStore() {
 			} catch {
 				// Ignore logout errors
 			}
+			clearClientCaches();
 			set({
 				authenticated: false,
 				authDisabled: false,

--- a/frontend/src/lib/stores/detailCache.ts
+++ b/frontend/src/lib/stores/detailCache.ts
@@ -12,3 +12,18 @@ export const singboxOutboundCache = new Map<
 	{ tag: string; outbound: Record<string, unknown> }
 >();
 export const subscriptionDetailCache = new Map<string, Subscription>();
+
+/** Очистить все клиентские кэши при выходе/401 — данные не должны переживать сессию. */
+export function clearClientCaches(): void {
+	tunnelDetailCache.clear();
+	singboxOutboundCache.clear();
+	subscriptionDetailCache.clear();
+	if (typeof sessionStorage === 'undefined') return;
+	try {
+		for (const key of Object.keys(sessionStorage)) {
+			if (key.startsWith('awgm:')) sessionStorage.removeItem(key);
+		}
+	} catch {
+		// private mode — нечего чистить
+	}
+}

--- a/frontend/src/lib/stores/detailCache.ts
+++ b/frontend/src/lib/stores/detailCache.ts
@@ -1,0 +1,14 @@
+/**
+ * In-memory per-id кэши для страниц-редакторов (SWR: при повторном заходе
+ * рендерим закэшированную сущность мгновенно, рефетч — фоном).
+ * Сознательно НЕ персистится: детальные payload'ы содержат секреты
+ * (privateKey туннеля, креды outbound'ов).
+ */
+import type { AWGTunnel, Subscription } from '$lib/types';
+
+export const tunnelDetailCache = new Map<string, AWGTunnel>();
+export const singboxOutboundCache = new Map<
+	string,
+	{ tag: string; outbound: Record<string, unknown> }
+>();
+export const subscriptionDetailCache = new Map<string, Subscription>();

--- a/frontend/src/lib/stores/hydraroute.ts
+++ b/frontend/src/lib/stores/hydraroute.ts
@@ -9,7 +9,7 @@ async function fetchStatus(): Promise<HydraRouteStatus> {
 
 export const hydrarouteStatus: PollingStore<HydraRouteStatus> = createPollingStore<HydraRouteStatus>(
 	fetchStatus,
-	{ staleTime: 30_000, pollInterval: 30_000 },
+	{ staleTime: 30_000, pollInterval: 30_000, persistKey: 'awgm:routing.hydrarouteStatus' },
 );
 
 registerStore('routing.hydrarouteStatus', hydrarouteStatus);

--- a/frontend/src/lib/stores/polling.test.ts
+++ b/frontend/src/lib/stores/polling.test.ts
@@ -150,6 +150,40 @@ describe('createPollingStore', () => {
         u();
     });
 
+	describe('phaseMs', () => {
+		it('delays the first poll tick by phaseMs', async () => {
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 0, pollInterval: 1000, phaseMs: 300,
+			});
+			const u = s.subscribe(() => {});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(fetcher).toHaveBeenCalledTimes(1); // initial fetch — сразу
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(fetcher).toHaveBeenCalledTimes(1); // тик ещё не пришёл (придёт на 1300)
+
+			await vi.advanceTimersByTimeAsync(300);
+			expect(fetcher).toHaveBeenCalledTimes(2); // 1300ms — первый тик
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(fetcher).toHaveBeenCalledTimes(3); // 2300ms — интервал держится
+			u();
+		});
+
+		it('clears pending phase timer on unsubscribe', async () => {
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 0, pollInterval: 1000, phaseMs: 500,
+			});
+			const u = s.subscribe(() => {});
+			await vi.advanceTimersByTimeAsync(0);
+			u();
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(fetcher).toHaveBeenCalledTimes(1); // после отписки тиков нет
+		});
+	});
+
 	describe('persistKey', () => {
 		beforeEach(() => sessionStorage.clear());
 

--- a/frontend/src/lib/stores/polling.test.ts
+++ b/frontend/src/lib/stores/polling.test.ts
@@ -150,96 +150,109 @@ describe('createPollingStore', () => {
         u();
     });
 
-	describe('phaseMs', () => {
-		it('delays the first poll tick by phaseMs', async () => {
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 0, pollInterval: 1000, phaseMs: 300,
-			});
-			const u = s.subscribe(() => {});
-			await vi.advanceTimersByTimeAsync(0);
-			expect(fetcher).toHaveBeenCalledTimes(1); // initial fetch — сразу
+    describe('phaseMs', () => {
+        it('delays the first poll tick by phaseMs', async () => {
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 0, pollInterval: 1000, phaseMs: 300,
+            });
+            const u = s.subscribe(() => {});
+            await vi.advanceTimersByTimeAsync(0);
+            expect(fetcher).toHaveBeenCalledTimes(1); // initial fetch fires immediately
 
-			await vi.advanceTimersByTimeAsync(1000);
-			expect(fetcher).toHaveBeenCalledTimes(1); // тик ещё не пришёл (придёт на 1300)
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(fetcher).toHaveBeenCalledTimes(1); // tick not yet fired (due at 1300)
 
-			await vi.advanceTimersByTimeAsync(300);
-			expect(fetcher).toHaveBeenCalledTimes(2); // 1300ms — первый тик
+            await vi.advanceTimersByTimeAsync(300);
+            expect(fetcher).toHaveBeenCalledTimes(2); // 1300ms — first tick
 
-			await vi.advanceTimersByTimeAsync(1000);
-			expect(fetcher).toHaveBeenCalledTimes(3); // 2300ms — интервал держится
-			u();
-		});
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(fetcher).toHaveBeenCalledTimes(3); // 2300ms — interval holds
+            u();
+        });
 
-		it('clears pending phase timer on unsubscribe', async () => {
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 0, pollInterval: 1000, phaseMs: 500,
-			});
-			const u = s.subscribe(() => {});
-			await vi.advanceTimersByTimeAsync(0);
-			u();
-			await vi.advanceTimersByTimeAsync(5000);
-			expect(fetcher).toHaveBeenCalledTimes(1); // после отписки тиков нет
-		});
-	});
+        it('clears pending phase timer on unsubscribe', async () => {
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 0, pollInterval: 1000, phaseMs: 500,
+            });
+            const u = s.subscribe(() => {});
+            await vi.advanceTimersByTimeAsync(0);
+            u();
+            await vi.advanceTimersByTimeAsync(5000);
+            expect(fetcher).toHaveBeenCalledTimes(1); // no ticks after unsubscribe
+        });
+    });
 
-	describe('persistKey', () => {
-		beforeEach(() => sessionStorage.clear());
+    describe('persistKey', () => {
+        beforeEach(() => sessionStorage.clear());
 
-		it('hydrates data from sessionStorage with stale status', () => {
-			sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
-			});
-			const snap = get(s);
-			expect(snap.data).toEqual({ v: 42 });
-			expect(snap.status).toBe('stale');
-			expect(snap.lastFetchedAt).toBe(0);
-		});
+        it('hydrates data from sessionStorage with stale status', () => {
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            const snap = get(s);
+            expect(snap.data).toEqual({ v: 42 });
+            expect(snap.status).toBe('stale');
+            expect(snap.lastFetchedAt).toBe(0);
+        });
 
-		it('refetches on first subscribe despite hydrated data', async () => {
-			sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
-			});
-			const u = s.subscribe(() => {});
-			await vi.advanceTimersByTimeAsync(0);
-			expect(fetcher).toHaveBeenCalledTimes(1);
-			expect(get(s).data).toEqual({ v: 1 });
-			u();
-		});
+        it('refetches on first subscribe despite hydrated data', async () => {
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            const u = s.subscribe(() => {});
+            await vi.advanceTimersByTimeAsync(0);
+            expect(fetcher).toHaveBeenCalledTimes(1);
+            expect(get(s).data).toEqual({ v: 1 });
+            u();
+        });
 
-		it('writes snapshot to sessionStorage after successful fetch', async () => {
-			const fetcher = vi.fn().mockResolvedValue({ v: 7 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
-			});
-			const u = s.subscribe(() => {});
-			await vi.advanceTimersByTimeAsync(0);
-			expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 7 }));
-			u();
-		});
+        it('writes snapshot to sessionStorage after successful fetch', async () => {
+            const fetcher = vi.fn().mockResolvedValue({ v: 7 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            const u = s.subscribe(() => {});
+            await vi.advanceTimersByTimeAsync(0);
+            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 7 }));
+            u();
+        });
 
-		it('writes snapshot on applyMutationResponse', () => {
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
-			});
-			s.applyMutationResponse({ v: 9 });
-			expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 9 }));
-		});
+        it('writes snapshot on applyMutationResponse', () => {
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            s.applyMutationResponse({ v: 9 });
+            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 9 }));
+        });
 
-		it('ignores corrupt persisted JSON', () => {
-			sessionStorage.setItem('awgm:test', '{broken');
-			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
-			const s = createPollingStore(fetcher, {
-				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
-			});
-			expect(get(s).data).toBeNull();
-			expect(get(s).status).toBe('loading'); // corrupt cache skipped → cold fetch path
-		});
-	});
+        it('ignores corrupt persisted JSON', () => {
+            sessionStorage.setItem('awgm:test', '{broken');
+            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            expect(get(s).data).toBeNull();
+            expect(get(s).status).toBe('loading'); // corrupt cache skipped → cold fetch path
+        });
+
+        it('keeps hydrated data with stale status on fetch failure', async () => {
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+            const fetcher = vi.fn().mockRejectedValue(new Error('down'));
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            const u = s.subscribe(() => {});
+            await vi.advanceTimersByTimeAsync(0);
+            expect(get(s).data).toEqual({ v: 42 });
+            expect(get(s).status).toBe('stale'); // error badge only after errorThreshold
+            u();
+        });
+    });
 });

--- a/frontend/src/lib/stores/polling.test.ts
+++ b/frontend/src/lib/stores/polling.test.ts
@@ -239,7 +239,7 @@ describe('createPollingStore', () => {
 				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
 			});
 			expect(get(s).data).toBeNull();
-			expect(get(s).status).toBe('idle');
+			expect(get(s).status).toBe('loading'); // corrupt cache skipped → cold fetch path
 		});
 	});
 });

--- a/frontend/src/lib/stores/polling.test.ts
+++ b/frontend/src/lib/stores/polling.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { get } from 'svelte/store';
 import { createPollingStore } from './polling';
 
+vi.mock('$app/environment', () => ({ version: 'test-build' }));
+const version = 'test-build';
+
 describe('createPollingStore', () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => vi.useRealTimers());
@@ -188,53 +191,53 @@ describe('createPollingStore', () => {
         beforeEach(() => sessionStorage.clear());
 
         it('hydrates data from sessionStorage with stale status', () => {
-            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
-            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: version, data: { val: 42 } }));
+            const fetcher = vi.fn().mockResolvedValue({ val: 1 });
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
             const snap = get(s);
-            expect(snap.data).toEqual({ v: 42 });
+            expect(snap.data).toEqual({ val: 42 });
             expect(snap.status).toBe('stale');
             expect(snap.lastFetchedAt).toBe(0);
         });
 
         it('refetches on first subscribe despite hydrated data', async () => {
-            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
-            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: version, data: { val: 42 } }));
+            const fetcher = vi.fn().mockResolvedValue({ val: 1 });
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
             const u = s.subscribe(() => {});
             await vi.advanceTimersByTimeAsync(0);
             expect(fetcher).toHaveBeenCalledTimes(1);
-            expect(get(s).data).toEqual({ v: 1 });
+            expect(get(s).data).toEqual({ val: 1 });
             u();
         });
 
         it('writes snapshot to sessionStorage after successful fetch', async () => {
-            const fetcher = vi.fn().mockResolvedValue({ v: 7 });
+            const fetcher = vi.fn().mockResolvedValue({ val: 7 });
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
             const u = s.subscribe(() => {});
             await vi.advanceTimersByTimeAsync(0);
-            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 7 }));
+            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: version, data: { val: 7 } }));
             u();
         });
 
         it('writes snapshot on applyMutationResponse', () => {
-            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const fetcher = vi.fn().mockResolvedValue({ val: 1 });
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
-            s.applyMutationResponse({ v: 9 });
-            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 9 }));
+            s.applyMutationResponse({ val: 9 });
+            expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: version, data: { val: 9 } }));
         });
 
         it('ignores corrupt persisted JSON', () => {
             sessionStorage.setItem('awgm:test', '{broken');
-            const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+            const fetcher = vi.fn().mockResolvedValue({ val: 1 });
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
@@ -243,16 +246,25 @@ describe('createPollingStore', () => {
         });
 
         it('keeps hydrated data with stale status on fetch failure', async () => {
-            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: version, data: { val: 42 } }));
             const fetcher = vi.fn().mockRejectedValue(new Error('down'));
             const s = createPollingStore(fetcher, {
                 staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
             });
             const u = s.subscribe(() => {});
             await vi.advanceTimersByTimeAsync(0);
-            expect(get(s).data).toEqual({ v: 42 });
+            expect(get(s).data).toEqual({ val: 42 });
             expect(get(s).status).toBe('stale'); // error badge only after errorThreshold
             u();
+        });
+
+        it('discards snapshot from a different build version', () => {
+            sessionStorage.setItem('awgm:test', JSON.stringify({ v: 'other-build', data: { val: 42 } }));
+            const fetcher = vi.fn().mockResolvedValue({ val: 1 });
+            const s = createPollingStore(fetcher, {
+                staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+            });
+            expect(get(s).data).toBeNull();
         });
     });
 });

--- a/frontend/src/lib/stores/polling.test.ts
+++ b/frontend/src/lib/stores/polling.test.ts
@@ -149,4 +149,63 @@ describe('createPollingStore', () => {
 
         u();
     });
+
+	describe('persistKey', () => {
+		beforeEach(() => sessionStorage.clear());
+
+		it('hydrates data from sessionStorage with stale status', () => {
+			sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+			});
+			const snap = get(s);
+			expect(snap.data).toEqual({ v: 42 });
+			expect(snap.status).toBe('stale');
+			expect(snap.lastFetchedAt).toBe(0);
+		});
+
+		it('refetches on first subscribe despite hydrated data', async () => {
+			sessionStorage.setItem('awgm:test', JSON.stringify({ v: 42 }));
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+			});
+			const u = s.subscribe(() => {});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(fetcher).toHaveBeenCalledTimes(1);
+			expect(get(s).data).toEqual({ v: 1 });
+			u();
+		});
+
+		it('writes snapshot to sessionStorage after successful fetch', async () => {
+			const fetcher = vi.fn().mockResolvedValue({ v: 7 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+			});
+			const u = s.subscribe(() => {});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 7 }));
+			u();
+		});
+
+		it('writes snapshot on applyMutationResponse', () => {
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+			});
+			s.applyMutationResponse({ v: 9 });
+			expect(sessionStorage.getItem('awgm:test')).toBe(JSON.stringify({ v: 9 }));
+		});
+
+		it('ignores corrupt persisted JSON', () => {
+			sessionStorage.setItem('awgm:test', '{broken');
+			const fetcher = vi.fn().mockResolvedValue({ v: 1 });
+			const s = createPollingStore(fetcher, {
+				staleTime: 1000, pollInterval: 10_000, persistKey: 'awgm:test',
+			});
+			expect(get(s).data).toBeNull();
+			expect(get(s).status).toBe('idle');
+		});
+	});
 });

--- a/frontend/src/lib/stores/polling.ts
+++ b/frontend/src/lib/stores/polling.ts
@@ -20,6 +20,13 @@ export interface PollingOptions {
     pollInterval: number;
     // Error threshold before badge shows (default 3).
     errorThreshold?: number;
+    /**
+     * sessionStorage key for SWR snapshot persistence across page reloads.
+     * Hydrated data renders instantly with status 'stale'; first subscribe
+     * still refetches (lastFetchedAt stays 0). Don't use for payloads with
+     * secrets — sessionStorage is plaintext.
+     */
+    persistKey?: string;
 }
 
 /**
@@ -35,15 +42,38 @@ export interface PollingOptions {
  *  - applyMutationResponse(data): update cache, reset error counter.
  *  - Failed fetches: increment consecutiveFailures; stay in 'error' status
  *    once threshold is crossed. Cached data is NOT discarded.
+ *  - persistKey: if set, hydrates initial state from sessionStorage (status
+ *    'stale') and writes back on every successful fetch / applyMutationResponse.
  */
 export function createPollingStore<T>(
     fetcher: () => Promise<T>,
     opts: PollingOptions
 ): PollingStore<T> {
     const threshold = opts.errorThreshold ?? 3;
+
+    function readPersisted(): T | null {
+        if (!opts.persistKey || typeof sessionStorage === 'undefined') return null;
+        try {
+            const raw = sessionStorage.getItem(opts.persistKey);
+            return raw ? (JSON.parse(raw) as T) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    function writePersisted(data: T): void {
+        if (!opts.persistKey || typeof sessionStorage === 'undefined') return;
+        try {
+            sessionStorage.setItem(opts.persistKey, JSON.stringify(data));
+        } catch {
+            // quota / private mode — кэш необязателен
+        }
+    }
+
+    const persisted = readPersisted();
     const state = writable<PollingState<T>>({
-        data: null,
-        status: 'idle',
+        data: persisted,
+        status: persisted !== null ? 'stale' : 'idle',
         error: null,
         lastFetchedAt: 0,
         consecutiveFailures: 0,
@@ -72,6 +102,7 @@ export function createPollingStore<T>(
                     lastFetchedAt: Date.now(),
                     consecutiveFailures: 0,
                 });
+                writePersisted(data);
             } catch (e) {
                 state.update(s => {
                     const fails = s.consecutiveFailures + 1;
@@ -130,16 +161,16 @@ export function createPollingStore<T>(
     return {
         subscribe(run, invalidate) {
             subCount++;
+            const unsub = state.subscribe(run, invalidate);
             if (subCount === 1) {
                 const s = get(state);
                 const age = Date.now() - s.lastFetchedAt;
                 if (s.lastFetchedAt === 0 || age > opts.staleTime) {
-                    void doFetch();
+                    void Promise.resolve().then(() => doFetch());
                 }
                 startPoll();
                 attachVisibilityHandler();
             }
-            const unsub = state.subscribe(run, invalidate);
             return () => {
                 unsub();
                 subCount--;
@@ -170,6 +201,7 @@ export function createPollingStore<T>(
                 lastFetchedAt: Date.now(),
                 consecutiveFailures: 0,
             });
+            writePersisted(data);
         },
     };
 }

--- a/frontend/src/lib/stores/polling.ts
+++ b/frontend/src/lib/stores/polling.ts
@@ -25,6 +25,9 @@ export interface PollingOptions {
      * Hydrated data renders instantly with status 'stale'; first subscribe
      * still refetches (lastFetchedAt stays 0). Don't use for payloads with
      * secrets — sessionStorage is plaintext.
+     * Tradeoff: with hydrated data a failing backend shows status 'stale'
+     * (data retained) until errorThreshold consecutive failures, instead of
+     * 'error' on first failure as on a cold start.
      */
     persistKey?: string;
     /**
@@ -72,7 +75,7 @@ export function createPollingStore<T>(
         try {
             sessionStorage.setItem(opts.persistKey, JSON.stringify(data));
         } catch {
-            // quota / private mode — кэш необязателен
+            // quota / private mode — cache is optional
         }
     }
 

--- a/frontend/src/lib/stores/polling.ts
+++ b/frontend/src/lib/stores/polling.ts
@@ -27,6 +27,12 @@ export interface PollingOptions {
      * secrets — sessionStorage is plaintext.
      */
     persistKey?: string;
+    /**
+     * Delay (ms) before the poll interval starts ticking. Staggers tick
+     * phases across stores that share the same pollInterval so they don't
+     * fire simultaneous request bursts at the backend.
+     */
+    phaseMs?: number;
 }
 
 /**
@@ -81,6 +87,7 @@ export function createPollingStore<T>(
 
     let subCount = 0;
     let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let phaseTimer: ReturnType<typeof setTimeout> | null = null;
     let inflight: Promise<void> | null = null;
 
     async function doFetch(): Promise<void> {
@@ -125,7 +132,7 @@ export function createPollingStore<T>(
         return inflight;
     }
 
-    function startPoll() {
+    function startInterval() {
         if (pollTimer !== null) return;
         pollTimer = setInterval(() => {
             if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
@@ -133,7 +140,24 @@ export function createPollingStore<T>(
         }, opts.pollInterval);
     }
 
+    function startPoll() {
+        if (pollTimer !== null || phaseTimer !== null) return;
+        const phase = opts.phaseMs ?? 0;
+        if (phase > 0) {
+            phaseTimer = setTimeout(() => {
+                phaseTimer = null;
+                startInterval();
+            }, phase);
+        } else {
+            startInterval();
+        }
+    }
+
     function stopPoll() {
+        if (phaseTimer !== null) {
+            clearTimeout(phaseTimer);
+            phaseTimer = null;
+        }
         if (pollTimer !== null) {
             clearInterval(pollTimer);
             pollTimer = null;

--- a/frontend/src/lib/stores/polling.ts
+++ b/frontend/src/lib/stores/polling.ts
@@ -185,16 +185,16 @@ export function createPollingStore<T>(
     return {
         subscribe(run, invalidate) {
             subCount++;
-            const unsub = state.subscribe(run, invalidate);
             if (subCount === 1) {
                 const s = get(state);
                 const age = Date.now() - s.lastFetchedAt;
                 if (s.lastFetchedAt === 0 || age > opts.staleTime) {
-                    void Promise.resolve().then(() => doFetch());
+                    void doFetch();
                 }
                 startPoll();
                 attachVisibilityHandler();
             }
+            const unsub = state.subscribe(run, invalidate);
             return () => {
                 unsub();
                 subCount--;

--- a/frontend/src/lib/stores/polling.ts
+++ b/frontend/src/lib/stores/polling.ts
@@ -1,4 +1,5 @@
 import { writable, get, type Readable } from 'svelte/store';
+import { version } from '$app/environment';
 
 export type PollingState<T> = {
     data: T | null;
@@ -25,6 +26,8 @@ export interface PollingOptions {
      * Hydrated data renders instantly with status 'stale'; first subscribe
      * still refetches (lastFetchedAt stays 0). Don't use for payloads with
      * secrets — sessionStorage is plaintext.
+     * Snapshots are stamped with the SvelteKit build version and discarded on
+     * mismatch, so a self-update reload never hydrates an old-shape snapshot.
      * Tradeoff: with hydrated data a failing backend shows status 'stale'
      * (data retained) until errorThreshold consecutive failures, instead of
      * 'error' on first failure as on a cold start.
@@ -64,7 +67,11 @@ export function createPollingStore<T>(
         if (!opts.persistKey || typeof sessionStorage === 'undefined') return null;
         try {
             const raw = sessionStorage.getItem(opts.persistKey);
-            return raw ? (JSON.parse(raw) as T) : null;
+            if (!raw) return null;
+            const envelope = JSON.parse(raw) as { v?: string; data?: T };
+            // Discard snapshots written by a different build — shape may have changed.
+            if (envelope.v !== version) return null;
+            return envelope.data ?? null;
         } catch {
             return null;
         }
@@ -73,7 +80,7 @@ export function createPollingStore<T>(
     function writePersisted(data: T): void {
         if (!opts.persistKey || typeof sessionStorage === 'undefined') return;
         try {
-            sessionStorage.setItem(opts.persistKey, JSON.stringify(data));
+            sessionStorage.setItem(opts.persistKey, JSON.stringify({ v: version, data }));
         } catch {
             // quota / private mode — cache is optional
         }

--- a/frontend/src/lib/stores/routing.ts
+++ b/frontend/src/lib/stores/routing.ts
@@ -40,6 +40,7 @@ function createSection<T>(url: string, resourceKey: ResourceKey): PollingStore<T
 		{
 			staleTime: 30_000,
 			pollInterval: 30_000,
+			persistKey: `awgm:${resourceKey}`,
 		}
 	);
 	registerStore(resourceKey, store);
@@ -77,9 +78,9 @@ export const routingTunnelsStore = createSection<RoutingTunnel[]>(
 
 export { hydrarouteStatusStore };
 
-/** First successful fetch or terminal error — section can render cached/empty body. */
+/** Hydrated cache, first successful fetch, or terminal error — section can render cached/empty body. */
 function sectionFetched(s: PollingState<unknown>): boolean {
-	return s.lastFetchedAt > 0 || s.status === 'error';
+	return s.data !== null || s.lastFetchedAt > 0 || s.status === 'error';
 }
 
 /** NDMS DNS tab: dns lists + tunnels + HR install flag (for hasDnsEngine on OS4). */
@@ -141,7 +142,7 @@ export const routing: Readable<RoutingComposite> = derived(
 			tunnels: rt.data ?? [],
 			hydrarouteStatus: hr.data ?? null,
 			loaded: [d, s, a, pd, pi, cr, rt, hr].every(
-				(x) => x.lastFetchedAt > 0 || x.status === 'error'
+				(x) => x.data !== null || x.lastFetchedAt > 0 || x.status === 'error'
 			),
 			missing,
 		};

--- a/frontend/src/lib/stores/servers.ts
+++ b/frontend/src/lib/stores/servers.ts
@@ -16,8 +16,10 @@ async function fetchServers(): Promise<ServersSnapshot> {
 }
 
 export const servers = createPollingStore<ServersSnapshot>(fetchServers, {
-	staleTime: 5_000,
+	staleTime: 30_000,
 	pollInterval: 5_000,
+	persistKey: 'awgm:servers',
+	phaseMs: 3_400,
 });
 
 registerStore('servers', servers);

--- a/frontend/src/lib/stores/servers.ts
+++ b/frontend/src/lib/stores/servers.ts
@@ -18,6 +18,7 @@ async function fetchServers(): Promise<ServersSnapshot> {
 export const servers = createPollingStore<ServersSnapshot>(fetchServers, {
 	staleTime: 30_000,
 	pollInterval: 5_000,
+	// /servers/all отдаёт редактированные DTO (без приватных ключей) — персистить безопасно.
 	persistKey: 'awgm:servers',
 	phaseMs: 3_400,
 });

--- a/frontend/src/lib/stores/singbox.ts
+++ b/frontend/src/lib/stores/singbox.ts
@@ -28,7 +28,7 @@ async function fetchStatus(): Promise<SingboxStatus> {
 
 export const singboxStatus: PollingStore<SingboxStatus> = createPollingStore<SingboxStatus>(
 	fetchStatus,
-	{ staleTime: 30_000, pollInterval: 30_000 }
+	{ staleTime: 30_000, pollInterval: 30_000, persistKey: 'awgm:singbox.status' }
 );
 
 registerStore('singbox.status', singboxStatus);
@@ -42,7 +42,7 @@ async function fetchTunnels(): Promise<SingboxTunnel[]> {
 
 export const singboxTunnels: PollingStore<SingboxTunnel[]> = createPollingStore<SingboxTunnel[]>(
 	fetchTunnels,
-	{ staleTime: 5_000, pollInterval: 5_000 }
+	{ staleTime: 30_000, pollInterval: 5_000, persistKey: 'awgm:singbox.tunnels', phaseMs: 1_700 }
 );
 
 registerStore('singbox.tunnels', singboxTunnels);

--- a/frontend/src/lib/stores/subscriptions.ts
+++ b/frontend/src/lib/stores/subscriptions.ts
@@ -4,5 +4,5 @@ import type { Subscription } from '$lib/types';
 
 export const subscriptionsStore = createPollingStore<Subscription[]>(
 	() => api.listSubscriptions(),
-	{ staleTime: 5_000, pollInterval: 30_000 },
+	{ staleTime: 30_000, pollInterval: 30_000, persistKey: 'awgm:subscriptions' },
 );

--- a/frontend/src/lib/stores/subscriptions.ts
+++ b/frontend/src/lib/stores/subscriptions.ts
@@ -4,5 +4,5 @@ import type { Subscription } from '$lib/types';
 
 export const subscriptionsStore = createPollingStore<Subscription[]>(
 	() => api.listSubscriptions(),
-	{ staleTime: 30_000, pollInterval: 30_000, persistKey: 'awgm:subscriptions' },
+	{ staleTime: 30_000, pollInterval: 30_000 },
 );

--- a/frontend/src/lib/stores/system.ts
+++ b/frontend/src/lib/stores/system.ts
@@ -22,6 +22,7 @@ async function fetchSysInfo(): Promise<SystemInfo> {
 export const systemInfo: PollingStore<SystemInfo> = createPollingStore<SystemInfo>(fetchSysInfo, {
 	staleTime: 30_000,
 	pollInterval: 30_000,
+	persistKey: 'awgm:sysInfo',
 });
 
 registerStore('sysInfo', systemInfo);

--- a/frontend/src/lib/stores/tunnels.ts
+++ b/frontend/src/lib/stores/tunnels.ts
@@ -46,7 +46,7 @@ async function fetchTunnels(): Promise<TunnelsSnapshot> {
 
 const basePolling: PollingStore<TunnelsSnapshot> = createPollingStore<TunnelsSnapshot>(
 	fetchTunnels,
-	{ staleTime: 5_000, pollInterval: 5_000 }
+	{ staleTime: 30_000, pollInterval: 5_000, persistKey: 'awgm:tunnels' }
 );
 
 registerStore('tunnels', basePolling);

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -24,7 +24,8 @@
 		PukhososPatrol,
 		SettingsSectionLabel,
 	} from "$lib/components/settings";
-	import { setSettings as setGlobalSettings } from "$lib/stores/settings";
+	import { setSettings as setGlobalSettings, settings as settingsGlobal } from "$lib/stores/settings";
+	import { systemInfo as systemInfoStore } from "$lib/stores/system";
 	import {
 		downloadOutbounds,
 		downloadOutboundsLoading,
@@ -288,6 +289,14 @@
 	}
 
 onMount(() => {
+	// SWR: render immediately from global stores (layout already loaded them);
+	// the fetch below still runs and revalidates in the background.
+	const cachedSettings = get(settingsGlobal);
+	const cachedSysInfo = get(systemInfoStore).data;
+	if (cachedSettings) settings = cachedSettings;
+	if (cachedSysInfo) systemInfo = cachedSysInfo;
+	if (cachedSettings && cachedSysInfo) loading = false;
+
 	const timer = setInterval(() => {
 		void fetchSystemInfo(true);
 	}, 30000);
@@ -298,8 +307,10 @@ onMount(() => {
 				fetchSystemInfo(true),
 				api.getSettings(),
 			]);
-			settings = appSettings;
-			setGlobalSettings(appSettings);
+			if (!saving) {
+				settings = appSettings;
+				setGlobalSettings(appSettings);
+			}
 			scrollToSettingsHashTarget();
 		} catch (e) {
 			notifications.error(e instanceof Error ? e.message : "Не удалось загрузить настройки");

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -293,6 +293,7 @@ onMount(() => {
 	// the fetch below still runs and revalidates in the background.
 	const cachedSettings = get(settingsGlobal);
 	const cachedSysInfo = get(systemInfoStore).data;
+	const hydratedSnapshot = cachedSettings ? JSON.stringify(cachedSettings) : null;
 	if (cachedSettings) settings = cachedSettings;
 	if (cachedSysInfo) systemInfo = cachedSysInfo;
 	if (cachedSettings && cachedSysInfo) loading = false;
@@ -307,7 +308,11 @@ onMount(() => {
 				fetchSystemInfo(true),
 				api.getSettings(),
 			]);
-			if (!saving) {
+			// Применяем рефетч, только если локальное состояние не менялось с
+			// момента гидрации: правки пользователя и результаты сохранений
+			// важнее снапшота. Холодный путь (без гидрации) применяет всегда.
+			const untouched = hydratedSnapshot === null || JSON.stringify(settings) === hydratedSnapshot;
+			if (!saving && untouched) {
 				settings = appSettings;
 				setGlobalSettings(appSettings);
 			}

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -65,6 +65,7 @@
 			initialOutboundFingerprint = outboundFingerprint(outbound);
 			loading = false;
 		}
+		const tagAtFetchStart = editableTag;
 		try {
 			const r = await api.singboxGetTunnel(tag);
 			singboxOutboundCache.set(tag, {
@@ -75,8 +76,12 @@
 			if (!hasUnsavedChanges) {
 				outbound = r.outbound as Record<string, any>;
 				protocol = outbound?.type ?? '';
-				editableTag = r.tag;
 				initialOutboundFingerprint = outboundFingerprint(outbound);
+			}
+			// Tag правится отдельно от outbound — применяем серверное значение,
+			// только если пользователь не успел его изменить за время фетча.
+			if (editableTag === tagAtFetchStart) {
+				editableTag = r.tag;
 			}
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -108,6 +108,10 @@
 				fresh = await api.singboxUpdateTunnel(nextTag, outbound);
 				singboxTunnels.applyMutationResponse(fresh);
 			}
+			singboxOutboundCache.set(nextTag, {
+				tag: nextTag,
+				outbound: structuredClone($state.snapshot(outbound)) as Record<string, unknown>,
+			});
 			goto('/?tab=singbox');
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -85,6 +85,13 @@
 			}
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
+			const status = (e as Error & { status?: number }).status;
+			if (status === 404) {
+				// Туннель удалён — кэш устарел, показываем страницу «не найден» вместо stale-формы.
+				singboxOutboundCache.delete(tag);
+				outbound = null;
+				error = error || 'Туннель не найден';
+			}
 		} finally {
 			loading = false;
 		}

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { singboxTunnels } from '$lib/stores/singbox';
+	import { singboxOutboundCache } from '$lib/stores/detailCache';
 	import { PageContainer } from '$lib/components/layout';
 	import { SettingsSectionLabel } from '$lib/components/settings';
 	import {
@@ -56,12 +57,27 @@
 	);
 
 	onMount(async () => {
+		const cached = singboxOutboundCache.get(tag);
+		if (cached) {
+			outbound = structuredClone(cached.outbound) as Record<string, any>;
+			protocol = outbound?.type ?? '';
+			editableTag = cached.tag;
+			initialOutboundFingerprint = outboundFingerprint(outbound);
+			loading = false;
+		}
 		try {
 			const r = await api.singboxGetTunnel(tag);
-			outbound = r.outbound as Record<string, any>;
-			protocol = outbound?.type ?? '';
-			editableTag = r.tag;
-			initialOutboundFingerprint = outboundFingerprint(outbound);
+			singboxOutboundCache.set(tag, {
+				tag: r.tag,
+				outbound: structuredClone(r.outbound) as Record<string, unknown>,
+			});
+			// Не перетираем форму, если пользователь уже начал править поверх кэша.
+			if (!hasUnsavedChanges) {
+				outbound = r.outbound as Record<string, any>;
+				protocol = outbound?.type ?? '';
+				editableTag = r.tag;
+				initialOutboundFingerprint = outboundFingerprint(outbound);
+			}
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
 		} finally {

--- a/frontend/src/routes/singbox/[tag]/+page.svelte
+++ b/frontend/src/routes/singbox/[tag]/+page.svelte
@@ -102,6 +102,7 @@
 			if (tagChanged) {
 				fresh = await api.singboxRenameTunnel(tag, nextTag);
 				singboxTunnels.applyMutationResponse(fresh);
+				singboxOutboundCache.delete(tag);
 			}
 			if (outboundChanged) {
 				fresh = await api.singboxUpdateTunnel(nextTag, outbound);

--- a/frontend/src/routes/subscriptions/[id]/+page.svelte
+++ b/frontend/src/routes/subscriptions/[id]/+page.svelte
@@ -16,6 +16,7 @@
 		type SingboxLayoutMode,
 	} from '$lib/constants/singboxLayout';
 	import { isMockDevMode } from '$lib/env';
+	import { subscriptionDetailCache } from '$lib/stores/detailCache';
 
 	// Poll Clash for the live "now" pointer this often when on members tab in urltest
 	// mode. 5s balances responsiveness with Clash API load.
@@ -56,6 +57,9 @@
 	const showSingboxGridListToggle = $derived(showSingboxListOption && showSingboxLayoutPicker);
 
 	let evtSrc: EventSource | null = null;
+	// Выставляется в onMount при гидрации из кэша; loadStream() потребляет один раз:
+	// первый рефетч идёт фоном и не сбрасывает уже отрендеренный контент.
+	let hydratedFromCache = false;
 
 	function patchSubscriptionEnabled(nextEnabled: boolean): void {
 		if (subscription) {
@@ -66,17 +70,24 @@
 	function loadStream(): void {
 		if (!id) return;
 		const isMockDev = isMockDevMode();
+		// Фоновый рефетч поверх кэша: контент не сбрасываем, стримим в теневой
+		// объект и подменяем целиком на done.
+		const background = hydratedFromCache;
+		hydratedFromCache = false;
 		progressLoaded = 0;
 		progressTotal = 0;
-		loading = true;
 		error = '';
-		subscription = null;
+		if (!background) {
+			loading = true;
+			subscription = null;
+		}
 		evtSrc?.close();
 		if (isMockDev) {
 			void (async () => {
 				try {
 					const sub = await api.getSubscription(id);
 					subscription = sub;
+					subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
 					progressTotal = sub.memberTags?.length ?? sub.members?.length ?? 0;
 					progressLoaded = progressTotal;
 				} catch {
@@ -94,10 +105,13 @@
 		// onerror on the closed connection, but we treat that as success.
 		let streamDone = false;
 		let fallbackTried = false;
+		// Теневой объект для фонового рефетча (background): собираем сюда, чтобы
+		// не перетирать отображаемый из кэша subscription до завершения стрима.
+		let target: Subscription | null = null;
 
 		evtSrc.addEventListener('meta', (e) => {
 			const meta = JSON.parse((e as MessageEvent).data);
-			subscription = {
+			const next = {
 				...meta,
 				members: [],
 				memberTags: [],
@@ -106,24 +120,32 @@
 				infoItems: meta.infoItems ?? [],
 				activeMember: '',
 			} as Subscription;
+			if (background) target = next;
+			else subscription = next;
 			progressTotal = meta.total ?? 0;
 		});
 
 		evtSrc.addEventListener('member', (e) => {
-			if (!subscription) return;
+			const t = background ? target : subscription;
+			if (!t) return;
 			const { member } = JSON.parse((e as MessageEvent).data);
-			subscription.members = [...(subscription.members ?? []), member];
-			subscription.memberTags = [...subscription.memberTags, member.tag];
+			t.members = [...(t.members ?? []), member];
+			t.memberTags = [...t.memberTags, member.tag];
 			progressLoaded += 1;
 		});
 
 		evtSrc.addEventListener('done', (e) => {
-			if (subscription) {
+			const t = background ? target : subscription;
+			if (t) {
 				const data = JSON.parse((e as MessageEvent).data);
-				subscription.orphanTags = data.orphanTags ?? [];
-				subscription.activeMember = data.activeMember ?? '';
-				subscription.rejectedMembers = data.rejectedMembers ?? subscription.rejectedMembers ?? [];
-				subscription.infoItems = data.infoItems ?? subscription.infoItems ?? [];
+				t.orphanTags = data.orphanTags ?? [];
+				t.activeMember = data.activeMember ?? '';
+				t.rejectedMembers = data.rejectedMembers ?? t.rejectedMembers ?? [];
+				t.infoItems = data.infoItems ?? t.infoItems ?? [];
+			}
+			if (background && t) subscription = t;
+			if (subscription) {
+				subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
 			}
 			streamDone = true;
 			loading = false;
@@ -140,6 +162,7 @@
 				try {
 					const sub = await api.getSubscription(id);
 					subscription = sub;
+					subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
 					progressTotal = sub.memberTags?.length ?? sub.members?.length ?? 0;
 					progressLoaded = progressTotal;
 					loading = false;
@@ -169,6 +192,12 @@
 		const parsed = parseSingboxLayoutMode(sb);
 		if (parsed) singboxLayoutMode = parsed;
 		singboxLayoutReady = true;
+		const cached = subscriptionDetailCache.get(id);
+		if (cached) {
+			subscription = cached;
+			loading = false;
+			hydratedFromCache = true;
+		}
 		loadStream();
 	});
 

--- a/frontend/src/routes/subscriptions/[id]/+page.svelte
+++ b/frontend/src/routes/subscriptions/[id]/+page.svelte
@@ -60,10 +60,15 @@
 	// Выставляется в onMount при гидрации из кэша; loadStream() потребляет один раз:
 	// первый рефетч идёт фоном и не сбрасывает уже отрендеренный контент.
 	let hydratedFromCache = false;
+	// Пользователь мутировал subscription (PATCH enabled) во время загрузки —
+	// фоновому стриму нельзя перетирать локальный стейт на done.
+	let mutatedDuringLoad = false;
 
 	function patchSubscriptionEnabled(nextEnabled: boolean): void {
 		if (subscription) {
 			subscription = { ...subscription, enabled: nextEnabled };
+			mutatedDuringLoad = true;
+			subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
 		}
 	}
 
@@ -74,6 +79,7 @@
 		// объект и подменяем целиком на done.
 		const background = hydratedFromCache;
 		hydratedFromCache = false;
+		mutatedDuringLoad = false;
 		progressLoaded = 0;
 		progressTotal = 0;
 		error = '';
@@ -143,9 +149,14 @@
 				t.rejectedMembers = data.rejectedMembers ?? t.rejectedMembers ?? [];
 				t.infoItems = data.infoItems ?? t.infoItems ?? [];
 			}
-			if (background && t) subscription = t;
-			if (subscription) {
-				subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
+			// Пользователь успел изменить состояние во время фонового стрима —
+			// локальный patched-стейт новее, не перетираем и не кэшируем устаревшее.
+			const skipSwap = background && mutatedDuringLoad;
+			if (!skipSwap) {
+				if (background && t) subscription = t;
+				if (subscription) {
+					subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
+				}
 			}
 			streamDone = true;
 			loading = false;
@@ -175,8 +186,11 @@
 				}
 			}
 			// Browser fires onerror on connection drop. Surface partial state
-			// if we got members, generic error otherwise.
-			if (progressLoaded > 0 && progressTotal > 0) {
+			// if we got members, generic error otherwise. В фоновом режиме контент
+			// из кэша уже отрендерен полностью — баннер ошибки не показываем.
+			if (background) {
+				console.warn('Фоновый рефетч подписки прервался — показываем кэшированные данные');
+			} else if (progressLoaded > 0 && progressTotal > 0) {
 				error = `Загружено ${progressLoaded} из ${progressTotal} серверов. Соединение прервалось.`;
 			} else {
 				error = 'Не удалось загрузить подписку';

--- a/frontend/src/routes/subscriptions/[id]/+page.svelte
+++ b/frontend/src/routes/subscriptions/[id]/+page.svelte
@@ -17,6 +17,7 @@
 	} from '$lib/constants/singboxLayout';
 	import { isMockDevMode } from '$lib/env';
 	import { subscriptionDetailCache } from '$lib/stores/detailCache';
+	import { subscriptionsStore } from '$lib/stores/subscriptions';
 
 	// Poll Clash for the live "now" pointer this often when on members tab in urltest
 	// mode. 5s balances responsiveness with Clash API load.
@@ -69,6 +70,8 @@
 			subscription = { ...subscription, enabled: nextEnabled };
 			mutatedDuringLoad = true;
 			subscriptionDetailCache.set(id, $state.snapshot(subscription) as Subscription);
+			// Список на главной поллится раз в 30с — подтягиваем изменение сразу.
+			subscriptionsStore.invalidate();
 		}
 	}
 
@@ -334,7 +337,10 @@
 				<SubscriptionMembersTab
 					{subscription}
 					{liveActiveMember}
-					onUpdated={loadStream}
+					onUpdated={() => {
+						loadStream();
+						subscriptionsStore.invalidate();
+					}}
 					autoDelayCheckNonce={membersAutoDelayCheckNonce}
 					layout={singboxEffectiveLayout}
 				/>
@@ -342,7 +348,10 @@
 				<div class="edit-wrapper">
 					<SubscriptionSettingsTab
 						{subscription}
-						onUpdated={loadStream}
+						onUpdated={() => {
+							loadStream();
+							subscriptionsStore.invalidate();
+						}}
 						onEnabledChanged={patchSubscriptionEnabled}
 					/>
 				</div>

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -180,6 +180,9 @@
 		$form.endpoint = tunnel.peer.endpoint;
 		$form.allowedIPs = tunnel.peer.allowedIPs.join(', ');
 		$form.persistentKeepalive = tunnel.peer.persistentKeepalive || 25;
+		// Программное заполнение — не «правка пользователя»: сбрасываем taint,
+		// чтобы guard в loadTunnel реагировал только на реальные правки.
+		tainted.set(undefined);
 	}
 
 	function buildUpdatePayload() {

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -24,7 +24,7 @@
 
 	// superForm is initialized once with initial data - capturing initial value is intentional
 	// svelte-ignore state_referenced_locally
-	const { form, errors, tainted } = superForm(data.form, {
+	const { form, errors, tainted, isTainted } = superForm(data.form, {
 		validators: zod4Client(editTunnelSchema),
 		SPA: true,
 	});
@@ -133,12 +133,17 @@
 			tunnelDetailCache.set(tunnelId, fresh);
 			tunnel = fresh;
 			// Поверх кэша пользователь мог начать править — форму не перетираем.
-			const formTouched =
-				renderedFromCache && $tainted != null && Object.keys($tainted).length > 0;
+			const formTouched = renderedFromCache && isTainted();
 			if (!formTouched) populateForm();
 		} catch (e) {
-			notifications.error(`Ошибка загрузки: ${(e as Error).message}`);
-			goto('/');
+			// Поверх кэша уже показана рабочая форма — не уводим пользователя
+			// (и его правки) со страницы из-за временной ошибки рефетча.
+			if (renderedFromCache) {
+				notifications.error(`Не удалось обновить данные туннеля: ${(e as Error).message}`);
+			} else {
+				notifications.error(`Ошибка загрузки: ${(e as Error).message}`);
+				goto('/');
+			}
 		} finally {
 			loading = false;
 		}

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { onMount, onDestroy } from 'svelte';
 	import { tunnels } from '$lib/stores/tunnels';
+	import { tunnelDetailCache } from '$lib/stores/detailCache';
 	import { usageLevel } from '$lib/stores/settings';
 	import { notifications } from '$lib/stores/notifications';
 	import { api } from '$lib/api/client';
@@ -23,7 +24,7 @@
 
 	// superForm is initialized once with initial data - capturing initial value is intentional
 	// svelte-ignore state_referenced_locally
-	const { form, errors } = superForm(data.form, {
+	const { form, errors, tainted } = superForm(data.form, {
 		validators: zod4Client(editTunnelSchema),
 		SPA: true,
 	});
@@ -105,7 +106,13 @@
 	onMount(async () => {
 		window.addEventListener('keydown', handleKeydown);
 		api.getSystemInfo().then(info => systemInfo = info).catch(() => null);
-		await loadTunnel();
+		const cached = tunnelDetailCache.get(tunnelId);
+		if (cached) {
+			tunnel = cached;
+			populateForm();
+			loading = false;
+		}
+		await loadTunnel(cached !== undefined);
 		loadWanData().catch(() => {});
 	});
 
@@ -113,17 +120,22 @@
 		window.removeEventListener('keydown', handleKeydown);
 	});
 
-	async function loadTunnel() {
+	async function loadTunnel(renderedFromCache = false) {
 		if (!tunnelId) {
 			notifications.error('ID туннеля не указан');
 			goto('/');
 			return;
 		}
 
-		loading = true;
+		if (!renderedFromCache) loading = true;
 		try {
-			tunnel = await api.getTunnel(tunnelId);
-			populateForm();
+			const fresh = await api.getTunnel(tunnelId);
+			tunnelDetailCache.set(tunnelId, fresh);
+			tunnel = fresh;
+			// Поверх кэша пользователь мог начать править — форму не перетираем.
+			const formTouched =
+				renderedFromCache && $tainted != null && Object.keys($tainted).length > 0;
+			if (!formTouched) populateForm();
 		} catch (e) {
 			notifications.error(`Ошибка загрузки: ${(e as Error).message}`);
 			goto('/');

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -158,6 +158,7 @@
 
 		$form.name = tunnel.name;
 		parseAddress(tunnel.interface.address);
+		$form.address = joinAddress();
 		$form.mtu = tunnel.interface.mtu || 1280;
 		$form.dns = tunnel.interface.dns || '';
 		$form.jc = tunnel.interface.jc ?? 4;

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -227,7 +227,8 @@
 
 		saving = true;
 		try {
-			await tunnels.update(tunnelId, buildUpdatePayload());
+			const updated = await tunnels.update(tunnelId, buildUpdatePayload());
+			tunnelDetailCache.set(tunnelId, updated);
 			notifications.success('Туннель сохранён');
 			goto('/');
 		} catch (e) {
@@ -244,7 +245,8 @@
 		actionStatus = 'loading';
 		saving = true;
 		try {
-			await tunnels.update(tunnelId, buildUpdatePayload());
+			const updated = await tunnels.update(tunnelId, buildUpdatePayload());
+			tunnelDetailCache.set(tunnelId, updated);
 			if (isRunning) {
 				await tunnels.restart(tunnelId);
 			} else {

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -136,9 +136,15 @@
 			const formTouched = renderedFromCache && isTainted();
 			if (!formTouched) populateForm();
 		} catch (e) {
+			const status = (e as Error & { status?: number }).status;
 			// Поверх кэша уже показана рабочая форма — не уводим пользователя
 			// (и его правки) со страницы из-за временной ошибки рефетча.
-			if (renderedFromCache) {
+			// Исключение — 404: туннель удалён, оставаться на странице бессмысленно.
+			if (renderedFromCache && status === 404) {
+				tunnelDetailCache.delete(tunnelId);
+				notifications.error(`Ошибка загрузки: ${(e as Error).message}`);
+				goto('/');
+			} else if (renderedFromCache) {
 				notifications.error(`Не удалось обновить данные туннеля: ${(e as Error).message}`);
 			} else {
 				notifications.error(`Ошибка загрузки: ${(e as Error).message}`);
@@ -272,6 +278,8 @@
 		try {
 			const data = await api.toggleDefaultRoute(tunnelId);
 			tunnel.defaultRoute = data.defaultRoute;
+			// $state-прокси не пишет в сырой объект из кэша — синкаем снапшотом.
+			if (tunnel) tunnelDetailCache.set(tunnelId, $state.snapshot(tunnel) as AWGTunnel);
 			// Tunnels list view shows the default-route chip — keep its
 			// polling snapshot in sync with the single-tunnel view.
 			tunnels.invalidate();
@@ -300,6 +308,8 @@
 			});
 			tunnel.ispInterface = value === 'auto' ? '' : value;
 			tunnel.ispInterfaceLabel = ispLabel;
+			// $state-прокси не пишет в сырой объект из кэша — синкаем снапшотом.
+			if (tunnel) tunnelDetailCache.set(tunnelId, $state.snapshot(tunnel) as AWGTunnel);
 			tunnels.invalidate();
 		} catch (e) {
 			notifications.error(`Ошибка: ${(e as Error).message}`);


### PR DESCRIPTION
Ускорение фронтенда на медленных роутерах: страницы рендерятся мгновенно из кэша (SWR) при этом данные обновляются фоном. По итогам аудита производительности от 2026-06-10: после бэкенд-фиксов v2.12.3 узким местом остались холодные store'ы после reload, безусловные залпы поллеров.

  ## Изменения

  **Ядро (`createPollingStore`, +18 unit-тестов):**
  - `persistKey` — снапшоты в sessionStorage: списки видны сразу после F5 и reload после
  самообновления. Конверт `{v, data}` с версией сборки — снапшот чужой сборки отбрасывается;
  первый subscribe всегда рефетчит.
  - `phaseMs` — расфазировка тиков поллеров (tunnels 0 / singboxTunnels 1.7с / servers 3.4с),
  конец одновременным залпам из 3 запросов каждые 5с.

  **Подключение:** persist для tunnels / servers / singbox / sysInfo / routing.* /
  hydraroute; staleTime 5с→30с; гейты вкладок «Маршрутизации» и HrNeo принимают гидрированные
  данные. Подписки сознательно **не** персистятся — URL и заголовки несут токены. Детальные
  payload'ы (privateKey, креды outbound'ов) — только in-memory.

  **Страницы:**
  - Настройки: мгновенный рендер из глобальных store'ов, фоновый рефетч не затирает начатые
  правки (snapshot-guard).
  - Редакторы tunnels/[id], singbox/[tag], subscriptions/[id]: in-memory per-id кэш +
  dirty-guard'ы (superforms taint-reset, fingerprint, теневой буфер SSE-стрима). Кэш
  обновляется при сохранении и мутациях, чистится при переименовании/404/logout.

  **Безопасность:**
  - `clearClientCaches()` на logout и 401 — sessionStorage и in-memory кэши не переживают
  сессию.
  - Персистируемые payload'ы проверены по Go DTO (не по TS-типам):  (`/servers/all` отдаёт редактированные DTO без приватных ключей).

  ## Краевые случаи

  - 404 поверх кэша (сущность удалена): редакторы чистят кэш и показывают «не найден» /
  уходят на главную; транзиентная ошибка рефетча не уводит со страницы и не трогает правки.
  - Toggle подписки во время фонового стрима не откатывается его завершением; правки списка
  инвалидируют list-store.
  - Ошибка бэкенда при гидрированных данных: показываем stale-данные, бейдж ошибки после 3
  неудач подряд (задокументировано, закрыто тестом).

  ## Ручная проверка

  - [ ] F5 на главной / серверах / маршрутизации — контент сразу, без спиннера
  - [ ] Повторное открытие редактора туннеля — форма сразу; ввод не сбрасывается фоновым
  рефетчем
  - [ ] Logout → Session Storage не содержит `awgm:*`
  - [ ] После обновления прошивки/пакета (новая сборка) — снапшоты отброшены, холодная
  загрузка без ошибок