### PR TITLE
fix(vlink): increase Clash YAML scan limit from 4 KB to 64 KB

### DIFF
--- a/internal/singbox/vlink/clash.go
+++ b/internal/singbox/vlink/clash.go
@@ -19,7 +19,7 @@ import (
 
 // scanLimit is how many bytes IsClashYAML inspects. A real Clash subscription
 // has "proxies:" within the first few hundred bytes; 4 KB is a forgiving cap.
-const scanLimit = 4 * 1024
+const scanLimit = 64 * 1024
 
 // matches a top-level "proxies:" key — accepts block (proxies: + newline),
 // inline ("proxies: []"), null marker ("proxies: null"), and any other


### PR DESCRIPTION
## Problem

`IsClashYAML` scans only the first 4 096 bytes of the response body looking for a top-level `proxies:` key. Some providers (e.g. VoxGate) generate Clash/mihomo configs that begin with large `tun.exclude-package` lists — hundreds of Android package IDs — pushing `proxies:` well past the 4 KB boundary. As a result `IsClashYAML` returns `false`, the body is handed to the share-link parser, and the subscription fails with:

```
subscription: ни одной валидной ссылки. Поддерживаются: …
```

## Root cause

`internal/singbox/vlink/clash.go`:

```diff
- const scanLimit = 4 * 1024
+ const scanLimit = 64 * 1024
```

## Why 64 KB?

Real-world Clash subscriptions with `tun.exclude-package` blocks can easily reach 30–50 KB before `proxies:`. 64 KB covers this with headroom while remaining cheap to scan (it is a single regex match on an in-memory byte slice).

## Reproduction

Subscribe to a VoxGate URL with the current build — subscription fails with the error above. After this change — subscription is parsed and imported correctly (14 VLESS + 2 Hysteria2 outbounds).