### PR TITLE
sing-box: прунить висячие ссылки селектора перед reload

### DIFF
--- a/internal/singbox/orchestrator/orchestrator_test.go
+++ b/internal/singbox/orchestrator/orchestrator_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -853,5 +854,55 @@ func TestSetEnabledReconcilesMapDiskDrift(t *testing.T) {
 	}
 	if _, err := os.Stat(disabled); err != nil {
 		t.Errorf("parked disabled copy must survive: %v", err)
+	}
+}
+
+// TestReloadPrunesDanglingSelectorRefs reproduces the live FATAL
+// "dependency[YC-FIN] not found for outbound[device-proxy-selector]": a selector
+// keeps a member tag whose outbound was deleted from another slot. sing-box check
+// does not catch it (like composite cycles, it only surfaces at "start service"),
+// so the broken config reaches the daemon. Reload must prune dangling selector
+// members (and a dangling default) from the slot file before applying.
+func TestReloadPrunesDanglingSelectorRefs(t *testing.T) {
+	o, dir := newTestOrch(t)
+	_ = o.Register(SlotMeta{Slot: SlotDeviceProxy, Filename: "30-deviceproxy.json"})
+
+	// Active slot: selector references "direct" (builtin, ok) + "YC-FIN" (gone).
+	active := filepath.Join(dir, "30-deviceproxy.json")
+	dp := `{"inbounds":[{"type":"mixed","tag":"device-proxy-in","listen_port":1090}],` +
+		`"outbounds":[{"type":"selector","tag":"device-proxy-selector","outbounds":["direct","YC-FIN"],"default":"YC-FIN"}]}`
+	if err := os.WriteFile(active, []byte(dp), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Bootstrap(); err != nil { // file present → enabled[deviceproxy]=true
+		t.Fatal(err)
+	}
+
+	if err := o.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	data, err := os.ReadFile(active)
+	if err != nil {
+		t.Fatalf("read pruned slot: %v", err)
+	}
+	var c slotConfig
+	if err := json.Unmarshal(data, &c); err != nil {
+		t.Fatalf("unmarshal pruned slot: %v", err)
+	}
+	if len(c.Outbounds) != 1 {
+		t.Fatalf("want 1 outbound, got %d", len(c.Outbounds))
+	}
+	sel := c.Outbounds[0]
+	for _, m := range sel.Outbounds {
+		if m == "YC-FIN" {
+			t.Errorf("dangling member YC-FIN must be pruned, got %v", sel.Outbounds)
+		}
+	}
+	if sel.Default == "YC-FIN" {
+		t.Errorf("dangling default YC-FIN must be cleared, got %q", sel.Default)
+	}
+	if len(sel.Outbounds) == 0 {
+		t.Errorf("selector must keep surviving member \"direct\"")
 	}
 }

--- a/internal/singbox/orchestrator/reload.go
+++ b/internal/singbox/orchestrator/reload.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -38,10 +39,19 @@ func (o *Orchestrator) Reload() error {
 	}
 	o.reloading = true
 	o.dirty = false
+	// Defense-in-depth: strip dangling selector/urltest members and defaults
+	// (a tag whose outbound was deleted from another slot) BEFORE validating.
+	// sing-box check does not catch these — like composite cycles, a missing
+	// selector dependency only surfaces at "start service" (FATAL), so a stale
+	// reference would otherwise reach the daemon and take the whole config down.
+	pruneLogs := o.pruneDanglingSelectorRefsLocked()
 	res := o.validateLocked()
 	if !res.Ok() {
 		o.reloading = false
 		o.mu.Unlock()
+		for _, m := range pruneLogs {
+			o.log("info", m)
+		}
 		msg := fmt.Sprintf("orchestrator validation failed; reload skipped: %s", res.Error())
 		o.log("error", msg)
 		return res
@@ -52,6 +62,9 @@ func (o *Orchestrator) Reload() error {
 	prevHasTun := o.prevHasTun
 	newHasTun := res.HasTun
 	o.mu.Unlock()
+	for _, m := range pruneLogs {
+		o.log("info", m)
+	}
 
 	var err error
 	if proc == nil {
@@ -101,6 +114,105 @@ func (o *Orchestrator) Reload() error {
 	o.prevHasTun = newHasTun
 	o.mu.Unlock()
 	return err
+}
+
+// pruneDanglingSelectorRefsLocked rewrites enabled slot files in place,
+// dropping any selector/urltest member or `default` that points at an
+// outbound tag no slot declares. Caller MUST hold o.mu. Returns log lines
+// describing what was pruned — the caller logs them AFTER releasing o.mu
+// (o.log takes o.mu, so logging here would self-deadlock).
+//
+// A selector member is the ONLY ref sing-box check lets through (the error
+// is deferred to "start service"), so this is the one place the orchestrator
+// must self-heal rather than merely reject. The surviving-member guard keeps
+// a selector from being emptied (sing-box rejects a memberless selector); an
+// all-dangling selector is left untouched so validateLocked still reports it.
+func (o *Orchestrator) pruneDanglingSelectorRefsLocked() []string {
+	var logs []string
+	// builtins sing-box defines implicitly (mirrors validateWith).
+	known := map[string]bool{"direct": true, "block": true, "dns": true}
+	for _, m := range KnownSlots() {
+		if _, ok := o.slots[m.Slot]; !ok || !o.enabled[m.Slot] {
+			continue
+		}
+		data, err := o.readActiveBytes(m.Slot)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		var c slotConfig
+		if json.Unmarshal(data, &c) != nil {
+			continue
+		}
+		for _, ob := range c.Outbounds {
+			if ob.Tag != "" {
+				known[ob.Tag] = true
+			}
+		}
+	}
+
+	for _, m := range KnownSlots() {
+		meta := m
+		if _, ok := o.slots[meta.Slot]; !ok || !o.enabled[meta.Slot] {
+			continue
+		}
+		data, err := o.readActiveBytes(meta.Slot)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		var root map[string]any
+		if json.Unmarshal(data, &root) != nil {
+			continue
+		}
+		obs, ok := root["outbounds"].([]any)
+		if !ok {
+			continue
+		}
+		changed := false
+		for _, v := range obs {
+			ob, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			members, ok := ob["outbounds"].([]any)
+			if !ok || len(members) == 0 {
+				continue // not a selector/urltest
+			}
+			kept := make([]any, 0, len(members))
+			var dropped []string
+			for _, mv := range members {
+				tag, _ := mv.(string)
+				if tag == "" || known[tag] {
+					kept = append(kept, mv)
+					continue
+				}
+				dropped = append(dropped, tag)
+			}
+			// Never empty a selector — leave it for validateLocked to flag.
+			if len(dropped) > 0 && len(kept) > 0 {
+				ob["outbounds"] = kept
+				changed = true
+				tag, _ := ob["tag"].(string)
+				logs = append(logs, fmt.Sprintf("orchestrator: pruned dangling selector members %v from %q in [%s]", dropped, tag, meta.Slot))
+			}
+			if def, _ := ob["default"].(string); def != "" && !known[def] {
+				delete(ob, "default")
+				changed = true
+				tag, _ := ob["tag"].(string)
+				logs = append(logs, fmt.Sprintf("orchestrator: cleared dangling selector default %q from %q in [%s]", def, tag, meta.Slot))
+			}
+		}
+		if !changed {
+			continue
+		}
+		out, err := json.MarshalIndent(root, "", "  ")
+		if err != nil {
+			continue
+		}
+		if err := writeAtomic(o.activePath(meta), out); err != nil {
+			logs = append(logs, fmt.Sprintf("orchestrator: rewrite pruned slot [%s]: %v", meta.Slot, err))
+		}
+	}
+	return logs
 }
 
 // hasActiveWorkLocked reports whether sing-box has anything to do


### PR DESCRIPTION
При удалении подписки/сервера его тег оставался в device-proxy-selector.outbounds (каскада к пересборке нет, sing-box check висячий selector-dep не ловит) — sing-box падал с FATAL dependency[...] not found, инет лежал до перезапуска AWGM.

Orchestrator.Reload перед валидацией чистит из любого selector/urltest висячие члены outbounds и default по живому набору outbound-тегов активных слотов. + тест.