### PR TITLE
проверка наличия nmds вместо ожидания 120сек, рестарт hr-neo после по…

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -1412,6 +1412,61 @@ func main() {
 						fmt.Sprintf("Phase 1: NDMS ready after %s", time.Since(bootStart).Round(time.Second)))
 				}
 				ndmsWaitCancel()
+
+				// === Phase 1b: Wait for WAN gateway stability ===
+				//
+				// RCI alive does not guarantee the WAN interface has settled —
+				// USB modems and slow carrier links can flap for tens of seconds
+				// after NDMS reports ready. Without a stable WAN, opkgtun tunnels
+				// loop start/stop because their active-WAN anchor disappears.
+				//
+				// Poll GetDefaultGatewayInterface every second; proceed when
+				// the same gateway name has been returned for wanStableDuration
+				// without change. Deadline equals Phase 1 ceiling — if WAN
+				// never stabilises, proceed anyway (WAN-down path handles it).
+				const wanStableDuration = 5 * time.Second
+				wanDeadline := bootStart.Add(ndmsWait)
+				var lastGW string
+				var stableSince time.Time
+
+				for {
+					select {
+					case <-shutdownCtx.Done():
+						return
+					case <-time.After(time.Second):
+					}
+
+					gw, err := ndmsQueries.Routes.GetDefaultGatewayInterface(shutdownCtx)
+					now := time.Now()
+
+					if err == nil && gw != "" {
+						if gw != lastGW {
+							lastGW = gw
+							stableSince = now
+							bootLog.Debug("startup", "",
+								fmt.Sprintf("Phase 1b: WAN gateway changed to %s at %s", gw,
+									time.Since(bootStart).Round(time.Second)))
+						}
+						if now.Sub(stableSince) >= wanStableDuration {
+							bootLog.Info("startup", "",
+								fmt.Sprintf("Phase 1b: WAN stable (%s) after %s", gw,
+									time.Since(bootStart).Round(time.Second)))
+							break
+						}
+					} else {
+						// Gateway unavailable — reset so a reappearing
+						// gateway with the same name does not inherit
+						// stability from before the outage.
+						lastGW = ""
+						stableSince = time.Time{}
+					}
+					if now.After(wanDeadline) {
+						bootLog.Info("startup", "",
+							fmt.Sprintf("Phase 1b: WAN stability deadline expired after %s — proceeding anyway",
+								time.Since(bootStart).Round(time.Second)))
+						break
+					}
+				}
 			} else {
 				bootLog.Info("startup", "",
 					fmt.Sprintf("Phase 1: skipped (uptime %ds ≥ %ds)", int(uptime), minBootUptime))

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -1436,6 +1436,12 @@ func main() {
 					case <-time.After(time.Second):
 					}
 
+					// Force a fresh /show/ip/route read each poll: the route
+					// cache (routeTTL 30m) is warmed by Phase 1's WaitForNDMS and
+					// is invalidated only out-of-band by NDMS hooks, so without
+					// this drop Phase 1b would re-read a frozen gateway and never
+					// observe a flap — degenerating into a fixed delay.
+					ndmsQueries.Routes.InvalidateAll()
 					gw, err := ndmsQueries.Routes.GetDefaultGatewayInterface(shutdownCtx)
 					now := time.Now()
 

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -708,7 +708,7 @@ func main() {
 	// after startup would miss CONNMARK rules without this.
 	if hydraService != nil {
 		orch.SetOnTunnelRunning(func(id string) {
-			hydraService.ScheduleRestart("tunnel-running: " + id)
+			go hydraService.ScheduleRestart("tunnel-running: " + id)
 		})
 	}
 	loggingService.SetEventBus(eventBus)

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -702,6 +703,14 @@ func main() {
 	// a frozen "down" snapshot and policy/WAN/all-interface lists misreport the
 	// tunnel as down (#328). Async — Invalidate does a blocking HTTP.
 	orch.SetInterfaceInvalidator(func(name string) { go ndmsQueries.Interfaces.Invalidate(name) })
+	// Full hr-neo restart on tunnel-running — NDMS assigns fwmarks only
+	// during rci_create_policies (hr-neo startup), so tunnels appearing
+	// after startup would miss CONNMARK rules without this.
+	if hydraService != nil {
+		orch.SetOnTunnelRunning(func(id string) {
+			hydraService.ScheduleRestart("tunnel-running: " + id)
+		})
+	}
 	loggingService.SetEventBus(eventBus)
 	tunnelService.SetEventBus(eventBus)
 	pingCheckFacade.SetEventBus(eventBus)
@@ -1373,37 +1382,65 @@ func main() {
 			fmt.Sprintf("Boot detected (uptime %ds), starting tunnels", int(uptime)))
 
 		go func() {
+			bootStart := time.Now()
 
-			// Wait for NDMS to fully initialize interface subsystem.
-			// Without this delay, tunnels enter start/stop loops because
-			// NDMS cycles their conf layer between running/disabled.
-			const minBootUptime = 120 // seconds
+			// === Phase 1: Wait for NDMS readiness ===
+			//
+			// Previously used a fixed sleep to reach 120s system uptime. The
+			// fixed window was brittle: slow NDMS (interface subsystem not yet
+			// initialized) delayed the tunnel start by several extra minutes
+			// because the sequential migration steps that followed each needed
+			// a working RCI endpoint.
+			//
+			// Now we probe NDMS every second and return as soon as it answers
+			// — even "no default route yet" is sufficient signal that the RCI
+			// endpoint is alive. If the deadline expires, we proceed anyway
+			// (the WAN-down path later handles the missing-default-route case).
+			const minBootUptime = 120 // seconds — minimum uptime before tunnel start
 			if uptime < float64(minBootUptime) {
-				waitSec := int(float64(minBootUptime) - uptime)
+				ndmsWait := time.Duration(float64(minBootUptime)-uptime) * time.Second
 				bootLog.Info("startup", "",
-					fmt.Sprintf("Waiting %ds for NDMS initialization (uptime %ds, target %ds)", waitSec, int(uptime), minBootUptime))
-				select {
-				case <-time.After(time.Duration(waitSec) * time.Second):
-				case <-shutdownCtx.Done():
-					return
+					fmt.Sprintf("Phase 1: wait for NDMS (uptime %ds, max wait %v)", int(uptime), ndmsWait))
+
+				ndmsWaitCtx, ndmsWaitCancel := context.WithTimeout(shutdownCtx, ndmsWait)
+				if err := ndmsinfo.WaitForNDMS(ndmsWaitCtx, ndmsQueries.Routes, bootLog); err != nil {
+					bootLog.Info("startup", "",
+						fmt.Sprintf("Phase 1: NDMS wait deadline expired (%v) after %s — proceeding anyway",
+							ndmsWait, time.Since(bootStart).Round(time.Second)))
+				} else {
+					bootLog.Info("startup", "",
+						fmt.Sprintf("Phase 1: NDMS ready after %s", time.Since(bootStart).Round(time.Second)))
 				}
+				ndmsWaitCancel()
+			} else {
+				bootLog.Info("startup", "",
+					fmt.Sprintf("Phase 1: skipped (uptime %ds ≥ %ds)", int(uptime), minBootUptime))
 			}
 
 			// Seed WAN model with current interface state from NDMS.
 			// Must happen before tunnel start so ISP resolution works.
 			populateWANModel(shutdownCtx, ndmsQueries, wanModel, bootLog)
 
-			// Back-fill ManagedServer.PrivateKey for entries created before
-			// the field existed in storage. Best-effort, idempotent — already
-			// populated entries are skipped. Must run AFTER the NDMS interface
-			// cache is ready so kernel-name resolution works.
-			managedService.MigratePrivateKeys(shutdownCtx)
-
-			// One-time sweep: strip the legacy default 0.0.0.0/0 from
-			// managed-server peers' allow-ips (per-peer /32 only). New
-			// firmware rejects multiple peers sharing 0.0.0.0/0. Gated by a
-			// persisted flag; best-effort, retries next boot if NDMS is down.
-			managedService.MigratePeerAllowIPs(shutdownCtx)
+			// Best-effort, idempotent migrations — must NOT block tunnel start.
+			// tunnelService cleanup below is fast and stays inline.
+			var bgDone sync.WaitGroup
+			bgDone.Add(2)
+			go func() {
+				defer bgDone.Done()
+				// Back-fill ManagedServer.PrivateKey for entries created before
+				// the field existed in storage. Best-effort, idempotent — already
+				// populated entries are skipped. Must run AFTER the NDMS interface
+				// cache is ready so kernel-name resolution works.
+				managedService.MigratePrivateKeys(shutdownCtx)
+			}()
+			go func() {
+				defer bgDone.Done()
+				// One-time sweep: strip the legacy default 0.0.0.0/0 from
+				// managed-server peers' allow-ips (per-peer /32 only). New
+				// firmware rejects multiple peers sharing 0.0.0.0/0. Gated by a
+				// persisted flag; best-effort, retries next boot if NDMS is down.
+				managedService.MigratePeerAllowIPs(shutdownCtx)
+			}()
 
 			// Migrate legacy NDMS ID values to kernel names (one-time after model is populated).
 			tunnelService.MigrateISPInterfaceToKernel()
@@ -1414,14 +1451,24 @@ func main() {
 			// Detect actual WAN state.
 			if _, err := ndmsQueries.Routes.GetDefaultGatewayInterface(shutdownCtx); err != nil {
 				bootLog.Info("startup", "",
-					"WAN down at boot — waiting for WAN UP event")
+					fmt.Sprintf("WAN down at boot after %s — waiting for WAN UP event",
+						time.Since(bootStart).Round(time.Second)))
 			} else {
+				bootLog.Info("startup", "",
+					fmt.Sprintf("Tunnel start at %s (uptime ~%ds)",
+						time.Since(bootStart).Round(time.Second),
+						int(time.Since(bootStart).Seconds())+int(uptime)))
 				orch.LoadState(shutdownCtx)
 				orch.HandleEvent(shutdownCtx, orchestrator.Event{Type: orchestrator.EventBoot})
 			}
 
+			// Wait for background migrations to finish (non-critical but
+			// we track them so they don't leak on shutdown).
+			bgDone.Wait()
+
 			atomic.StoreInt32(&bootDone, 1)
-			bootLog.Info("startup", "", "Boot initialization complete")
+			bootLog.Info("startup", "",
+				fmt.Sprintf("Boot initialization complete after %s", time.Since(bootStart).Round(time.Second)))
 		}()
 	} else {
 		atomic.StoreInt32(&bootDone, 1) // Not booting — mark done immediately.

--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -1504,11 +1504,13 @@ func main() {
 			tunnelService.HealStaleActiveWAN()
 
 			// Detect actual WAN state.
-			if _, err := ndmsQueries.Routes.GetDefaultGatewayInterface(shutdownCtx); err != nil {
+			gwIface, err := ndmsQueries.Routes.GetDefaultGatewayInterface(shutdownCtx)
+			if err != nil {
 				bootLog.Info("startup", "",
 					fmt.Sprintf("WAN down at boot after %s — waiting for WAN UP event",
 						time.Since(bootStart).Round(time.Second)))
 			} else {
+				bootLog.Info("startup", "", fmt.Sprintf("wan-decision gw=%s after=%s", gwIface, time.Since(bootStart).Round(time.Second)))
 				bootLog.Info("startup", "",
 					fmt.Sprintf("Tunnel start at %s (uptime ~%ds)",
 						time.Since(bootStart).Round(time.Second),
@@ -1698,7 +1700,11 @@ func populateWANModel(ctx context.Context, queries *ndmsquery.Queries, model *wa
 		return
 	}
 	model.Populate(interfaces)
-	appLog.Info("populate-wan", "", fmt.Sprintf("WAN model populated, count=%d", len(interfaces)))
+	ifaceList := make([]string, 0, len(interfaces))
+	for _, iface := range interfaces {
+		ifaceList = append(ifaceList, fmt.Sprintf("%s(up=%t)", iface.Name, iface.Up))
+	}
+	appLog.Info("populate-wan", "", fmt.Sprintf("WAN model populated, count=%d ifaces=[%s]", len(interfaces), strings.Join(ifaceList, " ")))
 }
 
 // getInterfaceIP returns the first IPv4 address of the given interface.

--- a/internal/hydraroute/service.go
+++ b/internal/hydraroute/service.go
@@ -184,7 +184,11 @@ func (s *Service) scheduleRestart(reason string) {
 	})
 }
 
-func (s *Service) ScheduleRestart(reason string) { s.scheduleRestart(reason) }
+func (s *Service) ScheduleRestart(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scheduleRestart(reason)
+}
 
 func (s *Service) getVersionCachedLocked() string {
 	if !s.status.Installed {

--- a/internal/hydraroute/service.go
+++ b/internal/hydraroute/service.go
@@ -184,6 +184,8 @@ func (s *Service) scheduleRestart(reason string) {
 	})
 }
 
+func (s *Service) ScheduleRestart(reason string) { s.scheduleRestart(reason) }
+
 func (s *Service) getVersionCachedLocked() string {
 	if !s.status.Installed {
 		s.versionCached = ""

--- a/internal/hydraroute/service_race_test.go
+++ b/internal/hydraroute/service_race_test.go
@@ -1,0 +1,32 @@
+package hydraroute
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestScheduleRestart_ConcurrentLockSafe ловит гонку на s.restartTimer:
+// экспортный ScheduleRestart должен брать s.mu (как все callsite scheduleRestart
+// и timer-callback). Запускать под -race. До фикса детектирует DATA RACE на
+// чтении/записи s.restartTimer.
+func TestScheduleRestart_ConcurrentLockSafe(t *testing.T) {
+	svc := &Service{}
+	svc.SetStatusForTest(true) // Installed=true → таймер реально ставится
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			svc.ScheduleRestart("race-probe")
+		}()
+	}
+	wg.Wait()
+
+	// Не дать AfterFunc(2s) форкнуть /opt/bin/neo в CI.
+	svc.mu.Lock()
+	if svc.restartTimer != nil {
+		svc.restartTimer.Stop()
+	}
+	svc.mu.Unlock()
+}

--- a/internal/orchestrator/on_tunnel_running_test.go
+++ b/internal/orchestrator/on_tunnel_running_test.go
@@ -1,0 +1,25 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// Переход туннеля в running должен дёрнуть onTunnelRunning с его ID
+// (колбэк рестартит hr-neo — fwmark раздаётся только при старте hr-neo, #247).
+func TestUpdateState_Running_InvokesOnTunnelRunning(t *testing.T) {
+	const id = "abc42"
+	o := &Orchestrator{state: newState(), bus: events.NewBus(), store: storage.NewAWGTunnelStore(t.TempDir())}
+	o.state.tunnels[id] = &tunnelState{ID: id, Name: "vpn", Backend: "kernel", Running: true}
+
+	var got []string
+	o.SetOnTunnelRunning(func(tid string) { got = append(got, tid) })
+
+	o.updateState(Action{Type: ActionColdStartKernel, Tunnel: id})
+
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("onTunnelRunning calls = %v, want exactly [%q]", got, id)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -95,6 +95,10 @@ type Orchestrator struct {
 	// nil-safe. Production wires an async closure; the orchestrator calls it
 	// synchronously so async-ness stays a wiring detail (and tests deterministic).
 	ifaceInvalidator func(name string)
+
+	// onTunnelRunning is an optional callback on confirmed running
+	// transition. Nil-safe.
+	onTunnelRunning func(tunnelID string)
 }
 
 // New creates a new Orchestrator.
@@ -136,6 +140,11 @@ func (o *Orchestrator) SetEventBus(bus *events.Bus) { o.bus = bus }
 // SetInterfaceInvalidator wires the NDMS interface-cache refresh invoked on a
 // kernel tunnel's confirmed "running" transition. nil-safe. See issue #328.
 func (o *Orchestrator) SetInterfaceInvalidator(fn func(name string)) { o.ifaceInvalidator = fn }
+
+// SetOnTunnelRunning wires a callback invoked when any tunnel (kernel or
+// NativeWG) reaches confirmed running state. Used to restart HydraRoute Neo
+// so it re-applies CONNMARK rules.
+func (o *Orchestrator) SetOnTunnelRunning(fn func(tunnelID string)) { o.onTunnelRunning = fn }
 
 // SetSupportsASC sets the ASC support flag.
 func (o *Orchestrator) SetSupportsASC(fn func() bool) {
@@ -454,6 +463,9 @@ func (o *Orchestrator) updateState(action Action) {
 				if ndmsName := tunnel.NewNames(t.ID).NDMSName; ndmsName != "" {
 					o.ifaceInvalidator(ndmsName)
 				}
+			}
+			if o.onTunnelRunning != nil {
+				o.onTunnelRunning(t.ID)
 			}
 		case ActionStopKernel, ActionStopNativeWG, ActionSuspendProxy, ActionSuspendKernel:
 			o.bus.Publish("tunnel:state", events.TunnelStateEvent{

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -275,6 +275,8 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event Event) error {
 		consumed := o.consumeExpectedHook(event.NDMSName, event.Level)
 		o.mu.Unlock()
 		if consumed {
+			o.appLog.Debug("boot-trace", event.NDMSName,
+				fmt.Sprintf("expected-hook consumed level=%s", event.Level))
 			return nil
 		}
 	}
@@ -290,6 +292,27 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event Event) error {
 		o.state.ensureTunnel(event.Tunnel, o.store)
 	}
 	actions := decide(event, &o.state)
+	// conf=disabled detail: тот же резолвер, что decideNDMSHook —
+	// findByNDMSName(event.NDMSName), layer=="conf" (НЕ event.Tunnel).
+	if event.Type == EventNDMSHook && event.Layer == "conf" && event.Level == "disabled" {
+		if t := o.state.findByNDMSName(event.NDMSName); t != nil && t.Running {
+			sinceStart := bootQuiescenceWindow - t.quiescentUntil.Sub(event.Now)
+			windowLeft := t.quiescentUntil.Sub(event.Now)
+			stop := false
+			for _, a := range actions {
+				if a.Type == ActionStopKernel || a.Type == ActionStopNativeWG {
+					stop = true
+				}
+			}
+			if stop {
+				o.appLog.Warn("boot-trace", t.ID,
+					fmt.Sprintf("conf=disabled OUTSIDE-WINDOW->STOP sinceStart=%s windowLeft=%s", sinceStart.Round(time.Second), windowLeft.Round(time.Second)))
+			} else {
+				o.appLog.Debug("boot-trace", t.ID,
+					fmt.Sprintf("conf=disabled suppressed sinceStart=%s windowLeft=%s", sinceStart.Round(time.Second), windowLeft.Round(time.Second)))
+			}
+		}
+	}
 	o.mu.Unlock()
 
 	if len(actions) == 0 {
@@ -418,6 +441,7 @@ func (o *Orchestrator) updateState(action Action) {
 	case ActionColdStartKernel, ActionStartNativeWG, ActionReconcileNativeWG, ActionReconcileKernel, ActionResumeKernel:
 		t.Running = true
 		t.quiescentUntil = o.nowFn().Add(bootQuiescenceWindow)
+		o.appLog.Debug("boot-trace", t.ID, fmt.Sprintf("tunnel-start action=%d", action.Type))
 		// Refresh ActiveWAN from store. Execute layer persists the resolved
 		// WAN; we mirror it into the in-memory cache so decideWANDown can
 		// match correctly via affectedByWANDown.
@@ -428,6 +452,7 @@ func (o *Orchestrator) updateState(action Action) {
 		t.Running = false
 		t.Monitoring = false
 		t.ActiveWAN = ""
+		o.appLog.Debug("boot-trace", t.ID, fmt.Sprintf("tunnel-stop action=%d", action.Type))
 	case ActionSuspendProxy, ActionSuspendKernel:
 		// Keep t.Running=true so the next WANUp picks Resume/Reconcile,
 		// not a fresh ColdStart. Keep ActiveWAN so a duplicate WANDown

--- a/internal/sys/ndmsinfo/wait.go
+++ b/internal/sys/ndmsinfo/wait.go
@@ -26,7 +26,7 @@ func WaitForNDMS(ctx context.Context, routes *query.RouteStore, log *logging.Sco
 	start := time.Now()
 
 	// Try once before entering the poll loop — NDMS may already be up.
-	if err := ndmsResponds(routes); err == nil {
+	if err := ndmsResponds(ctx, routes); err == nil {
 		log.Debug("ndms-wait", "", "NDMS ready immediately")
 		return nil
 	}
@@ -36,7 +36,7 @@ func WaitForNDMS(ctx context.Context, routes *query.RouteStore, log *logging.Sco
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := ndmsResponds(routes); err == nil {
+			if err := ndmsResponds(ctx, routes); err == nil {
 				log.Debug("ndms-wait", "",
 					fmt.Sprintf("NDMS ready after %s polling", time.Since(start).Round(time.Second)))
 				return nil
@@ -56,8 +56,8 @@ func WaitForNDMS(ctx context.Context, routes *query.RouteStore, log *logging.Sco
 // goroutine already checks after the wait). A successful response
 // ("there is a default gateway") AND ErrNoDefaultRoute ("NDMS answered
 // but no default route exists yet") both signal a working RCI endpoint.
-func ndmsResponds(routes *query.RouteStore) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func ndmsResponds(ctx context.Context, routes *query.RouteStore) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	_, err := routes.GetDefaultGatewayInterface(ctx)
 	if err == nil || errors.Is(err, query.ErrNoDefaultRoute) {

--- a/internal/sys/ndmsinfo/wait.go
+++ b/internal/sys/ndmsinfo/wait.go
@@ -1,0 +1,67 @@
+package ndmsinfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/ndms/query"
+)
+
+// WaitForNDMS polls NDMS every second until it responds to a basic RCI
+// query (GetDefaultGatewayInterface). Returns as soon as NDMS answers,
+// even when the answer is "no default route yet" — the key signal is that
+// the RCI endpoint is alive and the interface subsystem has initialized.
+//
+// Logs every failed probe with the error for post-boot diagnostics, and
+// logs the successful probe with elapsed time.
+//
+// The caller MUST supply a context with a deadline or timeout — this
+// function loops until NDMS responds OR the context is cancelled/expired.
+func WaitForNDMS(ctx context.Context, routes *query.RouteStore, log *logging.ScopedLogger) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	start := time.Now()
+
+	// Try once before entering the poll loop — NDMS may already be up.
+	if err := ndmsResponds(routes); err == nil {
+		log.Debug("ndms-wait", "", "NDMS ready immediately")
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := ndmsResponds(routes); err == nil {
+				log.Debug("ndms-wait", "",
+					fmt.Sprintf("NDMS ready after %s polling", time.Since(start).Round(time.Second)))
+				return nil
+			} else {
+				log.Debug("ndms-wait", "",
+					fmt.Sprintf("NDMS not ready yet (probe: %v)", err))
+			}
+		}
+	}
+}
+
+// ndmsResponds performs a lightweight NDMS health probe and returns nil
+// when the RCI endpoint is reachable. Returns the error on failure.
+//
+// Uses GetDefaultGatewayInterface because it's the simplest read-path
+// query available at every consumer call-site (it's what the boot
+// goroutine already checks after the wait). A successful response
+// ("there is a default gateway") AND ErrNoDefaultRoute ("NDMS answered
+// but no default route exists yet") both signal a working RCI endpoint.
+func ndmsResponds(routes *query.RouteStore) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := routes.GetDefaultGatewayInterface(ctx)
+	if err == nil || errors.Is(err, query.ErrNoDefaultRoute) {
+		return nil
+	}
+	return err
+}

--- a/internal/sys/ndmsinfo/wait_test.go
+++ b/internal/sys/ndmsinfo/wait_test.go
@@ -1,0 +1,133 @@
+package ndmsinfo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/ndms"
+	"github.com/hoaxisr/awg-manager/internal/ndms/query"
+)
+
+// fakeGetter implements query.Getter. Get returns either a configured slice
+// of routes or a configured error, switchable under a mutex so a goroutine
+// can flip the mode mid-test.
+type fakeGetter struct {
+	mu     sync.Mutex
+	routes []ndms.Route
+	err    error
+}
+
+func (f *fakeGetter) setRoutes(routes []ndms.Route) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.routes = routes
+	f.err = nil
+}
+
+func (f *fakeGetter) setError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.routes = nil
+	f.err = err
+}
+
+func (f *fakeGetter) Get(_ context.Context, _ string, dst any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	out, ok := dst.(*[]ndms.Route)
+	if !ok {
+		return errors.New("fakeGetter: unexpected dst type")
+	}
+	*out = f.routes
+	return nil
+}
+
+func (f *fakeGetter) GetRaw(_ context.Context, _ string) ([]byte, error) { return nil, nil }
+
+func (f *fakeGetter) Post(_ context.Context, _ any) (json.RawMessage, error) { return nil, nil }
+
+func newRouteStore(g query.Getter) *query.RouteStore {
+	return query.NewRouteStore(g, query.NopLogger())
+}
+
+func TestWaitForNDMS_ImmediateReady(t *testing.T) {
+	fg := &fakeGetter{}
+	fg.setRoutes([]ndms.Route{{Destination: "0.0.0.0/0", Gateway: "1.2.3.4", Interface: "PPPoE0"}})
+	routes := newRouteStore(fg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := WaitForNDMS(ctx, routes, nil); err != nil {
+		t.Fatalf("WaitForNDMS: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Errorf("expected pre-loop success, took %s", elapsed)
+	}
+}
+
+func TestWaitForNDMS_ErrNoDefaultRouteCountsAsReady(t *testing.T) {
+	fg := &fakeGetter{}
+	// NDMS answered, but no default route exists yet — must count as alive.
+	fg.setRoutes([]ndms.Route{{Destination: "10.0.0.0/24", Gateway: "", Interface: "Wireguard0"}})
+	routes := newRouteStore(fg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := WaitForNDMS(ctx, routes, nil); err != nil {
+		t.Fatalf("WaitForNDMS: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Errorf("expected pre-loop success, took %s", elapsed)
+	}
+}
+
+func TestWaitForNDMS_ContextCancelled(t *testing.T) {
+	fg := &fakeGetter{}
+	// Never ready: transport error on every probe.
+	fg.setError(errors.New("rci: connection refused"))
+	routes := newRouteStore(fg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call
+
+	start := time.Now()
+	err := WaitForNDMS(ctx, routes, nil)
+	if err == nil {
+		t.Fatal("WaitForNDMS: want non-nil error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want context.Canceled, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Errorf("expected prompt return, took %s", elapsed)
+	}
+}
+
+func TestWaitForNDMS_BecomesReadyDuringLoop(t *testing.T) {
+	fg := &fakeGetter{}
+	fg.setError(errors.New("rci: connection refused"))
+	routes := newRouteStore(fg)
+
+	go func() {
+		time.Sleep(1200 * time.Millisecond)
+		fg.setRoutes([]ndms.Route{{Destination: "0.0.0.0/0", Gateway: "1.2.3.4", Interface: "PPPoE0"}})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := WaitForNDMS(ctx, routes, nil); err != nil {
+		t.Fatalf("WaitForNDMS: %v", err)
+	}
+}


### PR DESCRIPTION
Исправление для #247 (проверка наличия nmds вместо ожидания 120сек, рестарт hr-neo после поднятия интерфейса)