### PR TITLE
Fix/issue 376 keendns ndns

### DIFF
--- a/internal/api/server_peers.go
+++ b/internal/api/server_peers.go
@@ -465,6 +465,7 @@ func (h *ServersHandler) resolveServerEndpoint(ctx context.Context, serverID str
 	if host := resolveWireguardClientEndpointHost(storedEndpoint, keenDNSDomain); host != "" {
 		return host, nil
 	}
+	h.log.Info("endpoint", serverID, "KeenDNS/CrazeDNS не настроен — endpoint WireGuard-сервера будет указан как WAN IP")
 	return testing.GetWANIPWithFallback(ctx, h.queries.WANInterfaceAddress)
 }
 

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/managed"
 	"github.com/hoaxisr/awg-manager/internal/ndms"
 	ndmscommand "github.com/hoaxisr/awg-manager/internal/ndms/command"
@@ -57,8 +58,8 @@ type WireguardServerDTO struct {
 	KeenDNSDomain string                   `json:"keenDnsDomain,omitempty" example:"home.keenetic.pro"`
 	// Endpoint is the user-configured connect host for client .conf files.
 	// Empty = WAN IP at generation time.
-	Endpoint      string                   `json:"endpoint,omitempty" example:"203.0.113.42"`
-	BuiltIn       bool                     `json:"builtIn,omitempty" example:"true"`
+	Endpoint string `json:"endpoint,omitempty" example:"203.0.113.42"`
+	BuiltIn  bool   `json:"builtIn,omitempty" example:"true"`
 	// NATModeKnown/PolicyKnown are false when the corresponding NDMS read
 	// failed (e.g. transient router error). The frontend must render an
 	// "unknown" state instead of trusting the zero-valued NATMode/Policy,
@@ -146,13 +147,14 @@ func isValidWireguardName(name string) bool {
 // resource:invalidated hints on mark/unmark and poller metrics ticks so
 // subscribers refetch immediately instead of waiting for the next poll.
 type ServersHandler struct {
-	queries     *query.Queries
-	commands    *ndmscommand.Commands
-	settings    *storage.SettingsStore
-	awgStore    *storage.AWGTunnelStore
-	bus         *events.Bus
-	managed     *ManagedServerHandler
-	managedSvc  *managed.Service
+	queries    *query.Queries
+	commands   *ndmscommand.Commands
+	settings   *storage.SettingsStore
+	awgStore   *storage.AWGTunnelStore
+	bus        *events.Bus
+	managed    *ManagedServerHandler
+	managedSvc *managed.Service
+	log        *logging.ScopedLogger
 }
 
 // SetEventBus sets the event bus used for SSE publishing.
@@ -186,8 +188,13 @@ func (h *ServersHandler) publishServerInvalidated(reason string) {
 }
 
 // NewServersHandler creates a new servers handler.
-func NewServersHandler(queries *query.Queries, settings *storage.SettingsStore, awgStore *storage.AWGTunnelStore) *ServersHandler {
-	return &ServersHandler{queries: queries, settings: settings, awgStore: awgStore}
+func NewServersHandler(queries *query.Queries, settings *storage.SettingsStore, awgStore *storage.AWGTunnelStore, appLogger logging.AppLogger) *ServersHandler {
+	return &ServersHandler{
+		queries:  queries,
+		settings: settings,
+		awgStore: awgStore,
+		log:      logging.NewScopedLogger(appLogger, logging.GroupServer, logging.SubWan),
+	}
 }
 
 type serverEnabledRequest struct {

--- a/internal/ndms/query/keendns.go
+++ b/internal/ndms/query/keendns.go
@@ -1,13 +1,15 @@
 package query
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/ndms/cache"
+	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
 )
 
 const keenDNSTTL = 60 * time.Second
@@ -37,81 +39,37 @@ func (s *KeenDNSStore) Get(ctx context.Context) (*KeenDNSInfo, error) {
 }
 
 func (s *KeenDNSStore) fetch(ctx context.Context, _ string) (*KeenDNSInfo, error) {
-	for _, path := range []string{"/show/ndns", "/show/sc/ndns", "/show/ip/dns/domain"} {
-		info, err := s.fetchFromPath(ctx, path)
-		if err != nil {
-			s.log.Warnf("keendns: %s: %v", path, err)
-			continue
-		}
-		if info != nil && info.Domain != "" {
-			return info, nil
-		}
-	}
-	return nil, nil
-}
-
-func (s *KeenDNSStore) fetchFromPath(ctx context.Context, path string) (*KeenDNSInfo, error) {
-	raw, err := s.getter.GetRaw(ctx, path)
+	// Только /show/ndns — авторитетный эндпоинт KeenDNS на всех поддерживаемых
+	// прошивках. 404 означает, что подсистема отсутствует на этой OS → KeenDNS
+	// не настроен (а не ошибка), без него поллер сыпал бы ошибками каждый тик.
+	raw, err := s.getter.GetRaw(ctx, "/show/ndns")
 	if err != nil {
+		var httpErr *transport.HTTPError
+		if errors.As(err, &httpErr) && httpErr.Status == http.StatusNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("{}")) {
-		return nil, nil
-	}
-	return parseKeenDNSJSON(trimmed), nil
+	return parseKeenDNS(raw), nil
 }
 
-func parseKeenDNSJSON(raw []byte) *KeenDNSInfo {
-	var v any
+// parseKeenDNS строит FQDN доступа из полей booked + domain ответа /show/ndns
+// (например booked="impod", domain="crazedns.ru" → "impod.crazedns.ru").
+// Любой домен Keenetic покрывается автоматически — без allowlist суффиксов.
+// Допущение: domain — это зона, а не уже готовый FQDN (verified на ребренд-OS,
+// для стоковой *.keenetic.pro не перепроверялось).
+func parseKeenDNS(raw []byte) *KeenDNSInfo {
+	var v struct {
+		Booked string `json:"booked"`
+		Domain string `json:"domain"`
+	}
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return nil
 	}
-	domain := findKeenDNSDomain(v)
-	if domain == "" {
+	booked := strings.TrimSpace(v.Booked)
+	domain := strings.TrimSpace(v.Domain)
+	if booked == "" || domain == "" {
 		return nil
 	}
-	return &KeenDNSInfo{Domain: domain, Enabled: true}
-}
-
-func findKeenDNSDomain(v any) string {
-	switch t := v.(type) {
-	case string:
-		s := strings.TrimSpace(t)
-		if looksLikeKeenDNSDomain(s) {
-			return s
-		}
-	case map[string]any:
-		for _, key := range []string{"domain", "name", "hostname", "fqdn", "address"} {
-			if raw, ok := t[key]; ok {
-				if d := findKeenDNSDomain(raw); d != "" {
-					return d
-				}
-			}
-		}
-		for _, child := range t {
-			if d := findKeenDNSDomain(child); d != "" {
-				return d
-			}
-		}
-	case []any:
-		for _, item := range t {
-			if d := findKeenDNSDomain(item); d != "" {
-				return d
-			}
-		}
-	}
-	return ""
-}
-
-func looksLikeKeenDNSDomain(s string) bool {
-	if s == "" || strings.Contains(s, " ") {
-		return false
-	}
-	lower := strings.ToLower(s)
-	return strings.HasSuffix(lower, ".keenetic.pro") ||
-		strings.HasSuffix(lower, ".keenetic.name") ||
-		strings.HasSuffix(lower, ".keenetic.link") ||
-		strings.HasSuffix(lower, ".netcraze.pro") ||
-		strings.HasSuffix(lower, ".netcraze.link")
+	return &KeenDNSInfo{Domain: booked + "." + domain, Enabled: true}
 }

--- a/internal/ndms/query/keendns_test.go
+++ b/internal/ndms/query/keendns_test.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
+)
+
+// На современной прошивке /show/ndns отдаёт booked + domain раздельно;
+// доменом для доступа служит их склейка booked.domain.
+func TestKeenDNSFetch_BuildsFQDNFromBookedAndDomain(t *testing.T) {
+	g := NewFakeGetter()
+	g.SetRaw("/show/ndns", []byte(`{"name":"impod","booked":"impod","domain":"crazedns.ru","address":"91.144.142.72"}`))
+	s := NewKeenDNSStore(g, NopLogger())
+
+	info, err := s.Get(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info == nil || info.Domain != "impod.crazedns.ru" {
+		t.Fatalf("Domain=%v want impod.crazedns.ru", info)
+	}
+}
+
+// Регрессия #376: дёргаем ТОЛЬКО /show/ndns, легаси-пути больше не зондируем
+// (иначе они 404'ят и спамят журналы awgm и keenetic).
+func TestKeenDNSFetch_OnlyQueriesShowNdns(t *testing.T) {
+	g := NewFakeGetter()
+	g.SetRaw("/show/ndns", []byte(`{"booked":"","domain":""}`)) // KeenDNS не настроен
+	s := NewKeenDNSStore(g, NopLogger())
+
+	info, err := s.Get(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("info=%v want nil (не настроено)", info)
+	}
+	if n := g.Calls("/show/sc/ndns"); n != 0 {
+		t.Errorf("/show/sc/ndns вызван %d раз, ожидалось 0", n)
+	}
+	if n := g.Calls("/show/ip/dns/domain"); n != 0 {
+		t.Errorf("/show/ip/dns/domain вызван %d раз, ожидалось 0", n)
+	}
+}
+
+// 404 на /show/ndns = подсистема KeenDNS отсутствует на этой OS → «не
+// настроено», а не ошибка (чтобы поллер не сыпал ошибками каждый тик).
+func TestKeenDNSFetch_NotFoundIsNotError(t *testing.T) {
+	g := NewFakeGetter()
+	g.SetError("/show/ndns", &transport.HTTPError{Method: "GET", Path: "/show/ndns", Status: http.StatusNotFound})
+	s := NewKeenDNSStore(g, NopLogger())
+
+	info, err := s.Get(context.Background())
+	if err != nil {
+		t.Fatalf("404 должен трактоваться как nil,nil, получили err: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("info=%v want nil", info)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -869,7 +869,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// runningInterfacesAdapter (wired in main.go).
 
 	// VPN Servers (protected + boot guarded)
-	serverHandler := api.NewServersHandler(s.ndmsQueries, s.settings, s.tunnels)
+	serverHandler := api.NewServersHandler(s.ndmsQueries, s.settings, s.tunnels, appLog)
 	serverHandler.SetCommands(s.ndmsCommands)
 	serverHandler.SetEventBus(s.bus)
 	mux.HandleFunc("/api/servers", guarded(serverHandler.List))


### PR DESCRIPTION
  ---
  fix: KeenDNS-зонд спамил журналы 404; INFO про WAN-IP endpoint (#376)

  Проблема

  На роутере без настроенного KeenDNS (Ultra NC-1812, OS 5.01) журналы awgm и keenetic засыпались ошибками раз в минуту:
  [ERROR] [system/ndms] GET /show/sc/ndns: status 404
  [WARN]  [system/ndms-query] keendns: /show/sc/ndns: ... status 404
  [ERROR] [system/ndms] GET /show/ip/dns/domain: status 404
  [WARN]  [system/ndms-query] keendns: /show/ip/dns/domain: ... status 404

  Причина

  KeenDNSStore.fetch каждые 60 c перебирал 3 пути (/show/ndns → /show/sc/ndns → /show/ip/dns/domain). /show/ndns отвечал 200 без домена, но цикл не отличал «путь ответил, домена нет» от «путь
  отсутствует» и проваливался на два легаси-пути, которых на этой прошивке нет → по 404, каждый логировался дважды (транспорт ERROR + query WARN).

  Решение

  - Только /show/ndns — авторитетный эндпоинт KeenDNS. 404 трактуется как «подсистема отсутствует → не настроено» (nil, не ошибка). Иные пути больше не зондируются.
  - Домен из booked + domain (**** + crazedns.ru → ****.crazedns.ru). 
  Проверено на живом RCI.


  - INFO в журнал, когда нет ни override, ни KeenDNS и endpoint берётся как WAN IP:
  KeenDNS/CrazeDNS не настроен — endpoint WireGuard-сервера будет указан как WAN IP. Логируется при генерации конфига (не фоном), поэтому не спамит.

  Изменения

  - ndms/query/keendns.go — single-path + парс booked.domain; 
  
  - удалены fetchFromPath/parseKeenDNSJSON/findKeenDNSDomain/looksLikeKeenDNSDomain.
  - ndms/query/keendns_test.go — 3 теста (incl. regression-guard: старые пути не вызываются).
  - api/servers.go, api/server_peers.go, server/server.go — ScopedLogger в ServersHandler + INFO-лог.

  Проверка

  go build ./... · go test ./... (все зелёные, 3 новых теста) · gofmt чисто.

  Если domain на каких-то роутерах уже полный FQDN  — будет дубль, правка в 1 строку.

  Closes #376