### PR TITLE
pingcheck: не показывать FAIL для nativewg до первой проверки

### DIFF
--- a/frontend/src/lib/components/pingcheck/WatchdogCard.svelte
+++ b/frontend/src/lib/components/pingcheck/WatchdogCard.svelte
@@ -10,7 +10,7 @@
 		name: string;
 		backend: 'kernel' | 'nativewg';
 		awgVersion?: string;
-		statusKind: 'alive' | 'recovering' | 'disabled' | 'stopped';
+		statusKind: 'alive' | 'recovering' | 'disabled' | 'stopped' | 'warming';
 		hasPingcheck: boolean;
 		isWatchdog: boolean;
 		configLine: string;
@@ -29,6 +29,7 @@
 		recovering: { dot: 'warning', pulse: true, label: 'восстановление', badge: 'warning' },
 		disabled: { dot: 'muted', pulse: false, label: 'выключен', badge: 'muted' },
 		stopped: { dot: 'muted', pulse: false, label: 'остановлен', badge: 'muted' },
+		warming: { dot: 'muted', pulse: true, label: 'ждём первого интервала', badge: 'muted' },
 	};
 	const st = $derived(STATUS[statusKind]);
 	const fmt = (v: number | null) => (v === null ? '—' : `${v}ms`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -832,7 +832,7 @@ export interface TunnelPingStatus {
 	tunnelName: string;
 	enabled: boolean;
 	backend: 'kernel' | 'nativewg';
-	status: 'alive' | 'recovering' | 'disabled' | 'stopped';
+	status: 'alive' | 'recovering' | 'disabled' | 'stopped' | 'warming';
 	method: string;
 	lastCheck?: string;
 	lastLatency: number;

--- a/internal/pingcheck/facade.go
+++ b/internal/pingcheck/facade.go
@@ -193,30 +193,9 @@ func (f *Facade) getNativeWGStatuses() []TunnelStatus {
 			// interface → status/counts are meaningless. Show "stopped" so the
 			// UI can distinguish "monitoring enabled but tunnel not running"
 			// from "alive and checking".
-			if !status.Bound {
-				ts.Status = "stopped"
-			} else {
-				switch status.Status {
-				case "pass":
-					ts.Status = "alive"
-				case "fail":
-					if status.FailCount > 0 {
-						// Active failures — NDMS is counting towards threshold.
-						ts.Status = "recovering"
-						ts.RestartCount = 1
-					} else if f.isNwgRestartDetected(t.ID) {
-						// Post-restart: NDMS reset counters after interface
-						// restart, no checks completed yet. Show "recovering"
-						// so user sees the tunnel was just restarted.
-						ts.Status = "recovering"
-						ts.RestartCount = 1
-					} else {
-						// Fresh start or stale "fail" with no active failures.
-						ts.Status = "alive"
-					}
-				default:
-					ts.Status = "alive" // pending/unknown → treat as alive
-				}
+			ts.Status = nwgCardStatus(status.Status, status.FailCount, status.SuccessCount, status.Bound, f.isNwgRestartDetected(t.ID))
+			if ts.Status == "recovering" {
+				ts.RestartCount = 1
 			}
 		}
 
@@ -224,6 +203,40 @@ func (f *Facade) getNativeWGStatuses() []TunnelStatus {
 	}
 
 	return result
+}
+
+// nwgCardStatus maps an NDMS ping-check profile status to a UI card status.
+//
+//   - not bound                         → "stopped" (interface down)
+//   - bound, no check completed yet     → "warming" (interval hasn't ticked;
+//     NDMS reports a provisional "fail" with zeroed counters on a fresh start —
+//     this is NOT a real failure, so we surface a distinct waiting state)
+//   - bound, "pass"                     → "alive"
+//   - bound, "fail" with real failures  → "recovering" (counting to threshold)
+//   - bound, "fail" right after restart → "recovering"
+//   - anything else                     → "alive"
+//
+// restartDetected distinguishes a post-restart counter reset (recovering) from a
+// never-yet-checked fresh start (warming): both show fail/0/0, but only the
+// fresh start should read as "warming".
+func nwgCardStatus(status string, failCount, successCount int, bound, restartDetected bool) string {
+	if !bound {
+		return "stopped"
+	}
+	if failCount == 0 && successCount == 0 && status != "pass" && !restartDetected {
+		return "warming"
+	}
+	switch status {
+	case "pass":
+		return "alive"
+	case "fail":
+		if failCount > 0 || restartDetected {
+			return "recovering"
+		}
+		return "alive"
+	default:
+		return "alive" // pending/unknown → treat as alive
+	}
 }
 
 // isNwgRestartDetected returns true if the nwgMonitor for the given tunnel

--- a/internal/pingcheck/facade_test.go
+++ b/internal/pingcheck/facade_test.go
@@ -229,3 +229,35 @@ func TestFacade_MinInterval(t *testing.T) {
 		t.Errorf("interval = %v, want 10s (minimum)", mon.interval)
 	}
 }
+
+// TestNwgCardStatus_WarmupVsRealStates verifies the card status mapping:
+// a freshly started tunnel (NDMS reports provisional "fail" with zero counters
+// and the interval has not ticked yet) must read as "warming", NOT a fail/
+// recovering — see the live fail/0/0 NDMS payload. Once a real check lands
+// (fail or success counter > 0) the warming label gives way to the real state.
+func TestNwgCardStatus_WarmupVsRealStates(t *testing.T) {
+	cases := []struct {
+		name                       string
+		status                     string
+		failCount, successCount    int
+		bound, restartDetected     bool
+		want                       string
+	}{
+		{"fresh warmup fail/0/0", "fail", 0, 0, true, false, "warming"},
+		{"warmup empty status", "", 0, 0, true, false, "warming"},
+		{"real failing", "fail", 2, 0, true, false, "recovering"},
+		{"post-restart zeroed", "fail", 0, 0, true, true, "recovering"},
+		{"passing", "pass", 0, 5, true, false, "alive"},
+		{"first success", "pass", 0, 1, true, false, "alive"},
+		{"not bound", "fail", 0, 0, false, false, "stopped"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := nwgCardStatus(c.status, c.failCount, c.successCount, c.bound, c.restartDetected)
+			if got != c.want {
+				t.Errorf("nwgCardStatus(%q,%d,%d,%v,%v) = %q, want %q",
+					c.status, c.failCount, c.successCount, c.bound, c.restartDetected, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/pingcheck/nwg_monitor.go
+++ b/internal/pingcheck/nwg_monitor.go
@@ -87,28 +87,41 @@ func (m *nwgMonitor) processDelta(failCount, successCount int, status string, bo
 		m.initialized = true
 		m.startupPhase = true
 
-		success := status != "fail"
-		entry := LogEntry{
-			Timestamp:   time.Now(),
-			TunnelID:    m.tunnelID,
-			TunnelName:  m.tunnelName,
-			Backend:     "nativewg",
-			Success:     success,
-			Latency:     latency,
-			FailCount:   failCount,
-			Threshold:   m.threshold,
-			StateChange: "initial",
+		// Warmup: a freshly started tunnel reports NDMS's provisional fail/0/0
+		// before the check interval has ticked. That is not a real failure, so
+		// emit NO initial log entry (a bogus "✗" would drive the UI to 100% loss
+		// and a red history bar) and publish a neutral "" status so dnsroute
+		// failover does not treat the warmup as down. The first real check
+		// (fail or success counter > 0) flows through the delta path below.
+		warmup := status == "fail" && failCount == 0 && successCount == 0
+		if !warmup {
+			success := status != "fail"
+			entry := LogEntry{
+				Timestamp:   time.Now(),
+				TunnelID:    m.tunnelID,
+				TunnelName:  m.tunnelName,
+				Backend:     "nativewg",
+				Success:     success,
+				Latency:     latency,
+				FailCount:   failCount,
+				Threshold:   m.threshold,
+				StateChange: "initial",
+			}
+			m.logBuffer.Add(entry)
+			m.publishLog(entry)
 		}
-		m.logBuffer.Add(entry)
-		m.publishLog(entry)
 
 		// Still publish current state immediately so internal subscribers
 		// (dnsroute failover) react. Frontend polls the status list; the
 		// invalidation hint below prompts an immediate refetch.
 		if m.bus != nil {
+			publishStatus := status
+			if warmup {
+				publishStatus = "" // pending — not a real fail
+			}
 			m.bus.Publish("pingcheck:state", events.PingCheckStateEvent{
 				TunnelID:     m.tunnelID,
-				Status:       status,
+				Status:       publishStatus,
 				FailCount:    failCount,
 				SuccessCount: successCount,
 			})

--- a/internal/pingcheck/nwg_monitor_test.go
+++ b/internal/pingcheck/nwg_monitor_test.go
@@ -52,13 +52,14 @@ func TestNwgDelta_FailIncrement(t *testing.T) {
 	defer buf.Stop()
 	m := newTestNwgMonitor(buf)
 
-	// Baseline with status "fail" so no state change on next poll.
+	// Baseline with status "fail"/0/0 — a warmup poll that emits NO initial
+	// entry (provisional NDMS fail before the interval ticks).
 	m.processDelta(0, 0, "fail", true)
 
 	// 2 new failures, same status — no state change entry.
 	m.processDelta(2, 0, "fail", true)
-	if buf.Len() != 3 {
-		t.Fatalf("got %d entries, want 3 (INIT + 2 fails)", buf.Len())
+	if buf.Len() != 2 {
+		t.Fatalf("got %d entries, want 2 (warmup suppressed + 2 fails)", buf.Len())
 	}
 
 	entries := buf.GetAll()
@@ -241,5 +242,38 @@ func TestNwgDelta_StartupMixedDelta_SuppressesTransientFail(t *testing.T) {
 	entries := buf.GetAll()
 	if !entries[0].Success {
 		t.Fatalf("got transient fail, want success-only entry")
+	}
+}
+
+// TestNwgDelta_WarmupFirstPoll_NoFailEntry verifies that the very first poll of
+// a freshly started tunnel — NDMS reports the provisional fail/0/0 before the
+// interval has ticked — does NOT emit a fail log entry. A bogus "✗" entry would
+// otherwise drive the UI to 100% loss and a red history bar on a healthy tunnel.
+func TestNwgDelta_WarmupFirstPoll_NoFailEntry(t *testing.T) {
+	buf := NewLogBuffer()
+	defer buf.Stop()
+	m := newTestNwgMonitor(buf)
+
+	m.processDelta(0, 0, "fail", true) // fresh-start warmup
+
+	if buf.Len() != 0 {
+		t.Fatalf("warmup first poll must emit no log entry, got %d: %+v", buf.Len(), buf.GetAll())
+	}
+	if !m.initialized {
+		t.Error("baseline must still be initialized after warmup poll")
+	}
+}
+
+// TestNwgDelta_NonWarmupFirstPoll_EmitsInitial confirms a first poll that is
+// already healthy still emits its initial entry (unchanged behavior).
+func TestNwgDelta_NonWarmupFirstPoll_EmitsInitial(t *testing.T) {
+	buf := NewLogBuffer()
+	defer buf.Stop()
+	m := newTestNwgMonitor(buf)
+
+	m.processDelta(0, 1, "pass", true)
+
+	if buf.Len() != 1 {
+		t.Fatalf("healthy first poll must emit 1 initial entry, got %d", buf.Len())
 	}
 }


### PR DESCRIPTION
Свежезапущенный nativewg-туннель: NDMS отдаёт status=fail при нулевых счётчиках (интервал ещё не оттикал) — это не реальный отказ. На карточке теперь статус «ждём первого интервала» (warming), а первый опрос монитора не пишет ложную fail-запись в журнал (убирает LOSS 100% и красную полосу) и публикует нейтральное состояние. После первой реальной проверки надпись уходит. + тесты.