### PR TITLE
Pr349 review fixes 2

### DIFF
--- a/frontend/src/lib/components/sb-router/AddWizardPanel.svelte
+++ b/frontend/src/lib/components/sb-router/AddWizardPanel.svelte
@@ -41,6 +41,7 @@
   import { mode } from './modeStore';
   import { ensureTunnelDnsInfra, syncTunnelDnsRule } from './emptyStateActions';
   import { pluralize, RULE_WORDS, SERVICE_WORDS, SET_WORDS } from '$lib/utils/pluralize';
+  import { findScrollContainer } from '$lib/utils/findScrollContainer';
   import { previewTunnelOutboundResolution, formatWizardOutboundPreview } from './wizardCompositeOutbound';
 
   const outbounds = singboxRouterStore.outbounds;
@@ -105,21 +106,6 @@
   // визард не уничтожается, поэтому локальный value формы надо сбросить вместе со стором.
   let customResetKey = $state(0);
   let wizardEl = $state<HTMLElement | null>(null);
-
-  function findScrollContainer(start: HTMLElement | null): HTMLElement | null {
-    let el = start?.parentElement ?? null;
-    while (el) {
-      const { overflowY } = getComputedStyle(el);
-      if (
-        (overflowY === 'auto' || overflowY === 'scroll')
-        && el.scrollHeight > el.clientHeight + 1
-      ) {
-        return el;
-      }
-      el = el.parentElement;
-    }
-    return null;
-  }
 
   const STICKY_HEADER_OFFSET = 72;
 

--- a/frontend/src/lib/components/sb-router/RulesPanel.svelte
+++ b/frontend/src/lib/components/sb-router/RulesPanel.svelte
@@ -197,12 +197,15 @@
 
   function requestRulesetEdit(tag: string) {
     cancelDrag();
-    const rs = $ruleSets.find((r) => r.tag === tag);
+    // Чип несёт display-тег (без -srs); если inline-база удалена, а компаньон
+    // ещё не вычищен, в $ruleSets остался только тег с суффиксом — ищем по нему.
+    const rs = $ruleSets.find((r) => r.tag === tag)
+      ?? $ruleSets.find((r) => !!r.tag && displayRuleSetTag(r.tag) === tag);
     if (!rs) {
       notifications.error(`Набор «${tag}» не найден в конфигурации`);
       return;
     }
-    rsEditTag = tag;
+    rsEditTag = rs.tag;
   }
 
   async function handleRsEditSave(rs: SingboxRouterRuleSet) {

--- a/frontend/src/lib/components/sb-router/RulesPanel.svelte
+++ b/frontend/src/lib/components/sb-router/RulesPanel.svelte
@@ -353,10 +353,16 @@
   }
 
   function scheduleDropSkeleton() {
-    dropExpanded = false;
-    clearDropSkeletonTimer();
     const target = targetDropAt(insertionIndex);
-    if (!dragState?.started || target === null || target !== dropAt) return;
+    if (!dragState?.started || target === null || target !== dropAt) {
+      dropExpanded = false;
+      clearDropSkeletonTimer();
+      return;
+    }
+    // Цель не менялась: раскрытый скелетон не схлопываем (раскрытие сдвигает
+    // геометрию → insertionIndex меняется → безусловный сброс рушил только что
+    // показанный скелетон), идущий таймер не перезапускаем.
+    if (dropExpanded || dropSkeletonTimer !== null) return;
     dropSkeletonTimer = setTimeout(() => {
       if (dragState?.started && targetDropAt(insertionIndex) === dropAt && dropAt !== null) {
         dropExpanded = true;

--- a/frontend/src/lib/components/sb-router/RulesPanel.svelte
+++ b/frontend/src/lib/components/sb-router/RulesPanel.svelte
@@ -30,6 +30,7 @@
   import { syncTunnelDnsRule } from './emptyStateActions';
   import { pluralize, RULE_WORDS } from '$lib/utils/pluralize';
   import { displayRuleSetTag } from '$lib/utils/singboxInlineRules';
+  import { findScrollContainer } from '$lib/utils/findScrollContainer';
   import type { RuleCardData } from './types';
 
   const rules = singboxRouterStore.rules;
@@ -276,21 +277,6 @@
         }
       },
     };
-  }
-
-  function findScrollContainer(start: HTMLElement | null): HTMLElement | null {
-    let el = start?.parentElement ?? null;
-    while (el) {
-      const { overflowY } = getComputedStyle(el);
-      if (
-        (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay')
-        && el.scrollHeight > el.clientHeight + 1
-      ) {
-        return el;
-      }
-      el = el.parentElement;
-    }
-    return null;
   }
 
   function canScrollWindow(): boolean {

--- a/frontend/src/lib/components/sb-router/RulesPanel.svelte
+++ b/frontend/src/lib/components/sb-router/RulesPanel.svelte
@@ -677,6 +677,7 @@
       dropCommitPending = true;
       detachDragInteraction();
       requestAnimationFrame(() => {
+        if (!dropCommitPending) return;
         dropExpanded = true;
         dropCommitTimer = setTimeout(async () => {
           dropCommitTimer = null;

--- a/frontend/src/lib/utils/findScrollContainer.ts
+++ b/frontend/src/lib/utils/findScrollContainer.ts
@@ -1,0 +1,15 @@
+/** Ближайший прокручиваемый предок: overflow-y auto/scroll/overlay с реальным переполнением. */
+export function findScrollContainer(start: HTMLElement | null): HTMLElement | null {
+	let el = start?.parentElement ?? null;
+	while (el) {
+		const { overflowY } = getComputedStyle(el);
+		if (
+			(overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay')
+			&& el.scrollHeight > el.clientHeight + 1
+		) {
+			return el;
+		}
+		el = el.parentElement;
+	}
+	return null;
+}


### PR DESCRIPTION
  1.  не коммитить перенос правила после ухода со страницы — guard if (!dropCommitPending) return в rAF deferred-commit ветки: закрывает однокадровое окно, в котором  onDestroy → cleanupDrag не мог отменить ещё не созданный dropCommitTimer, и через 360мс уходил moveRule с устаревшим индексом.
  2.  не схлопывать раскрытый скелетон дроп-зоны — scheduleDropSkeleton больше не сбрасывает dropExpanded и не перезапускает 680мс-таймер на same-target reconcile (раскрытие  меняло геометрию → повторный вызов → осцилляция).
  3.  редактор набора при осиротевшем -srs-компаньоне — fallback-поиск по display-тегу; в rsEditTag кладётся фактический тег. реальная проблема была только в тосте «не найден» вместо открытия редактора.
  4.  общий findScrollContainer в lib/utils — единая версия (с overflow-y: overlay), убраны обе расходившиеся копии.