### PR TITLE
fix(sb-router): ждать биндинга инбаунд-сокетов в Enable

### DIFF
--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -504,15 +504,24 @@ func (s *ServiceImpl) prepareNetfilter(ctx context.Context) error {
 	return nil
 }
 
-// waitForSingbox polls SingboxController.IsRunning until it reports true
-// or the deadline expires. Used by Enable after SetEnabled triggers the
-// orchestrator's debounced cold-start so iptables redirects don't land
-// on a TPROXY port that nothing is listening on yet.
+// waitForSingbox polls until sing-box is BOTH process-alive and actually
+// listening on the router inbound sockets (TCP RedirectPort + UDP
+// TPROXYPort), or the deadline expires. Used by Enable after SetEnabled
+// triggers the orchestrator's debounced cold-start so iptables redirects
+// don't land on a TPROXY port that nothing is listening on yet.
 //
-// Returns nil immediately if sing-box is already running. Returns ctx.Err
-// on cancellation, or a timeout error after the deadline; callers can
-// treat the timeout as soft (proceed with iptables and accept the brief
-// race) or hard at their discretion.
+// PID-alive alone is not enough (issue #354): the router config reaches
+// sing-box via the orchestrator's debounced (250ms) reload, so an
+// already-running process keeps serving the OLD inbound set for a moment,
+// and a freshly started one binds inbounds only at the end of startup
+// (after config parse + rule-set load — seconds on mipsel). Gating on the
+// same socket probe GetStatus uses means the status emitted at the end of
+// Enable reflects a truly active interception path instead of a transient
+// «СБОЙ».
+//
+// Returns ctx.Err on cancellation, or a timeout error after the deadline;
+// callers can treat the timeout as soft (proceed with iptables and accept
+// the brief race) or hard at their discretion.
 func (s *ServiceImpl) waitForSingbox(ctx context.Context, timeout time.Duration) error {
 	if s.deps.Singbox == nil {
 		return nil
@@ -520,7 +529,7 @@ func (s *ServiceImpl) waitForSingbox(ctx context.Context, timeout time.Duration)
 	deadline := time.Now().Add(timeout)
 	const pollInterval = 100 * time.Millisecond
 	for {
-		if running, _ := s.deps.Singbox.IsRunning(); running {
+		if running, _ := s.deps.Singbox.IsRunning(); running && singboxListeningProbe() {
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/internal/singbox/router/service_persistdirect_test.go
+++ b/internal/singbox/router/service_persistdirect_test.go
@@ -132,6 +132,7 @@ func TestPersistConfigDirect_WritesActiveWhenAbsent(t *testing.T) {
 
 func TestWaitForSingbox_ReturnsWhenRunning(t *testing.T) {
 	svc, _ := newOrchedTestService(t)
+	stubListeningProbe(t, func() bool { return true })
 
 	calls := 0
 	svc.deps.Singbox.(*fakeSingbox).isRunningFn = func() (bool, int) {

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/ndms/query"
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
@@ -139,6 +140,15 @@ func newTestService(_ *testing.T, deps Deps) *ServiceImpl {
 	return &ServiceImpl{deps: deps}
 }
 
+// stubListeningProbe overrides the singboxListeningProbe seam for the test
+// duration so waitForSingbox/GetStatus don't read the real procfs.
+func stubListeningProbe(t *testing.T, fn func() bool) {
+	t.Helper()
+	old := singboxListeningProbe
+	singboxListeningProbe = fn
+	t.Cleanup(func() { singboxListeningProbe = old })
+}
+
 // ---------------------------------------------------------------------------
 // Enable error-path tests
 // ---------------------------------------------------------------------------
@@ -204,6 +214,7 @@ func TestEnable_AllDevicesMode_DoesNotRequirePolicyMark(t *testing.T) {
 	policies := &fakeAccessPolicyProvider{markErr: query.ErrPolicyMarkNotFound}
 	singbox := newTestSingbox(t)
 	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	stubListeningProbe(t, func() bool { return true })
 	svc := newTestService(t, Deps{
 		Settings:           settingsStore,
 		Policies:           policies,
@@ -220,6 +231,41 @@ func TestEnable_AllDevicesMode_DoesNotRequirePolicyMark(t *testing.T) {
 	}
 	if !strings.Contains(restoreInput, "-A PREROUTING -m conntrack ! --ctstate INVALID -j "+ChainName) {
 		t.Fatalf("expected unconditional mangle PREROUTING jump, got:\n%s", restoreInput)
+	}
+}
+
+// Issue #354: PID-alive is not enough — Enable's wait gate must hold until
+// sing-box actually binds the router inbound sockets, otherwise iptables
+// starts redirecting into unbound ports and the status emitted at the end
+// of Enable reports Active=false («СБОЙ») despite a successful enable.
+func TestWaitForSingbox_WaitsForSocketBinding(t *testing.T) {
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc := newTestService(t, Deps{Singbox: singbox})
+
+	probeCalls := 0
+	stubListeningProbe(t, func() bool {
+		probeCalls++
+		return probeCalls >= 3
+	})
+
+	if err := svc.waitForSingbox(context.Background(), 5*time.Second); err != nil {
+		t.Fatalf("waitForSingbox: %v", err)
+	}
+	if probeCalls < 3 {
+		t.Fatalf("expected wait to poll the listening probe until it turns true, got %d calls", probeCalls)
+	}
+}
+
+func TestWaitForSingbox_TimesOutWhenSocketsNeverBind(t *testing.T) {
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc := newTestService(t, Deps{Singbox: singbox})
+
+	stubListeningProbe(t, func() bool { return false })
+
+	if err := svc.waitForSingbox(context.Background(), 300*time.Millisecond); err == nil {
+		t.Fatal("expected timeout when sing-box never binds inbound sockets")
 	}
 }
 


### PR DESCRIPTION
(#354)

Статус после включения движка снимался до того, как sing-box успевал забиндить tproxy/redirect-порты (debounce 250мс + старт на mipsel) — SSE и reloadStatus получали active=false, UI показывал «СБОЙ» до ручного обновления. waitForSingbox теперь ждёт тот же сокет-probe, которым GetStatus считает Active.