### PR TITLE
фронт: выровнять колонки таблицы peer'ов (managed + системные)

### DIFF
--- a/frontend/src/lib/components/servers/ManagedPeerTable.svelte
+++ b/frontend/src/lib/components/servers/ManagedPeerTable.svelte
@@ -168,6 +168,18 @@
 		white-space: nowrap;
 	}
 	.col-rx, .col-tx { text-align: right; }
+	.col-actions { text-align: right; }
+	/* Узкие колонки сжимаем по контенту (width:1% + nowrap), слабину забирают
+	   Имя и Endpoint — иначе авто-раскладка растягивает всё и колонки разъезжаются. */
+	.managed-peer-table th.col-status,
+	.managed-peer-table th.col-ip,
+	.managed-peer-table th.col-rx,
+	.managed-peer-table th.col-tx,
+	.managed-peer-table th.col-handshake,
+	.managed-peer-table th.col-actions { width: 1%; }
+	.managed-peer-table :global(td.col-rx),
+	.managed-peer-table :global(td.col-tx),
+	.managed-peer-table :global(td.col-handshake) { white-space: nowrap; }
 	.managed-peer-table :global(td) {
 		padding: 0.625rem;
 		border-bottom: 1px solid var(--color-border-subtle, var(--color-border));

--- a/frontend/src/lib/components/ui/TableSortHeader.svelte
+++ b/frontend/src/lib/components/ui/TableSortHeader.svelte
@@ -32,10 +32,10 @@
 
 <style>
 	.sort-header-btn {
-		width: 100%;
+		/* inline-flex без width:100% → кнопка inline-level и наследует text-align <th>,
+		   чтобы ярлык совпадал с выравниванием данных в колонке (а не центрировался) */
 		display: inline-flex;
 		align-items: center;
-		justify-content: center;
 		gap: 0.3rem;
 		padding: 0;
 		border: 0;


### PR DESCRIPTION
Заголовки сортировки наследуют выравнивание колонки вместо центрирования; узкие колонки сжаты по контенту, заголовок Действия над иконками.