### PR TITLE
Pr/server cards redesign

### DIFF
--- a/frontend/src/lib/components/servers/ManagedPeerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerCard.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { STATUS_LABEL, type PeerRowProps } from '$lib/utils/peerRowVM';
+	import { Toggle } from '$lib/components/ui';
+	import { Download, SquarePen, Trash2 } from 'lucide-svelte';
+
+	let { peer, vm, showToggle, showDownload, showActions, toggling, onToggle, onConf, onEdit, onDelete, onCopy }: PeerRowProps = $props();
+</script>
+
+<article class="mobile-peer-card" class:peer-disabled={!vm.enabled}>
+	<div class="mobile-peer-card-top">
+		<div class="mobile-peer-title-row">
+			{#if showToggle}
+				<span class="peer-inline-toggle">
+					<Toggle checked={vm.enabled} onchange={() => onToggle(peer)} disabled={toggling} size="sm" spinner="none" />
+				</span>
+			{/if}
+			<div class="peer-name-block">
+				<span class="mobile-peer-name">{vm.name}</span>
+				<div class="peer-status-sub status-{vm.status}">
+					<span class="status-dot" class:dot-online={vm.status === 'online'} class:dot-offline={vm.status === 'offline'} class:dot-disabled={vm.status === 'disabled'}></span>
+					<span>{STATUS_LABEL[vm.status]}</span>
+				</div>
+			</div>
+		</div>
+
+		{#if showDownload || showActions}
+			<div class="mobile-peer-actions">
+				{#if showDownload}
+					<button class="peer-action-btn" onclick={() => onConf(peer)} title={`Скачать .conf для «${vm.name}»`}>
+						<Download size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+				{/if}
+				{#if showActions}
+					<button class="peer-action-btn" onclick={() => onEdit(peer)} title={`Редактировать «${vm.name}»`}>
+						<SquarePen size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+					<button class="peer-action-btn peer-action-btn-danger" onclick={() => onDelete(peer)} title={`Удалить «${vm.name}»`}>
+						<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<div class="mobile-peer-card-middle">
+		<span class="mobile-peer-handshake mono tech-value">
+			{#if vm.handshake}{vm.handshake.main}{#if vm.handshake.suffix}{" "}{vm.handshake.suffix}{/if}{:else}-{/if}
+		</span>
+		<div class="mobile-peer-net-row mono tech-value">
+			<button type="button" class="cell-copy mobile-peer-ip" onclick={() => onCopy(vm.ip, 'IP')} title={`Скопировать IP ${vm.ip}`}>
+				<span class="mobile-label">IP</span> {vm.ip}
+			</button>
+			<span class="mobile-peer-endpoint"><span class="mobile-label">EP</span> {vm.endpointHost}</span>
+		</div>
+	</div>
+
+	<div class="mobile-peer-card-bottom mono tech-value">
+		<span>RX: {vm.rx}</span>
+		<span>TX: {vm.tx}</span>
+	</div>
+</article>
+
+<style>
+	.mobile-peer-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-secondary);
+		min-width: 0;
+	}
+	.mobile-peer-card.peer-disabled { opacity: 0.55; }
+	.mobile-peer-card-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.5rem; min-width: 0; }
+	.mobile-peer-title-row { display: flex; align-items: center; gap: 0.5rem; min-width: 0; }
+	.peer-name-block { display: flex; flex-direction: column; gap: 0.125rem; min-width: 0; }
+	.mobile-peer-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.peer-status-sub { display: inline-flex; align-items: center; gap: 0.375rem; font-size: 0.625rem; letter-spacing: 0.04em; }
+	.status-online { color: var(--color-success); }
+	.status-offline, .status-disabled { color: var(--color-text-muted); }
+	.status-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+	.dot-online { background: var(--color-success); }
+	.dot-offline { background: var(--color-text-muted); }
+	.dot-disabled { background: var(--color-border); }
+	.mobile-peer-actions { display: flex; gap: 0.25rem; flex-shrink: 0; }
+	.mobile-peer-card-middle { display: flex; flex-direction: column; gap: 0.25rem; min-width: 0; }
+	.mobile-peer-net-row { display: flex; flex-wrap: wrap; gap: 0.75rem; min-width: 0; }
+	.mobile-peer-ip, .mobile-peer-endpoint { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+	.mobile-label { color: var(--color-text-muted); margin-right: 0.25rem; }
+	.mobile-peer-card-bottom { display: flex; gap: 1rem; }
+</style>

--- a/frontend/src/lib/components/servers/ManagedPeerRow.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerRow.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { STATUS_LABEL, type PeerRowProps } from '$lib/utils/peerRowVM';
+	import { Toggle } from '$lib/components/ui';
+	import { Download, SquarePen, Trash2 } from 'lucide-svelte';
+
+	let { peer, vm, showToggle, showDownload, showActions, toggling, onToggle, onConf, onEdit, onDelete, onCopy }: PeerRowProps = $props();
+</script>
+
+<tr class="peer-row" class:peer-disabled={!vm.enabled}>
+	<td class="col-name">
+		<div class="name-cell">
+			{#if showToggle}
+				<span class="peer-inline-toggle">
+					<Toggle checked={vm.enabled} onchange={() => onToggle(peer)} disabled={toggling} size="sm" spinner="none" />
+				</span>
+			{/if}
+			<span class="peer-name">{vm.name}</span>
+		</div>
+	</td>
+	<td class="col-status">
+		<span class="peer-status status-{vm.status}">
+			<span class="status-dot" class:dot-online={vm.status === 'online'} class:dot-offline={vm.status === 'offline'} class:dot-disabled={vm.status === 'disabled'}></span>
+			{STATUS_LABEL[vm.status]}
+		</span>
+	</td>
+	<td class="col-ip">
+		<button type="button" class="cell-copy mono tech-value" onclick={() => onCopy(vm.ip, 'IP')} title={`Скопировать IP ${vm.ip}`}>
+			{vm.ip}
+		</button>
+	</td>
+	<td class="col-endpoint mono tech-value">{vm.endpointHost}</td>
+	<td class="col-rx mono tech-value">{vm.rx}</td>
+	<td class="col-tx mono tech-value">{vm.tx}</td>
+	<td class="col-handshake mono tech-value">
+		{#if vm.handshake}{vm.handshake.main}{#if vm.handshake.suffix}{" "}{vm.handshake.suffix}{/if}{:else}-{/if}
+	</td>
+	{#if showDownload || showActions}
+		<td class="col-actions">
+			<div class="peer-actions">
+				{#if showDownload}
+					<button class="peer-action-btn" onclick={() => onConf(peer)} title={`Скачать .conf для «${vm.name}»`}>
+						<Download size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+				{/if}
+				{#if showActions}
+					<button class="peer-action-btn" onclick={() => onEdit(peer)} title={`Редактировать «${vm.name}»`}>
+						<SquarePen size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+					<button class="peer-action-btn peer-action-btn-danger" onclick={() => onDelete(peer)} title={`Удалить «${vm.name}»`}>
+						<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
+					</button>
+				{/if}
+			</div>
+		</td>
+	{/if}
+</tr>
+
+<style>
+	.name-cell {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+	.peer-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.peer-row.peer-disabled {
+		opacity: 0.55;
+	}
+	.peer-status {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.6875rem;
+		letter-spacing: 0.04em;
+	}
+	.status-online { color: var(--color-success); }
+	.status-offline { color: var(--color-text-muted); }
+	.status-disabled { color: var(--color-text-muted); }
+	.status-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+	.dot-online { background: var(--color-success); }
+	.dot-offline { background: var(--color-text-muted); }
+	.dot-disabled { background: var(--color-border); }
+	.col-rx, .col-tx { text-align: right; }
+	.peer-actions { display: flex; gap: 0.25rem; justify-content: flex-end; }
+</style>

--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import type { ManagedPeer, ManagedPeerStats } from '$lib/types';
-	import { Trash2 } from 'lucide-svelte';
-	import { ConfirmModal, Toggle } from '$lib/components/ui';
-	import { formatBytes, formatRelativeTime } from '$lib/utils/format';
+	import { ConfirmModal } from '$lib/components/ui';
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { peerSort } from '$lib/stores/peerSort';
 	import { peerAriaSort } from '$lib/utils/peerSort';
+	import { buildPeerRowVM } from '$lib/utils/peerRowVM';
 	import PeerTableSortHeader from './PeerTableSortHeader.svelte';
+	import ManagedPeerRow from './ManagedPeerRow.svelte';
+	import ManagedPeerCard from './ManagedPeerCard.svelte';
 
 	interface Props {
 		peers: ManagedPeer[];
@@ -38,6 +39,8 @@
 	let deletePeerTarget = $state<ManagedPeer | null>(null);
 	let deletingPeer = $state(false);
 
+	let rows = $derived(peers.map((peer) => ({ peer, vm: buildPeerRowVM(peer, getPeerStats(peer.publicKey)) })));
+
 	function requestDeletePeer(peer: ManagedPeer) {
 		deletePeerTarget = peer;
 	}
@@ -49,49 +52,14 @@
 			await onDeletePeer(deletePeerTarget);
 			deletePeerTarget = null;
 		} catch {
-			// keep modal open on error
+			// оставить модалку открытой при ошибке
 		} finally {
 			deletingPeer = false;
 		}
 	}
 
-	function peerName(peer: ManagedPeer): string {
-		return peer.description || `${peer.publicKey.slice(0, 8)}...`;
-	}
-
-	function peerStatus(peer: ManagedPeer, peerStats: ManagedPeerStats | undefined): 'disabled' | 'online' | 'offline' {
-		if (!peer.enabled) return 'disabled';
-		return peerStats?.online ? 'online' : 'offline';
-	}
-
-	function splitHandshakeLabel(value: string): { main: string; suffix?: string } {
-		const trimmed = value.trim();
-		if (trimmed.endsWith(' назад')) {
-			return { main: trimmed.slice(0, -' назад'.length), suffix: 'назад' };
-		}
-		return { main: trimmed };
-	}
-
-	function splitEndpoint(endpoint: string): { host: string; port?: string } {
-		const trimmed = endpoint.trim();
-		if (!trimmed || trimmed === '-') return { host: '-' };
-		const bracketMatch = /^(\[[^\]]+\]):(\d+)$/.exec(trimmed);
-		if (bracketMatch) return { host: bracketMatch[1], port: `:${bracketMatch[2]}` };
-		const lastColon = trimmed.lastIndexOf(':');
-		if (lastColon <= 0) return { host: trimmed };
-		const host = trimmed.slice(0, lastColon);
-		const port = trimmed.slice(lastColon + 1);
-		if (!/^\d+$/.test(port)) return { host: trimmed };
-		if (host.includes(':')) return { host: trimmed };
-		return { host, port: `:${port}` };
-	}
-
-	function isInsideInlineToggle(event: Event): boolean {
-		return event.target instanceof HTMLElement && !!event.target.closest('.peer-inline-toggle');
-	}
-
 	async function copyCellValue(value: string, label: string): Promise<void> {
-		if (!value || value === '-') {
+		if (!value || value === '—' || value === '-') {
 			notifications.warning(`${label} отсутствует`, { duration: 2000 });
 			return;
 		}
@@ -102,8 +70,10 @@
 		}
 	}
 
+	let showActionsCol = $derived(showPeerDownload || showPeerActions);
 </script>
 
+<div class="peer-views">
 <div class="desktop-peer-table">
 	<div class="table-wrap">
 		<table class="managed-peer-table">
@@ -112,153 +82,40 @@
 					<th class="col-name" aria-sort={peerAriaSort($peerSort, 'name')}>
 						<PeerTableSortHeader label="Имя" sortKey="name" />
 					</th>
+					<th class="col-status">Статус</th>
 					<th class="col-ip" aria-sort={peerAriaSort($peerSort, 'ip')}>
 						<PeerTableSortHeader label="IP" sortKey="ip" />
 					</th>
 					<th class="col-endpoint" aria-sort={peerAriaSort($peerSort, 'endpoint')}>
 						<PeerTableSortHeader label="Endpoint" sortKey="endpoint" />
 					</th>
-					<th class="col-traffic" aria-sort={peerAriaSort($peerSort, 'traffic')}>
-						<PeerTableSortHeader label="Трафик" sortKey="traffic" />
+					<th class="col-rx" aria-sort={peerAriaSort($peerSort, 'traffic')}>
+						<PeerTableSortHeader label="RX" sortKey="traffic" />
 					</th>
+					<th class="col-tx">TX</th>
 					<th class="col-handshake" aria-sort={peerAriaSort($peerSort, 'handshake')}>
 						<PeerTableSortHeader label="Handshake" sortKey="handshake" />
 					</th>
-					{#if showPeerDownload || showPeerActions}
+					{#if showActionsCol}
 						<th class="col-actions">Действия</th>
 					{/if}
 				</tr>
 			</thead>
 			<tbody>
-				{#each peers as peer (peer.publicKey)}
-					{@const peerStats = getPeerStats(peer.publicKey)}
-					{@const status = peerStatus(peer, peerStats)}
-					{@const endpointValue = peerStats?.endpoint || '-'}
-					{@const ep = splitEndpoint(endpointValue)}
-					{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
-					<tr class:peer-disabled={!peer.enabled}>
-						<td
-							class="peer-name-cell"
-							class:peer-name-cell-readonly={!showPeerToggle}
-							role={showPeerToggle ? 'button' : undefined}
-							tabindex={showPeerToggle ? 0 : undefined}
-							title={showPeerToggle
-								? peer.enabled
-									? `Отключить «${peerName(peer)}»`
-									: `Включить «${peerName(peer)}»`
-								: undefined}
-							onclick={showPeerToggle
-								? (e) => {
-										if (isInsideInlineToggle(e) || isPeerToggling(peer.publicKey)) return;
-										onTogglePeer(peer);
-									}
-								: undefined}
-							onkeydown={showPeerToggle
-								? (e) => {
-										if (isInsideInlineToggle(e) || isPeerToggling(peer.publicKey)) return;
-										if (e.key === 'Enter' || e.key === ' ') {
-											e.preventDefault();
-											onTogglePeer(peer);
-										}
-									}
-								: undefined}
-						>
-							<div class="peer-name-row">
-								{#if showPeerToggle}
-									<span class="peer-inline-toggle">
-										<Toggle
-											checked={peer.enabled}
-											onchange={() => onTogglePeer(peer)}
-											disabled={isPeerToggling(peer.publicKey)}
-											size="sm"
-											spinner="none"
-										/>
-									</span>
-								{/if}
-								<div class="peer-name-block">
-									<span class="peer-name">{peerName(peer)}</span>
-									<div class="peer-status-sub">
-										<span
-											class="status-dot"
-											class:dot-online={status === 'online'}
-											class:dot-offline={status === 'offline'}
-											class:dot-disabled={status === 'disabled'}
-										></span>
-										<span>{status}</span>
-									</div>
-								</div>
-							</div>
-						</td>
-						<td class="col-ip">
-							<button
-								type="button"
-								class="cell-copy mono tech-value"
-								onclick={() => void copyCellValue(peer.tunnelIP, 'IP')}
-								title={`Скопировать IP ${peer.tunnelIP}`}
-							>
-								{peer.tunnelIP}
-							</button>
-						</td>
-						<td class="col-endpoint">
-							<button
-								type="button"
-								class="cell-copy endpoint-copy mono tech-value"
-								onclick={() => void copyCellValue(endpointValue, 'Endpoint')}
-								title={endpointValue !== '-' ? `Скопировать Endpoint ${endpointValue}` : 'Endpoint отсутствует'}
-							>
-								<span class="endpoint-text">{ep.host}</span>
-								{#if ep.port}
-									<span class="endpoint-port">{ep.port}</span>
-								{/if}
-							</button>
-						</td>
-						<td class="col-traffic">
-							<div class="traffic-cell mono tech-value">
-								<span class="traffic-rx">RX: {formatBytes(peerStats?.rxBytes ?? 0)}</span>
-								<span class="traffic-tx">TX: {formatBytes(peerStats?.txBytes ?? 0)}</span>
-							</div>
-						</td>
-						<td class="col-handshake tech-value">
-							{#if hs}
-								<span class="handshake-text">{hs.main}</span>
-								{#if hs.suffix}
-									<span class="handshake-suffix">{" "}{hs.suffix}</span>
-								{/if}
-							{:else}
-								-
-							{/if}
-						</td>
-						{#if showPeerDownload || showPeerActions}
-							<td class="col-actions">
-								<div class="peer-actions">
-									{#if showPeerDownload}
-										<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-											<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-												<polyline points="7 10 12 15 17 10" />
-												<line x1="12" y1="15" x2="12" y2="3" />
-											</svg>
-										</button>
-									{/if}
-									{#if showPeerActions}
-									<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-										<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-											<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-											<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-										</svg>
-									</button>
-									<button
-										class="peer-action-btn peer-action-btn-danger"
-										onclick={() => requestDeletePeer(peer)}
-										title={`Удалить «${peerName(peer)}»`}
-									>
-										<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
-									</button>
-									{/if}
-								</div>
-							</td>
-						{/if}
-					</tr>
+				{#each rows as { peer, vm } (peer.publicKey)}
+					<ManagedPeerRow
+						{peer}
+						{vm}
+						showToggle={showPeerToggle}
+						showDownload={showPeerDownload}
+						showActions={showPeerActions}
+						toggling={isPeerToggling(peer.publicKey)}
+						onToggle={onTogglePeer}
+						onConf={onOpenConf}
+						onEdit={onOpenEditPeer}
+						onDelete={requestDeletePeer}
+						onCopy={copyCellValue}
+					/>
 				{/each}
 			</tbody>
 		</table>
@@ -266,586 +123,65 @@
 </div>
 
 <div class="mobile-peer-list">
-	{#each peers as peer (peer.publicKey)}
-		{@const peerStats = getPeerStats(peer.publicKey)}
-		{@const status = peerStatus(peer, peerStats)}
-		{@const endpointValue = peerStats?.endpoint || '-'}
-		{@const hs = peerStats?.lastHandshake ? splitHandshakeLabel(formatRelativeTime(peerStats.lastHandshake)) : null}
-		<article class="mobile-peer-card" class:peer-disabled={!peer.enabled} class:has-actions={showPeerDownload || showPeerActions}>
-			<div class="mobile-peer-card-top">
-				<div class="mobile-peer-title-row">
-					{#if showPeerToggle}
-						<span class="peer-inline-toggle">
-							<Toggle
-								checked={peer.enabled}
-								onchange={() => onTogglePeer(peer)}
-								disabled={isPeerToggling(peer.publicKey)}
-								size="sm"
-								spinner="none"
-							/>
-						</span>
-					{/if}
-					<div class="peer-name-block">
-						<span class="mobile-peer-name">{peerName(peer)}</span>
-						<div class="peer-status-sub">
-							<span
-								class="status-dot"
-								class:dot-online={status === 'online'}
-								class:dot-offline={status === 'offline'}
-								class:dot-disabled={status === 'disabled'}
-							></span>
-							<span>{status}</span>
-						</div>
-					</div>
-				</div>
-
-				{#if showPeerDownload || showPeerActions}
-					<div class="mobile-peer-actions">
-						{#if showPeerDownload}
-							<button class="peer-action-btn" onclick={() => onOpenConf(peer)} title={`Скачать .conf для «${peerName(peer)}»`}>
-								<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-									<polyline points="7 10 12 15 17 10" />
-									<line x1="12" y1="15" x2="12" y2="3" />
-								</svg>
-							</button>
-						{/if}
-						{#if showPeerActions}
-						<button class="peer-action-btn" onclick={() => onOpenEditPeer(peer)} title={`Редактировать «${peerName(peer)}»`}>
-							<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-								<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-							</svg>
-						</button>
-						<button
-							class="peer-action-btn peer-action-btn-danger"
-							onclick={() => requestDeletePeer(peer)}
-							title={`Удалить «${peerName(peer)}»`}
-						>
-							<Trash2 size={18} strokeWidth={2} aria-hidden="true" />
-						</button>
-						{/if}
-					</div>
-				{/if}
-			</div>
-
-			<div class="mobile-peer-card-middle">
-				<div class="mobile-peer-status-row">
-					<span class="mobile-peer-handshake">
-						{#if hs}
-							{hs.main}{#if hs.suffix}{" "}{hs.suffix}{/if}
-						{:else}
-							-
-						{/if}
-					</span>
-				</div>
-
-				<div class="mobile-peer-net-row mono tech-value">
-					<button
-						type="button"
-						class="cell-copy mobile-peer-ip"
-						onclick={() => void copyCellValue(peer.tunnelIP, 'IP')}
-						title={`Скопировать IP ${peer.tunnelIP}`}
-					>
-						<span class="mobile-label">IP</span> {peer.tunnelIP}
-					</button>
-
-					<button
-						type="button"
-						class="cell-copy mobile-peer-endpoint"
-						onclick={() => void copyCellValue(endpointValue, 'Endpoint')}
-						title={endpointValue !== '-' ? `Скопировать Endpoint ${endpointValue}` : 'Endpoint отсутствует'}
-					>
-						<span class="mobile-label">EP</span>
-						<span class="mobile-endpoint-value">{endpointValue}</span>
-					</button>
-				</div>
-			</div>
-
-			<div class="mobile-peer-card-bottom">
-				<div class="mobile-peer-traffic-row mono tech-value">
-					<span>RX: {formatBytes(peerStats?.rxBytes ?? 0)}</span>
-					<span>TX: {formatBytes(peerStats?.txBytes ?? 0)}</span>
-				</div>
-			</div>
-		</article>
+	{#each rows as { peer, vm } (peer.publicKey)}
+		<ManagedPeerCard
+			{peer}
+			{vm}
+			showToggle={showPeerToggle}
+			showDownload={showPeerDownload}
+			showActions={showPeerActions}
+			toggling={isPeerToggling(peer.publicKey)}
+			onToggle={onTogglePeer}
+			onConf={onOpenConf}
+			onEdit={onOpenEditPeer}
+			onDelete={requestDeletePeer}
+			onCopy={copyCellValue}
+		/>
 	{/each}
+</div>
 </div>
 
 {#if deletePeerTarget}
 	<ConfirmModal
 		open={true}
 		title="Удаление клиента"
-		message={`Удалить клиента «${peerName(deletePeerTarget)}»?`}
+		message={`Удалить клиента «${deletePeerTarget.description || deletePeerTarget.publicKey.slice(0, 8) + '...'}»?`}
 		secondary={`Туннельный IP: ${deletePeerTarget.tunnelIP}. Конфигурация и ключи будут удалены без возможности восстановления.`}
 		confirmLabel="Удалить"
 		busy={deletingPeer}
 		onConfirm={confirmDeletePeer}
-		onClose={() => {
-			if (!deletingPeer) deletePeerTarget = null;
-		}}
+		onClose={() => { if (!deletingPeer) deletePeerTarget = null; }}
 	/>
 {/if}
 
 <style>
-	.table-wrap {
-		overflow-x: auto;
-	}
-
-	.desktop-peer-table {
-		display: block;
-	}
-
-	.mobile-peer-list {
-		display: none;
-	}
-
-	.managed-peer-table {
-		width: 100%;
-		border-collapse: collapse;
-		font-size: 12px;
-		table-layout: auto;
-	}
-
+	.table-wrap { overflow-x: auto; }
+	.managed-peer-table { width: 100%; border-collapse: collapse; }
 	.managed-peer-table th {
-		text-align: center;
-		background: var(--bg-tertiary, var(--color-bg-tertiary));
-		color: var(--text-muted, var(--color-text-muted));
-		font-weight: 600;
-		padding: 0.65rem 0.75rem;
-		line-height: 1.2;
-		border-bottom: 1px solid var(--border, var(--color-border));
-		white-space: nowrap;
-	}
-
-	.managed-peer-table td {
-		padding: 0.55rem 0.5rem;
-		border-bottom: 1px solid var(--border);
-		vertical-align: middle;
-		transition: background-color 0.15s ease;
-	}
-
-	.managed-peer-table tbody tr:hover td {
-		background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
-	}
-
-	.managed-peer-table tbody tr.peer-disabled:hover td {
-		background: color-mix(in srgb, var(--bg-hover) 45%, transparent);
-	}
-
-	.peer-disabled {
-		opacity: 0.5;
-	}
-
-	td.peer-name-cell {
-		min-width: 140px;
 		text-align: left;
-		cursor: pointer;
+		font: 600 0.6875rem/1.2 var(--font-sans);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--color-text-muted);
+		padding: 0.5rem 0.625rem;
+		border-bottom: 1px solid var(--color-border);
+		white-space: nowrap;
 	}
-
-	td.peer-name-cell-readonly {
-		cursor: default;
-	}
-
-	.peer-name {
-		font-weight: 500;
-		font-size: 13px;
-		line-height: 1.15;
-		color: var(--text-primary);
-		white-space: normal;
-		overflow-wrap: anywhere;
-		word-break: break-word;
-	}
-
-	.peer-name-row {
-		display: flex;
-		align-items: center;
-		gap: 0.3rem;
-		min-width: 0;
-	}
-
-	.peer-name-block {
-		display: flex;
-		flex-direction: column;
-		gap: 0.1rem;
-		min-width: 0;
-		flex: 1 1 auto;
-	}
-
-	.peer-name-row .peer-name {
-		min-width: 0;
-	}
-
-	.peer-status-sub {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		font-size: 10px;
-		color: var(--text-muted);
-		line-height: 1;
-	}
-
-	.peer-inline-toggle {
-		display: inline-flex;
-		align-items: center;
-		line-height: 1;
-		margin-right: 0.35rem;
-	}
-
-	.peer-inline-toggle :global(.toggle-container) {
-		gap: 0;
-		padding: 0;
-		min-height: 0;
-	}
-
-	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider) {
-		width: 30px;
-		height: 18px;
-	}
-
-	.peer-inline-toggle :global(.toggle-container.sm .toggle-slider::before) {
-		width: 14px;
-		height: 14px;
-		left: 2px;
-		bottom: 2px;
-	}
-
-	.peer-inline-toggle :global(.toggle-container.sm input:checked ~ .toggle-slider::before) {
-		transform: translateX(12px);
-	}
-
-	.peer-inline-toggle :global(.toggle-spinner-slot) {
-		width: 0;
-		margin: 0;
-	}
-
-	.mono {
-		font-family: var(--font-mono, monospace);
-	}
-
-	.tech-value {
-		font-size: 10px;
-		line-height: 1.15;
-	}
-
-	.status-dot {
-		display: inline-block;
-		width: 6px;
-		height: 6px;
-		border-radius: 999px;
-		flex-shrink: 0;
+	.col-rx, .col-tx { text-align: right; }
+	.managed-peer-table :global(td) {
+		padding: 0.625rem;
+		border-bottom: 1px solid var(--color-border-subtle, var(--color-border));
 		vertical-align: middle;
 	}
+	/* Переключение таблица/карточки по ШИРИНЕ КОНТЕЙНЕРА (а не вьюпорта):
+	   при наличии rail доступная ширина < вьюпорта, поэтому viewport-медиазапрос
+	   ошибается. Десктоп-таблицу показываем только когда она реально влезает. */
+	.peer-views { container-type: inline-size; }
+	.desktop-peer-table { display: none; }
+	.mobile-peer-list { display: flex; flex-direction: column; gap: 0.5rem; }
 
-	.dot-online {
-		background: var(--success, #22c55e);
-		box-shadow: 0 0 3px var(--success, #22c55e);
-	}
-
-	.dot-offline {
-		background: var(--text-muted);
-	}
-
-	.dot-disabled {
-		background: var(--text-muted);
-	}
-
-	.traffic-cell {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0;
-		line-height: 1.05;
-		white-space: nowrap;
-	}
-
-	.col-name {
-		width: 24%;
-	}
-
-	.col-ip {
-		width: 12%;
-		white-space: nowrap;
-	}
-
-	.col-endpoint {
-		width: auto;
-		max-width: 180px;
-	}
-
-	.managed-peer-table th.col-endpoint {
-		text-align: center;
-	}
-
-	.managed-peer-table td.col-endpoint {
-		text-align: center;
-		vertical-align: middle;
-	}
-
-	.managed-peer-table td.col-endpoint .endpoint-copy {
-		display: inline-flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		max-width: 100%;
-		text-align: center;
-	}
-
-	.endpoint-text {
-		display: block;
-		white-space: normal;
-		overflow-wrap: anywhere;
-		word-break: break-word;
-		line-height: 1.15;
-	}
-
-	.endpoint-port {
-		display: block;
-		white-space: nowrap;
-		line-height: 1.15;
-	}
-
-	.col-traffic {
-		width: 14%;
-	}
-
-	.col-handshake {
-		width: 12%;
-		white-space: nowrap;
-	}
-
-	.handshake-text,
-	.handshake-suffix {
-		display: block;
-	}
-
-	.col-actions {
-		width: 11%;
-		white-space: nowrap;
-	}
-
-	td.col-ip,
-	td.col-endpoint,
-	td.col-traffic,
-	td.col-handshake {
-		text-align: center;
-	}
-
-	td.col-actions {
-		text-align: center;
-		vertical-align: middle;
-	}
-
-	.peer-actions {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 100%;
-		gap: 0.375rem;
-	}
-
-	.peer-action-btn {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0.375rem;
-		background: transparent;
-		border: none;
-		color: var(--text-secondary);
-		cursor: pointer;
-		border-radius: var(--radius-sm);
-		transition: color 0.15s ease, background 0.15s ease;
-	}
-
-	.peer-action-btn:hover {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-	}
-
-	.peer-action-btn-danger:hover {
-		color: var(--error, #ef4444);
-	}
-
-	.cell-copy {
-		padding: 0;
-		border: 0;
-		background: none;
-		color: inherit;
-		cursor: pointer;
-		text-align: inherit;
-	}
-
-	.cell-copy:hover {
-		text-decoration: underline;
-		color: var(--text-primary);
-	}
-
-	@media (max-width: 640px) {
-		.desktop-peer-table {
-			display: none;
-		}
-
-		.mobile-peer-list {
-			display: flex;
-			flex-direction: column;
-			gap: 0.6rem;
-		}
-
-		.mobile-peer-card {
-			display: flex;
-			flex-direction: column;
-			gap: 0.65rem;
-			padding: 0.7rem 0.75rem;
-			border: 1px solid var(--border);
-			border-radius: var(--radius);
-			background: var(--bg-primary);
-		}
-
-		.mobile-peer-card-top {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) auto;
-			align-items: start;
-			gap: 0.5rem;
-		}
-
-		.mobile-peer-card-middle,
-		.mobile-peer-card-bottom,
-		.mobile-peer-title-row {
-			min-width: 0;
-		}
-
-		.mobile-peer-title-row {
-			display: flex;
-			align-items: center;
-			gap: 0.45rem;
-			min-width: 0;
-		}
-
-		.mobile-peer-name {
-			min-width: 0;
-			max-width: 100%;
-			font-size: 13px;
-			font-weight: 600;
-			line-height: 1.15;
-			color: var(--text-primary);
-			overflow-wrap: anywhere;
-		}
-
-		.mobile-peer-status-row {
-			display: flex;
-			justify-content: flex-start;
-			align-items: center;
-			font-size: 10px;
-			line-height: 1;
-			color: var(--text-muted);
-		}
-
-		.mobile-peer-handshake {
-			text-align: left;
-			white-space: nowrap;
-			color: var(--text-muted);
-			margin-left: 0.1rem;
-		}
-
-		.mobile-peer-net-row {
-			display: grid;
-			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.25fr);
-			gap: 0.5rem;
-			margin-top: 0.45rem;
-			line-height: 1.1;
-		}
-
-		.mobile-peer-ip {
-			min-width: 0;
-			text-align: left;
-			white-space: nowrap;
-		}
-
-		.mobile-peer-endpoint {
-			display: inline-flex;
-			flex-direction: row;
-			align-items: flex-end;
-			justify-content: flex-end;
-			gap: 0.25rem;
-			min-width: 0;
-			justify-self: end;
-			max-width: 100%;
-			text-align: right;
-			white-space: nowrap;
-		}
-
-		.mobile-endpoint-value {
-			display: block;
-			min-width: 0;
-			max-width: 100%;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-		}
-
-		.mobile-label {
-			flex: 0 0 auto;
-			color: var(--text-muted);
-			font-size: 9px;
-			line-height: 1;
-			letter-spacing: 0.04em;
-		}
-
-		.mobile-peer-traffic-row {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-			gap: 0.5rem;
-			margin-top: 0.35rem;
-			line-height: 1.1;
-		}
-
-		.mobile-peer-traffic-row > span:first-child {
-			justify-self: start;
-		}
-
-		.mobile-peer-traffic-row > span:last-child {
-			justify-self: end;
-			text-align: right;
-		}
-
-		.mobile-peer-actions {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-start;
-			justify-content: flex-end;
-			gap: 0.25rem;
-			align-self: start;
-		}
-
-		.mobile-peer-actions .peer-action-btn {
-			width: 32px;
-			height: 32px;
-			flex: 0 0 32px;
-			padding: 0;
-			border: 1px solid var(--border);
-			border-radius: var(--radius-sm);
-			background: var(--bg-secondary);
-		}
-
-		@media (max-width: 360px) {
-			.mobile-peer-card-top {
-				grid-template-columns: minmax(0, 1fr) auto;
-			}
-
-			.mobile-peer-actions {
-				flex-wrap: nowrap;
-				gap: 0.2rem;
-			}
-
-			.mobile-peer-actions .peer-action-btn {
-				width: 30px;
-				height: 30px;
-				flex-basis: 30px;
-			}
-		}
-
-		.peer-disabled {
-			opacity: 0.6;
-		}
+	@container (min-width: 820px) {
+		.desktop-peer-table { display: block; }
+		.mobile-peer-list { display: none; }
 	}
 </style>

--- a/frontend/src/lib/components/servers/ManagedServerCard.svelte
+++ b/frontend/src/lib/components/servers/ManagedServerCard.svelte
@@ -6,7 +6,8 @@
 	import { servers } from '$lib/stores/servers';
 	import { formatBytes } from '$lib/utils/format';
 	import { EarthLock, Plus, RefreshCw, Settings, Trash2 } from 'lucide-svelte';
-	import { Toggle, Button, Dropdown, ChipMultiSelect, VersionBadge, type DropdownOption } from '$lib/components/ui';
+	import { Toggle, Button, IconButton, SegmentedControl, ChipMultiSelect, VersionBadge, Stat, StatStrip } from '$lib/components/ui';
+	import type { SegmentedOption } from '$lib/components/ui/segmentedControl';
 	import {
 		EditManagedServerModal,
 		AddManagedPeerModal,
@@ -15,6 +16,7 @@
 		PeerSortControls,
 		ManagedPeerTable,
 		ServerAccessPolicyDropdown,
+		ServerSettingsPanel,
 	} from '$lib/components/servers';
 	import { comparePeerFieldsDirected } from '$lib/utils/peerSort';
 	import { peerSort } from '$lib/stores/peerSort';
@@ -207,9 +209,9 @@
 
 	let natMode = $derived<NatMode>(resolveNatMode(server.natMode, server.natEnabled));
 
-	const natModeOptions: DropdownOption<'full' | 'internet-only' | 'none'>[] = [
-		{ value: 'full', label: 'Полный NAT' },
-		{ value: 'internet-only', label: 'NAT только для интернета' },
+	const natModeOptions: SegmentedOption<'full' | 'internet-only' | 'none'>[] = [
+		{ value: 'full', label: 'Полный' },
+		{ value: 'internet-only', label: 'Интернет' },
 		{ value: 'none', label: 'Без NAT' },
 	];
 
@@ -342,74 +344,41 @@
 				{#if server.mtu}
 					<span class="meta mono">MTU {server.mtu}</span>
 				{/if}
-				{#if stats && (totalRx > 0 || totalTx > 0)}
-					<span class="meta mono">↓{formatBytes(totalRx)} ↑{formatBytes(totalTx)}</span>
-				{/if}
 			</div>
 		</div>
 		<div class="header-right">
 			<div class="header-actions">
-			<Button
-				variant="secondary"
-				size="sm"
-				onclick={handleRestartOrStart}
-				disabled={restartingServer || togglingEnabled || deleting}
-				loading={restartingServer}
-				iconBefore={restartIcon}
-				title={statusUnknown
-					? `Статус сервера «${serverDisplayName}» загружается`
-					: isUp
-						? `Перезапустить сервер «${serverDisplayName}»`
-						: `Запустить сервер «${serverDisplayName}»`}
-			>
-				{statusUnknown ? 'Рестарт' : isUp ? 'Рестарт' : 'Запуск'}
-			</Button>
-			<Button
-				variant="secondary"
-				size="sm"
-				onclick={onOpenASC}
-				iconBefore={ascIcon}
-				title={`Параметры обфускации сервера «${serverDisplayName}»`}
-			>
-				Обфускация
-			</Button>
-			<Button
-				variant="secondary"
-				size="sm"
-				onclick={() => editServerOpen = true}
-				iconBefore={settingsIcon}
-				title={`Настройки сервера «${serverDisplayName}»`}
-			>
-				Настройки
-			</Button>
+			<IconButton ariaLabel={isUp ? 'Рестарт' : 'Запуск'} title={statusUnknown ? `Статус сервера «${serverDisplayName}» загружается` : isUp ? `Перезапустить «${serverDisplayName}»` : `Запустить «${serverDisplayName}»`} disabled={restartingServer || togglingEnabled || deleting} onclick={handleRestartOrStart}>
+				<span class="restart-icon" class:spin={restartingServer}><RefreshCw size={16} strokeWidth={2} aria-hidden="true" /></span>
+			</IconButton>
+			<IconButton ariaLabel="Обфускация" title={`Параметры обфускации «${serverDisplayName}»`} onclick={onOpenASC}>
+				<EarthLock size={16} strokeWidth={2} aria-hidden="true" />
+			</IconButton>
+			<IconButton ariaLabel="Настройки" title={`Настройки сервера «${serverDisplayName}»`} onclick={() => (editServerOpen = true)}>
+				<Settings size={16} strokeWidth={2} aria-hidden="true" />
+			</IconButton>
 			{#if confirmDelete}
-				<Button
-					variant="danger"
-					size="sm"
-					onclick={handleDeleteServer}
-					loading={deleting}
-					title={`Подтвердить удаление сервера «${serverDisplayName}»`}
-				>
+				<Button variant="danger" size="sm" onclick={handleDeleteServer} loading={deleting} title={`Подтвердить удаление «${serverDisplayName}»`}>
 					Подтвердить?
 				</Button>
 			{:else}
-				<Button
-					variant="outline-danger"
-					size="sm"
-					onclick={handleDeleteServer}
-					disabled={deleting}
-					iconBefore={deleteIcon}
-					title={`Удалить сервер «${serverDisplayName}»`}
-				>
-					Удалить
-				</Button>
+				<IconButton variant="danger" ariaLabel="Удалить" title={`Удалить сервер «${serverDisplayName}»`} disabled={deleting} onclick={handleDeleteServer}>
+					<Trash2 size={16} strokeWidth={2} aria-hidden="true" />
+				</IconButton>
 			{/if}
 			</div>
 		</div>
 	</div>
 
+	<StatStrip>
+		<Stat value={stats ? formatBytes(totalRx) : '—'} label="RX" />
+		<Stat value={stats ? formatBytes(totalTx) : '—'} label="TX" />
+		<Stat value={`${onlineCount} / ${(server.peers ?? []).length}`} label="Клиенты" sub={onlineCount > 0 ? `${onlineCount} онлайн` : 'нет активных'} />
+		<Stat value={`UDP :${server.listenPort}`} label="Listen" />
+	</StatStrip>
+
 	<!-- Settings -->
-	<div class="server-settings">
+	<ServerSettingsPanel persistKey="awgm:servers:settingsCollapsed">
 		<div class="setting-row">
 			<div class="setting-copy">
 				<span class="setting-title">NAT</span>
@@ -429,12 +398,12 @@
 				{/if}
 			</div>
 			<div class="setting-control">
-				<Dropdown
+				<SegmentedControl
 					value={natMode}
 					options={natModeOptions}
+					ariaLabel="Режим NAT"
 					disabled={togglingNAT}
 					onchange={handleSetNATMode}
-					fullWidth
 				/>
 			</div>
 		</div>
@@ -464,7 +433,7 @@
 			disabled={policyChanging}
 			onchange={handlePolicyChange}
 		/>
-	</div>
+	</ServerSettingsPanel>
 
 	<!-- Peers -->
 	<div class="peers-section">
@@ -552,22 +521,6 @@
 	<Plus size={14} strokeWidth={2} aria-hidden="true" />
 {/snippet}
 
-{#snippet restartIcon()}
-	<RefreshCw size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
-
-{#snippet ascIcon()}
-	<EarthLock size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
-
-{#snippet settingsIcon()}
-	<Settings size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
-
-{#snippet deleteIcon()}
-	<Trash2 size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
-
 
 <style>
 	.title-badges {
@@ -612,7 +565,11 @@
 		border-radius: 2px;
 	}
 
-	.server-settings :global(.picker .chips) {
+	.restart-icon { display: inline-flex; }
+	.restart-icon.spin { animation: restart-spin 0.8s linear infinite; }
+	@keyframes restart-spin { to { transform: rotate(360deg); } }
+
+	:global(.settings-panel-body .picker .chips) {
 		background: var(--color-settings-surface-bg);
 		border-color: var(--color-border);
 		border-radius: var(--radius-sm);

--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -25,8 +25,9 @@
 		ConfGeneratorModal,
 		ServerAccessPolicyDropdown,
 		ServerEndpointSetting,
+		ServerSettingsPanel,
 	} from '$lib/components/servers';
-	import { Toggle, Button, Stat, StatStrip } from '$lib/components/ui';
+	import { Toggle, Button, Stat, StatStrip, IconButton } from '$lib/components/ui';
 	import { Plus, RefreshCw, ExternalLink } from 'lucide-svelte';
 
 	interface Props {
@@ -359,9 +360,6 @@
 				{#if server.mtu}
 					<span class="meta mono">MTU {server.mtu}</span>
 				{/if}
-				{#if isBuiltIn && (totalRx > 0 || totalTx > 0)}
-					<span class="meta mono">↓{formatBytes(totalRx)} ↑{formatBytes(totalTx)}</span>
-				{/if}
 			</div>
 			{#if server.keenDnsDomain}
 				<div class="keendns-row">
@@ -374,37 +372,22 @@
 		</div>
 		<div class="header-right">
 			<div class="header-actions">
-				<Button
-					variant="secondary"
-					size="sm"
-					onclick={handleRestartOrStart}
-					disabled={restartingServer || togglingEnabled}
-					loading={restartingServer}
-					iconBefore={restartIcon}
-				>
-					{isUp ? 'Рестарт' : 'Запуск'}
-				</Button>
+				<IconButton ariaLabel={isUp ? 'Рестарт' : 'Запуск'} title={isUp ? `Перезапустить «${serverName}»` : `Запустить «${serverName}»`} disabled={restartingServer || togglingEnabled} onclick={handleRestartOrStart}>
+					<span class="restart-icon" class:spin={restartingServer}><RefreshCw size={16} strokeWidth={2} aria-hidden="true" /></span>
+				</IconButton>
 			</div>
 		</div>
 	</div>
 
-	{#if isMarked}
-		<div class="kpi-rows">
-			<StatStrip>
-				<Stat value={formatBytes(totalRx)} label="принято" sub="суммарно по клиентам" />
-				<Stat value={formatBytes(totalTx)} label="отправлено" sub="суммарно по клиентам" />
-				<Stat
-					value={`${onlineCount}/${totalPeers}`}
-					label="Клиенты"
-					sub={onlineCount > 0 ? `${onlineCount} онлайн` : 'нет активных'}
-				/>
-				
-			</StatStrip>
-		</div>
-	{/if}
+	<StatStrip>
+		<Stat value={formatBytes(totalRx)} label="RX" />
+		<Stat value={formatBytes(totalTx)} label="TX" />
+		<Stat value={`${onlineCount} / ${totalPeers}`} label="Клиенты" sub={onlineCount > 0 ? `${onlineCount} онлайн` : 'нет активных'} />
+		<Stat value={`UDP :${server.listenPort}`} label="Listen" />
+	</StatStrip>
 
 	{#if isBuiltIn}
-		<div class="server-settings">
+		<ServerSettingsPanel persistKey="awgm:servers:settingsCollapsed">
 			<div class="setting-row setting-row-toggle">
 				<div class="setting-copy">
 					<span class="setting-title">NAT</span>
@@ -466,7 +449,7 @@
 				keenDnsDomain={server.keenDnsDomain}
 				loadingWanIP={loadingBuiltinWanIP}
 			/>
-		</div>
+		</ServerSettingsPanel>
 	{/if}
 
 	<div class="peers-section">
@@ -566,10 +549,6 @@
 	<Plus size={14} strokeWidth={2} aria-hidden="true" />
 {/snippet}
 
-{#snippet restartIcon()}
-	<RefreshCw size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
-
 <style>
 	.badge {
 		display: inline-flex;
@@ -607,10 +586,18 @@
 		text-decoration: underline;
 	}
 
-	.kpi-rows {
-		display: flex;
-		flex-direction: column;
-		gap: 0.625rem;
+	.restart-icon {
+		display: inline-flex;
+	}
+
+	.restart-icon.spin {
+		animation: restart-spin 0.8s linear infinite;
+	}
+
+	@keyframes restart-spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.server-actions {
@@ -618,19 +605,4 @@
 		gap: 0.5rem;
 	}
 
-	@media (max-width: 640px) {
-		.header-actions {
-			align-self: stretch;
-			display: grid;
-			grid-template-columns: 1fr;
-			gap: 0.5rem;
-			width: 100%;
-		}
-
-		.header-actions :global(.btn) {
-			width: 100%;
-			min-width: 0;
-			justify-content: center;
-		}
-	}
 </style>

--- a/frontend/src/lib/components/servers/ServerSettingsPanel.svelte
+++ b/frontend/src/lib/components/servers/ServerSettingsPanel.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { ChevronDown } from 'lucide-svelte';
+
+	interface Props {
+		title?: string;
+		/** Ключ localStorage для персиста свёрнутости; без ключа — не персистится. */
+		persistKey?: string;
+		children: Snippet;
+	}
+
+	let { title = 'Настройки доступа', persistKey, children }: Props = $props();
+
+	function readCollapsed(): boolean {
+		if (!persistKey || typeof localStorage === 'undefined') return false;
+		try {
+			return localStorage.getItem(persistKey) === '1';
+		} catch {
+			return false;
+		}
+	}
+
+	let collapsed = $state(readCollapsed());
+
+	function toggle() {
+		collapsed = !collapsed;
+		if (!persistKey || typeof localStorage === 'undefined') return;
+		try {
+			localStorage.setItem(persistKey, collapsed ? '1' : '0');
+		} catch {
+			// localStorage может быть недоступен — игнорируем, состояние в памяти
+		}
+	}
+</script>
+
+<section class="settings-panel" class:collapsed>
+	<button
+		type="button"
+		class="settings-panel-header"
+		onclick={toggle}
+		aria-expanded={!collapsed}
+	>
+		<span class="settings-panel-title">{title}</span>
+		<ChevronDown class="settings-panel-chevron" size={16} strokeWidth={2} aria-hidden="true" />
+	</button>
+	{#if !collapsed}
+		<div class="settings-panel-body">
+			{@render children()}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.settings-panel {
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md, 12px);
+		background: var(--color-bg-tertiary);
+		overflow: hidden;
+		/* padding контролируют header/body; гасим глобальный .settings-panel { padding:1rem } из app.css */
+		padding: 0;
+	}
+
+	.settings-panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 0.625rem 0.875rem;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		color: var(--color-text-secondary);
+		font: 600 0.6875rem/1.2 var(--font-sans);
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+	}
+
+	.settings-panel-header:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: -2px;
+	}
+
+	:global(.settings-panel-chevron) {
+		transition: transform var(--t-fast) ease;
+	}
+
+	.settings-panel.collapsed :global(.settings-panel-chevron) {
+		transform: rotate(-90deg);
+	}
+
+	.settings-panel-body {
+		padding: 0 0.875rem 0.875rem;
+	}
+</style>

--- a/frontend/src/lib/components/servers/index.ts
+++ b/frontend/src/lib/components/servers/index.ts
@@ -6,6 +6,8 @@ export { default as ConfGeneratorModal } from './ConfGeneratorModal.svelte';
 export { default as AddServerModal } from './AddServerModal.svelte';
 export { default as ManagedServerCard } from './ManagedServerCard.svelte';
 export { default as ManagedPeerTable } from './ManagedPeerTable.svelte';
+export { default as ManagedPeerRow } from './ManagedPeerRow.svelte';
+export { default as ManagedPeerCard } from './ManagedPeerCard.svelte';
 export { default as CreateManagedServerModal } from './CreateManagedServerModal.svelte';
 export { default as EditManagedServerModal } from './EditManagedServerModal.svelte';
 export { default as AddManagedPeerModal } from './AddManagedPeerModal.svelte';
@@ -20,3 +22,4 @@ export { default as ManagedServerImportModal } from './ManagedServerImportModal.
 export { default as ManagedServerDriftBanner } from './ManagedServerDriftBanner.svelte';
 export { default as ServerAccessPolicyDropdown } from './ServerAccessPolicyDropdown.svelte';
 export { default as ServerEndpointSetting } from './ServerEndpointSetting.svelte';
+export { default as ServerSettingsPanel } from './ServerSettingsPanel.svelte';

--- a/frontend/src/lib/components/servers/serverCardShared.css
+++ b/frontend/src/lib/components/servers/serverCardShared.css
@@ -327,3 +327,81 @@
 		grid-column: 1 / -1;
 	}
 }
+
+/* Таблица клиентов: общие классы строки/карточки. Row/Card рендерятся внутри
+   .server-detail-card; перенесено сюда при выносе ManagedPeerRow/ManagedPeerCard
+   из монолита ManagedPeerTable (иначе кнопки/копирование/мелкий toggle без стилей). */
+.server-detail-card .peer-inline-toggle {
+	display: inline-flex;
+	align-items: center;
+	line-height: 1;
+	margin-right: 0.35rem;
+}
+
+.server-detail-card .peer-inline-toggle .toggle-container {
+	gap: 0;
+	padding: 0;
+	min-height: 0;
+}
+
+.server-detail-card .peer-inline-toggle .toggle-container.sm .toggle-slider {
+	width: 30px;
+	height: 18px;
+}
+
+.server-detail-card .peer-inline-toggle .toggle-container.sm .toggle-slider::before {
+	width: 14px;
+	height: 14px;
+	left: 2px;
+	bottom: 2px;
+}
+
+.server-detail-card .peer-inline-toggle .toggle-container.sm input:checked ~ .toggle-slider::before {
+	transform: translateX(12px);
+}
+
+.server-detail-card .peer-inline-toggle .toggle-spinner-slot {
+	width: 0;
+	margin: 0;
+}
+
+.server-detail-card .tech-value {
+	font-size: 10px;
+	line-height: 1.15;
+}
+
+.server-detail-card .peer-action-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.375rem;
+	background: transparent;
+	border: none;
+	color: var(--text-secondary);
+	cursor: pointer;
+	border-radius: var(--radius-sm);
+	transition: color 0.15s ease, background 0.15s ease;
+}
+
+.server-detail-card .peer-action-btn:hover {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+}
+
+.server-detail-card .peer-action-btn-danger:hover {
+	color: var(--error, #ef4444);
+}
+
+.server-detail-card .cell-copy {
+	padding: 0;
+	border: 0;
+	background: none;
+	color: inherit;
+	cursor: pointer;
+	text-align: inherit;
+}
+
+.server-detail-card .cell-copy:hover {
+	text-decoration: underline;
+	color: var(--text-primary);
+}

--- a/frontend/src/lib/utils/peerRowVM.test.ts
+++ b/frontend/src/lib/utils/peerRowVM.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { stripHostMask, endpointHost, peerStatus, buildPeerRowVM, STATUS_LABEL } from './peerRowVM';
+import type { ManagedPeer, ManagedPeerStats } from '$lib/types';
+
+describe('stripHostMask', () => {
+	it('срезает только /32', () => {
+		expect(stripHostMask('10.20.0.2/32')).toBe('10.20.0.2');
+	});
+	it('не трогает прочие маски и голый ip', () => {
+		expect(stripHostMask('10.20.0.0/24')).toBe('10.20.0.0/24');
+		expect(stripHostMask('10.20.0.2')).toBe('10.20.0.2');
+	});
+});
+
+describe('endpointHost', () => {
+	it('убирает порт у ipv4', () => {
+		expect(endpointHost('78.108.40.214:51820')).toBe('78.108.40.214');
+	});
+	it('убирает порт у ipv6 в скобках', () => {
+		expect(endpointHost('[2001:db8::1]:51820')).toBe('[2001:db8::1]');
+	});
+	it('пустой/прочерк → тире', () => {
+		expect(endpointHost('-')).toBe('—');
+		expect(endpointHost('')).toBe('—');
+		expect(endpointHost(undefined)).toBe('—');
+	});
+	it('голый ipv6 без порта оставляет как есть', () => {
+		expect(endpointHost('2001:db8::1')).toBe('2001:db8::1');
+	});
+});
+
+describe('peerStatus', () => {
+	it('disabled важнее online', () => {
+		expect(peerStatus(false, true)).toBe('disabled');
+	});
+	it('online/offline по флагу', () => {
+		expect(peerStatus(true, true)).toBe('online');
+		expect(peerStatus(true, false)).toBe('offline');
+		expect(peerStatus(true, null)).toBe('offline');
+	});
+});
+
+describe('buildPeerRowVM', () => {
+	const peer: ManagedPeer = {
+		publicKey: 'ABCDEFGH12345', privateKey: '', presharedKey: '',
+		description: 'Mac', tunnelIP: '10.20.0.2/32', enabled: true,
+	};
+	const stats: ManagedPeerStats = {
+		publicKey: 'ABCDEFGH12345', endpoint: '78.108.40.214:51820',
+		rxBytes: 1024, txBytes: 2048, lastHandshake: '2026-06-13T12:00:00Z', online: true,
+	};
+	it('маппит поля, режет /32, убирает порт', () => {
+		const vm = buildPeerRowVM(peer, stats);
+		expect(vm.name).toBe('Mac');
+		expect(vm.ip).toBe('10.20.0.2');
+		expect(vm.endpointHost).toBe('78.108.40.214');
+		expect(vm.status).toBe('online');
+		expect(vm.enabled).toBe(true);
+	});
+	it('имя из ключа, если нет description', () => {
+		const vm = buildPeerRowVM({ ...peer, description: '' }, undefined);
+		expect(vm.name).toBe('ABCDEFGH...');
+		expect(vm.endpointHost).toBe('—');
+		expect(vm.status).toBe('offline');
+	});
+	it('STATUS_LABEL маппит в верхний регистр', () => {
+		expect(STATUS_LABEL.online).toBe('ONLINE');
+		expect(STATUS_LABEL.offline).toBe('OFFLINE');
+		expect(STATUS_LABEL.disabled).toBe('OFF');
+	});
+});

--- a/frontend/src/lib/utils/peerRowVM.ts
+++ b/frontend/src/lib/utils/peerRowVM.ts
@@ -1,0 +1,81 @@
+import type { ManagedPeer, ManagedPeerStats } from '$lib/types';
+import { formatBytes, formatRelativeTime } from '$lib/utils/format';
+
+export type PeerStatus = 'online' | 'offline' | 'disabled';
+
+export interface PeerRowVM {
+	publicKey: string;
+	name: string;
+	enabled: boolean;
+	status: PeerStatus;
+	ip: string;            // tunnelIP без /32 (показ и копирование)
+	endpointHost: string;  // host без порта; '—' если отсутствует
+	rx: string;
+	tx: string;
+	handshake: { main: string; suffix?: string } | null;
+}
+
+/** Общий контракт пропсов для desktop-строки и mobile-карточки клиента. */
+export interface PeerRowProps {
+	peer: ManagedPeer;
+	vm: PeerRowVM;
+	showToggle: boolean;
+	showDownload: boolean;
+	showActions: boolean;
+	toggling: boolean;
+	onToggle: (peer: ManagedPeer) => void;
+	onConf: (peer: ManagedPeer) => void;
+	onEdit: (peer: ManagedPeer) => void;
+	onDelete: (peer: ManagedPeer) => void;
+	onCopy: (value: string, label: string) => void;
+}
+
+export const STATUS_LABEL: Record<PeerStatus, string> = {
+	online: 'ONLINE',
+	offline: 'OFFLINE',
+	disabled: 'OFF',
+};
+
+/** Срезает только host-маску /32. Прочие маски и голый ip не трогает. */
+export function stripHostMask(ip: string): string {
+	return ip.endsWith('/32') ? ip.slice(0, -'/32'.length) : ip;
+}
+
+/** Host из endpoint без порта; '—' если пусто/'-'. IPv6 без порта остаётся как есть. */
+export function endpointHost(endpoint: string | undefined): string {
+	const t = (endpoint ?? '').trim();
+	if (!t || t === '-') return '—';
+	const bracket = /^(\[[^\]]+\]):\d+$/.exec(t);
+	if (bracket) return bracket[1];
+	const lastColon = t.lastIndexOf(':');
+	if (lastColon <= 0) return t;
+	const host = t.slice(0, lastColon);
+	const port = t.slice(lastColon + 1);
+	if (!/^\d+$/.test(port) || host.includes(':')) return t;
+	return host;
+}
+
+export function peerStatus(enabled: boolean, online: boolean | null | undefined): PeerStatus {
+	if (!enabled) return 'disabled';
+	return online ? 'online' : 'offline';
+}
+
+function splitHandshake(value: string): { main: string; suffix?: string } {
+	const t = value.trim();
+	if (t.endsWith(' назад')) return { main: t.slice(0, -' назад'.length), suffix: 'назад' };
+	return { main: t };
+}
+
+export function buildPeerRowVM(peer: ManagedPeer, stats: ManagedPeerStats | undefined): PeerRowVM {
+	return {
+		publicKey: peer.publicKey,
+		name: peer.description || `${peer.publicKey.slice(0, 8)}...`,
+		enabled: peer.enabled,
+		status: peerStatus(peer.enabled, stats?.online),
+		ip: stripHostMask(peer.tunnelIP),
+		endpointHost: endpointHost(stats?.endpoint),
+		rx: formatBytes(stats?.rxBytes ?? 0),
+		tx: formatBytes(stats?.txBytes ?? 0),
+		handshake: stats?.lastHandshake ? splitHandshake(formatRelativeTime(stats.lastHandshake)) : null,
+	};
+}


### PR DESCRIPTION
  
     Редизайн и **унификация** карточек серверов (managed + system) на странице «Серверы»:
     единый презентационный слой и рефактор таблицы клиентов. **Backend не затронут** — все
     данные уже были в API.

  
     Доменные различия остались в двух тонких оболочках; общий слой (`StatStrip`,
     `IconButton`, `SegmentedControl`, `ServerSettingsPanel`, таблица) переиспользуется
     обеими карточками.

     ## Скриншоты (до / после)

  
<img width="2600" height="955" alt="marked-desktop" src="https://github.com/user-attachments/assets/7b2409da-ca35-4604-b314-38e9bcfd860a" />

<img width="2600" height="1344" alt="managed-desktop" src="https://github.com/user-attachments/assets/4c22aedb-ffbe-41fb-ae6e-3504ee3b4755" />


<img width="2600" height="1306" alt="builtin-desktop" src="https://github.com/user-attachments/assets/52cf4d32-8acb-466e-bf0a-a633e8e4a4eb" />

     **Mobile (320px)**

<img width="680" height="2664" alt="managed-mobile" src="https://github.com/user-attachments/assets/767d8c44-0511-4d90-a0f0-d59e3b08de82" />


     ## Технические решения

     - **Переключение таблица ↔ карточки — через container-query, не viewport-медиазапрос.**
   Таблица показывается только когда реально влезает (контейнер ≥ 820px), иначе
     карточки.
     - Общие классы строки/карточки вынесены в `serverCardShared.css` (под
     `.server-detail-card`) 
     - NAT-сегмент — существующий `ui/SegmentedControl`; дашборд — `ui/StatStrip`+`Stat`;
     шапка — `ui/IconButton`. 
     - Read-only поведение marked-пиров сохранено через флаги
     `showPeerToggle/Actions/Download`.
  

     ## Проверка

     - `npm run check` — **0 errors, 0 warnings**
     - `npm run test` — **955/955** (вкл. юнит-тесты `peerRowVM`)
     - e2e-верстка — **15/15**: ширины **320 · 640 · 760 · 1180 · 1280** × под-виды **managed
     / builtin / marked**, без горизонтального overflow
     
     