### PR TITLE
Feature/rule sets alpha sort

### DIFF
--- a/frontend/src/lib/components/sb-router/ExpertPanel.svelte
+++ b/frontend/src/lib/components/sb-router/ExpertPanel.svelte
@@ -57,6 +57,7 @@
   import { DNSRewritesList } from '$lib/components/routing/singboxRouter';
   import { ConfirmModal, Dropdown, Button, type DropdownOption } from '$lib/components/ui';
   import { LayoutGrid } from 'lucide-svelte';
+  import { browser } from '$app/environment';
 
   // Store subscriptions
   const storeStatus = singboxRouterStore.status;
@@ -69,6 +70,31 @@
   const storeDnsRewrites = singboxRouterStore.dnsRewrites;
   const storeDnsGlobals = singboxRouterStore.dnsGlobals;
   const storeOptions = singboxRouterStore.options;
+
+  // Сортировка наборов rule-sets по алфавиту (только отображение, UI-преференс)
+  const RULESET_SORT_KEY = 'awg.sb-router.ruleset-sort-alpha';
+  function readAlphaSortRuleSets(): boolean {
+    if (!browser) return false;
+    try {
+      return localStorage.getItem(RULESET_SORT_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  }
+  function persistAlphaSortRuleSets(on: boolean): void {
+    if (!browser) return;
+    try {
+      localStorage.setItem(RULESET_SORT_KEY, on ? 'true' : 'false');
+    } catch {
+      /* приватный режим / quota — игнор */
+    }
+  }
+  let alphaSortRuleSets = $state(readAlphaSortRuleSets());
+  const sortedRuleSets = $derived(
+    alphaSortRuleSets
+      ? [...$storeRuleSets].sort((a, b) => a.tag.localeCompare(b.tag))
+      : $storeRuleSets,
+  );
 
   // ── Globals (route-final + DNS final/strategy) ──────────────────────
   // route-final: direct + все outbounds, кроме группы «Специальные»
@@ -618,7 +644,12 @@
         <div class="panel-cap">наборы доменов и IP, на которые ссылаются правила</div>
         <RuleSetsTable
           bare
-          ruleSets={$storeRuleSets}
+          ruleSets={sortedRuleSets}
+          alphaSort={alphaSortRuleSets}
+          onToggleAlphaSort={() => {
+            alphaSortRuleSets = !alphaSortRuleSets;
+            persistAlphaSortRuleSets(alphaSortRuleSets);
+          }}
           onEdit={(tag) => (rsEditTag = tag)}
           onDelete={handleDeleteRs}
         />
@@ -811,7 +842,7 @@
 {#if dnsRuleAddOpen}
   <DNSRuleEditModal
     servers={$storeDnsServers}
-    availableRuleSets={$storeRuleSets}
+    availableRuleSets={sortedRuleSets}
     ruleSetUsage={ruleSetUsageForDnsAdd}
     onClose={() => (dnsRuleAddOpen = false)}
     onSave={handleDnsRuleAddSave}
@@ -823,7 +854,7 @@
   <DNSRuleEditModal
     rule={dnsRuleEditTarget}
     servers={$storeDnsServers}
-    availableRuleSets={$storeRuleSets}
+    availableRuleSets={sortedRuleSets}
     ruleSetUsage={ruleSetUsageForDnsEdit}
     onClose={() => (dnsRuleEditIdx = null)}
     onSave={handleDnsRuleEditSave}

--- a/frontend/src/lib/components/sb-router/RuleSetsTable.svelte
+++ b/frontend/src/lib/components/sb-router/RuleSetsTable.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
   import type { SingboxRouterRuleSet } from '$lib/types';
-  import { Edit3, Trash2 } from 'lucide-svelte';
+  import { Edit3, Trash2, ArrowDownAZ } from 'lucide-svelte';
   import RuleSetTypeBadge from './RuleSetTypeBadge.svelte';
   import {
     datInfo,
@@ -19,9 +19,11 @@
     onEdit: (tag: string) => void;
     onDelete: (tag: string) => void;
     bare?: boolean;
+    alphaSort?: boolean;
+    onToggleAlphaSort?: () => void;
   }
 
-  let { ruleSets, onEdit, onDelete, bare = false }: Props = $props();
+  let { ruleSets, onEdit, onDelete, bare = false, alphaSort = false, onToggleAlphaSort }: Props = $props();
 
   let filter = $state<RsFilter>('all');
 
@@ -60,6 +62,19 @@
         </button>
       {/each}
     </div>
+    {#if onToggleAlphaSort}
+      <button
+        type="button"
+        class="seg-tab sort"
+        class:active={alphaSort}
+        title="Сортировать наборы по алфавиту"
+        aria-label="Сортировать наборы по алфавиту"
+        aria-pressed={alphaSort}
+        onclick={onToggleAlphaSort}
+      >
+        <ArrowDownAZ size={15} />
+      </button>
+    {/if}
   </div>
 
   <div class="table" class:bare>
@@ -121,6 +136,8 @@
   .seg {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
+    flex: 1;
+    min-width: 0;
     width: 100%;
     gap: 0;
     padding: 0;
@@ -156,6 +173,11 @@
     background: var(--accent-soft);
     color: var(--text-primary);
     box-shadow: inset 0 -2px 0 var(--accent);
+  }
+  .seg-tab.sort {
+    flex: 0 0 auto;
+    border-right: 0;
+    border-left: 1px solid var(--border);
   }
   .table {
     background: var(--bg-secondary);


### PR DESCRIPTION
Closes #364

Тоггл «по алфавиту» для наборов Rule-sets в экспертном режиме Sing-box Router.
Только отображение — порядок в конфиге sing-box не меняется (наборы ссылаются
по tag, порядок незначим). Один флаг в localStorage применяется к двум местам:
основной список Rule-sets и пикер наборов в DNS-правиле.