### PR TITLE
fakeip: пустой DNS-UI и смешивание DNS-слотов

### DIFF
--- a/frontend/src/lib/components/fakeip/dns/DnsTab.svelte
+++ b/frontend/src/lib/components/fakeip/dns/DnsTab.svelte
@@ -30,7 +30,7 @@
   поддерживают (общий DNSRewritesList без грипа). MoveDNSServer — в бэкенде.
 -->
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { get } from 'svelte/store';
 	import { fakeipConfig } from '$lib/stores/fakeipConfig';
 	import { createReorderDrag } from '$lib/components/sb-router/reorderDrag.svelte';
@@ -147,6 +147,10 @@
 				notifications.error(`Ошибка перемещения: ${e instanceof Error ? e.message : String(e)}`);
 			}
 		},
+	});
+
+	onMount(() => {
+		void fakeipConfig.loadAll();
 	});
 
 	onDestroy(() => {

--- a/internal/singbox/orchestrator/orchestrator.go
+++ b/internal/singbox/orchestrator/orchestrator.go
@@ -270,27 +270,11 @@ func (o *Orchestrator) saveLocked(slot Slot, jsonBytes []byte) error {
 
 // SetEnabled toggles slot activity by renaming the file between
 // active and disabled locations. AlwaysOn slots reject disable.
-// Marks the orchestrator dirty.
+// Marks the orchestrator dirty and schedules a debounced reload.
 func (o *Orchestrator) SetEnabled(slot Slot, enabled bool) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	meta, ok := o.slots[slot]
-	if !ok {
-		return ErrUnknownSlot
-	}
-	if !enabled && meta.AlwaysOn {
-		return ErrSlotAlwaysOn
-	}
-	if o.enabled[slot] == enabled {
-		return nil // already in target state
-	}
-	if err := o.renameForToggle(meta, enabled); err != nil {
-		return fmt.Errorf("toggle %s: %w", slot, err)
-	}
-	o.enabled[slot] = enabled
-	o.dirty = true
-	o.scheduleReload()
-	return nil
+	return o.setEnabledLocked(slot, enabled, true)
 }
 
 // SetEnabledSilent toggles slot activity without scheduling a debounced reload.
@@ -298,7 +282,15 @@ func (o *Orchestrator) SetEnabled(slot Slot, enabled bool) error {
 func (o *Orchestrator) SetEnabledSilent(slot Slot, enabled bool) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	return o.setEnabledLocked(slot, enabled, false)
+}
 
+// setEnabledLocked is the shared body. Caller MUST hold o.mu. The short-circuit
+// reconciles against the ACTUAL on-disk layout, not just the in-memory map: a
+// map↔disk drift (e.g. saveLocked wrote the active file while the map said
+// disabled) must not let a no-op leave a stray active file that MergeDir would
+// still pick up. renameForToggle already heals the both-locations case.
+func (o *Orchestrator) setEnabledLocked(slot Slot, enabled, scheduleReload bool) error {
 	meta, ok := o.slots[slot]
 	if !ok {
 		return ErrUnknownSlot
@@ -306,7 +298,15 @@ func (o *Orchestrator) SetEnabledSilent(slot Slot, enabled bool) error {
 	if !enabled && meta.AlwaysOn {
 		return ErrSlotAlwaysOn
 	}
-	if o.enabled[slot] == enabled {
+	a, d := o.scanDirForSlot(meta)
+	// Disk already in the target shape? enabled → active present, no stray
+	// disabled copy; disabled → no active file (a parked copy may or may not
+	// exist). Only then is a no-op safe.
+	diskMatches := !a
+	if enabled {
+		diskMatches = a && !d
+	}
+	if o.enabled[slot] == enabled && diskMatches {
 		return nil
 	}
 	if err := o.renameForToggle(meta, enabled); err != nil {
@@ -314,6 +314,9 @@ func (o *Orchestrator) SetEnabledSilent(slot Slot, enabled bool) error {
 	}
 	o.enabled[slot] = enabled
 	o.dirty = true
+	if scheduleReload {
+		o.scheduleReload()
+	}
 	return nil
 }
 

--- a/internal/singbox/orchestrator/orchestrator_test.go
+++ b/internal/singbox/orchestrator/orchestrator_test.go
@@ -817,3 +817,41 @@ func TestKnownSlots_FakeIP(t *testing.T) {
 		t.Fatalf("SlotFakeIP missing/wrong: %+v", fi)
 	}
 }
+
+// TestSetEnabledReconcilesMapDiskDrift reproduces the live bug where a
+// map↔disk drift left 20-router.json in BOTH config.d/ and config.d/disabled/
+// while the in-memory enabled-map still said "disabled". The old no-op
+// short-circuit (o.enabled[slot]==enabled → return nil) skipped renameForToggle,
+// so the stray active file kept leaking into MergeDir (mixed FakeIP+TPROXY DNS).
+// SetEnabled(false) must reconcile against disk and remove the stray active file.
+func TestSetEnabledReconcilesMapDiskDrift(t *testing.T) {
+	o, dir := newTestOrch(t)
+	_ = o.Register(SlotMeta{Slot: SlotRouter, Filename: "20-router.json"})
+	if err := o.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+
+	active := filepath.Join(dir, "20-router.json")
+	disabled := filepath.Join(dir, "disabled", "20-router.json")
+
+	// Drift: both copies present on disk, but the map still says disabled
+	// (Bootstrap saw no active file, so o.enabled[SlotRouter] == false).
+	if err := os.WriteFile(active, []byte(`{"dns":{"servers":[{"tag":"tproxy"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(disabled, []byte(`{"dns":{"servers":[{"tag":"tproxy"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disabling must remove the stray active file rather than no-op on the
+	// stale map.
+	if err := o.SetEnabled(SlotRouter, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if _, err := os.Stat(active); !os.IsNotExist(err) {
+		t.Errorf("stray active file must be removed; stat err=%v", err)
+	}
+	if _, err := os.Stat(disabled); err != nil {
+		t.Errorf("parked disabled copy must survive: %v", err)
+	}
+}

--- a/internal/singbox/router/service_fakeip_test.go
+++ b/internal/singbox/router/service_fakeip_test.go
@@ -324,7 +324,7 @@ func TestEnable_DispatchesFakeIPTun(t *testing.T) {
 //   - 21-fakeip.json contains the engine-locked overlay bits (tun-in, fakeip DNS
 //     server, hijack-dns at route.rules[0]) and the seeded A/AAAA→fakeip DNS rule.
 //   - route.final is set (seed provides "direct").
-//   - SlotRouter was NOT promoted by enable (20-router.json is unchanged).
+//   - SlotRouter is parked under disabled/ by the XOR, content unchanged.
 func TestEnableFakeIPTun_SlotFakeIPWritten(t *testing.T) {
 	h := newFakeIPEnableHarness(t, "")
 
@@ -412,11 +412,15 @@ func TestEnableFakeIPTun_SlotFakeIPWritten(t *testing.T) {
 		t.Errorf("21-fakeip.json: seeded A/AAAA→fakeip DNS rule missing: %s", data)
 	}
 
-	// 20-router.json was NOT promoted (still the file we seeded the harness with,
-	// not overwritten by fakeip enable).
-	routerData, err := os.ReadFile(filepath.Join(h.dir, "20-router.json"))
+	// 20-router.json was parked under disabled/ by the XOR (not deleted, not
+	// modified) — fakeip enable must move the router slot out of the active dir
+	// so MergeDir no longer concatenates its DNS, while leaving its content intact.
+	if _, err := os.Stat(filepath.Join(h.dir, "20-router.json")); !os.IsNotExist(err) {
+		t.Errorf("20-router.json must not stay in the active dir after fakeip enable (XOR); stat err=%v", err)
+	}
+	routerData, err := os.ReadFile(filepath.Join(h.dir, "disabled", "20-router.json"))
 	if err != nil {
-		t.Fatalf("20-router.json missing: %v", err)
+		t.Fatalf("parked 20-router.json missing from disabled/: %v", err)
 	}
 	var routerCfg RouterConfig
 	if err := json.Unmarshal(routerData, &routerCfg); err != nil {


### PR DESCRIPTION
DnsTab не грузил конфиг при монтировании (не было onMount), поэтому списки DNS пустые, редактировать нечего.

SetEnabled был без сверки с диском: при рассинхроне карты и файлов осиротевший активный 20-router.json не переносился, и его DNS склеивался с fakeip-слотом в merge. Теперь сверяемся с реальным размещением файла на иске. 