### PR TITLE
Селективный перехват TPROXY через ipset

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -57,6 +57,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
 	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 	"github.com/hoaxisr/awg-manager/internal/singbox/subscription"
 	"github.com/hoaxisr/awg-manager/internal/staticroute"
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -120,6 +121,16 @@ func detectArch() string {
 		return "aarch64-3.10"
 	}
 	return ""
+}
+
+func applyGoMemoryLimits(disableMemorySaving bool) {
+	for _, entry := range osdetect.GetGCEnv(disableMemorySaving) {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 || os.Getenv(parts[0]) != "" {
+			continue
+		}
+		_ = os.Setenv(parts[0], parts[1])
+	}
 }
 
 // deviceproxySubscriptionOutboundsAdapter adapts *subscription.Service to
@@ -286,6 +297,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to load settings: %v\n", err)
 		os.Exit(1)
 	}
+	applyGoMemoryLimits(settings.DisableMemorySaving)
 
 	awgStore := storage.NewAWGTunnelStore(
 		filepath.Join(*dataDir, "tunnels"),
@@ -1192,11 +1204,51 @@ func main() {
 			p.CachePath = singbox.DefaultCacheDBPath()
 			return p
 		}(),
+		ClashHealthy: func() bool {
+			return singboxOp.Clash().IsHealthy()
+		},
 	})
+	// Wire selective-bypass builder. The adapter wraps selective.Builder with the
+	// router service's live config so reconcileInstalled can trigger an ipset
+	// rebuild with a single Rebuild(ctx) call.
+	selectiveGeo := selective.GeoPaths{}
+	if geoCfg, err := hydraroute.ReadConfig(); err == nil {
+		selectiveGeo.GeoSite = geoCfg.GeoSiteFiles
+		selectiveGeo.GeoIP = geoCfg.GeoIPFiles
+	}
+	selectiveBuilder := selective.NewBuilder(selective.BuilderConfig{
+		ConfigDir:         singboxOp.ConfigDir(),
+		DNSSource:         ndmsQueries.DNSProxyStatus,
+		Log:               logging.NewScopedLogger(loggingService, logging.GroupRouting, logging.SubSelective),
+		Bus:               eventBus,
+		Geo:               selectiveGeo,
+		OpenRuleSetJSON:   routerSvc.OpenSelectiveRuleSetJSON,
+	})
+	selectiveAdapter := router.NewSelectiveBuilderAdapter(routerSvc, selectiveBuilder)
+	routerSvc.SetSelectiveBuilder(selectiveAdapter)
+	srv.SetSelectiveHandler(api.NewSelectiveHandler(
+		settingsStore,
+		singboxOp.ConfigDir(),
+		selectiveAdapter,
+		selectiveBuilder,
+	))
+	selectiveCDNRefresh := selective.StartCDNRefreshLoop(
+		selective.CDNRefreshInterval,
+		func() bool {
+			st, err := settingsStore.Load()
+			if err != nil {
+				return false
+			}
+			return st.SingboxRouter.Enabled && st.SingboxRouter.SelectiveBypass
+		},
+		selectiveAdapter.RefreshCDN,
+		logging.NewScopedLogger(loggingService, logging.GroupRouting, logging.SubSelective),
+	)
+	_ = selectiveCDNRefresh // stopped via process exit; no explicit Stop on shutdown today
+
 	// Exclude interfaces already bound by an existing direct outbound from the
 	// bindable picker (#323). Wired post-construction — needs routerSvc.
-	bindableAdapter.occupiedBinds = func(ctx context.Context) (map[string]bool, error) {
-		obs, err := routerSvc.ListCompositeOutbounds(ctx)
+	bindableAdapter.occupiedBinds = func(ctx context.Context) (map[string]bool, error) {		obs, err := routerSvc.ListCompositeOutbounds(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/debug.md
+++ b/debug.md
@@ -1,534 +1,94 @@
-# DEBUG: Сборка IPK (руководство по командам для слабых ИИ-агентов)
+# feat/tproxy-ipset-selective-bypass — задачи
 
-Ниже ровно те сценарии, по которым уже были успешно собраны пакеты:
-- `awg-manager_2.6.3_mipsel-3.4-kn.ipk` (MIPS)
-- `awg-manager_2.6.3_aarch64-3.10-kn.ipk` (Filogic 820 / ARM64)
-
-## 1. Где запускать
-
-Откройте PowerShell в **корне репозитория** (там, где лежат `scripts`, `VERSION`, `go.mod`).
-
-## 2. Быстрая проверка перед сборкой
-
-```powershell
-go version
-Get-ChildItem scripts
-```
-
-Ожидается:
-- `go version go1.23.12 windows/amd64` (или другой `go1.23.x`)
-- в `scripts` есть `build-ipk.sh`, `build-backend.sh`, `build-frontend.sh`
-
-## 3. Команда сборки IPK для MIPS (однострочная, без хардкода)
-
-```powershell
-$b="$(Split-Path -Parent (Split-Path -Parent (Get-Command git).Source))\bin\bash.exe";$w=(Get-Location).Path;$u="/$($w[0].ToString().ToLowerInvariant())"+$w.Substring(2).Replace('\','/');&$b -lc "cd '$u' && ./scripts/build-ipk.sh mipsel-3.4"
-```
-
-## 4. Что должно получиться
-
-В конце лога должна быть строка вида:
-
-```text
-IPK package created: dist/awg-manager_2.6.3_mipsel-3.4-kn.ipk
-```
-
-Проверка файла:
-
-```powershell
-Get-Item .\dist\awg-manager_2.6.3_mipsel-3.4-kn.ipk
-```
-
-## 5. Команда сборки IPK для Filogic 820 (ARM64)
-
-Filogic 820 собираем как `aarch64-3.10`.
-
-```powershell
-$b="$(Split-Path -Parent (Split-Path -Parent (Get-Command git).Source))\bin\bash.exe";$w=(Get-Location).Path;$u="/$($w[0].ToString().ToLowerInvariant())"+$w.Substring(2).Replace('\','/');&$b -lc "cd '$u' && ./scripts/build-ipk.sh aarch64-3.10"
-```
-
-Ожидаемая строка в конце:
-
-```text
-IPK package created: dist/awg-manager_2.6.3_aarch64-3.10-kn.ipk
-```
-
-Проверка файла:
-
-```powershell
-Get-Item .\dist\awg-manager_2.6.3_aarch64-3.10-kn.ipk
-```
-
-## 6. Если сборка падает с Bash ошибкой на Windows
-
-Ошибка:
-
-```text
-fatal error - couldn't create signal pipe, Win32 error 5
-```
-
-Что делать:
-- перезапустить PowerShell/терминал с повышенными правами
-- повторить нужную однострочную команду из п.3 или п.5
-
-## 7. Если ругается на CRLF в shell-скриптах
-
-Проверить `.gitattributes`:
-
-```text
-*.sh text eol=lf
-```
-
-И пересохранить `scripts/*.sh` в LF (не CRLF), затем снова выполнить сборку.
-
-## 8. Замечания
-
-- Предупреждения Svelte/a11y при `npm run build` допустимы, если итоговый `.ipk` создан.
-- Для Keenetic MIPS целевой арх — `mipsel-3.4`.
-- Для Filogic 820 целевой арх — `aarch64-3.10`.
-- Версия пакета берётся из файла `VERSION`.
-- **Как это работает:** Команда сама находит `git.exe` в системе, от него добирается до `bash.exe` из состава Git for Windows, конвертирует текущую папку в Unix‑путь и запускает сборочный скрипт. WSL‑bash не используется.
-
-## 9. Установка IPK на роутер (если файл уже в `/opt/tmp`)
-
-Пример для Filogic 820:
-`/opt/tmp/awg-manager_2.6.3_aarch64-3.10-kn.ipk`
-
-Команды на роутере:
-
-```sh
-# остановить сервис
-/opt/etc/init.d/S99awg-manager stop
-
-# установить/переустановить пакет
-opkg install /opt/tmp/awg-manager_2.6.3_aarch64-3.10-kn.ipk --force-reinstall
-
-# запустить сервис
-/opt/etc/init.d/S99awg-manager start
-
-# проверить статус
-/opt/etc/init.d/S99awg-manager status
-```
-
-## 10. Обновление программы на роутере из консоли (без потери данных)
-
-Фронтенд обновляет программу через API `/api/system/update/apply`, которое скачивает IPK из GitHub релизов и устанавливает его через `opkg install`. Данные не теряются, так как конфиги хранятся в `/opt/etc` и `/opt/var`, которые opkg не трогает.
-
-Чтобы обновить вручную из консоли роутера:
-
-1. **Найти URL IPK для вашей архитектуры:**
-   - Перейдите на https://github.com/hoaxisr/awg-manager/releases
-   - Скачайте подходящий `.ipk` файл (например, `awg-manager_2.8.3_mipsel-3.4-kn.ipk` для MIPS Keenetic или `awg-manager_2.8.3_aarch64-3.10-kn.ipk` для ARM64 Filogic).
-
-2. **Скопировать IPK на роутер:**
-   - Используйте `scp` или загрузите по HTTP в `/opt/tmp/`.
-
-3. **Команды обновления на роутере:**
-   ```sh
-   # Остановить сервис (рекомендуется)
-   /opt/etc/init.d/S99awg-manager stop
-
-   # Установить новый IPK (автоматически обновит существующий пакет)
-   opkg install /opt/tmp/awg-manager_2.8.3_mipsel-3.4-kn.ipk
-
-   # Запустить сервис
-   /opt/etc/init.d/S99awg-manager start
-
-   # Проверить статус
-   /opt/etc/init.d/S99awg-manager status
-
-   # Очистить временный файл
-   rm /opt/tmp/awg-manager_2.8.3_mipsel-3.4-kn.ipk
-   ```
-
-**Примечания:**
-- Сервис перезапускается автоматически после установки пакета.
-- Если обновление прервётся, данные останутся нетронутыми.
-- Для автоматического обновления используйте фронтенд (кнопка "Обновить").
-- Версия берётся из файла `VERSION` в репозитории.
+## Уже сделано
+- [x] Поддержка диапазонов портов в исключениях (`5000-5500 UDP`)
+  - Go: `PortRange` тип, `parseExtraPorts`, iptables `--dport N:M`
+  - Frontend: `ports.ts` (from/to), `PortChipsInput.svelte`, подсказка в StatusDrawer
 
 ---
 
-## 11. Проверки и тесты backend на Win11 (правильный Linux-рантайм)
-
-### Приоритет запуска (обязательно)
-
-Для backend-тестов в этом репозитории **всегда сначала использовать**:
-
-```powershell
-scripts\dev\dev-backend-tests.bat
-```
-
-И только если этот скрипт недоступен/сломался локально — использовать `docker run ... go test ...` как fallback.
-
-Порядок приоритета:
-
-1. `scripts\dev\dev-backend-tests.bat` (основной путь, приоритетный)
-2. `docker run ... go test ...` (запасной путь)
-
-### Зачем это нужно
-
-На Win11 часть backend-тестов (особенно под Linux/Keenetic) может давать ложные падения, если запускать их:
-- напрямую через `go test` в PowerShell (Windows-бинарь `go.exe` пытается выполнить Linux test binary),
-- через WSL без установленного Go,
-- через Git Bash с `bash -lc` (login-shell может сломать `PATH` внутри контейнера).
-
-Надёжный способ в проекте: запускать тесты через `scripts\dev\dev-backend-tests.bat`, который уже обслуживает правильное окружение.  
-Прямой `docker run` — только запасной вариант.
-
-### Рекомендуемые команды (через project script)
-
-Из корня репозитория:
-
-```powershell
-scripts\dev\dev-backend-tests.bat status
-scripts\dev\dev-backend-tests.bat start
-scripts\dev\dev-backend-tests.bat run ./internal/orchestrator
-scripts\dev\dev-backend-tests.bat full
-scripts\dev\dev-backend-tests.bat stop
-```
-
-### Fallback: базовая команда Docker (только если script недоступен)
-
-Из корня репозитория:
-
-```powershell
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'go test ./internal/orchestrator'
-```
-
-### Важно для Codex/песочницы
-
-Если тесты запускаются из Codex-агента с sandbox-ограничениями, Docker-команды нужно выполнять **с выходом из песочницы** (escalated permissions).  
-Иначе возможна ошибка доступа к Docker daemon:
-
-```text
-permission denied while trying to connect to the docker API at npipe:////./pipe/docker_engine
-```
-
-Ожидаемый результат:
-
-```text
-ok  	github.com/hoaxisr/awg-manager/internal/orchestrator	0.0xxs
-```
-
-### Fallback: точечный запуск одного теста
-
-```powershell
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'go test ./internal/orchestrator -run TestDecide_Reconnect_ASCSoftRestart_MonitoringRestartedOnce'
-```
-
-### Важный нюанс: `bash -c`, не `bash -lc`
-
-Использовать нужно `bash -c`.  
-`bash -lc` в этом окружении может обнулить/урезать `PATH`, и тогда даже в образе `golang:*` появляется ошибка:
-
-```text
-bash: line 1: go: command not found
-```
-
-### Быстрый self-check окружения контейнера
-
-Если сомневаетесь, что Go виден:
-
-```powershell
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'command -v go && go version'
-```
-
-Ожидается:
-- путь `/usr/local/go/bin/go`
-- версия `go1.24.x linux/amd64`
-
-### Типовые ошибки и что они значат
-
-1. `%1 is not a valid Win32 application`  
-Причина: Windows `go.exe` собрал Linux test binary и пытается запустить его в Windows.
-
-2. `go: command not found` в WSL  
-Причина: в конкретном WSL-дистрибутиве не установлен Go.
-
-3. `go: command not found` в `golang:*` контейнере  
-Обычно это следствие `bash -lc` (сломанный `PATH`), переключиться на `bash -c`.
-
-4. `fatal error - couldn't create signal pipe, Win32 error 5`  
-Это проблема запуска Git Bash/прав, не проблема кода теста.
-
-### Практический вывод для проекта
-
-- Сборка IPK остаётся через Git Bash (как в `scripts/build-all-ipk.bat`).
-- На **Windows 11** (локальная разработка) backend-тесты под Linux/Keenetic выполняем **только** через Docker `golang:*` + `bash -c` (или через `dev-backend-tests.bat`).
-- На **нативном Linux**, в WSL с установленным Go и в CI — можно и нужно использовать обычный `go test ./...` напрямую (это эталон).
-- Автоматизация на Windows — через `scripts\dev\dev-backend-tests.bat` (постоянный контейнер + кэши).
-
-### Подход к запуску backend-тестов (обязательно)
-
-Полный прогон `go test ./...` в Docker — дорогая операция (обычно 5+ минут).  
-Чтобы не терять время и не перегружать цикл отладки, используем строгий порядок:
-
-1. Сначала **точечные тесты** только по изменённым пакетам/файлам.
-2. Если точечные тесты падают — **фикс и повтор только точечных** тестов.
-3. Полный `go test ./...` запускать **только на финише**, когда точечные тесты уже зелёные.
-4. Если упал полный прогон:
-   - не гонять его по кругу;
-   - выделить проблемный пакет/тест;
-   - отлаживать его точечно;
-   - после фикса снова один финальный полный прогон.
-
-Рекомендуемая последовательность:
-
-```powershell
-# 1) Точечно (пример)
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'go test ./internal/managed ./internal/api'
-
-# 2) Отдельно упавший пакет/тест (пример)
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'go test ./internal/sys/httpdownload -run TestReader_EmitsAfterByteThreshold'
-
-# 3) Только в конце — полный прогон
-docker run --rm -v "$(Get-Location):/src" -w /src golang:1.24-bullseye bash -c 'go test ./...'
-```
-
-### Более прогрессивный путь запуска backend-тестов
-
-Теперь в проекте есть ускоренный раннер:
-
-```powershell
-scripts\dev\dev-backend-tests.bat
-```
-
-Что он делает:
-- держит постоянный Docker-контейнер для тестов (без пересоздания на каждый запуск);
-- использует постоянные кэши `GOCACHE` и `GOMODCACHE`;
-- поддерживает точечные и полные прогоны в едином формате;
-- по умолчанию запускает тесты с `-count=1`, чтобы не получать ложноположительные результаты из test-cache.
-
-Базовые команды:
-
-```powershell
-# поднять раннер (один раз на сессию)
-scripts\dev\dev-backend-tests.bat start
-
-# статус раннера
-scripts\dev\dev-backend-tests.bat status
-
-# открыть интерактивную bash внутри раннера (для ручной отладки, go list, ps и т.д.)
-scripts\dev\dev-backend-tests.bat shell
-
-# точечный прогон пакета
-scripts\dev\dev-backend-tests.bat run ./internal/managed
-
-# точечный прогон одного теста
-scripts\dev\dev-backend-tests.bat run ./internal/sys/httpdownload -run TestReader_EmitsAfterByteThreshold
-
-# полный прогон (только на финише)
-scripts\dev\dev-backend-tests.bat full
-
-# остановить раннер после работы
-scripts\dev\dev-backend-tests.bat stop
-```
-
-### Coverage baseline через dev-runner
-
-Для локального baseline покрытия backend используйте отдельную команду раннера:
-
-```powershell
-scripts\dev\dev-backend-tests.bat coverage
-```
-
-Что делает команда:
-- запускает backend-тесты с `-count=1`;
-- собирает профиль покрытия `coverage.out`;
-- генерирует сводку `go tool cover -func` в `coverage.txt`;
-- генерирует HTML-отчёт `coverage.html` для визуального просмотра.
-
-Быстрая проверка после прогона:
-
-```powershell
-Test-Path coverage.out
-Test-Path coverage.txt
-Test-Path coverage.html
-Get-Content coverage.txt | Select-String "total:"
-```
-
-Рекомендуемый workflow:
-1. Во время отладки использовать `run` только по изменённым пакетам/тестам.
-2. `full` запускать один раз в конце, когда точечные прогоны уже зелёные.
-3. Если `full` упал — снова вернуться к точечному `run`, исправить, и только потом повторить `full`.
-
-### Тесты в CI (GitHub Actions)
-
-В настоящем Linux-окружении (ubuntu-latest в GitHub Actions) тесты выполняются **нативно** (без Docker):
-
-- Backend: `go test ./...`
-- Frontend: `cd frontend && npm ci && npx vitest run`
-
-См. job `test` в `.github/workflows/build.yml`.
-
-CI — это эталонная проверка для всего, что зависит от Linux/Keenetic (ndms, iptables, sing-box, ASC и т.д.). Прогоняется автоматически на каждый push и PR.
+## Бэкенд
+
+### 1–5. `internal/singbox/router/selective/`
+- [x] `deps_check.go` — `IsIPSetAvailable`, `IsXtSetAvailable`, `InstallIPSet`, `EnsureXtSetModule`
+- [x] `ipset.go` — `CreateSet`, `DestroySet`, `FlushSet`, `AddEntries`, `SetExists`, `EntryCount`, `SetName`
+- [x] `collector.go` — `CollectFromRules`, `CollectResult`, inline/dat rule-set JSON парсинг
+- [x] `resolver.go` — `ResolveDomains`, `BuildDNSServers` (приоритет singbox→NDMS→system)
+- [x] `builder.go` — `Builder.Rebuild`, `Progress`, `EventPublisher`, SSE публикация
+- [x] `errors.go` — `ErrOpkgNotFound`, `ErrIPSetNotAvailable`, `ErrXtSetNotAvailable`
+
+### 6. `internal/storage/types.go`
+- [x] `SelectiveBypass bool` в `SingboxRouterSettings`
+
+### 7. `internal/singbox/router/iptables.go`
+- [x] `SelectiveIPSet bool` в `RestoreInputSpec`
+- [x] guard-правила `-m set ! --match-set AWGM-SELECTIVE dst -j RETURN` в обеих цепочках (после DNS, перед catch-all)
+- [x] `selectiveSetName` константа
+
+### 8. `internal/singbox/router/iptables_test.go`
+- [x] `TestBuildRestoreInput_SelectiveIPSet_AddsGuardRules`
+- [x] `TestBuildRestoreInput_SelectiveIPSet_Disabled_NoGuardRules`
+- [x] `TestBuildRestoreInput_SelectiveIPSet_GuardAfterDNS`
+
+### 9. `internal/singbox/router/service.go` + `service_selective.go`
+- [x] `SelectiveBuilder`, `SelectiveDNSSource` интерфейсы в Deps
+- [x] `currentSelectiveBypass`, `currentRulesHash` tracking-поля в ServiceImpl
+- [x] `selectiveChanged` детект в `reconcileInstalled`
+- [x] `SelectiveIPSet: sr.SelectiveBypass` в `RestoreInputSpec`
+- [x] `destroySelectiveSet` при отключении
+- [x] `triggerSelectiveRebuild` (async) при включении или изменении правил
+- [x] `rulesHash` для детекта изменений правил
+
+### 10. `internal/events/types.go`
+- [x] `SelectiveProgressEvent`
+- [x] `SelectiveStatusEvent`
+
+### 11. `internal/api/singbox_selective.go` + `internal/server/server.go`
+- [x] `GET  /api/singbox/router/selective/status`
+- [x] `POST /api/singbox/router/selective/install-deps`
+- [x] `POST /api/singbox/router/selective/rebuild`
+- [x] `selectiveHandler` поле + сеттер + регистрация маршрутов в server.go
 
 ---
 
-## 12. Swagger, mock-server и правило для новых endpoint
+## Фронтенд
 
-Важно: в проекте OpenAPI-спека **автогенерируется из Go-аннотаций**.
-Источник автогена:
+### 12. `frontend/src/lib/types.ts`
+- [x] `SelectiveStatus` interface
+- [x] `SelectiveProgress` interface
+- [x] `selectiveBypass?: boolean` в `SingboxRouterSettings`
 
-- `cmd/awg-manager/docs.go`
-- директива: `//go:generate ... swag ... -o ../../internal/openapi --ot yaml`
+### 13. `frontend/src/lib/api/client.ts`
+- [x] `singboxRouterSelectiveStatus()`
+- [x] `singboxRouterSelectiveInstallDeps()`
+- [x] `singboxRouterSelectiveRebuild()`
 
-Это означает:
+### 14. `frontend/src/lib/api/events.ts`
+- [x] `onSingboxRouterSelectiveProgress`
+- [x] `onSingboxRouterSelectiveStatus`
+- [x] зарегистрированы в `connectSSE`
 
-1. Для каждого нового endpoint (или изменения старого) в `internal/api/*.go` нужно обновлять swagger-аннотации (`@Summary`, `@Tags`, `@Param`, `@Success`, `@Failure`, `@Router` и т.д.).
-2. В конце работы по фиче обязательно запускать:
+### 15. `frontend/src/lib/stores/selectiveBypass.ts`
+- [x] store с `status`, `progress`, `applyStatus`, `applyProgress`
 
-```powershell
-go generate ./cmd/awg-manager
-```
+### 16. `frontend/src/routes/+layout.svelte`
+- [x] SSE wiring: `onSingboxRouterSelectiveProgress` → `selectiveBypass.applyProgress`
+- [x] SSE wiring: `onSingboxRouterSelectiveStatus` → `selectiveBypass.applyStatus`
 
-3. Если изменился файл `internal/openapi/swagger.yaml`, его нужно включать в коммит вместе с кодом endpoint.
+### 17. `frontend/src/lib/components/sb-router/SelectiveRebuildModal.svelte`
+- [x] Модалка с 3 шагами (collecting / resolving / populating)
+- [x] Итог: done (зелёный) / error (красный)
+- [x] Кнопка «Закрыть» после завершения
 
-Практическое правило:
-
-- Не редактировать `internal/openapi/swagger.yaml` руками.
-- Если swagger «поправлен вручную», это ошибка процесса: правильный источник истины — Go-аннотации в `internal/api`.
-
-Почему это критично:
-
-- Mock-server/UI docs опираются на актуальную OpenAPI-спеку.
-- Если аннотации не обновлены и `go generate` не прогнан, новые поля/эндпоинты (например, данные роутера в Настройках) не мокируются корректно.
-
-### Mock KeeneticOS и extended ASC (frontend mock-proxy)
-
-Локальный `frontend/scripts/mock-proxy.mjs` (порт **8081**) подменяет часть ответов поверх Prism. Для ASC важно, какую версию KeeneticOS «видит» UI:
-
-| Профиль | `supportsExtendedASC` | Поля ASC в mock |
-|---------|----------------------|-----------------|
-| **5.1** (дефолт) | `true` | Jc–H4, S1–S4, I1–I5 |
-| **5.0** | `false` | только Jc–H4, S1–S2 |
-
-По умолчанию mock стартует с **KeeneticOS 5.1** (extended ASC включён).
-
-**Зафиксировать версию при запуске** (до старта mock-proxy / `yarn dev`):
-
-```bash
-MOCK_KEENETIC_OS=5.0 yarn dev   # базовый ASC (9 полей)
-MOCK_KEENETIC_OS=5.1 yarn dev   # extended ASC (16 полей), то же что дефолт
-```
-
-**Переключить в runtime** (mock-proxy уже запущен):
-
-```bash
-# Явно 5.0 или 5.1
-curl -X POST http://127.0.0.1:8081/__mock/keenetic-os \
-  -H 'Content-Type: application/json' -d '{"version":"5.0"}'
-
-curl -X POST http://127.0.0.1:8081/__mock/keenetic-os \
-  -H 'Content-Type: application/json' -d '{"version":"5.1"}'
-
-# Сброс к дефолту (5.1 или значение из MOCK_KEENETIC_OS, если было задано при старте)
-curl -X POST http://127.0.0.1:8081/__mock/keenetic-os
-```
-
-Текущее состояние также видно в `GET /__mock/capabilities` → `state.keeneticOS`, `state.supportsExtendedASC`.
-
-`POST /__mock/reset-runtime` сбрасывает runtime-фикстуры и возвращает KeeneticOS к дефолту.
-
-Затронутые mock-endpoint'ы ASC:
-
-- `GET/PUT /managed-servers/{id}/asc`
-- `GET/PUT /system-tunnels/asc?name=...`
-- `GET /system/info` (`supportsExtendedASC`, `supportsHRanges`, `firmwareVersion`)
+### 18. `frontend/src/lib/components/sb-router/StatusDrawer.svelte`
+- [x] Секция «Селективный перехват» в expert-режиме
+- [x] Toggle disabled когда `!available`
+- [x] Если `!available`: текст + кнопка «Установить ipset»
+- [x] Если `available && enabled`: счётчик записей + дата обновления + кнопка «Пересобрать»
+- [x] SelectiveRebuildModal подключён
 
 ---
 
-## 13. Git safety (RO по умолчанию)
+## Осталось
 
-Правило безопасности для работы ИИ-агента:
-
-- По умолчанию Git используется **только в read-only режиме**.
-- Любые изменяющие Git-действия (`commit`, `push`, `merge`, `rebase`, `reset`, `checkout -b`, удаление веток, правка истории) выполнять **только после прямого явного запроса пользователя**.
-
-Разрешено без отдельного запроса:
-
-- `git status`, `git log`, `git show`, `git diff`, `git branch --show-current`, `git remote -v` и другие команды чтения.
-
-Запрещено без отдельного запроса:
-
-- Любые команды, меняющие рабочее дерево, индекс, коммиты, ветки или удалённый репозиторий.
-
----
-
-## 14. `git diff` и почему файл может быть `0 байт`
-
-Если выполнить:
-
-```powershell
-git diff > diff.md
-```
-
-и `diff.md` получился `0 байт`, это обычно означает:
-
-- нет **unstaged** изменений (рабочее дерево чистое), или
-- все изменения уже добавлены в индекс (`staged`), и `git diff` их не показывает.
-
-Полезные команды:
-
-```powershell
-# 1) Только unstaged изменения (рабочее дерево)
-git diff > diff_unstaged.md
-
-# 2) Только staged изменения (индекс)
-git diff --cached > diff_staged.md
-
-# 3) Все изменения относительно последнего коммита (unstaged + staged)
-git diff HEAD > diff_all.md
-
-# 4) Быстрая проверка текущего состояния
-git status
-```
-
-Практика для проекта:
-
-- если нужен «полный дифф текущей работы» — используйте `git diff HEAD > diff_all.md`;
-- если нужен дифф «только что ещё не добавлено» — `git diff > diff_unstaged.md`;
-- если нужен дифф «что уже в staged» — `git diff --cached > diff_staged.md`.
-
----
-
-## 15. Рекомендации по запуску frontend-тестов (Win11/PowerShell)
-
-Все frontend-проверки и тесты запускаются из папки `frontend`.
-
-### Проверка типов / Svelte / a11y (svelte-check)
-
-```powershell
-cd frontend
-& "C:\Program Files\nodejs\npm.cmd" run check
-```
-
-Запускает `svelte-kit sync && svelte-check --tsconfig ./tsconfig.json`.
-Выводит количество ошибок и предупреждений. Цель — 0 errors, 0 warnings.
-
-### Запуск vitest (unit-тесты компонентов и утилит)
-
-```powershell
-cd frontend
-npm exec -- vitest run
-```
-
-- Без параметров — прогоняет **все** тесты (23 файла, 177+ тестов на май 2026).
-- Конкретный файл:
-  ```powershell
-  cd frontend; npm exec -- vitest run src/lib/utils/singboxInlineRules.test.ts
-  ```
-- Конкретный тест по названию:
-  ```powershell
-  npm exec -- vitest run ... -t "название теста или часть"
-  ```
-
-**Полная проверка фронтенда (перед коммитом / PR):**
-
-1. `npm run check`
-2. `npm exec -- vitest run`
-
-Оба шага должны завершаться успешно (зелёный).
-
-Примечание: в `frontend/package.json` нет скрипта `"test"`. Vitest всегда вызывается через `npm exec -- vitest run`.
+Всё выполнено ✅

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -99,6 +99,7 @@ import type {
 	RestoreOptions,
 	DnsProxyInfo,
 	CatalogPreset,
+	SelectiveStatus,
 } from '$lib/types';
 import { sanitizeDnsServerForApi } from '$lib/utils/dnsServerDetour';
 import { isMockDevMode as envIsMockDevMode } from '$lib/env';
@@ -174,12 +175,22 @@ class ApiClient {
 			throw new Error('Сессия истекла');
 		}
 
-		// Handle 503 Service Unavailable
+		const contentType = response.headers.get('content-type') || '';
+
+		// Handle 503 Service Unavailable — preserve server message when present.
 		if (response.status === 503) {
-			throw new Error('Сервер временно недоступен');
+			let message = 'Сервер временно недоступен';
+			if (contentType.includes('application/json')) {
+				try {
+					const body = (await response.json()) as ApiResponse<unknown>;
+					if (body.message) message = body.message;
+				} catch {
+					// keep default
+				}
+			}
+			throw new Error(message);
 		}
 
-		const contentType = response.headers.get('content-type') || '';
 		if (!contentType.includes('application/json')) {
 			const text = await response.text();
 			throw new Error(`Ошибка сервера (${response.status}): ${text.substring(0, 100)}`);
@@ -2202,6 +2213,38 @@ class ApiClient {
 			method: 'POST',
 		});
 	}
+
+	// #endregion
+
+	// ─────────────────────────────────────────────
+	// #region Selective Bypass
+	// ─────────────────────────────────────────────
+
+	async singboxRouterSelectiveStatus(): Promise<SelectiveStatus> {
+		return this.request('/singbox/router/selective/status');
+	}
+
+	async singboxRouterSelectiveInstallDeps(): Promise<SelectiveStatus> {
+		return this.request('/singbox/router/selective/install-deps', { method: 'POST' });
+	}
+
+	async singboxRouterSelectiveInstallConntrack(): Promise<SelectiveStatus> {
+		return this.request('/singbox/router/selective/install-conntrack', { method: 'POST' });
+	}
+
+	async singboxRouterSelectiveRebuild(): Promise<SelectiveStatus> {
+		return this.request('/singbox/router/selective/rebuild', { method: 'POST' });
+	}
+
+	async singboxRouterSelectiveSnapshotMatchers(
+		offset = 0,
+		limit = 100,
+	): Promise<{ matchers: import('$lib/types').SelectiveDomainMatcherRecord[]; total: number }> {
+		const q = new URLSearchParams({ offset: String(offset), limit: String(limit) });
+		return this.request(`/singbox/router/selective/snapshot/matchers?${q}`);
+	}
+
+	// #endregion
 
 	// #region FakeIP config CRUD
 

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -134,6 +134,12 @@ export interface SSEEventHandlers {
 
 	// Monitoring matrix snapshot (every scheduler tick).
 	onMonitoringMatrixUpdate?: (data: MonitoringSnapshot) => void;
+
+	// Selective-bypass: ipset rebuild progress (singbox-router:selective-progress).
+	onSingboxRouterSelectiveProgress?: (data: import('$lib/types').SelectiveProgress) => void;
+
+	// Selective-bypass: status update after rebuild or install (singbox-router:selective-status).
+	onSingboxRouterSelectiveStatus?: (data: import('$lib/types').SelectiveStatus) => void;
 }
 
 export function parseConnectedEvent(data: string): { ok?: boolean; instanceId?: string } | undefined {
@@ -199,6 +205,10 @@ export function connectSSE(handlers: SSEEventHandlers): () => void {
 
 	// Monitoring matrix snapshots
 	handle('monitoring:matrix-update', handlers.onMonitoringMatrixUpdate);
+
+	// Selective-bypass progress and status
+	handle('singbox-router:selective-progress', handlers.onSingboxRouterSelectiveProgress);
+	handle('singbox-router:selective-status', handlers.onSingboxRouterSelectiveStatus);
 
 	// Server sends "connected" event immediately on stream start
 	es.addEventListener('connected', ((e: MessageEvent) => {

--- a/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
+++ b/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
@@ -47,6 +47,7 @@
     'access-policy': 'Access policies',
     'client-route': 'Per-client routes',
     'singbox-router': 'Sing-box router',
+    selective: 'Селективный ipset',
     deviceproxy: 'Device proxy',
     hrneo: 'HrNeo',
     catalog: 'Каталог',

--- a/frontend/src/lib/components/fakeip/SwitchProgress.svelte
+++ b/frontend/src/lib/components/fakeip/SwitchProgress.svelte
@@ -11,22 +11,22 @@
 
 	interface Props {
 		open: boolean;
-		state: FakeIPTransitionState | null;
+		transitionState: FakeIPTransitionState | null;
 		onClose: () => void;
 	}
 
-	let { open, state, onClose }: Props = $props();
+	let { open, transitionState, onClose }: Props = $props();
 
-	const done = $derived(state?.done ?? false);
-	const succeeded = $derived(done && state != null && state.finalState === state.to);
+	const done = $derived(transitionState?.done ?? false);
+	const succeeded = $derived(done && transitionState != null && transitionState.finalState === transitionState.to);
 	const failed = $derived(done && !succeeded);
 
-	const fromMode = $derived((state?.from ?? 'tproxy') as FakeIPMode);
-	const toMode = $derived((state?.to ?? 'fakeip-tun') as FakeIPMode);
+	const fromMode = $derived((transitionState?.from ?? 'tproxy') as FakeIPMode);
+	const toMode = $derived((transitionState?.to ?? 'fakeip-tun') as FakeIPMode);
 	const title = $derived(`Переключение: ${humanLabel(fromMode)} → ${humanLabel(toMode)}`);
 
-	const rows = $derived(deriveSteps(fromMode, toMode, state?.steps ?? [], { failed }));
-	const finalLabel = $derived(humanLabel((state?.finalState as FakeIPMode) ?? fromMode));
+	const rows = $derived(deriveSteps(fromMode, toMode, transitionState?.steps ?? [], { failed }));
+	const finalLabel = $derived(humanLabel((transitionState?.finalState as FakeIPMode) ?? fromMode));
 	const failedRow = $derived(rows.find((r) => r.state === 'error') ?? null);
 </script>
 
@@ -42,7 +42,11 @@
 				</span>
 				<span class="text">
 					<span class="title">{row.title}</span>
-					{#if row.detail}<span class="detail">{row.detail}</span>{/if}
+					{#if row.state === 'current' && row.liveMessage}
+						<span class="detail">{row.liveMessage}</span>
+					{:else if row.detail}
+						<span class="detail">{row.detail}</span>
+					{/if}
 				</span>
 			</li>
 		{/each}
@@ -52,7 +56,7 @@
 		<p class="result ok">✓ Режим «{finalLabel}» активен.</p>
 	{:else if failed}
 		<p class="result err">
-			✕ Откат в «{finalLabel}».{#if failedRow}&nbsp;Упавший шаг: {failedRow.title}.{/if}{#if state?.error}&nbsp;{state.error}{/if}
+			✕ Откат в «{finalLabel}».{#if failedRow}&nbsp;Упавший шаг: {failedRow.title}.{/if}{#if transitionState?.error}&nbsp;{transitionState.error}{/if}
 		</p>
 	{/if}
 

--- a/frontend/src/lib/components/fakeip/switchSteps.ts
+++ b/frontend/src/lib/components/fakeip/switchSteps.ts
@@ -24,6 +24,8 @@ export interface UIStepDef {
 
 export interface UIStep extends UIStepDef {
 	state: UIStepState;
+	/** Live detail from the latest SSE event for this milestone (if any). */
+	liveMessage?: string;
 }
 
 // Ordered milestone progression for the lifecycle. Used to decide whether a
@@ -62,7 +64,7 @@ const ENABLE_STEPS: UIStepDef[] = [
 	{
 		milestone: 'readiness',
 		title: 'Перезапуск sing-box',
-		detail: 'ожидаем Clash API',
+		detail: 'ожидаем inbounds (TPROXY/REDIRECT)',
 	},
 	{
 		milestone: 'ready',
@@ -86,7 +88,7 @@ const DISABLE_STEPS: UIStepDef[] = [
 	{
 		milestone: 'readiness',
 		title: 'Перезапуск sing-box',
-		detail: 'ожидаем Clash API',
+		detail: 'ожидаем inbounds (TPROXY/REDIRECT)',
 	},
 	{
 		milestone: 'ready',
@@ -95,19 +97,18 @@ const DISABLE_STEPS: UIStepDef[] = [
 	},
 ];
 
-// TProxy bring-up (off|fakeip-tun → tproxy).
+// TProxy bring-up (off|fakeip-tun → tproxy). Order matches Enable: sing-box
+// readiness first, then iptables install.
 const TPROXY_ENABLE_STEPS: UIStepDef[] = [
 	{ milestone: 'teardown', title: 'Снят предыдущий режим', detail: 'прежние маршруты/перехват убраны (если были)' },
+	{ milestone: 'readiness', title: 'Перезапуск sing-box', detail: 'ожидаем inbounds (TPROXY/REDIRECT)' },
 	{ milestone: 'provision', title: 'iptables TPROXY установлен', detail: 'jumps + AWGM-цепочки' },
-	{ milestone: 'readiness', title: 'Перезапуск sing-box', detail: 'ожидаем Clash API' },
 	{ milestone: 'ready', title: 'Проверка готовности', detail: 'TPROXY-перехват активен' },
 ];
-
-// TProxy switch-out (tproxy → off).
 const TPROXY_DISABLE_STEPS: UIStepDef[] = [
 	{ milestone: 'teardown', title: 'Снят TPROXY-перехват', detail: 'iptables jumps + цепочки убраны' },
 	{ milestone: 'provision', title: 'sing-box перестроен', detail: 'без перехвата' },
-	{ milestone: 'readiness', title: 'Перезапуск sing-box', detail: 'ожидаем Clash API' },
+	{ milestone: 'readiness', title: 'Перезапуск sing-box', detail: 'ожидаем inbounds (TPROXY/REDIRECT)' },
 	{ milestone: 'ready', title: 'Проверка готовности', detail: 'маршрутизация выключена' },
 ];
 
@@ -148,7 +149,13 @@ export function deriveSteps(
 	// Latest status per milestone (events may repeat current→done in place; the
 	// store already upserts, but be defensive and take the last occurrence).
 	const status = new Map<Milestone, SingboxRouterTransitionStep['status']>();
-	for (const s of received) status.set(s.step, s.status);
+	const messages = new Map<Milestone, string>();
+	for (const s of received) {
+		status.set(s.step, s.status);
+		if (s.message) {
+			messages.set(s.step, s.message);
+		}
+	}
 
 	// Highest milestone rank that has reached `done`.
 	let maxDoneRank = -1;
@@ -176,24 +183,25 @@ export function deriveSteps(
 
 	return defs.map((def): UIStep => {
 		const r = rank(def.milestone);
+		const liveMessage = messages.get(def.milestone);
 
 		const isDone = r <= maxDoneRank;
 		if (isDone) {
-			return { ...def, state: 'done' };
+			return { ...def, state: 'done', liveMessage };
 		}
 
 		if (failed) {
 			if (!errorAssigned) {
 				errorAssigned = true;
-				return { ...def, state: 'error' };
+				return { ...def, state: 'error', liveMessage };
 			}
-			return { ...def, state: 'pending' };
+			return { ...def, state: 'pending', liveMessage };
 		}
 
 		if (r === currentRank) {
-			return { ...def, state: 'current' };
+			return { ...def, state: 'current', liveMessage };
 		}
 
-		return { ...def, state: 'pending' };
+		return { ...def, state: 'pending', liveMessage };
 	});
 }

--- a/frontend/src/lib/components/routing/ModeSwitchHost.svelte
+++ b/frontend/src/lib/components/routing/ModeSwitchHost.svelte
@@ -22,6 +22,6 @@
 
 <SwitchProgress
 	open={$modeSwitch.phase === 'running'}
-	state={$fakeipTransition}
+	transitionState={$fakeipTransition}
 	onClose={() => modeSwitch.closeProgress()}
 />

--- a/frontend/src/lib/components/sb-router/ExpertPanel.svelte
+++ b/frontend/src/lib/components/sb-router/ExpertPanel.svelte
@@ -15,6 +15,7 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
   import { subscriptionsStore } from '$lib/stores/subscriptions';
   import { singboxProxies } from '$lib/stores/singboxProxies';
@@ -117,10 +118,14 @@
 
   async function saveRouteFinal() {
     if (!routeFinalDirty || routeFinalBusy) return;
+    const wasSelective = get(singboxRouterStore.settings)?.selectiveBypass ?? false;
     routeFinalBusy = true;
     try {
       await api.singboxRouterPutRouteFinal(draftRouteFinal);
       await singboxRouterStore.loadAll();
+      if (draftRouteFinal !== 'direct' && wasSelective) {
+        notifications.info('Селективный перехват выключен: несовместим с route.final ≠ direct');
+      }
     } catch (e) {
       notifications.error(e instanceof Error ? e.message : String(e));
     } finally {

--- a/frontend/src/lib/components/sb-router/SelectiveIpListSpoiler.svelte
+++ b/frontend/src/lib/components/sb-router/SelectiveIpListSpoiler.svelte
@@ -1,0 +1,78 @@
+<!--
+  Сворачиваемый список IP/CIDR для снимка ipset.
+  Используется в SelectiveIpsetSnapshot (модалка пересборки и «Содержимое ipset»).
+-->
+<script lang="ts">
+  interface Props {
+    items?: string[] | null;
+    /** Текст в заголовке спойлера, напр. «179 подсетей» или «12 IP». */
+    summary: string;
+    /** Раскрыт по умолчанию (для коротких списков при отладке). */
+    defaultOpen?: boolean;
+  }
+  let { items, summary, defaultOpen = false }: Props = $props();
+
+  const safeItems = $derived(items ?? []);
+</script>
+
+{#if safeItems.length === 0}
+  <span class="empty">—</span>
+{:else}
+  <details class="ip-spoiler" open={defaultOpen || undefined}>
+    <summary>{summary}</summary>
+    <ul class="chip-list">
+      {#each safeItems as item (item)}
+        <li>{item}</li>
+      {/each}
+    </ul>
+  </details>
+{/if}
+
+<style>
+  .empty {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .ip-spoiler {
+    margin: 0;
+  }
+  .ip-spoiler summary {
+    cursor: pointer;
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--color-accent, var(--accent));
+    user-select: none;
+    list-style: none;
+    width: fit-content;
+  }
+  .ip-spoiler summary::-webkit-details-marker {
+    display: none;
+  }
+  .ip-spoiler summary::before {
+    content: '▸ ';
+    display: inline-block;
+    transition: transform 0.15s ease;
+    color: var(--text-muted);
+  }
+  .ip-spoiler[open] summary::before {
+    transform: rotate(90deg);
+  }
+  .chip-list {
+    list-style: none;
+    margin: 6px 0 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    max-height: 12rem;
+    overflow-y: auto;
+  }
+  .chip-list li {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+  }
+</style>

--- a/frontend/src/lib/components/sb-router/SelectiveIpsetSnapshot.svelte
+++ b/frontend/src/lib/components/sb-router/SelectiveIpsetSnapshot.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import type { SelectiveDomainMatcherRecord, SelectiveRebuildSnapshot } from '$lib/types';
+	import SelectiveMatcherTable from './SelectiveMatcherTable.svelte';
+
+	interface Props {
+		snapshot: SelectiveRebuildSnapshot;
+	}
+
+	let { snapshot }: Props = $props();
+
+	const PAGE = 100;
+
+	let matchers = $state<SelectiveDomainMatcherRecord[]>([]);
+	let total = $state(0);
+	let loading = $state(false);
+	let loadError = $state('');
+
+	const matcherTotal = $derived(
+		snapshot.domainMatcherCount ?? snapshot.domainResults?.length ?? 0,
+	);
+
+	onMount(() => {
+		if (matcherTotal > 0) {
+			void loadMatchers(0);
+		}
+	});
+
+	async function loadMatchers(offset: number) {
+		loading = true;
+		loadError = '';
+		try {
+			const res = await api.singboxRouterSelectiveSnapshotMatchers(offset, PAGE);
+			if (offset === 0) {
+				matchers = res.matchers;
+			} else {
+				matchers = [...matchers, ...res.matchers];
+			}
+			total = res.total;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function loadMore() {
+		if (!loading && matchers.length < total) {
+			void loadMatchers(matchers.length);
+		}
+	}
+</script>
+
+<div class="snap">
+	<div class="snap-meta">
+		<span>Записей в ipset: <strong>{snapshot.entryCount}</strong></span>
+		{#if snapshot.staticCidrCount != null && snapshot.staticCidrCount > 0}
+			<span>· статических CIDR: {snapshot.staticCidrCount}</span>
+		{/if}
+		{#if matcherTotal > 0}
+			<span>· доменных правил: {matcherTotal}</span>
+		{/if}
+		{#if snapshot.lastCDNRefresh}
+			<span>· CDN refresh: {snapshot.lastCDNRefresh}</span>
+		{/if}
+	</div>
+
+	{#if snapshot.staticCidrs?.length}
+		<details class="snap-block">
+			<summary>Статические CIDR ({snapshot.staticCidrs.length})</summary>
+			<ul class="ip-list">
+				{#each snapshot.staticCidrs as cidr (cidr)}
+					<li class="mono">{cidr}</li>
+				{/each}
+			</ul>
+		</details>
+	{/if}
+
+	{#if matcherTotal > 0}
+		<details class="snap-block" open>
+			<summary>Доменные правила ({matcherTotal})</summary>
+			<SelectiveMatcherTable
+				{matchers}
+				{total}
+				{loading}
+				{loadError}
+				showLoadMore
+				onLoadMore={loadMore}
+			/>
+		</details>
+	{/if}
+</div>
+
+<style>
+	.snap {
+		font-size: 12px;
+	}
+	.snap-meta {
+		color: var(--text-muted, #888);
+		margin-bottom: 8px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px 8px;
+	}
+	.snap-block {
+		margin-top: 8px;
+	}
+	.snap-block summary {
+		cursor: pointer;
+		font-weight: 500;
+		margin-bottom: 4px;
+	}
+	.mono {
+		font-family: var(--font-mono, monospace);
+	}
+	.ip-list {
+		margin: 4px 0 0;
+		padding-left: 1.2em;
+		max-height: 120px;
+		overflow-y: auto;
+	}
+</style>

--- a/frontend/src/lib/components/sb-router/SelectiveMatcherTable.svelte
+++ b/frontend/src/lib/components/sb-router/SelectiveMatcherTable.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import type { SelectiveDomainMatcherRecord } from '$lib/types';
+	import { pluralize } from '$lib/utils/pluralize';
+	import SelectiveIpListSpoiler from './SelectiveIpListSpoiler.svelte';
+
+	const QUERY_WORDS = ['запрос', 'запроса', 'запросов'] as const;
+
+	interface Props {
+		matchers: SelectiveDomainMatcherRecord[];
+		total?: number;
+		loading?: boolean;
+		loadError?: string;
+		showLoadMore?: boolean;
+		onLoadMore?: () => void;
+	}
+
+	let {
+		matchers,
+		total = 0,
+		loading = false,
+		loadError = '',
+		showLoadMore = false,
+		onLoadMore,
+	}: Props = $props();
+
+	function querySummary(hosts: string[] | undefined): string {
+		const n = hosts?.length ?? 0;
+		if (n === 0) return '—';
+		return pluralize(n, QUERY_WORDS);
+	}
+</script>
+
+{#if loadError}
+	<p class="snap-err">{loadError}</p>
+{:else if matchers.length === 0 && loading}
+	<p class="snap-hint">Загрузка…</p>
+{:else if matchers.length === 0}
+	<p class="snap-hint">Нет доменных правил</p>
+{:else}
+	<table class="snap-table">
+		<thead>
+			<tr>
+				<th>Matcher</th>
+				<th>Kind</th>
+				<th>DNS</th>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each matchers as row (row.matcher + row.kind)}
+				<tr class:has-err={!!row.error}>
+					<td class="mono">{row.matcher}</td>
+					<td>{row.kind}</td>
+					<td class="hosts">
+						<SelectiveIpListSpoiler
+							items={row.queryHosts}
+							summary={querySummary(row.queryHosts)}
+						/>
+					</td>
+					<td class="flags">
+						{#if row.cdn}
+							<span class="badge cdn">CDN</span>
+						{/if}
+						{#if row.error}
+							<span class="badge err" title={row.error}>ошибка</span>
+						{/if}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+	{#if showLoadMore && matchers.length < total}
+		<button type="button" class="load-more" disabled={loading} onclick={() => onLoadMore?.()}>
+			{loading ? 'Загрузка…' : `Ещё (${matchers.length} / ${total})`}
+		</button>
+	{/if}
+{/if}
+
+<style>
+	.snap-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 11px;
+	}
+	.snap-table th,
+	.snap-table td {
+		text-align: left;
+		padding: 4px 6px;
+		border-bottom: 1px solid var(--border, #333);
+		vertical-align: top;
+	}
+	.snap-table .hosts {
+		max-width: 200px;
+	}
+	.mono {
+		font-family: var(--font-mono, monospace);
+	}
+	.badge {
+		font-size: 10px;
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	.badge.cdn {
+		background: #1a3a5c;
+		color: #7eb8ff;
+	}
+	.badge.err {
+		background: #3a1a1a;
+		color: #ff8a8a;
+	}
+	.has-err td {
+		opacity: 0.85;
+	}
+	.load-more {
+		margin-top: 6px;
+		font-size: 11px;
+		cursor: pointer;
+		background: transparent;
+		border: 1px solid var(--border, #444);
+		color: inherit;
+		padding: 4px 10px;
+		border-radius: 4px;
+	}
+	.load-more:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.snap-err {
+		color: #f88;
+		font-size: 12px;
+	}
+	.snap-hint {
+		color: var(--text-muted, #888);
+		font-size: 12px;
+	}
+</style>

--- a/frontend/src/lib/components/sb-router/SelectiveRebuildModal.svelte
+++ b/frontend/src/lib/components/sb-router/SelectiveRebuildModal.svelte
@@ -1,0 +1,298 @@
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import type { SelectiveDomainMatcherRecord, SelectiveProgress } from '$lib/types';
+	import SelectiveMatcherTable from './SelectiveMatcherTable.svelte';
+
+	interface Props {
+		open: boolean;
+		progress: SelectiveProgress | null;
+		/** Свернуть окно, rebuild продолжается в фоне. */
+		onMinimize: () => void;
+		/** Закрыть после завершения и сбросить прогресс. */
+		onDismiss: () => void;
+	}
+
+	let { open, progress, onMinimize, onDismiss }: Props = $props();
+
+	const steps = [
+		{ key: 'collecting', label: 'Сбор правил' },
+		{ key: 'resolving', label: 'DNS-резолв' },
+		{ key: 'populating', label: 'Активация ipset' },
+		{ key: 'done', label: 'Готово' },
+	] as const;
+
+	const PAGE = 100;
+
+	let doneMatchers = $state<SelectiveDomainMatcherRecord[]>([]);
+	let doneTotal = $state(0);
+	let doneLoading = $state(false);
+	let doneLoadError = $state('');
+	let doneMatchersLoaded = $state(false);
+
+	function stepState(key: string, p: SelectiveProgress | null): 'pending' | 'active' | 'done' | 'error' {
+		if (!p) return 'pending';
+		if (p.phase === 'error') {
+			const order = ['collecting', 'resolving', 'populating', 'done'];
+			const idx = order.indexOf(key);
+			const cur = order.indexOf('populating');
+			if (idx < cur) return 'done';
+			if (idx === cur) return 'error';
+			return 'pending';
+		}
+		const order = ['collecting', 'resolving', 'populating', 'done'];
+		const idx = order.indexOf(key);
+		const cur = order.indexOf(p.phase);
+		if (idx < cur) return 'done';
+		if (idx === cur) return 'active';
+		return 'pending';
+	}
+
+	const pct = $derived(
+		progress && progress.total > 0
+			? Math.min(100, Math.round((progress.current / progress.total) * 100))
+			: 0,
+	);
+
+	const finished = $derived(progress?.phase === 'done' || progress?.phase === 'error');
+
+	function handleBackdrop() {
+		if (finished) onDismiss();
+		else onMinimize();
+	}
+
+	function handleCloseButton() {
+		if (finished) onDismiss();
+		else onMinimize();
+	}
+
+	async function loadDoneMatchers(offset: number) {
+		doneLoading = true;
+		doneLoadError = '';
+		try {
+			const res = await api.singboxRouterSelectiveSnapshotMatchers(offset, PAGE);
+			if (offset === 0) {
+				doneMatchers = res.matchers;
+			} else {
+				doneMatchers = [...doneMatchers, ...res.matchers];
+			}
+			doneTotal = res.total;
+		} catch (e) {
+			doneLoadError = e instanceof Error ? e.message : String(e);
+		} finally {
+			doneLoading = false;
+		}
+	}
+
+	function loadMoreDone() {
+		if (!doneLoading && doneMatchers.length < doneTotal) {
+			void loadDoneMatchers(doneMatchers.length);
+		}
+	}
+
+	$effect(() => {
+		if (progress?.phase === 'done' && open && !doneMatchersLoaded) {
+			doneMatchersLoaded = true;
+			void loadDoneMatchers(0);
+		}
+		if (progress?.phase !== 'done') {
+			doneMatchersLoaded = false;
+			doneMatchers = [];
+			doneTotal = 0;
+		}
+	});
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+	<div class="overlay" role="presentation" onclick={handleBackdrop}>
+		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="sel-rebuild-title"
+			tabindex="-1"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<header class="modal-head">
+				<h2 id="sel-rebuild-title">Обновление ipset</h2>
+				<button type="button" class="close" aria-label="Закрыть" onclick={handleCloseButton}>×</button>
+			</header>
+
+			<div class="steps">
+				{#each steps as step (step.key)}
+					{@const st = stepState(step.key, progress)}
+					<div class="step" data-state={st}>
+						<span class="step-icon">
+							{#if st === 'done'}✓{:else if st === 'error'}✕{:else if st === 'active'}…{:else}○{/if}
+						</span>
+						<span class="step-label">{step.label}</span>
+					</div>
+				{/each}
+			</div>
+
+			{#if progress}
+				<p class="msg">{progress.message}</p>
+				{#if progress.total > 0 && progress.phase !== 'done' && progress.phase !== 'error'}
+					<div class="bar-wrap">
+						<div class="bar" style="width: {pct}%"></div>
+					</div>
+					<p class="counter">{progress.current} / {progress.total}</p>
+				{/if}
+				{#if progress.matcher && progress.phase !== 'done'}
+					<p class="detail mono">
+						{progress.matcher}
+						{#if progress.queryHost}
+							→ {progress.queryHost}
+						{/if}
+					</p>
+				{/if}
+				{#if progress.phase === 'error'}
+					<p class="err">Ошибка при обновлении ipset. Проверьте логи awg-manager.</p>
+				{/if}
+				{#if progress.phase === 'done'}
+					<details class="done-block" open>
+						<summary>Доменные правила ({doneTotal || progress.current})</summary>
+						<SelectiveMatcherTable
+							matchers={doneMatchers}
+							total={doneTotal}
+							loading={doneLoading}
+							loadError={doneLoadError}
+							showLoadMore={doneMatchers.length < doneTotal}
+							onLoadMore={loadMoreDone}
+						/>
+					</details>
+				{/if}
+			{:else}
+				<p class="msg">Ожидание…</p>
+			{/if}
+
+			<footer class="modal-foot">
+				<button type="button" class="btn" onclick={handleCloseButton}>
+					{finished ? 'Закрыть' : 'Свернуть'}
+				</button>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.55);
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 16px;
+	}
+	.modal {
+		background: var(--surface, #1e1e1e);
+		border: 1px solid var(--border, #333);
+		border-radius: 8px;
+		max-width: 520px;
+		width: 100%;
+		max-height: 90vh;
+		overflow: auto;
+		padding: 16px;
+	}
+	.modal-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 12px;
+	}
+	.modal-head h2 {
+		margin: 0;
+		font-size: 16px;
+	}
+	.close {
+		background: none;
+		border: none;
+		font-size: 22px;
+		cursor: pointer;
+		color: inherit;
+		line-height: 1;
+	}
+	.steps {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		margin-bottom: 12px;
+	}
+	.step {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-size: 13px;
+		opacity: 0.5;
+	}
+	.step[data-state='active'] {
+		opacity: 1;
+		font-weight: 500;
+	}
+	.step[data-state='done'] {
+		opacity: 0.85;
+		color: #6c6;
+	}
+	.step[data-state='error'] {
+		opacity: 1;
+		color: #f66;
+	}
+	.step-icon {
+		width: 1.2em;
+		text-align: center;
+	}
+	.msg {
+		font-size: 13px;
+		margin: 0 0 8px;
+	}
+	.bar-wrap {
+		height: 4px;
+		background: var(--border, #333);
+		border-radius: 2px;
+		overflow: hidden;
+		margin-bottom: 4px;
+	}
+	.bar {
+		height: 100%;
+		background: var(--accent, #4a9eff);
+		transition: width 0.2s;
+	}
+	.counter,
+	.detail {
+		font-size: 11px;
+		color: var(--text-muted, #888);
+		margin: 0 0 4px;
+	}
+	.mono {
+		font-family: var(--font-mono, monospace);
+	}
+	.err {
+		color: #f88;
+		font-size: 12px;
+	}
+	.done-block {
+		margin-top: 10px;
+		font-size: 12px;
+	}
+	.done-block summary {
+		cursor: pointer;
+		font-weight: 500;
+		margin-bottom: 6px;
+	}
+	.modal-foot {
+		margin-top: 16px;
+		text-align: right;
+	}
+	.btn {
+		padding: 6px 14px;
+		border-radius: 4px;
+		border: 1px solid var(--border, #444);
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 13px;
+	}
+</style>

--- a/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
+++ b/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
@@ -23,6 +23,31 @@
     type RouterMode,
   } from '$lib/components/sb-router';
 
+  import SelectiveRebuildModal from './SelectiveRebuildModal.svelte';
+  import { selectiveBypass } from '$lib/stores/selectiveBypass';
+
+  const { progress: globalSelectiveProgress, modalRequested: selectiveModalRequested } = selectiveBypass;
+
+  let globalRebuildOpen = $state(false);
+
+  // Open only when explicitly requested (Apply button or engine enable).
+  $effect(() => {
+    if ($selectiveModalRequested) {
+      globalRebuildOpen = true;
+    }
+  });
+
+  function minimizeGlobalRebuild() {
+    globalRebuildOpen = false;
+    selectiveBypass.clearModalRequest();
+  }
+
+  function dismissGlobalRebuild() {
+    globalRebuildOpen = false;
+    selectiveBypass.clearModalRequest();
+    selectiveBypass.resetProgress();
+  }
+
   let activeSingboxSub = $derived($page.url.searchParams.get('sub'));
   let inspectorOpen = $state(false);
   let jsonOpen = $state(false);
@@ -134,6 +159,13 @@
 
 <RouteInspector open={inspectorOpen} onClose={() => (inspectorOpen = false)} />
 <JsonConfigDrawer open={jsonOpen} onClose={() => (jsonOpen = false)} />
+
+<SelectiveRebuildModal
+  open={globalRebuildOpen}
+  progress={$globalSelectiveProgress}
+  onMinimize={minimizeGlobalRebuild}
+  onDismiss={dismissGlobalRebuild}
+/>
 
 <style>
   .sub-back {

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -4,7 +4,7 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { SideDrawer, Toggle, Button, Badge, StatusDot } from '$lib/components/ui';
+  import { SideDrawer, Toggle, Button, Badge, StatusDot, Modal } from '$lib/components/ui';
   import { api } from '$lib/api/client';
   import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
   import { modeSwitch, modeSwitchBusy } from '$lib/stores/modeSwitch';
@@ -18,11 +18,15 @@
   import PortChipsInput from './PortChipsInput.svelte';
   import SubnetChipsInput from './SubnetChipsInput.svelte';
   import TrafficSourceSettings from './TrafficSourceSettings.svelte';
+  import SelectiveIpsetSnapshot from './SelectiveIpsetSnapshot.svelte';
   import { deriveDeps, deriveIssues } from './drawerData';
   import { mergeAndSaveSettings, BYPASS_PRESETS } from './settingsActions';
   import { resolveWanAuto, planToggleAutoDetect, planSelectWanInterface, type WanAutoOverride } from './wanMode';
   import { pluralize, RULE_WORDS } from '$lib/utils/pluralize';
+  import { selectiveBypass } from '$lib/stores/selectiveBypass';
   import type { SingboxRouterSettings, SingboxRouterWANInterface } from '$lib/types';
+
+  const { status: selectiveBypassStatus } = selectiveBypass;
 
   const status = singboxRouterStore.status;
   const storeSettings = singboxRouterStore.settings;
@@ -93,6 +97,7 @@
     } catch (_e) {
       // ignore
     }
+    void loadSelectiveStatus();
   });
 
   // ── Engine control ──
@@ -152,6 +157,66 @@
     { value: '1h0m0s', label: '1 час' },
     { value: '3h0m0s', label: '3 часа' },
   ];
+
+  // ── Selective bypass ──
+  let selectiveInstalling = $state(false);
+  let rebuilding = $state(false);
+  let snapshotOpen = $state(false);
+
+  let routeFinal = $derived(s?.final || 'direct');
+  let selectiveFinalOk = $derived(routeFinal === 'direct');
+
+  let selectiveStatus = $derived($selectiveBypassStatus);
+  let selectiveStatusLoaded = $derived(selectiveStatus !== null);
+  let selectiveIpsetOk = $derived(selectiveStatus?.available ?? false);
+  let selectiveSnapshot = $derived(selectiveStatus?.snapshot ?? null);
+  let hasSnapshot = $derived(
+    !!selectiveSnapshot
+      && ((selectiveSnapshot.entryCount ?? 0) > 0
+        || (selectiveSnapshot.domainMatcherCount ?? selectiveSnapshot.domainResults?.length ?? 0) > 0
+        || (selectiveSnapshot.staticCidrCount ?? selectiveSnapshot.staticCidrs?.length ?? 0) > 0),
+  );
+
+  async function loadSelectiveStatus() {
+    try {
+      const status = await api.singboxRouterSelectiveStatus();
+      selectiveBypass.applyStatus(status);
+    } catch (_e) { /* ignore */ }
+  }
+
+  async function installSelectiveDeps() {
+    selectiveInstalling = true;
+    try {
+      const status = await api.singboxRouterSelectiveInstallDeps();
+      selectiveBypass.applyStatus(status);
+    } catch (e) {
+      notifications.error('Не удалось установить ipset: ' + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      selectiveInstalling = false;
+    }
+  }
+
+  async function triggerRebuild() {
+    rebuilding = true;
+    selectiveBypass.resetProgress();
+    selectiveBypass.requestModal();
+    try {
+      const status = await api.singboxRouterSelectiveRebuild();
+      selectiveBypass.applyStatus(status);
+    } catch (e) {
+      notifications.error('Не удалось пересобрать ipset: ' + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      rebuilding = false;
+    }
+  }
+
+  function toggleSelectiveBypass(checked: boolean) {
+    if (checked && !selectiveFinalOk) {
+      notifications.error('Селективный перехват требует route.final = direct');
+      return;
+    }
+    void applyPatch({ selectiveBypass: checked });
+  }
 </script>
 
 <SideDrawer {open} onClose={closeDrawer} title="Движок sing-box" width={420}>
@@ -251,6 +316,99 @@
         <p class="hint">Как долго sing-box держит UDP-сессии активными. Увеличьте если игры или другие UDP-приложения обрываются каждые несколько минут.</p>
       </section>
 
+      <!-- Селективный перехват -->
+      <section class="sec">
+        <div class="sec-cap">Селективный перехват</div>
+
+        <div class="field-row">
+          <span>Только трафик из правил</span>
+          <Toggle
+            checked={cfg.selectiveBypass ?? false}
+            disabled={!selectiveFinalOk || (selectiveStatusLoaded && !selectiveIpsetOk)}
+            onchange={toggleSelectiveBypass}
+          />
+        </div>
+
+        {#if !selectiveFinalOk}
+          <p class="hint selective-warn">
+            Несовместимо с route.final = «{routeFinal}»: при catch-all проксировании весь трафик идёт через sing-box,
+            селективный ipset не имеет смысла. Установите final в «direct» в разделе маршрутизации.
+          </p>
+        {:else if !selectiveStatusLoaded}
+          <!-- Статус ещё грузится — показываем описание, toggle активен -->
+          <p class="hint">
+            При включении в sing-box попадает только трафик к целевым IP из правил маршрутизации (proxy).
+            Весь остальной трафик полностью обходит sing-box — не только VPN, а сам движок — и идёт напрямую в WAN.
+            Так соединения стабильнее и предсказуемее: игры, стриминг и локальный трафик не проходят через прокси-цепочку.
+          </p>
+        {:else if !selectiveIpsetOk}
+          <!-- ipset не установлен -->
+          <p class="hint selective-warn">
+            Требуется пакет <code class="mono">ipset</code> — он не установлен на роутере.
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            fullWidth
+            loading={selectiveInstalling}
+            onclick={installSelectiveDeps}
+          >
+            {selectiveInstalling ? 'Установка…' : 'Установить ipset'}
+          </Button>
+        {:else if cfg.selectiveBypass}
+          <!-- Включено и доступно — показываем статистику всегда -->
+          <p class="hint">
+            В sing-box попадает только трафик к IP из правил proxy; остальное полностью обходит движок
+            и уходит в WAN напрямую — стабильнее для игр, стриминга и локального трафика.
+          </p>
+          <div class="selective-stats">
+            <div class="stat-line">
+              <span class="stat-label">Записей в ipset</span>
+              <span class="stat-value">{selectiveStatus?.entryCount ?? 0}</span>
+            </div>
+            <div class="stat-line">
+              <span class="stat-label">Последняя пересборка</span>
+              <span class="stat-value">
+                {selectiveStatus?.lastRebuild
+                  ? new Date(selectiveStatus.lastRebuild).toLocaleString()
+                  : '—'}
+              </span>
+            </div>
+          </div>
+
+          {#if selectiveStatus?.lastError}
+            <p class="hint selective-warn">Ошибка пересборки: {selectiveStatus.lastError}</p>
+          {/if}
+
+          <p class="hint">
+            После смены правил нажмите «Применить» — ipset пересоберётся автоматически.
+            Уже открытые соединения (вкладки браузера) могут идти по старому пути, пока не закроются —
+            откройте сайт в новой вкладке для проверки.
+          </p>
+          <p class="hint">
+            Подробный лог резолва: <a class="logs-link" href="/diagnostics?tab=logs">Диагностика → Журнал</a>,
+            группа «Маршрутизация», подгруппа «Селективный ipset».
+          </p>
+
+          {#if hasSnapshot}
+            <Button variant="ghost" size="sm" fullWidth onclick={() => (snapshotOpen = true)}>
+              Содержимое ipset (домены → IP)
+            </Button>
+          {/if}
+
+          <Button variant="ghost" size="sm" fullWidth loading={rebuilding} onclick={triggerRebuild}>
+            {rebuilding ? 'Пересборка…' : 'Пересобрать ipset'}
+          </Button>
+        {:else}
+          <!-- Доступно, но выключено -->
+          <p class="hint">
+            При включении в sing-box попадает только трафик к целевым IP из правил маршрутизации (proxy).
+            Весь остальной трафик полностью обходит sing-box — не только VPN, а сам движок — и идёт напрямую в WAN.
+            Так соединения стабильнее и предсказуемее: игры, стриминг и локальный трафик не проходят через прокси-цепочку.
+          </p>
+        {/if}
+      </section>
+
       <!-- Исключения портов -->
       <section class="sec">
         <div class="sec-cap">Исключения портов</div>
@@ -293,6 +451,17 @@
     </div>
   {/snippet}
 </SideDrawer>
+
+<Modal
+  open={snapshotOpen}
+  title="Содержимое ipset"
+  size="lg"
+  onclose={() => (snapshotOpen = false)}
+>
+  {#if selectiveSnapshot}
+    <SelectiveIpsetSnapshot snapshot={selectiveSnapshot} />
+  {/if}
+</Modal>
 
 <style>
   .sections { display: flex; flex-direction: column; }
@@ -393,6 +562,8 @@
   .udp-timeout-row { display: flex; gap: 6px; }
   .udp-timeout-row .inp { flex: 1; }
   .hint { margin: 0; font-size: 11.5px; color: var(--text-muted); line-height: 1.4; }
+  .logs-link { color: var(--accent); text-decoration: none; }
+  .logs-link:hover { text-decoration: underline; }
   .chips { display: flex; flex-direction: column; gap: 6px; }
   .chip {
     text-align: left; padding: 8px 10px; border-radius: var(--radius-sm); background: var(--bg-tertiary);
@@ -420,5 +591,31 @@
     border-radius: 3px;
     padding: 0 3px;
     color: var(--text-secondary);
+  }
+  .selective-warn {
+    color: var(--color-warning, #dab856);
+  }
+  .selective-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+  }
+  .stat-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 12px;
+  }
+  .stat-label { color: var(--text-muted); }
+  .stat-value {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    text-align: right;
   }
 </style>

--- a/frontend/src/lib/components/sb-router/selectiveRebuildTrigger.ts
+++ b/frontend/src/lib/components/sb-router/selectiveRebuildTrigger.ts
@@ -1,0 +1,31 @@
+/**
+ * Helper for triggering a selective-bypass ipset rebuild after rule mutations.
+ * Called from AddWizardPanel, RulesPanel and any other place that modifies
+ * router rules or rule sets while selective mode may be active.
+ *
+ * The rebuild runs in the background: progress arrives via SSE
+ * (singbox-router:selective-progress) → selectiveBypass store → the
+ * SelectiveRebuildModal in StatusDrawer opens automatically.
+ */
+import { get } from 'svelte/store';
+import { api } from '$lib/api/client';
+import { singboxRouter } from '$lib/stores/singboxRouter';
+import { selectiveBypass } from '$lib/stores/selectiveBypass';
+
+/**
+ * Trigger an ipset rebuild if the router settings have selectiveBypass enabled.
+ * Errors are silently swallowed — a stale ipset is preferable to surfacing an
+ * extra error notification after a successful rule save.
+ */
+export async function triggerSelectiveRebuildIfEnabled(): Promise<void> {
+  const settings = get(singboxRouter.settings);
+  if (!settings?.selectiveBypass) return;
+  selectiveBypass.resetProgress();
+  selectiveBypass.requestModal();
+  try {
+    const status = await api.singboxRouterSelectiveRebuild();
+    selectiveBypass.applyStatus(status);
+  } catch {
+    // non-fatal — progress/error arrives via SSE anyway
+  }
+}

--- a/frontend/src/lib/components/singbox-routing/StagingBanner.svelte
+++ b/frontend/src/lib/components/singbox-routing/StagingBanner.svelte
@@ -5,6 +5,7 @@
 	import { Button, Modal } from '$lib/components/ui';
 	import { formatTime } from '$lib/utils/format';
 	import { stripAnsi } from '$lib/utils/ansi';
+	import { triggerSelectiveRebuildIfEnabled } from '$lib/components/sb-router/selectiveRebuildTrigger';
 	import type { RouterStagingValidationError, RouterValidationErrorDTO } from '$lib/types';
 
 	const stagingStore = singboxRouter.staging;
@@ -25,7 +26,8 @@
 		inlineSbCheck = null;
 		try {
 			await api.singboxRouterStagingApply();
-			// success: SSE will flip hasDraft to false and the banner disappears
+			// Rebuild ipset once after Apply (opens progress modal inside trigger).
+			setTimeout(() => void triggerSelectiveRebuildIfEnabled(), 400);
 		} catch (e: unknown) {
 			const err = e as { status?: number; body?: RouterStagingValidationError };
 			if (err.status === 422 && err.body?.validation) {

--- a/frontend/src/lib/stores/fakeipTransition.test.ts
+++ b/frontend/src/lib/stores/fakeipTransition.test.ts
@@ -110,4 +110,20 @@ describe('fakeipTransition reducer', () => {
 		expect(s.finalState).toBe('tproxy');
 		expect(s.steps.some((x) => x.step === 'error' && x.status === 'error')).toBe(true);
 	});
+
+	it('fail() is not overwritten by late SSE before terminal done event', () => {
+		fakeipTransition.begin('off', 'tproxy');
+		fakeipTransition.fail('sing-box timeout');
+		fakeipTransition.applyTransition(
+			ev({
+				transitionId: 'switch-late',
+				from: 'off',
+				to: 'tproxy',
+				step: { step: 'provision', status: 'current' },
+			}),
+		);
+		const s = get(fakeipTransition)!;
+		expect(s.done).toBe(true);
+		expect(s.error).toBe('sing-box timeout');
+	});
 });

--- a/frontend/src/lib/stores/fakeipTransition.ts
+++ b/frontend/src/lib/stores/fakeipTransition.ts
@@ -59,6 +59,19 @@ function createFakeipTransitionStore() {
 	 */
 	function applyTransition(data: SingboxRouterTransitionData): void {
 		store.update((prev) => {
+			// HTTP may fail (fail()) before any SSE arrives, or SSE may reconnect
+			// late with a real transitionId while the placeholder id is still ''.
+			// Never regress a terminal transition back to a spinning state.
+			if (prev?.done) {
+				const sameTransition =
+					prev.transitionId === data.transitionId ||
+					prev.transitionId === '' ||
+					data.transitionId === '';
+				if (!sameTransition || !(data.done ?? false)) {
+					return prev;
+				}
+			}
+
 			const fresh = prev === null || prev.transitionId !== data.transitionId;
 			const base: FakeIPTransitionState = fresh
 				? {
@@ -115,11 +128,22 @@ function createFakeipTransitionStore() {
 		});
 	}
 
+	function completeSuccess(finalState: FakeIPMode): void {
+		store.update((prev) => {
+			if (prev === null || prev.done) return prev;
+			let steps = prev.steps;
+			steps = upsertStep(steps, { step: 'provision', status: 'done' });
+			steps = upsertStep(steps, { step: 'readiness', status: 'done' });
+			steps = upsertStep(steps, { step: 'ready', status: 'done' });
+			return { ...prev, steps, done: true, finalState };
+		});
+	}
+
 	function reset(): void {
 		store.set(null);
 	}
 
-	return { subscribe: store.subscribe, applyTransition, begin, fail, reset };
+	return { subscribe: store.subscribe, applyTransition, begin, fail, completeSuccess, reset };
 }
 
 export const fakeipTransition = createFakeipTransitionStore();

--- a/frontend/src/lib/stores/modeSwitch.ts
+++ b/frontend/src/lib/stores/modeSwitch.ts
@@ -7,6 +7,7 @@ import { get, writable } from 'svelte/store';
 import { api } from '$lib/api/client';
 import { fakeipTransition, type FakeIPMode } from '$lib/stores/fakeipTransition';
 import { singboxRouter } from '$lib/stores/singboxRouter';
+import { selectiveBypass } from '$lib/stores/selectiveBypass';
 import type { SingboxRouterStatus, SingboxRouterSettings } from '$lib/types';
 
 export type ModeSwitchPhase = 'idle' | 'confirming' | 'running';
@@ -58,12 +59,11 @@ function createModeSwitch() {
 		const { from, target } = get(store);
 		store.update((s) => ({ ...s, phase: 'running' }));
 		fakeipTransition.begin(from, target);
+		selectiveBypass.resetProgress();
 		try {
 			await api.singboxRouterSwitchMode(target);
+			// Переключение асинхронное: прогресс и финал — только из SSE.
 		} catch (e) {
-			// POST failed: STAY in 'running' — the progress modal surfaces the error
-			// (via fakeipTransition.fail below) and the user dismisses it through
-			// closeProgress → 'idle'. Mirrors the success path's modal lifecycle.
 			fakeipTransition.fail(e instanceof Error ? e.message : 'Не удалось переключить режим');
 		}
 	}
@@ -71,6 +71,7 @@ function createModeSwitch() {
 	function closeProgress(): void {
 		store.update((s) => ({ ...s, phase: 'idle' }));
 		fakeipTransition.reset();
+		selectiveBypass.resetProgress();
 		void singboxRouter.loadAll();
 	}
 

--- a/frontend/src/lib/stores/selectiveBypass.ts
+++ b/frontend/src/lib/stores/selectiveBypass.ts
@@ -1,0 +1,42 @@
+/**
+ * Lightweight store for selective-bypass status and rebuild progress.
+ * Populated via SSE events (singbox-router:selective-status and
+ * singbox-router:selective-progress) and REST polling on drawer open.
+ */
+import { writable } from 'svelte/store';
+import type { SelectiveStatus, SelectiveProgress } from '$lib/types';
+
+function createSelectiveBypassStore() {
+	const status = writable<SelectiveStatus | null>(null);
+	const progress = writable<SelectiveProgress | null>(null);
+	// Set to true by explicit triggers (Apply button, engine enable) to request
+	// the global modal open. The modal clears this on close.
+	const modalRequested = writable(false);
+
+	return {
+		status,
+		progress,
+		modalRequested,
+		applyStatus(data: SelectiveStatus) {
+			status.set(data);
+		},
+		applyProgress(data: SelectiveProgress) {
+			progress.set(data);
+			// Progress is cleared only when the modal closes (resetProgress), not on a
+			// timer — otherwise the UI reverts to empty pending steps while the user
+			// is still reading the domain→IP snapshot.
+		},
+		resetProgress() {
+			progress.set(null);
+		},
+		/** Explicitly request the rebuild modal to open (called by Apply / engine enable). */
+		requestModal() {
+			modalRequested.set(true);
+		},
+		clearModalRequest() {
+			modalRequested.set(false);
+		},
+	};
+}
+
+export const selectiveBypass = createSelectiveBypassStore();

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1322,6 +1322,12 @@ export interface SingboxRouterSettings {
 	// UDP session timeout for tproxy-in. Go duration string (e.g. "3m0s", "10m0s").
 	// Empty = backend default (3m0s). Increase to fix dropped sessions in games.
 	udpTimeout?: string;
+	/**
+	 * When true, only traffic matching the AWGM-SELECTIVE ipset reaches sing-box.
+	 * All other traffic bypasses sing-box entirely (goes straight to WAN).
+	 * Requires ipset binary and xt_set kernel module on the router.
+	 */
+	selectiveBypass?: boolean;
 }
 
 // WAN interface for the sing-box router WAN-binding picker. `name` is
@@ -2019,6 +2025,81 @@ export interface CatalogPreset {
 	sensitive?: boolean;
 	origin: 'builtin' | 'user';
 	engines: PresetEngines;
+}
+
+// #endregion
+
+// ─────────────────────────────────────────────
+// #region Selective Bypass (TProxy ipset feature)
+// ─────────────────────────────────────────────
+
+/**
+ * Status of the selective-bypass feature.
+ * Returned by GET /api/singbox/router/selective/status.
+ */
+export interface SelectiveDomainResolveResult {
+	matcher: string;
+	kind: 'domain' | 'suffix';
+	queryHosts: string[];
+	/** @deprecated IPs are no longer returned — use entryCount on snapshot. */
+	ips?: string[];
+	cdn?: boolean;
+	error?: string;
+	outbound?: string;
+}
+
+export interface SelectiveDomainMatcherRecord {
+	matcher: string;
+	kind: 'domain' | 'suffix';
+	queryHosts: string[];
+	cdn?: boolean;
+	error?: string;
+	outbound?: string;
+}
+
+export interface SelectiveRebuildSnapshot {
+	rebuiltAt: string;
+	staticCidrs: string[];
+	domainResults: SelectiveDomainResolveResult[];
+	entryCount: number;
+	staticCidrCount?: number;
+	domainMatcherCount?: number;
+	lastCDNRefresh?: string;
+}
+
+export interface SelectiveStatus {
+	/** True when the ipset binary is present on the router (/opt/sbin/ipset etc). */
+	available: boolean;
+	/** True when the xt_set kernel module is loaded or available as .ko. */
+	xtSetAvailable: boolean;
+	/** True when the conntrack binary is present. Without it a full rebuild
+	 *  only affects new connections; background CDN refresh never flushes conntrack. */
+	conntrackAvailable: boolean;
+	/** True while `opkg install ipset` is running. */
+	installing: boolean;
+	/** Mirrors SingboxRouterSettings.selectiveBypass. */
+	enabled: boolean;
+	/** Current number of entries in AWGM-SELECTIVE ipset. 0 when set doesn't exist. */
+	entryCount: number;
+	/** RFC3339 timestamp of the last successful rebuild. Empty if never rebuilt. */
+	lastRebuild?: string;
+	/** Error message from the last failed rebuild. Empty on success. */
+	lastError?: string;
+	/** Last successful rebuild: static CIDRs + domain→IP mapping. */
+	snapshot?: SelectiveRebuildSnapshot;
+}
+
+/**
+ * Progress update during an ipset rebuild.
+ * Delivered via SSE event "singbox-router:selective-progress".
+ */
+export interface SelectiveProgress {
+	phase: 'collecting' | 'resolving' | 'populating' | 'done' | 'error';
+	message: string;
+	current: number;
+	total: number;
+	matcher?: string;
+	queryHost?: string;
 }
 
 // #endregion

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -33,6 +33,7 @@
 	import { loadPresetCatalog } from '$lib/stores/presets';
 	import { donateModalOpen, openDonateModal, closeDonateModal } from '$lib/stores/donateModal';
 	import { outboundReferenced } from '$lib/stores/outboundReferenced';
+	import { selectiveBypass } from '$lib/stores/selectiveBypass';
 	import TunnelReferencedModal from '$lib/components/tunnels/TunnelReferencedModal.svelte';
 	import { TriangleAlert } from 'lucide-svelte';
 	import DevelopFeedbackFab from '$lib/components/layout/DevelopFeedbackFab.svelte';
@@ -237,6 +238,10 @@
 			onSingboxRouterRules: singboxRouter.applyRules,
 			onSingboxRouterRuleSets: singboxRouter.applyRuleSets,
 			onSingboxRouterOutbounds: singboxRouter.applyOutbounds,
+
+			// Selective-bypass rebuild progress and status.
+			onSingboxRouterSelectiveProgress: (data) => selectiveBypass.applyProgress(data),
+			onSingboxRouterSelectiveStatus: (data) => selectiveBypass.applyStatus(data),
 		});
 	}
 

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -495,11 +496,15 @@ func (h *SingboxRouterHandler) SwitchMode(w http.ResponseWriter, r *http.Request
 			"invalid routing mode (want off|tproxy|fakeip-tun)", "INVALID_MODE")
 		return
 	}
-	if err := h.svc.SwitchRoutingMode(r.Context(), body.Mode); err != nil {
-		h.handleErr(w, "request", err)
-		return
-	}
-	response.Success(w, map[string]bool{"ok": true})
+	mode := body.Mode
+	go func() {
+		if err := h.svc.SwitchRoutingMode(context.Background(), mode); err != nil {
+			// Terminal errors are emitted as singbox-router:transition events;
+			// log only for diagnostics.
+			_ = err
+		}
+	}()
+	response.Success(w, map[string]bool{"accepted": true})
 }
 
 // GetSettings reads singbox-router settings (policy-mode, defaults, etc.).

--- a/internal/api/singbox_router_test.go
+++ b/internal/api/singbox_router_test.go
@@ -233,6 +233,13 @@ func TestRouterSwitchMode_CallsService(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if svc.switchTarget == "fakeip-tun" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if svc.switchTarget != "fakeip-tun" {
 		t.Errorf("svc.SwitchRoutingMode target = %q want fakeip-tun", svc.switchTarget)
 	}

--- a/internal/api/singbox_selective.go
+++ b/internal/api/singbox_selective.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// ── DTOs ────────────────────────────────────────────────────────────────────
+
+// SelectiveStatusData is the payload for GET /singbox/router/selective/status.
+type SelectiveStatusData struct {
+	// Available reports whether the ipset binary is present on the router.
+	Available bool `json:"available"`
+	// XtSetAvailable reports whether the xt_set kernel module is loaded or
+	// available as a .ko file (required for -m set iptables matching).
+	XtSetAvailable bool `json:"xtSetAvailable"`
+	// ConntrackAvailable reports whether the conntrack binary is present.
+	// Without it a routing change applies only to new connections (existing
+	// flows linger until they expire).
+	ConntrackAvailable bool `json:"conntrackAvailable"`
+	// Installing is true while opkg install ipset is running.
+	Installing bool `json:"installing"`
+	// Enabled mirrors SingboxRouterSettings.SelectiveBypass.
+	Enabled bool `json:"enabled"`
+	// EntryCount is the current number of entries in the AWGM-SELECTIVE ipset.
+	// 0 when the set does not exist or is empty.
+	EntryCount int `json:"entryCount"`
+	// LastRebuild is the RFC3339 timestamp of the last successful rebuild, or
+	// empty string if no rebuild has run yet.
+	LastRebuild string `json:"lastRebuild,omitempty"`
+	// LastError is the error message from the last failed rebuild, or empty.
+	LastError string `json:"lastError,omitempty"`
+	// Snapshot is summary metadata from the last rebuild (no IP lists).
+	Snapshot *SelectiveRebuildSnapshotDTO `json:"snapshot,omitempty"`
+}
+
+// SelectiveRebuildSnapshotDTO is the API shape of last-rebuild summary metadata.
+type SelectiveRebuildSnapshotDTO struct {
+	RebuiltAt          string   `json:"rebuiltAt"`
+	StaticCIDRs        []string `json:"staticCidrs"`
+	DomainResults      []any    `json:"domainResults"`
+	EntryCount         int      `json:"entryCount"`
+	StaticCIDRCount    int      `json:"staticCidrCount,omitempty"`
+	DomainMatcherCount int      `json:"domainMatcherCount,omitempty"`
+	LastCDNRefresh     string   `json:"lastCDNRefresh,omitempty"`
+}
+
+// SelectiveDomainMatcherRecordDTO is one matcher row from the NDJSON snapshot.
+type SelectiveDomainMatcherRecordDTO struct {
+	Matcher    string   `json:"matcher"`
+	Kind       string   `json:"kind"`
+	QueryHosts []string `json:"queryHosts"`
+	CDN        bool     `json:"cdn,omitempty"`
+	Outbound   string   `json:"outbound,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+// SelectiveSnapshotMatchersData is the payload for GET .../snapshot/matchers.
+type SelectiveSnapshotMatchersData struct {
+	Matchers []SelectiveDomainMatcherRecordDTO `json:"matchers"`
+	Total    int                               `json:"total"`
+	Offset   int                               `json:"offset"`
+	Limit    int                               `json:"limit"`
+}
+
+func selectiveSnapshotDTO(s *selective.RebuildSnapshot) *SelectiveRebuildSnapshotDTO {
+	if s == nil {
+		return nil
+	}
+	domainResults := []any{}
+	if s.DomainResults != nil {
+		domainResults = make([]any, 0)
+	}
+	return &SelectiveRebuildSnapshotDTO{
+		RebuiltAt:          s.RebuiltAt,
+		StaticCIDRs:        s.StaticCIDRs,
+		DomainResults:      domainResults,
+		EntryCount:         s.EntryCount,
+		StaticCIDRCount:    s.StaticCIDRCount,
+		DomainMatcherCount: s.DomainMatcherCount,
+		LastCDNRefresh:     s.LastCDNRefresh,
+	}
+}
+
+func selectiveMatcherDTOs(in []selective.DomainMatcherRecord) []SelectiveDomainMatcherRecordDTO {
+	out := make([]SelectiveDomainMatcherRecordDTO, len(in))
+	for i, rec := range in {
+		qh := rec.QueryHosts
+		if qh == nil {
+			qh = []string{}
+		}
+		out[i] = SelectiveDomainMatcherRecordDTO{
+			Matcher:    rec.Matcher,
+			Kind:       rec.Kind,
+			QueryHosts: qh,
+			CDN:        rec.CDN,
+			Outbound:   rec.Outbound,
+			Error:      rec.Error,
+		}
+	}
+	return out
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+// SelectiveHandler serves the /api/singbox/router/selective/* endpoints.
+type SelectiveHandler struct {
+	settings   *storage.SettingsStore
+	configDir  string
+	installing bool
+	builder    SelectiveRebuildTriggerer
+	status     SelectiveStatusProvider
+}
+
+// SelectiveRebuildTriggerer is the narrow interface the handler needs from
+// the router service to force an ipset rebuild. Implemented by a wrapper
+// that calls ServiceImpl.triggerSelectiveRebuild or calls Rebuild directly.
+type SelectiveRebuildTriggerer interface {
+	Rebuild(ctx context.Context) error
+}
+
+// SelectiveStatusProvider exposes the last-rebuild bookkeeping the handler
+// reports in GetStatus. *selective.Builder satisfies it.
+type SelectiveStatusProvider interface {
+	LastRebuild() string
+	LastError() string
+	LastSnapshot() *selective.RebuildSnapshot
+}
+
+// NewSelectiveHandler creates a new handler. configDir is the sing-box config.d
+// path used to read NDJSON matcher snapshots. status may be nil.
+func NewSelectiveHandler(settings *storage.SettingsStore, configDir string, builder SelectiveRebuildTriggerer, status SelectiveStatusProvider) *SelectiveHandler {
+	return &SelectiveHandler{settings: settings, configDir: configDir, builder: builder, status: status}
+}
+
+// GetStatus handles GET /api/singbox/router/selective/status.
+//
+//	@Summary		Selective-bypass status
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SelectiveStatusData
+//	@Router			/singbox/router/selective/status [get]
+func (h *SelectiveHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
+	enabled := false
+	if h.settings != nil {
+		if settings, err := h.settings.Get(); err == nil {
+			enabled = settings.SingboxRouter.SelectiveBypass
+		}
+	}
+
+	entryCount := 0
+	if selective.SetExists(r.Context()) {
+		entryCount = selective.EntryCount(r.Context())
+	}
+
+	lastRebuild, lastError := "", ""
+	var snapshot *selective.RebuildSnapshot
+	if h.status != nil {
+		lastRebuild = h.status.LastRebuild()
+		lastError = h.status.LastError()
+		snapshot = h.status.LastSnapshot()
+	}
+
+	response.Success(w, SelectiveStatusData{
+		Available:          selective.IsIPSetAvailable(),
+		XtSetAvailable:     selective.IsXtSetAvailable(),
+		ConntrackAvailable: selective.IsConntrackAvailable(),
+		Installing:         h.installing,
+		Enabled:            enabled,
+		EntryCount:         entryCount,
+		LastRebuild:        lastRebuild,
+		LastError:          lastError,
+		Snapshot:           selectiveSnapshotDTO(snapshot),
+	})
+}
+
+// SelectiveSnapshotMatchersData is the payload for GET .../snapshot/matchers.
+//
+// GetSnapshotMatchers handles GET /api/singbox/router/selective/snapshot/matchers.
+//
+//	@Summary		List domain matchers from last ipset rebuild
+//	@Description	Returns a paginated slice of matcher records (DNS query hosts, no IPs) from the NDJSON snapshot.
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			offset	query		int	false	"Zero-based record offset"	default(0)
+//	@Param			limit	query		int	false	"Page size (max 1000)"		default(200)
+//	@Success		200		{object}	SelectiveSnapshotMatchersData
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/singbox/router/selective/snapshot/matchers [get]
+func (h *SelectiveHandler) GetSnapshotMatchers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	offset := queryIntDefault(r, "offset", 0)
+	limit := queryIntDefault(r, "limit", 200)
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	matchers, total, err := selective.ReadSnapshotMatchers(h.configDir, offset, limit)
+	if err != nil {
+		response.InternalError(w, err.Error())
+		return
+	}
+	response.Success(w, SelectiveSnapshotMatchersData{
+		Matchers: selectiveMatcherDTOs(matchers),
+		Total:    total,
+		Offset:   offset,
+		Limit:    limit,
+	})
+}
+
+func queryIntDefault(r *http.Request, key string, def int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return def
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		return def
+	}
+	return n
+}
+
+// InstallDeps handles POST /api/singbox/router/selective/install-deps.
+// Runs `opkg install ipset` and emits progress to SSE.
+//
+//	@Summary		Install ipset package
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SelectiveStatusData
+//	@Failure		409	{object}	APIErrorEnvelope	"already installing"
+//	@Router			/singbox/router/selective/install-deps [post]
+func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.installing {
+		response.ErrorWithStatus(w, http.StatusConflict, "ipset installation already in progress", "INSTALLING")
+		return
+	}
+	if selective.IsIPSetAvailable() {
+		// Already installed — just return current status.
+		h.GetStatus(w, r)
+		return
+	}
+
+	h.installing = true
+	ctx := r.Context()
+	err := selective.InstallIPSet(ctx, nil) // progress delivered via SSE by the builder
+	h.installing = false
+
+	if err != nil {
+		response.InternalError(w, "ipset installation failed: "+err.Error())
+		return
+	}
+
+	// Try to load xt_set now that ipset is installed.
+	_ = selective.EnsureXtSetModule(ctx)
+
+	h.GetStatus(w, r)
+}
+
+// InstallConntrack handles POST /api/singbox/router/selective/install-conntrack.
+// Installs the conntrack-tools package so routing changes evict stale flows
+// immediately instead of waiting for them to expire.
+//
+//	@Summary		Install conntrack-tools package
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SelectiveStatusData
+//	@Router			/singbox/router/selective/install-conntrack [post]
+func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if selective.IsConntrackAvailable() {
+		h.GetStatus(w, r)
+		return
+	}
+	if err := selective.InstallConntrackTools(r.Context(), nil); err != nil {
+		response.InternalError(w, "conntrack installation failed: "+err.Error())
+		return
+	}
+	h.GetStatus(w, r)
+}
+
+// Rebuild handles POST /api/singbox/router/selective/rebuild.
+// Forces an immediate ipset rebuild from current rules.
+//
+//	@Summary		Force ipset rebuild
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	SelectiveStatusData
+//	@Router			/singbox/router/selective/rebuild [post]
+func (h *SelectiveHandler) Rebuild(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if h.builder == nil {
+		response.ErrorWithStatus(w, http.StatusServiceUnavailable, "selective builder not configured", "NOT_CONFIGURED")
+		return
+	}
+	// Detach cancellation: a client disconnecting mid-rebuild must not abort
+	// the populate (a partial ipset is worse than a stale one). We still wait
+	// synchronously so the response carries the fresh status.
+	ctx := context.WithoutCancel(r.Context())
+	if err := h.builder.Rebuild(ctx); err != nil {
+		response.InternalError(w, "ipset rebuild failed: "+err.Error())
+		return
+	}
+	h.GetStatus(w, r)
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -138,3 +138,39 @@ type ResourceInvalidatedEvent struct {
 	// does not key off it. Examples: "tunnel-toggled", "ndms-restart".
 	Reason string `json:"reason,omitempty"`
 }
+
+// SelectiveProgressEvent is sent during an ipset rebuild for the
+// selective-bypass feature. Phase drives the step indicator in the
+// frontend rebuild modal. Delivered on "singbox-router:selective-progress".
+type SelectiveProgressEvent struct {
+	Phase      string `json:"phase"`   // "collecting"|"resolving"|"populating"|"done"|"error"
+	Message    string `json:"message"` // human-readable description of current step
+	Current    int    `json:"current"` // number of items processed so far
+	Total      int    `json:"total"`   // total items in this phase (0 = unknown)
+	Matcher    string `json:"matcher,omitempty"`
+	QueryHost  string `json:"queryHost,omitempty"`
+}
+
+// SelectiveRebuildSnapshotEvent is the persisted ipset rebuild outcome in SSE.
+type SelectiveRebuildSnapshotEvent struct {
+	RebuiltAt          string `json:"rebuiltAt"`
+	EntryCount         int    `json:"entryCount"`
+	StaticCIDRCount    int    `json:"staticCidrCount,omitempty"`
+	DomainMatcherCount int    `json:"domainMatcherCount,omitempty"`
+	LastCDNRefresh     string `json:"lastCDNRefresh,omitempty"`
+	StaticCIDRs        []string `json:"staticCidrs,omitempty"`
+}
+
+// SelectiveStatusEvent is sent when the selective-bypass availability or
+// entry count changes (e.g. after a successful rebuild or after ipset is
+// installed). Delivered on "singbox-router:selective-status".
+type SelectiveStatusEvent struct {
+	Available          bool   `json:"available"`             // ipset binary present
+	XtSetAvailable     bool   `json:"xtSetAvailable"`        // xt_set kernel module present
+	ConntrackAvailable bool   `json:"conntrackAvailable"`    // conntrack binary present
+	Enabled            bool   `json:"enabled"`               // setting enabled in storage
+	EntryCount         int    `json:"entryCount"`            // current ipset entry count
+	LastRebuild        string                         `json:"lastRebuild,omitempty"` // RFC3339 timestamp
+	LastError          string                         `json:"lastError,omitempty"`
+	Snapshot           *SelectiveRebuildSnapshotEvent `json:"snapshot,omitempty"`
+}

--- a/internal/hydraroute/geodat_expand_stream.go
+++ b/internal/hydraroute/geodat_expand_stream.go
@@ -1,0 +1,135 @@
+package hydraroute
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// StreamGeoSiteTagLines invokes emit for each sing-box inline list line in a
+// geosite tag without building a full []string in memory.
+func StreamGeoSiteTagLines(path, tag string, emit func(line string) error) error {
+	want := strings.ToUpper(strings.TrimSpace(tag))
+	if want == "" {
+		return fmt.Errorf("empty geosite tag")
+	}
+	return streamTagLines(path, want, "geosite", parseGeoSiteDomainLine, emit)
+}
+
+// StreamGeoIPTagLines invokes emit for each CIDR line in a geoip tag without
+// accumulating the full tag in memory.
+func StreamGeoIPTagLines(path, tag string, emit func(line string) error) error {
+	want := strings.ToUpper(strings.TrimSpace(tag))
+	if want == "" {
+		return fmt.Errorf("empty geoip tag")
+	}
+	return streamTagLines(path, want, "geoip", parseGeoIPCidrLine, emit)
+}
+
+func streamTagLines(path, wantTag, kind string, parseItem itemParser, emit func(line string) error) error {
+	found := false
+	err := walkGeoDatEntries(path, func(br *bufio.Reader, entryLen int) error {
+		name, err := streamParseEntryItems(br, entryLen, wantTag, parseItem, emit)
+		if err != nil {
+			return fmt.Errorf("%s: parse entry: %w", path, err)
+		}
+		if name != "" && strings.EqualFold(name, wantTag) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("%s tag %q not found in %s", kind, wantTag, path)
+	}
+	return nil
+}
+
+// streamParseEntryItems walks one dat entry and calls emit per matching item.
+// Returns the entry country_code tag name (may be empty).
+func streamParseEntryItems(br *bufio.Reader, entryLen int, wantTag string, parseItem itemParser, emit func(line string) error) (string, error) {
+	var name string
+	remaining := entryLen
+
+	for remaining > 0 {
+		fieldNum, wireType, n, err := readProtoTagBytes(br)
+		if err != nil {
+			return "", fmt.Errorf("entry tag: %w", err)
+		}
+		remaining -= n
+
+		switch wireType {
+		case 0:
+			_, n, err := readProtoVarintBytes(br)
+			if err != nil {
+				return "", fmt.Errorf("entry varint field %d: %w", fieldNum, err)
+			}
+			remaining -= n
+
+		case 1:
+			if _, err := br.Discard(8); err != nil {
+				return "", fmt.Errorf("entry fixed64: %w", err)
+			}
+			remaining -= 8
+
+		case 2:
+			length, n, err := readProtoVarintBytes(br)
+			if err != nil {
+				return "", fmt.Errorf("entry LD field %d length: %w", fieldNum, err)
+			}
+			remaining -= n
+			if int(length) > remaining {
+				return "", fmt.Errorf("entry field %d length %d exceeds remaining %d", fieldNum, length, remaining)
+			}
+
+			switch fieldNum {
+			case 1:
+				nameBuf := make([]byte, length)
+				if _, err := io.ReadFull(br, nameBuf); err != nil {
+					return "", fmt.Errorf("entry country_code: %w", err)
+				}
+				name = string(nameBuf)
+			case 2:
+				itemBuf := make([]byte, length)
+				if _, err := io.ReadFull(br, itemBuf); err != nil {
+					return "", fmt.Errorf("entry item: %w", err)
+				}
+				if name != "" && strings.EqualFold(name, wantTag) {
+					line, ok, err := parseItem(itemBuf)
+					if err != nil {
+						return "", err
+					}
+					if ok && line != "" {
+						if err := emit(line); err != nil {
+							return "", err
+						}
+					}
+				}
+			default:
+				if length > 0 {
+					if _, err := br.Discard(int(length)); err != nil {
+						return "", fmt.Errorf("entry field %d discard: %w", fieldNum, err)
+					}
+				}
+			}
+			remaining -= int(length)
+
+		case 5:
+			if _, err := br.Discard(4); err != nil {
+				return "", fmt.Errorf("entry fixed32: %w", err)
+			}
+			remaining -= 4
+
+		default:
+			return "", fmt.Errorf("entry field %d: unsupported wire type %d", fieldNum, wireType)
+		}
+	}
+
+	if remaining != 0 {
+		return "", fmt.Errorf("entry misaligned: %d bytes left over", remaining)
+	}
+	return name, nil
+}

--- a/internal/logging/types.go
+++ b/internal/logging/types.go
@@ -50,6 +50,7 @@ const (
 	SubAccessPolicy   = "access-policy"
 	SubClientRoute    = "client-route"
 	SubSingboxRouter  = "singbox-router"
+	SubSelective      = "selective"
 	SubSubscription   = "subscription"
 	SubDeviceProxy    = "deviceproxy"
 	SubHrNeo          = "hrneo"
@@ -113,7 +114,7 @@ var KnownSubgroups = map[string][]string{
 	},
 	GroupRouting: {
 		SubDnsRoute, SubStaticRoute, SubAccessPolicy, SubClientRoute,
-		SubSingboxRouter, SubSubscription, SubDeviceProxy, SubHrNeo, SubRoutingCatalog,
+		SubSingboxRouter, SubSelective, SubSubscription, SubDeviceProxy, SubHrNeo, SubRoutingCatalog,
 		SubAWGOutbounds,
 	},
 	GroupServer: {

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -2524,6 +2524,98 @@ definitions:
       state:
         type: string
     type: object
+  api.SelectiveDomainMatcherRecordDTO:
+    properties:
+      cdn:
+        type: boolean
+      error:
+        type: string
+      kind:
+        type: string
+      matcher:
+        type: string
+      outbound:
+        type: string
+      queryHosts:
+        items:
+          type: string
+        type: array
+    type: object
+  api.SelectiveRebuildSnapshotDTO:
+    properties:
+      domainMatcherCount:
+        type: integer
+      domainResults:
+        items: {}
+        type: array
+      entryCount:
+        type: integer
+      lastCDNRefresh:
+        type: string
+      rebuiltAt:
+        type: string
+      staticCidrCount:
+        type: integer
+      staticCidrs:
+        items:
+          type: string
+        type: array
+    type: object
+  api.SelectiveSnapshotMatchersData:
+    properties:
+      limit:
+        type: integer
+      matchers:
+        items:
+          $ref: '#/definitions/api.SelectiveDomainMatcherRecordDTO'
+        type: array
+      offset:
+        type: integer
+      total:
+        type: integer
+    type: object
+  api.SelectiveStatusData:
+    properties:
+      available:
+        description: Available reports whether the ipset binary is present on the
+          router.
+        type: boolean
+      conntrackAvailable:
+        description: |-
+          ConntrackAvailable reports whether the conntrack binary is present.
+          Without it a routing change applies only to new connections (existing
+          flows linger until they expire).
+        type: boolean
+      enabled:
+        description: Enabled mirrors SingboxRouterSettings.SelectiveBypass.
+        type: boolean
+      entryCount:
+        description: |-
+          EntryCount is the current number of entries in the AWGM-SELECTIVE ipset.
+          0 when the set does not exist or is empty.
+        type: integer
+      installing:
+        description: Installing is true while opkg install ipset is running.
+        type: boolean
+      lastError:
+        description: LastError is the error message from the last failed rebuild,
+          or empty.
+        type: string
+      lastRebuild:
+        description: |-
+          LastRebuild is the RFC3339 timestamp of the last successful rebuild, or
+          empty string if no rebuild has run yet.
+        type: string
+      snapshot:
+        allOf:
+        - $ref: '#/definitions/api.SelectiveRebuildSnapshotDTO'
+        description: Snapshot is summary metadata from the last rebuild (no IP lists).
+      xtSetAvailable:
+        description: |-
+          XtSetAvailable reports whether the xt_set kernel module is loaded or
+          available as a .ko file (required for -m set iptables matching).
+        type: boolean
+    type: object
   api.ServerAddPeerRequestDTO:
     properties:
       description:
@@ -12101,6 +12193,101 @@ paths:
       security:
       - CookieAuth: []
       summary: Update singbox-router ruleset
+      tags:
+      - singbox-router
+  /singbox/router/selective/install-conntrack:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SelectiveStatusData'
+      security:
+      - CookieAuth: []
+      summary: Install conntrack-tools package
+      tags:
+      - singbox-router
+  /singbox/router/selective/install-deps:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SelectiveStatusData'
+        "409":
+          description: already installing
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Install ipset package
+      tags:
+      - singbox-router
+  /singbox/router/selective/rebuild:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SelectiveStatusData'
+      security:
+      - CookieAuth: []
+      summary: Force ipset rebuild
+      tags:
+      - singbox-router
+  /singbox/router/selective/snapshot/matchers:
+    get:
+      description: Returns a paginated slice of matcher records (DNS query hosts,
+        no IPs) from the NDJSON snapshot.
+      parameters:
+      - default: 0
+        description: Zero-based record offset
+        in: query
+        name: offset
+        type: integer
+      - default: 200
+        description: Page size (max 1000)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SelectiveSnapshotMatchersData'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: List domain matchers from last ipset rebuild
+      tags:
+      - singbox-router
+  /singbox/router/selective/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SelectiveStatusData'
+      security:
+      - CookieAuth: []
+      summary: Selective-bypass status
       tags:
       - singbox-router
   /singbox/router/settings:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,6 +119,7 @@ type Server struct {
 	singboxFakeIPConfigHandler *api.SingboxFakeIPConfigHandler
 	singboxConfigHandler       *api.SingboxConfigHandler
 	singboxProxiesHandler      *api.SingboxProxiesHandler
+	selectiveHandler           *api.SelectiveHandler
 	awgOutboundsHandler        *api.AWGOutboundsHandler
 	subscriptionHandler        *api.SubscriptionHandler
 	dnsRewritesHandler         *api.DNSRewritesHandler
@@ -345,6 +346,12 @@ func (s *Server) SetSingboxConfigHandler(h *api.SingboxConfigHandler) {
 // (for the upstream URL) are constructed late.
 func (s *Server) SetSingboxProxiesHandler(h *api.SingboxProxiesHandler) {
 	s.singboxProxiesHandler = h
+}
+
+// SetSelectiveHandler wires the selective-bypass handler so
+// /api/singbox/router/selective/* routes can be registered.
+func (s *Server) SetSelectiveHandler(h *api.SelectiveHandler) {
+	s.selectiveHandler = h
 }
 
 // SetSubscriptionHandler wires the VPN subscription CRUD handler so the
@@ -1183,6 +1190,15 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 		mux.HandleFunc("/api/singbox/router/staging", guarded(rh.GetStaging))
 		mux.HandleFunc("/api/singbox/router/staging/apply", guarded(rh.PostStagingApply))
 		mux.HandleFunc("/api/singbox/router/staging/discard", guarded(rh.PostStagingDiscard))
+	}
+
+	if s.selectiveHandler != nil {
+		sh := s.selectiveHandler
+		mux.HandleFunc("/api/singbox/router/selective/status", guarded(sh.GetStatus))
+		mux.HandleFunc("/api/singbox/router/selective/snapshot/matchers", guarded(sh.GetSnapshotMatchers))
+		mux.HandleFunc("/api/singbox/router/selective/install-deps", guarded(sh.InstallDeps))
+		mux.HandleFunc("/api/singbox/router/selective/install-conntrack", guarded(sh.InstallConntrack))
+		mux.HandleFunc("/api/singbox/router/selective/rebuild", guarded(sh.Rebuild))
 	}
 
 	if s.singboxFakeIPConfigHandler != nil {

--- a/internal/singbox/heavyop/gate.go
+++ b/internal/singbox/heavyop/gate.go
@@ -1,0 +1,27 @@
+// Package heavyop serializes memory-heavy sing-box work (ipset rebuild, config apply).
+package heavyop
+
+import "sync"
+
+// Gate ensures selective ipset rebuild and sing-box config apply/reload do not run concurrently.
+type Gate struct {
+	mu sync.Mutex
+}
+
+// Default is the process-wide gate shared by orchestrator reload and selective rebuild.
+var Default Gate
+
+// Lock blocks until no other heavy operation is running.
+func (g *Gate) Lock() {
+	g.mu.Lock()
+}
+
+// Unlock releases the gate.
+func (g *Gate) Unlock() {
+	g.mu.Unlock()
+}
+
+// TryLock reports whether the gate was acquired without blocking.
+func (g *Gate) TryLock() bool {
+	return g.mu.TryLock()
+}

--- a/internal/singbox/orchestrator/reload.go
+++ b/internal/singbox/orchestrator/reload.go
@@ -4,7 +4,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
 )
+
+// ReloadNow cancels any pending debounced reload and applies the merged
+// config immediately. Enable/Disable call this after SetEnabled+Save so
+// sing-box cold-starts without waiting reloadDebounce — otherwise
+// waitForSingbox burns the whole boot window before the process even
+// starts (stand-found on aarch64 off→tproxy switches).
+func (o *Orchestrator) ReloadNow() error {
+	o.mu.Lock()
+	if o.reloadTimer != nil {
+		o.reloadTimer.Stop()
+		o.reloadTimer = nil
+	}
+	o.mu.Unlock()
+	return o.Reload()
+}
 
 // scheduleReload arms (or re-arms) the debounce timer. Caller MUST
 // hold o.mu. Calling repeatedly within the window coalesces into one
@@ -32,6 +49,9 @@ func (o *Orchestrator) scheduleReload() {
 // the internal debounce timer. Safe for concurrent callers — internally
 // serialized by mu and the reloading flag.
 func (o *Orchestrator) Reload() error {
+	heavyop.Default.Lock()
+	defer heavyop.Default.Unlock()
+
 	o.mu.Lock()
 	if o.reloading {
 		o.mu.Unlock()

--- a/internal/singbox/orchestrator/types.go
+++ b/internal/singbox/orchestrator/types.go
@@ -20,6 +20,7 @@ const (
 	SlotTunnels       Slot = "tunnels"       // 10-tunnels.json
 	SlotAwg           Slot = "awg"           // 15-awg.json
 	SlotDNSRewrites   Slot = "dns-rewrites"  // 17-dns-rewrites.json
+	SlotSelectiveRoutes Slot = "selective-routes" // 19-selective-routes.json
 	SlotRouter        Slot = "router"        // 20-router.json
 	SlotFakeIP        Slot = "fakeip"        // 21-fakeip.json
 	SlotDeviceProxy   Slot = "deviceproxy"   // 30-deviceproxy.json
@@ -67,6 +68,7 @@ func KnownSlots() []SlotMeta {
 		{Slot: SlotTunnels, Filename: "10-tunnels.json", AlwaysOn: true},
 		{Slot: SlotAwg, Filename: "15-awg.json", AlwaysOn: true},
 		{Slot: SlotDNSRewrites, Filename: "17-dns-rewrites.json"},
+		{Slot: SlotSelectiveRoutes, Filename: "19-selective-routes.json"},
 		{Slot: SlotRouter, Filename: "20-router.json"},
 		{Slot: SlotFakeIP, Filename: "21-fakeip.json"},
 		{Slot: SlotDeviceProxy, Filename: "30-deviceproxy.json"},

--- a/internal/singbox/orchestrator/types_test.go
+++ b/internal/singbox/orchestrator/types_test.go
@@ -4,19 +4,24 @@ import "testing"
 
 func TestKnownSlotsIncludesDNSRewritesBeforeRouter(t *testing.T) {
 	slots := KnownSlots()
-	idxRewrites, idxRouter := -1, -1
+	idxRewrites, idxSelective, idxRouter := -1, -1, -1
 	for i, m := range slots {
-		if m.Slot == SlotDNSRewrites {
+		switch m.Slot {
+		case SlotDNSRewrites:
 			idxRewrites = i
-		}
-		if m.Slot == SlotRouter {
+		case SlotSelectiveRoutes:
+			idxSelective = i
+		case SlotRouter:
 			idxRouter = i
 		}
 	}
 	if idxRewrites < 0 {
 		t.Fatal("SlotDNSRewrites not registered")
 	}
-	if !(idxRewrites < idxRouter) {
-		t.Errorf("rewrites slot must sort before router: rewrites=%d router=%d", idxRewrites, idxRouter)
+	if idxSelective < 0 {
+		t.Fatal("SlotSelectiveRoutes not registered")
+	}
+	if !(idxRewrites < idxSelective && idxSelective < idxRouter) {
+		t.Errorf("slot order: rewrites=%d selective=%d router=%d", idxRewrites, idxSelective, idxRouter)
 	}
 }

--- a/internal/singbox/router/fakeip_cidr_remote.go
+++ b/internal/singbox/router/fakeip_cidr_remote.go
@@ -19,6 +19,9 @@ var ruleSetDownload = func(ctx context.Context, url, format string) (string, err
 var ruleSetDecompileExec = func(binary, srsPath string) ([]byte, error) {
 	return defaultRuleSetDecompile(binary, srsPath)
 }
+var ruleSetDecompileToFile = func(binary, srsPath string) (string, error) {
+	return defaultRuleSetDecompileToFile(binary, srsPath)
+}
 
 // remoteCIDRCache is a process-wide on-disk cache for the Tier-2 download path.
 // It shares the same sha256-by-URL layout (and default $TMPDIR/awgm-router-rulesets
@@ -45,27 +48,38 @@ func defaultRuleSetDownload(_ context.Context, url, format string) (string, erro
 	return sharedRemoteCIDRCache().getOrDownload(url, format, nil, "")
 }
 
+// defaultRuleSetDecompileToFile runs sing-box rule-set decompile into a temp JSON
+// file and returns its path. The caller must remove the file when done.
+func defaultRuleSetDecompileToFile(binary, srsPath string) (string, error) {
+	if binary == "" {
+		return "", fmt.Errorf("no sing-box binary for decompile")
+	}
+	tmp, err := os.CreateTemp("", "awgm-decompile-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp: %w", err)
+	}
+	jsonPath := tmp.Name()
+	_ = tmp.Close()
+
+	cmd := exec.Command(binary, "rule-set", "decompile", "--output", jsonPath, srsPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.Remove(jsonPath)
+		return "", fmt.Errorf("sing-box decompile: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return jsonPath, nil
+}
+
 // defaultRuleSetDecompile runs `sing-box rule-set decompile --output <tmp.json>
 // <srs>` (the genpresets form) and returns the decompiled source JSON bytes.
 // sing-box writes to the --output file rather than stdout, so we point it at a
 // temp file, read it back, and remove it. An empty binary (dev box without
 // sing-box) yields an error the caller logs + skips.
 func defaultRuleSetDecompile(binary, srsPath string) ([]byte, error) {
-	if binary == "" {
-		return nil, fmt.Errorf("no sing-box binary for decompile")
-	}
-	tmp, err := os.CreateTemp("", "awgm-decompile-*.json")
+	jsonPath, err := defaultRuleSetDecompileToFile(binary, srsPath)
 	if err != nil {
-		return nil, fmt.Errorf("create temp: %w", err)
+		return nil, err
 	}
-	jsonPath := tmp.Name()
-	_ = tmp.Close()
 	defer os.Remove(jsonPath)
-
-	cmd := exec.Command(binary, "rule-set", "decompile", "--output", jsonPath, srsPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("sing-box decompile: %v: %s", err, strings.TrimSpace(string(out)))
-	}
 	return os.ReadFile(jsonPath)
 }
 

--- a/internal/singbox/router/fakeip_cidr_routes.go
+++ b/internal/singbox/router/fakeip_cidr_routes.go
@@ -30,8 +30,9 @@ func isProxyRoute(r Rule) bool {
 func loopSafeProxyRule(r Rule) bool {
 	return isProxyRoute(r) &&
 		r.Type == "" && r.Mode == "" && len(r.Rules) == 0 &&
-		len(r.DomainSuffix) == 0 && len(r.SourceIPCIDR) == 0 &&
-		len(r.Port) == 0 && r.Protocol == "" && r.IPIsPrivate == nil
+		len(r.DomainSuffix) == 0 && len(r.Domain) == 0 && len(r.SourceIPCIDR) == 0 &&
+		len(r.Port) == 0 && r.Protocol == "" && r.IPIsPrivate == nil &&
+		r.AwgmManaged == ""
 }
 
 // cgnat is RFC 6598 shared address space (100.64.0.0/10) — never a valid proxy

--- a/internal/singbox/router/fakeip_cidr_routes_test.go
+++ b/internal/singbox/router/fakeip_cidr_routes_test.go
@@ -347,7 +347,7 @@ func TestEnable_AppliesCIDRRoutes(t *testing.T) {
 	// Seed the fakeip config (21-fakeip.json) with a loop-safe proxy ip_cidr rule.
 	// route.final="direct" is a known built-in outbound so the egress check passes;
 	// a DNS rule keeps fakeIPConfigEmpty false so the seed path leaves our rules be.
-	fcfg := `{"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
+	fcfg := `{"outbounds":[{"tag":"proxy","type":"direct"}],"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
 		`"route":{"final":"direct","rules":[{"action":"route","outbound":"proxy","ip_cidr":["149.154.160.0/20"]}]}}`
 	if err := os.WriteFile(filepath.Join(h.dir, "21-fakeip.json"), []byte(fcfg), 0644); err != nil {
 		t.Fatalf("write 21-fakeip.json: %v", err)
@@ -379,7 +379,7 @@ func TestDisable_RemovesCIDRRoutes(t *testing.T) {
 	captureDrain(t) // capture the async pool-drain so it never runs inline
 
 	// Seed the fakeip config with a loop-safe proxy ip_cidr rule before provisioning.
-	fcfg := `{"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
+	fcfg := `{"outbounds":[{"tag":"proxy","type":"direct"}],"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
 		`"route":{"final":"direct","rules":[{"action":"route","outbound":"proxy","ip_cidr":["149.154.160.0/20"]}]}}`
 	if err := os.WriteFile(filepath.Join(h.dir, "21-fakeip.json"), []byte(fcfg), 0644); err != nil {
 		t.Fatalf("write 21-fakeip.json: %v", err)
@@ -407,7 +407,7 @@ func TestReconcileFakeIPTun_ReaddsCIDRRouteWhenMissing(t *testing.T) {
 
 	// Seed a loop-safe proxy ip_cidr rule before provisioning so loadFakeIPConfig
 	// returns it on reconcile.
-	fcfg := `{"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
+	fcfg := `{"outbounds":[{"tag":"proxy","type":"direct"}],"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
 		`"route":{"final":"direct","rules":[{"action":"route","outbound":"proxy","ip_cidr":["149.154.160.0/20"]}]}}`
 	if err := os.WriteFile(filepath.Join(h.dir, "21-fakeip.json"), []byte(fcfg), 0644); err != nil {
 		t.Fatalf("write 21-fakeip.json: %v", err)
@@ -451,7 +451,7 @@ func TestReconcileFakeIPTun_V6CIDRSelfHealNoV4(t *testing.T) {
 	h := newFakeIPEnableHarness(t, "")
 
 	// Seed a loop-safe proxy rule carrying ONLY a v6 ip_cidr — no v4 CIDR at all.
-	fcfg := `{"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
+	fcfg := `{"outbounds":[{"tag":"proxy","type":"direct"}],"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
 		`"route":{"final":"direct","rules":[{"action":"route","outbound":"proxy","ip_cidr":["2001:b28::/32"]}]}}`
 	if err := os.WriteFile(filepath.Join(h.dir, "21-fakeip.json"), []byte(fcfg), 0644); err != nil {
 		t.Fatalf("write 21-fakeip.json: %v", err)
@@ -492,7 +492,7 @@ func TestReconcileFakeIPTun_V6CIDRGatedOnPresenceProbe(t *testing.T) {
 
 	// Seed a loop-safe proxy rule carrying BOTH a v4 and a v6 ip_cidr so a v6 CIDR
 	// route exists in the desired set.
-	fcfg := `{"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
+	fcfg := `{"outbounds":[{"tag":"proxy","type":"direct"}],"dns":{"rules":[{"action":"route","server":"fakeip","query_type":["A","AAAA"]}]},` +
 		`"route":{"final":"direct","rules":[{"action":"route","outbound":"proxy","ip_cidr":["149.154.160.0/20","2001:b28::/32"]}]}}`
 	if err := os.WriteFile(filepath.Join(h.dir, "21-fakeip.json"), []byte(fcfg), 0644); err != nil {
 		t.Fatalf("write 21-fakeip.json: %v", err)

--- a/internal/singbox/router/fakeip_enable.go
+++ b/internal/singbox/router/fakeip_enable.go
@@ -279,6 +279,9 @@ func (s *ServiceImpl) enableFakeIPTun(ctx context.Context, settings *storage.Set
 	if err = s.persistFakeIPConfig(ctx, fcfg); err != nil {
 		return fmt.Errorf("enable fakeip-tun: persist fakeip config: %w", err)
 	}
+	if err = s.orchestratorApplyNow(); err != nil {
+		return fmt.Errorf("enable fakeip-tun: orchestrator reload: %w", err)
+	}
 
 	// Wait for sing-box to be truly ready (process + tun carrier + live fakeip
 	// DNS). The address flush already ran PRE-start (above), so the tun keeps the

--- a/internal/singbox/router/fakeip_transition.go
+++ b/internal/singbox/router/fakeip_transition.go
@@ -129,6 +129,9 @@ func (s *ServiceImpl) SwitchRoutingMode(ctx context.Context, target string) erro
 
 	source, err := s.currentState()
 	if err != nil {
+		s.emitTransition(id, stateOff, target,
+			TransitionStep{Step: "error", Status: "error", Message: err.Error()},
+			true, stateOff, err.Error())
 		return err
 	}
 
@@ -173,15 +176,43 @@ func (s *ServiceImpl) SwitchRoutingMode(ctx context.Context, target string) erro
 
 	// ── Bring up the TARGET mode ────────────────────────────────────────────
 	if err := s.persistMode(target, true); err != nil {
+		s.emitTransition(id, source, target,
+			TransitionStep{Step: "error", Status: "error", Message: err.Error()},
+			true, source, err.Error())
 		return fmt.Errorf("switch %s→%s: persist target mode: %w", source, target, err)
 	}
-	s.emitTransition(id, source, target,
-		TransitionStep{Step: "provision", Status: "current"}, false, "", "")
+	s.transitionReadinessProgress = func(msg string) {
+		s.emitTransition(id, source, target,
+			TransitionStep{Step: "readiness", Status: "current", Message: msg},
+			false, "", "")
+	}
+	defer func() { s.transitionReadinessProgress = nil }()
+
+	// tproxy Enable waits for sing-box BEFORE iptables install — emit readiness
+	// (not provision) so the UI spinner matches reality. fakeip-tun still uses
+	// provision:current because its long bring-up is mapped to that milestone.
+	if target == stateTProxy {
+		s.emitTransition(id, source, target,
+			TransitionStep{Step: "readiness", Status: "current", Message: "запуск sing-box"},
+			false, "", "")
+	} else {
+		s.emitTransition(id, source, target,
+			TransitionStep{Step: "provision", Status: "current"}, false, "", "")
+	}
 
 	if enableErr := s.Enable(ctx); enableErr != nil {
+		failStep := "provision"
+		if target == stateTProxy {
+			failStep = "readiness"
+		}
+		s.emitTransition(id, source, target,
+			TransitionStep{Step: failStep, Status: "error", Message: enableErr.Error()},
+			false, "", "")
 		return s.rollbackSwitch(ctx, id, source, target, enableErr)
 	}
 
+	s.emitTransition(id, source, target,
+		TransitionStep{Step: "provision", Status: "done"}, false, "", "")
 	s.emitTransition(id, source, target,
 		TransitionStep{Step: "readiness", Status: "done"}, false, "", "")
 	s.emitTransition(id, source, target,

--- a/internal/singbox/router/fakeip_transition_test.go
+++ b/internal/singbox/router/fakeip_transition_test.go
@@ -206,7 +206,7 @@ func TestSwitch_OffToFakeIP(t *testing.T) {
 		t.Fatalf("persisted = %q/%v want fakeip-tun/true", mode, enabled)
 	}
 	// No teardown (source=off): start → provision → readiness → ready.
-	want := []string{"start:current", "provision:current", "readiness:done", "ready:done"}
+	want := []string{"start:current", "provision:current", "provision:done", "readiness:done", "ready:done"}
 	assertSteps(t, h.steps(), want)
 	term, _ := h.terminal()
 	if term.FinalState != stateFakeIPTun {
@@ -229,7 +229,7 @@ func TestSwitch_TproxyToFakeIP(t *testing.T) {
 		t.Fatalf("persisted = %q/%v want fakeip-tun/true", mode, enabled)
 	}
 	// Teardown tproxy THEN provision fakeip.
-	want := []string{"start:current", "teardown:current", "teardown:done", "provision:current", "readiness:done", "ready:done"}
+	want := []string{"start:current", "teardown:current", "teardown:done", "provision:current", "provision:done", "readiness:done", "ready:done"}
 	assertSteps(t, h.steps(), want)
 }
 
@@ -251,7 +251,7 @@ func TestSwitch_FakeIPToTproxy(t *testing.T) {
 	if mode != stateTProxy || !enabled {
 		t.Fatalf("persisted = %q/%v want tproxy/true", mode, enabled)
 	}
-	want := []string{"start:current", "teardown:current", "teardown:done", "provision:current", "readiness:done", "ready:done"}
+	want := []string{"start:current", "teardown:current", "teardown:done", "readiness:current", "provision:done", "readiness:done", "ready:done"}
 	assertSteps(t, h.steps(), want)
 }
 

--- a/internal/singbox/router/iptables.go
+++ b/internal/singbox/router/iptables.go
@@ -75,6 +75,10 @@ var (
 	netfilterRulesPath = "/opt/etc/awg-manager/singbox/router-netfilter.rules"
 )
 
+// selectiveSetName is the ipset name used for selective bypass. Must match
+// selective.SetName in the selective sub-package.
+const selectiveSetName = "AWGM-SELECTIVE"
+
 func kernelModuleName() string { return "xt_TPROXY" }
 
 func buildTProxyModulePath(kernelVersion string) string {
@@ -245,6 +249,16 @@ type RestoreInputSpec struct {
 	// чей ingress-трафик помечается policy-меткой в mangle PREROUTING до
 	// connmark-jump'а. Пусто / MatchAll / пустой PolicyMark = no-op.
 	IngressInterfaces []string
+
+	// SelectiveIPSet, when true, inserts an iptables -m set guard rule in
+	// both AWGM-TPROXY (mangle) and AWGM-REDIRECT (nat) chains so that
+	// only traffic whose destination IP is listed in AWGM-SELECTIVE reaches
+	// sing-box. All other traffic gets an early RETURN and bypasses sing-box
+	// entirely (going straight to WAN). The guard is placed after user bypass
+	// RETURN rules (port/CIDR exclusions) but before the catch-all TPROXY /
+	// REDIRECT rule, so explicit bypass rules still take precedence.
+	// Only meaningful when the xt_set kernel module is loaded.
+	SelectiveIPSet bool
 }
 
 var bypassCIDRs = []string{
@@ -341,6 +355,15 @@ func buildRestoreInput(spec RestoreInputSpec) string {
 	fmt.Fprintf(&b, "-A %s -p udp --dport 53 -j TPROXY --on-port %d --on-ip 127.0.0.1 --tproxy-mark 0x%x\n",
 		ChainName, TPROXYPort, Fwmark)
 
+	// Selective-bypass guard: only traffic to IPs in AWGM-SELECTIVE reaches
+	// sing-box; everything else returns to PREROUTING and goes to WAN.
+	// Placed after DNS intercept so DNS still reaches sing-box regardless
+	// of ipset membership (DNS must always be intercepted for hijack-dns).
+	if spec.SelectiveIPSet {
+		fmt.Fprintf(&b, "-A %s -m set ! --match-set %s dst -j RETURN\n",
+			ChainName, selectiveSetName)
+	}
+
 	// set_chain_rules: bypass set. SKeen uses one ipset rule; we render
 	// the same destinations as discrete CIDR rules (semantically equal).
 	emitBypassReturns(&b, ChainName, spec.WANIPs)
@@ -386,6 +409,12 @@ func buildRestoreInput(spec RestoreInputSpec) string {
 	// Bypass ports: RETURN before catch-all TCP REDIRECT.
 	for _, pr := range spec.BypassTCPPorts {
 		fmt.Fprintf(&b, "-A %s -p tcp --dport %s -j RETURN\n", RedirectChain, pr.String())
+	}
+
+	// Selective-bypass guard for TCP: mirrors the mangle guard above.
+	if spec.SelectiveIPSet {
+		fmt.Fprintf(&b, "-A %s -m set ! --match-set %s dst -j RETURN\n",
+			RedirectChain, selectiveSetName)
 	}
 
 	// add_redirect_rules: catch-all REDIRECT for TCP.

--- a/internal/singbox/router/iptables_test.go
+++ b/internal/singbox/router/iptables_test.go
@@ -1311,3 +1311,59 @@ func TestBuildRestoreInput_BypassCIDRs(t *testing.T) {
 		t.Errorf("user bypass (%d) must precede DNS intercept (%d) in mangle", bypassIdx, dnsIdx)
 	}
 }
+
+func TestBuildRestoreInput_SelectiveIPSet_AddsGuardRules(t *testing.T) {
+	spec := RestoreInputSpec{
+		PolicyMark:     "0xffffaaa",
+		SelectiveIPSet: true,
+	}
+	out := buildRestoreInput(spec)
+
+	mangleGuard := fmt.Sprintf("-A %s -m set ! --match-set %s dst -j RETURN", ChainName, selectiveSetName)
+	natGuard := fmt.Sprintf("-A %s -m set ! --match-set %s dst -j RETURN", RedirectChain, selectiveSetName)
+
+	if !strings.Contains(out, mangleGuard) {
+		t.Errorf("mangle chain missing selective guard rule\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, natGuard) {
+		t.Errorf("nat chain missing selective guard rule\ngot:\n%s", out)
+	}
+}
+
+func TestBuildRestoreInput_SelectiveIPSet_Disabled_NoGuardRules(t *testing.T) {
+	spec := RestoreInputSpec{
+		PolicyMark:     "0xffffaaa",
+		SelectiveIPSet: false,
+	}
+	out := buildRestoreInput(spec)
+
+	if strings.Contains(out, "--match-set") {
+		t.Errorf("unexpected selective guard rule when SelectiveIPSet=false\ngot:\n%s", out)
+	}
+}
+
+func TestBuildRestoreInput_SelectiveIPSet_GuardAfterDNS(t *testing.T) {
+	// The selective guard must appear AFTER the DNS intercept rule so that
+	// DNS (port 53) is always intercepted regardless of ipset membership.
+	// This ensures that the hijack-dns action keeps working even when
+	// selective mode is on.
+	spec := RestoreInputSpec{
+		PolicyMark:     "0xffffaaa",
+		SelectiveIPSet: true,
+	}
+	out := buildRestoreInput(spec)
+
+	dnsIdx := strings.Index(out, fmt.Sprintf("-A %s -p udp --dport 53 -j TPROXY", ChainName))
+	guardIdx := strings.Index(out, fmt.Sprintf("-A %s -m set ! --match-set %s dst -j RETURN", ChainName, selectiveSetName))
+	catchAllIdx := strings.Index(out, fmt.Sprintf("-A %s -p udp -j TPROXY", ChainName))
+
+	if dnsIdx == -1 || guardIdx == -1 || catchAllIdx == -1 {
+		t.Fatalf("missing rule(s): dns=%d guard=%d catchAll=%d\n%s", dnsIdx, guardIdx, catchAllIdx, out)
+	}
+	if guardIdx < dnsIdx {
+		t.Errorf("selective guard (%d) must appear AFTER DNS intercept (%d)", guardIdx, dnsIdx)
+	}
+	if guardIdx > catchAllIdx {
+		t.Errorf("selective guard (%d) must appear BEFORE catch-all TPROXY (%d)", guardIdx, catchAllIdx)
+	}
+}

--- a/internal/singbox/router/selective/builder.go
+++ b/internal/singbox/router/selective/builder.go
@@ -1,0 +1,425 @@
+package selective
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
+)
+
+// Phase describes the current stage of an ipset rebuild.
+type Phase string
+
+const (
+	PhaseCollecting Phase = "collecting"
+	PhaseResolving  Phase = "resolving"
+	PhasePopulating Phase = "populating"
+	PhaseDone       Phase = "done"
+	PhaseError      Phase = "error"
+)
+
+// Progress carries rebuild state for SSE. Intentionally omits IP lists.
+type Progress struct {
+	Phase   Phase  `json:"phase"`
+	Message string `json:"message"`
+	Current int    `json:"current"`
+	Total   int    `json:"total"`
+	// Matcher is the domain rule currently being resolved (resolving phase).
+	Matcher string `json:"matcher,omitempty"`
+	// QueryHost is the expanded hostname being queried.
+	QueryHost string `json:"queryHost,omitempty"`
+}
+
+// ProgressFn is called with progress updates during a Rebuild. May be nil.
+type ProgressFn func(Progress)
+
+// EventPublisher is the narrow interface for publishing SSE events.
+type EventPublisher interface {
+	Publish(eventType string, data any)
+}
+
+// BuilderConfig holds the external dependencies for Builder.
+type BuilderConfig struct {
+	ConfigDir string
+	DNSSource DNSServerSource
+	Log       *logging.ScopedLogger
+	Bus       EventPublisher
+	Geo       GeoPaths
+	// OpenRuleSetJSON returns a streamable JSON path for remote/local rule sets.
+	OpenRuleSetJSON RuleSetJSONOpener
+}
+
+// Builder orchestrates streaming collection, DNS resolve, and ipset populate.
+type Builder struct {
+	cfg BuilderConfig
+
+	mu          sync.Mutex
+	opMu        sync.Mutex
+	lastRebuild time.Time
+	lastError   string
+	summary     *SnapshotSummary
+	routes      map[string][]string
+}
+
+// NewBuilder constructs a Builder with the given configuration.
+func NewBuilder(cfg BuilderConfig) *Builder {
+	RemoveLegacySnapshotJSON(cfg.ConfigDir)
+	b := &Builder{cfg: cfg}
+	if ts := readLastRebuild(cfg.ConfigDir); !ts.IsZero() {
+		b.lastRebuild = ts
+	}
+	b.summary = readSnapshotSummary(cfg.ConfigDir)
+	return b
+}
+
+func (b *Builder) LastRebuild() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastRebuild.IsZero() {
+		return ""
+	}
+	return b.lastRebuild.UTC().Format(time.RFC3339)
+}
+
+func (b *Builder) LastError() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.lastError
+}
+
+// LastSnapshot returns summary metadata only (no matcher list in RAM).
+func (b *Builder) LastSnapshot() *RebuildSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.summary == nil {
+		return nil
+	}
+	return summaryToLegacyAPI(b.summary)
+}
+
+// LastSummary returns the in-memory rebuild summary.
+func (b *Builder) LastSummary() *SnapshotSummary {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.summary == nil {
+		return nil
+	}
+	cp := *b.summary
+	return &cp
+}
+
+// LastIPRulesByOutbound returns /32 overlay rules for 19-selective-routes.json.
+func (b *Builder) LastIPRulesByOutbound() map[string][]string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.routes) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(b.routes))
+	for k, v := range b.routes {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+func summaryToLegacyAPI(s *SnapshotSummary) *RebuildSnapshot {
+	if s == nil {
+		return nil
+	}
+	return &RebuildSnapshot{
+		RebuiltAt:          s.RebuiltAt,
+		EntryCount:         s.EntryCount,
+		StaticCIDRCount:    s.StaticCIDRCount,
+		DomainMatcherCount: s.DomainMatcherCount,
+		LastCDNRefresh:     s.LastCDNRefresh,
+		StaticCIDRs:        []string{},
+		DomainResults:      []DomainResolveResult{},
+	}
+}
+
+// Rebuild streams matchers → DNS → staging ipset → atomic swap.
+func (b *Builder) Rebuild(
+	ctx context.Context,
+	rules []RuleJSON,
+	ruleSetRefs []RuleSetRef,
+	singboxDNS []SingboxDNSServer,
+	fn ProgressFn,
+) error {
+	heavyop.Default.Lock()
+	defer heavyop.Default.Unlock()
+	b.opMu.Lock()
+	defer b.opMu.Unlock()
+
+	emit := func(p Progress) {
+		if fn != nil {
+			fn(p)
+		}
+		if b.cfg.Bus != nil {
+			b.cfg.Bus.Publish("singbox-router:selective-progress", p)
+		}
+	}
+
+	emit(Progress{Phase: PhaseCollecting, Message: "Сбор IP-адресов и доменов из правил маршрутизации…"})
+
+	if err := CreateSet(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: create live set: %w", err))
+	}
+	if err := EnsureStagingSet(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: create staging set: %w", err))
+	}
+	if err := FlushStagingSet(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: flush staging: %w", err))
+	}
+
+	snapW, err := newSnapshotWriter(b.cfg.ConfigDir)
+	if err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: snapshot writer: %w", err))
+	}
+	defer snapW.Abort()
+
+	routes := NewRouteAccumulator()
+	ctQueue := newConntrackQueue()
+	var stagingChunk []string
+	var stagingMu sync.Mutex
+	flushStaging := func() error {
+		stagingMu.Lock()
+		defer stagingMu.Unlock()
+		if len(stagingChunk) == 0 {
+			return nil
+		}
+		chunk := stagingChunk
+		stagingChunk = nil
+		return ChunkedAddStaging(ctx, chunk)
+	}
+	addStaging := func(cidr string) error {
+		cidr = normalizeEntry(cidr)
+		if cidr == "" {
+			return nil
+		}
+		stagingMu.Lock()
+		stagingChunk = append(stagingChunk, cidr)
+		if len(stagingChunk) < IpsetChunkSize {
+			stagingMu.Unlock()
+			return nil
+		}
+		chunk := stagingChunk
+		stagingChunk = nil
+		stagingMu.Unlock()
+		return ChunkedAddStaging(ctx, chunk)
+	}
+
+	var staticCount atomic.Int32
+	var domainCount atomic.Int32
+	dnsServers := BuildDNSServers(ctx, singboxDNS, b.cfg.DNSSource)
+
+	var queries []DomainQuery
+	sink := CollectSink{
+		OnStaticCIDR: func(cidr string) error {
+			staticCount.Add(1)
+			return addStaging(cidr)
+		},
+		OnDomainQuery: func(q DomainQuery) error {
+			queries = append(queries, q)
+			return nil
+		},
+	}
+
+	collectErrs := StreamCollectFromRules(ctx, rules, ruleSetRefs, b.cfg.Geo, b.cfg.OpenRuleSetJSON, sink)
+	for _, e := range collectErrs {
+		if b.cfg.Log != nil {
+			b.cfg.Log.Warn("selective-rebuild", "collect", e.Error())
+		}
+	}
+
+	totalDomains := len(queries)
+	emit(Progress{
+		Phase:   PhaseResolving,
+		Message: fmt.Sprintf("DNS-резолв %d доменных правил…", totalDomains),
+		Total:   totalDomains,
+	})
+
+	ResolveDomainQueriesStream(ctx, queries, dnsServers, DomainQueryStreamSink{
+		OnIP: func(q DomainQuery, cidr string) {
+			_ = addStaging(cidr)
+			routes.Add(q.Outbound, cidr)
+			if conntrackDestArg(cidr) != "" {
+				ctQueue.Add(cidr)
+			}
+		},
+		OnRecord: func(q DomainQuery, rec MatcherRecord) {
+			if rec.Error != "" && b.cfg.Log != nil {
+				b.cfg.Log.Warn("selective-rebuild", q.Matcher, rec.Error)
+			}
+			_ = snapW.WriteRecord(DomainMatcherRecord{
+				Matcher:    rec.Matcher,
+				Kind:       string(rec.Kind),
+				QueryHosts: rec.QueryHosts,
+				CDN:        rec.CDN,
+				Outbound:   rec.Outbound,
+				Error:      rec.Error,
+			})
+			domainCount.Add(1)
+		},
+	}, func(done, total int, matcher string) {
+		emit(Progress{
+			Phase:   PhaseResolving,
+			Message: fmt.Sprintf("Резолвинг: %s", matcher),
+			Matcher: matcher,
+			Current: done,
+			Total:   total,
+		})
+	}, func(matcher, host string, hostIndex, hostTotal int) {
+		// Host-level SSE only for small lists — avoid flooding during bulk geosite.
+		if totalDomains > 200 {
+			return
+		}
+		emit(Progress{
+			Phase:     PhaseResolving,
+			Message:   fmt.Sprintf("Резолвинг: %s — %s (%d/%d)", matcher, host, hostIndex, hostTotal),
+			Matcher:   matcher,
+			QueryHost: host,
+			Current:   hostIndex,
+			Total:     hostTotal,
+		})
+	})
+
+	emit(Progress{
+		Phase:   PhasePopulating,
+		Message: "Активация ipset: подмена staging-набора…",
+	})
+
+	if err := flushStaging(); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: populate staging: %w", err))
+	}
+
+	if err := SwapWithStaging(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: swap ipset: %w", err))
+	}
+	_ = FlushStagingSet(ctx)
+
+	entryCount := EntryCount(ctx)
+	b.setSuccess()
+	b.mu.Lock()
+	b.routes = routes.RulesByOutbound()
+	b.mu.Unlock()
+
+	summary := SnapshotSummary{
+		RebuiltAt:          b.LastRebuild(),
+		EntryCount:         entryCount,
+		StaticCIDRCount:    int(staticCount.Load()),
+		DomainMatcherCount: int(domainCount.Load()),
+	}
+	if err := snapW.CloseAndCommit(summary); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: commit snapshot: %w", err))
+	}
+	b.mu.Lock()
+	b.summary = &summary
+	b.mu.Unlock()
+
+	go b.deferredConntrackFlush(ctQueue.Drain())
+
+	doneMsg := fmt.Sprintf("ipset обновлён. Записей: %d", entryCount)
+	if entryCount == 0 {
+		doneMsg = "ipset пустой — правил с IP/доменами нет. Весь трафик идёт в WAN мимо sing-box."
+	}
+	emit(Progress{Phase: PhaseDone, Message: doneMsg, Current: entryCount, Total: entryCount})
+	b.publishStatus(true, entryCount)
+	return nil
+}
+
+func (b *Builder) fail(ctx context.Context, emit func(Progress), err error) error {
+	errMsg := err.Error()
+	emit(Progress{Phase: PhaseError, Message: errMsg})
+	b.setError(errMsg)
+	b.publishStatus(false, EntryCount(ctx))
+	return err
+}
+
+func (b *Builder) deferredConntrackFlush(hosts []string) {
+	if len(hosts) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	flushed, available := FlushConntrackForCIDRs(ctx, hosts, func(ip, errMsg string) {
+		if b.cfg.Log != nil {
+			b.cfg.Log.Warn("selective-rebuild", ip, "conntrack: "+errMsg)
+		}
+	})
+	if b.cfg.Log != nil {
+		if available {
+			b.cfg.Log.Info("selective-rebuild", "conntrack",
+				fmt.Sprintf("deferred flush: %d hosts, %d flows evicted", len(hosts), flushed))
+		}
+	}
+}
+
+func (b *Builder) publishStatus(success bool, entryCount int) {
+	if b.cfg.Bus == nil {
+		return
+	}
+	b.cfg.Bus.Publish("singbox-router:selective-status", map[string]any{
+		"available":          IsIPSetAvailable(),
+		"xtSetAvailable":     IsXtSetAvailable(),
+		"conntrackAvailable": IsConntrackAvailable(),
+		"enabled":            true,
+		"entryCount":         entryCount,
+		"lastRebuild":        b.LastRebuild(),
+		"lastError":          b.LastError(),
+		"snapshot":           b.LastSnapshot(),
+	})
+}
+
+func (b *Builder) setSuccess() {
+	now := time.Now()
+	b.mu.Lock()
+	b.lastRebuild = now
+	b.lastError = ""
+	b.mu.Unlock()
+	writeLastRebuild(b.cfg.ConfigDir, now)
+}
+
+func (b *Builder) setError(msg string) {
+	b.mu.Lock()
+	b.lastError = msg
+	b.mu.Unlock()
+}
+
+const lastRebuildFileName = "selective-last-rebuild"
+
+func lastRebuildPath(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return filepath.Join(configDir, lastRebuildFileName)
+}
+
+func readLastRebuild(configDir string) time.Time {
+	p := lastRebuildPath(configDir)
+	if p == "" {
+		return time.Time{}
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339, string(data))
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
+}
+
+func writeLastRebuild(configDir string, t time.Time) {
+	p := lastRebuildPath(configDir)
+	if p == "" {
+		return
+	}
+	_ = os.WriteFile(p, []byte(t.UTC().Format(time.RFC3339)), 0644)
+}

--- a/internal/singbox/router/selective/cdn_detect.go
+++ b/internal/singbox/router/selective/cdn_detect.go
@@ -1,0 +1,76 @@
+package selective
+
+import (
+	"net/netip"
+	"strings"
+)
+
+// cdnEdgePrefixStrings lists IPv4 prefixes commonly used by anycast CDNs
+// (Cloudflare, Fastly, Akamai edge, AWS CloudFront frontends). Used only to
+// decide whether to run an extra-aggressive DNS sampling pass — we never add
+// whole provider ranges to ipset.
+var cdnEdgePrefixStrings = []string{
+	// Cloudflare (published https://www.cloudflare.com/ips-v4)
+	"173.245.48.0/20",
+	"103.21.244.0/22",
+	"103.22.200.0/22",
+	"103.31.4.0/22",
+	"141.101.64.0/18",
+	"108.162.192.0/18",
+	"190.93.240.0/20",
+	"188.114.96.0/20",
+	"197.234.240.0/22",
+	"198.41.128.0/17",
+	"162.158.0.0/15",
+	"104.16.0.0/13",
+	"104.24.0.0/14",
+	"172.64.0.0/13",
+	"131.0.72.0/22",
+	// Fastly (common anycast blocks)
+	"151.101.0.0/16",
+	"199.232.0.0/16",
+	"199.27.128.0/21",
+	// Akamai (representative edge ranges)
+	"23.32.0.0/11",
+	"23.64.0.0/14",
+	"2.16.0.0/13",
+	// AWS CloudFront / Global Accelerator (frequently seen on CDN CNAMEs)
+	"52.0.0.0/11",
+	"54.192.0.0/16",
+	"99.84.0.0/16",
+	"35.71.0.0/16",
+	"35.72.0.0/16",
+}
+
+var cdnEdgePrefixes []netip.Prefix
+
+func init() {
+	for _, s := range cdnEdgePrefixStrings {
+		if p, err := netip.ParsePrefix(s); err == nil {
+			cdnEdgePrefixes = append(cdnEdgePrefixes, p)
+		}
+	}
+}
+
+func isCDNEdgeIP(ip string) bool {
+	ip = strings.TrimSuffix(strings.TrimSpace(ip), "/32")
+	addr, err := netip.ParseAddr(ip)
+	if err != nil || !addr.Is4() {
+		return false
+	}
+	for _, p := range cdnEdgePrefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCDNEdgeIP(cidrs []string) bool {
+	for _, c := range cidrs {
+		if isCDNEdgeIP(c) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/singbox/router/selective/cdn_detect_test.go
+++ b/internal/singbox/router/selective/cdn_detect_test.go
@@ -1,0 +1,24 @@
+package selective
+
+import "testing"
+
+func TestIsCDNEdgeIP_Cloudflare(t *testing.T) {
+	if !isCDNEdgeIP("104.26.2.214") {
+		t.Fatal("expected Cloudflare IP to match")
+	}
+	if !isCDNEdgeIP("108.162.192.147/32") {
+		t.Fatal("expected Cloudflare /32 to match")
+	}
+}
+
+func TestIsCDNEdgeIP_NonCDN(t *testing.T) {
+	if isCDNEdgeIP("198.58.111.63") {
+		t.Fatal("Linode-like IP should not match CDN prefixes")
+	}
+}
+
+func TestContainsCDNEdgeIP(t *testing.T) {
+	if !containsCDNEdgeIP([]string{"1.2.3.4/32", "172.67.71.137/32"}) {
+		t.Fatal("expected contains CDN")
+	}
+}

--- a/internal/singbox/router/selective/cdn_refresh.go
+++ b/internal/singbox/router/selective/cdn_refresh.go
@@ -1,0 +1,161 @@
+package selective
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
+)
+
+// CDNRefreshInterval is how often background CDN matcher refresh runs.
+const CDNRefreshInterval = 20 * time.Minute
+
+// CDNQueriesFromConfigDir scans persisted NDJSON for CDN-flagged matchers.
+func CDNQueriesFromConfigDir(configDir string) ([]DomainQuery, error) {
+	var out []DomainQuery
+	err := ForEachCDNMatcher(configDir, func(rec DomainMatcherRecord) error {
+		kind := DomainKind(rec.Kind)
+		if kind != KindDomain && kind != KindDomainSuffix {
+			kind = KindDomainSuffix
+		}
+		out = append(out, DomainQuery{Matcher: rec.Matcher, Kind: kind, Outbound: rec.Outbound})
+		return nil
+	})
+	return out, err
+}
+
+// RefreshCDNMatchers re-resolves CDN matchers and adds new IPs via ipset -exist.
+func (b *Builder) RefreshCDNMatchers(
+	ctx context.Context,
+	queries []DomainQuery,
+	singboxDNS []SingboxDNSServer,
+) error {
+	if len(queries) == 0 {
+		return nil
+	}
+	if !heavyop.Default.TryLock() {
+		if b.cfg.Log != nil {
+			b.cfg.Log.Info("selective-cdn-refresh", "", "skipped: sing-box apply or rebuild in progress")
+		}
+		return nil
+	}
+	defer heavyop.Default.Unlock()
+	if !b.opMu.TryLock() {
+		if b.cfg.Log != nil {
+			b.cfg.Log.Info("selective-cdn-refresh", "", "skipped: full rebuild in progress")
+		}
+		return nil
+	}
+	defer b.opMu.Unlock()
+
+	if err := CreateSet(ctx); err != nil {
+		return fmt.Errorf("selective cdn refresh: create set: %w", err)
+	}
+
+	dnsServers := BuildDNSServers(ctx, singboxDNS, b.cfg.DNSSource)
+	var added int
+
+	for _, q := range queries {
+		var chunk []string
+		ResolveOneQueryStream(ctx, q, dnsServers, func(cidr string) {
+			chunk = append(chunk, cidr)
+			if len(chunk) >= IpsetChunkSize {
+				if err := ChunkedAddLive(ctx, chunk); err == nil {
+					added += len(chunk)
+				}
+				chunk = chunk[:0]
+			}
+		}, nil)
+		if len(chunk) > 0 {
+			if err := ChunkedAddLive(ctx, chunk); err != nil {
+				if b.cfg.Log != nil {
+					b.cfg.Log.Warn("selective-cdn-refresh", q.Matcher, err.Error())
+				}
+			} else {
+				added += len(chunk)
+			}
+		}
+	}
+
+	b.mu.Lock()
+	if b.summary != nil {
+		cp := *b.summary
+		cp.EntryCount = EntryCount(ctx)
+		cp.LastCDNRefresh = time.Now().UTC().Format(time.RFC3339)
+		b.summary = &cp
+		writeSnapshotMeta(b.cfg.ConfigDir, cp)
+	}
+	b.mu.Unlock()
+
+	if b.cfg.Log != nil {
+		b.cfg.Log.Info("selective-cdn-refresh", "",
+			fmt.Sprintf("CDN refresh: %d matchers, ~%d adds (ipset now %d entries)",
+				len(queries), added, EntryCount(ctx)))
+	}
+	b.publishStatus(true, EntryCount(ctx))
+	return nil
+}
+
+// CDNRefreshLoop runs periodic CDN-only ipset refresh until stop is closed.
+type CDNRefreshLoop struct {
+	Interval time.Duration
+	Enabled  func() bool
+	Refresh  func(ctx context.Context) error
+	Log      *logging.ScopedLogger
+	stop     chan struct{}
+	done     chan struct{}
+	once     sync.Once
+}
+
+// StartCDNRefreshLoop launches the background ticker.
+func StartCDNRefreshLoop(interval time.Duration, enabled func() bool, refresh func(context.Context) error, log *logging.ScopedLogger) *CDNRefreshLoop {
+	if interval <= 0 {
+		interval = CDNRefreshInterval
+	}
+	l := &CDNRefreshLoop{
+		Interval: interval,
+		Enabled:  enabled,
+		Refresh:  refresh,
+		Log:      log,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	go l.run()
+	return l
+}
+
+func (l *CDNRefreshLoop) Stop() {
+	l.once.Do(func() { close(l.stop) })
+	<-l.done
+}
+
+func (l *CDNRefreshLoop) run() {
+	defer close(l.done)
+	ticker := time.NewTicker(l.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			l.tick()
+		case <-l.stop:
+			return
+		}
+	}
+}
+
+func (l *CDNRefreshLoop) tick() {
+	if l.Enabled != nil && !l.Enabled() {
+		return
+	}
+	if l.Refresh == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := l.Refresh(ctx); err != nil && l.Log != nil {
+		l.Log.Warn("selective-cdn-refresh", "", err.Error())
+	}
+}

--- a/internal/singbox/router/selective/cdn_refresh_test.go
+++ b/internal/singbox/router/selective/cdn_refresh_test.go
@@ -1,0 +1,52 @@
+package selective
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCDNQueriesFromConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	w, err := newSnapshotWriter(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = w.WriteRecord(DomainMatcherRecord{Matcher: "cdn.example.com", Kind: "suffix", CDN: true})
+	_ = w.WriteRecord(DomainMatcherRecord{Matcher: "plain.example.com", Kind: "suffix"})
+	_ = w.WriteRecord(DomainMatcherRecord{Matcher: "broken.example.com", Kind: "suffix", CDN: true, Error: "no A"})
+	if err := w.CloseAndCommit(SnapshotSummary{RebuiltAt: "x", EntryCount: 1}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := CDNQueriesFromConfigDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Matcher != "cdn.example.com" {
+		t.Fatalf("expected only CDN matcher without error, got %v", got)
+	}
+}
+
+func TestReadSnapshotMatchersPagination(t *testing.T) {
+	dir := t.TempDir()
+	w, err := newSnapshotWriter(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		_ = w.WriteRecord(DomainMatcherRecord{Matcher: "host.example", Kind: "domain"})
+	}
+	if err := w.CloseAndCommit(SnapshotSummary{EntryCount: 5}); err != nil {
+		t.Fatal(err)
+	}
+	page, total, err := ReadSnapshotMatchers(dir, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 5 || len(page) != 2 {
+		t.Fatalf("total=%d page=%d", total, len(page))
+	}
+	if _, err := os.Stat(filepath.Join(dir, snapshotMetaFile)); err != nil {
+		t.Fatalf("meta file missing: %v", err)
+	}
+}

--- a/internal/singbox/router/selective/collector.go
+++ b/internal/singbox/router/selective/collector.go
@@ -1,0 +1,351 @@
+package selective
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DomainKind identifies how a matcher should be resolved for ipset population.
+type DomainKind string
+
+const (
+	KindDomain       DomainKind = "domain"
+	KindDomainSuffix DomainKind = "suffix"
+)
+
+// DomainQuery is one domain matcher from a route rule or rule-set.
+type DomainQuery struct {
+	Matcher  string     `json:"matcher"`
+	Kind     DomainKind `json:"kind"`
+	Outbound string     `json:"outbound,omitempty"`
+}
+
+// CollectResult holds the raw output of a collection pass over the router
+// rules and rule sets.
+type CollectResult struct {
+	// CIDRs are already-valid IPv4 CIDR strings extracted from ip_cidr
+	// matchers in rules and rule sets.
+	CIDRs []string
+	// DomainQueries lists domain / domain_suffix matchers that need DNS
+	// resolution before they can be added to ipset.
+	DomainQueries []DomainQuery
+	// Errors lists non-fatal errors encountered while reading rule set files
+	// (e.g. a remote rule set whose .srs sidecar JSON is missing). The
+	// collection continues with the remaining sets.
+	Errors []error
+}
+
+// RuleJSON is a minimal representation of a sing-box route rule used for
+// collecting matchers. Fields not relevant to ipset building are ignored.
+// Exported so the router adapter can convert router.Rule → RuleJSON without
+// importing router types into the selective package (import cycle).
+type RuleJSON struct {
+	Action       string     `json:"action,omitempty"`
+	Outbound     string     `json:"outbound,omitempty"`
+	IPCIDR       []string   `json:"ip_cidr"`
+	DomainSuffix []string   `json:"domain_suffix"`
+	Domain       []string   `json:"domain"`
+	RuleSet      []string   `json:"rule_set"`
+	Rules        []RuleJSON `json:"rules"` // logical rule nesting
+}
+
+// ruleSetSourceJSON is the on-disk shape of a compiled inline rule set
+// source file (<tag>.json alongside the <tag>.srs binary).
+type ruleSetSourceJSON struct {
+	Version int                      `json:"version"`
+	Rules   []map[string]interface{} `json:"rules"`
+}
+
+// RuleSetRef describes a rule set entry, carrying enough information for
+// the collector to locate its source JSON.
+type RuleSetRef struct {
+	Tag  string // rule set tag as referenced in rules
+	Type string // "inline", "local", "remote"
+	Path string // on-disk path (for local/materialized); empty for remote
+	URL    string // remote rule-set URL (for download/decompile)
+	Format string // "binary" or "source"
+	// InlineDir is the directory where inline rule set JSONs are compiled to.
+	InlineDir string
+	// DatDir is the directory where dat-derived rule set JSONs are written.
+	DatDir string
+	// DatKind and DatTags identify geosite/geoip dat rule-sets (streamed from .dat).
+	DatKind string
+	DatTags []string
+	// Rules carries the rule set's matchers in memory when they are already
+	// known (e.g. an inline set restored by the router's materializer). When
+	// non-empty the collector reads these directly and skips the on-disk JSON
+	// lookup — more robust than re-reading a sidecar that may be missing,
+	// stale, or named differently. Shape mirrors sing-box rule-set source
+	// rules (map per rule with ip_cidr / domain_suffix / domain keys).
+	Rules []map[string]interface{}
+}
+
+// CollectFromRules walks route rules and collects IPv4 CIDR / domain matchers
+// that belong to proxy (non-direct) route rules only. Rule sets are expanded
+// only when referenced by such a rule — never from the full rule_set catalog.
+func CollectFromRules(rules []RuleJSON, ruleSetRefs []RuleSetRef) CollectResult {
+	var result CollectResult
+	seen := &deduplicator{}
+	proxySetTags := make(map[string]string)
+
+	for i := range rules {
+		collectFromRule(&rules[i], "", seen, &result, proxySetTags)
+	}
+
+	if len(proxySetTags) == 0 {
+		return result
+	}
+
+	refsByTag := make(map[string]RuleSetRef, len(ruleSetRefs))
+	for _, ref := range ruleSetRefs {
+		refsByTag[ref.Tag] = ref
+	}
+	for tag, outbound := range proxySetTags {
+		ref, ok := refsByTag[tag]
+		if !ok {
+			continue
+		}
+		if err := collectFromRuleSetRef(ref, outbound, seen, &result); err != nil {
+			result.Errors = append(result.Errors, err)
+		}
+	}
+
+	return result
+}
+
+// isProxyRoute reports whether traffic matched by this rule should be sent to
+// sing-box in selective mode (non-direct proxy outbound).
+func isProxyRoute(r *RuleJSON, outbound string) bool {
+	if r.Action != "" && r.Action != "route" {
+		return false
+	}
+	ob := outbound
+	if r.Outbound != "" {
+		ob = r.Outbound
+	}
+	return ob != "" && ob != "direct"
+}
+
+func effectiveOutbound(r *RuleJSON, parent string) string {
+	if r.Outbound != "" {
+		return r.Outbound
+	}
+	return parent
+}
+
+func collectFromRule(r *RuleJSON, parentOutbound string, seen *deduplicator, result *CollectResult, proxySetTags map[string]string) {
+	outbound := effectiveOutbound(r, parentOutbound)
+	if isProxyRoute(r, outbound) {
+		for _, cidr := range r.IPCIDR {
+			if c := normalizeCIDR(cidr); c != "" && seen.addCIDR(c) {
+				result.CIDRs = append(result.CIDRs, c)
+			}
+		}
+		for _, d := range r.DomainSuffix {
+			if d = cleanDomain(d); d != "" && seen.addDomainQuery(d, KindDomainSuffix, outbound) {
+				result.DomainQueries = append(result.DomainQueries, DomainQuery{Matcher: d, Kind: KindDomainSuffix, Outbound: outbound})
+			}
+		}
+		for _, d := range r.Domain {
+			if d = cleanDomain(d); d != "" && seen.addDomainQuery(d, KindDomain, outbound) {
+				result.DomainQueries = append(result.DomainQueries, DomainQuery{Matcher: d, Kind: KindDomain, Outbound: outbound})
+			}
+		}
+		for _, tag := range r.RuleSet {
+			if tag == "" {
+				continue
+			}
+			if _, ok := proxySetTags[tag]; !ok {
+				proxySetTags[tag] = outbound
+			}
+		}
+	}
+	for i := range r.Rules {
+		collectFromRule(&r.Rules[i], outbound, seen, result, proxySetTags)
+	}
+}
+
+// collectFromRuleSetRef loads the source JSON for a rule set and extracts
+// ip_cidr and domain entries from its rules. outbound is taken from the proxy
+// route rule that referenced this set.
+func collectFromRuleSetRef(ref RuleSetRef, outbound string, seen *deduplicator, result *CollectResult) error {
+	if len(ref.Rules) > 0 {
+		for _, ruleMap := range ref.Rules {
+			extractFromRuleMap(ruleMap, seen, result, outbound)
+		}
+		return nil
+	}
+
+	jsonPath := resolveRuleSetJSONPath(ref)
+	if jsonPath == "" {
+		return nil
+	}
+	raw, err := os.ReadFile(jsonPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var src ruleSetSourceJSON
+	if err := json.Unmarshal(raw, &src); err != nil {
+		return err
+	}
+	for _, ruleMap := range src.Rules {
+		extractFromRuleMap(ruleMap, seen, result, outbound)
+	}
+	return nil
+}
+
+// resolveRuleSetJSONPath returns the path to the source JSON file for a
+// rule set, or "" if it cannot be determined.
+func resolveRuleSetJSONPath(ref RuleSetRef) string {
+	if ref.Path != "" {
+		if strings.HasSuffix(strings.ToLower(ref.Path), ".json") {
+			return ref.Path
+		}
+		return strings.TrimSuffix(ref.Path, ".srs") + ".json"
+	}
+	switch ref.Type {
+	case "inline":
+		if ref.InlineDir == "" {
+			return ""
+		}
+		return filepath.Join(ref.InlineDir, safeFilename(ref.Tag)+".json")
+	case "local":
+		return ""
+	case "remote":
+		if ref.DatDir == "" {
+			return ""
+		}
+		return filepath.Join(ref.DatDir, safeFilename(ref.Tag)+".json")
+	}
+	return ""
+}
+
+// normalizeCIDR validates and canonicalises an IPv4 CIDR string.
+// Returns "" for IPv6 or invalid input.
+func normalizeCIDR(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if _, ipnet, err := net.ParseCIDR(s); err == nil {
+		if ipnet.IP.To4() == nil {
+			return ""
+		}
+		return ipnet.String()
+	}
+	if ip := net.ParseIP(s); ip != nil && ip.To4() != nil {
+		return ip.To4().String() + "/32"
+	}
+	return ""
+}
+
+// cleanDomain strips leading dots/wildcards and lowercases the domain.
+func cleanDomain(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, ".")
+	s = strings.TrimPrefix(s, "*.")
+	return s
+}
+
+// toStringSlice coerces an interface{} value that may be []interface{}
+// or []string into a []string. Returns nil for other types.
+func toStringSlice(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case []string:
+		return val
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// safeFilename replaces characters not suitable for filenames with "-",
+// mirroring the safeRuleSetFilename logic in the router package.
+func safeFilename(tag string) string {
+	var b strings.Builder
+	for _, r := range tag {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	result := strings.Trim(b.String(), "-")
+	if result == "" {
+		return "ruleset"
+	}
+	return result
+}
+
+// deduplicator tracks seen CIDRs and domain queries to avoid duplicates.
+type deduplicator struct {
+	cidrs         map[string]struct{}
+	domainQueries map[string]string // key → outbound
+}
+
+func (d *deduplicator) addCIDR(s string) bool {
+	if d.cidrs == nil {
+		d.cidrs = make(map[string]struct{})
+	}
+	if _, ok := d.cidrs[s]; ok {
+		return false
+	}
+	d.cidrs[s] = struct{}{}
+	return true
+}
+
+func (d *deduplicator) addDomainQuery(matcher string, kind DomainKind, outbound string) bool {
+	if d.domainQueries == nil {
+		d.domainQueries = make(map[string]string)
+	}
+	key := string(kind) + "\x00" + matcher
+	if ob, ok := d.domainQueries[key]; ok {
+		if ob == "" && outbound != "" {
+			d.domainQueries[key] = outbound
+		}
+		return false
+	}
+	d.domainQueries[key] = outbound
+	return true
+}
+
+// extractFromRuleMap pulls ip_cidr and domain entries from the raw
+// map[string]interface{} form used in rule set source JSON files.
+func extractFromRuleMap(m map[string]interface{}, seen *deduplicator, result *CollectResult, outbound string) {
+	for _, key := range []string{"ip_cidr"} {
+		v, _ := m[key]
+		for _, s := range toStringSlice(v) {
+			if c := normalizeCIDR(s); c != "" && seen.addCIDR(c) {
+				result.CIDRs = append(result.CIDRs, c)
+			}
+		}
+	}
+	for _, key := range []string{"domain_suffix", "domain"} {
+		kind := KindDomain
+		if key == "domain_suffix" {
+			kind = KindDomainSuffix
+		}
+		v, _ := m[key]
+		for _, s := range toStringSlice(v) {
+			if d := cleanDomain(s); d != "" && seen.addDomainQuery(d, kind, outbound) {
+				result.DomainQueries = append(result.DomainQueries, DomainQuery{Matcher: d, Kind: kind, Outbound: outbound})
+			}
+		}
+	}
+}

--- a/internal/singbox/router/selective/collector_stream.go
+++ b/internal/singbox/router/selective/collector_stream.go
@@ -1,0 +1,199 @@
+package selective
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/hydraroute"
+)
+
+// CollectSink receives matchers during a streaming collection pass.
+type CollectSink struct {
+	OnStaticCIDR  func(cidr string) error
+	OnDomainQuery func(q DomainQuery) error
+}
+
+// GeoPaths lists on-disk geosite/geoip database files (HydraRoute / hrneo).
+type GeoPaths struct {
+	GeoSite []string
+	GeoIP   []string
+}
+
+// RuleSetJSONOpener resolves a rule-set ref to a streamable JSON file path.
+// cleanup must be called when done (may be noop).
+type RuleSetJSONOpener func(ctx context.Context, ref RuleSetRef) (path string, cleanup func(), err error)
+
+// StreamCollectFromRules walks proxy rules and rule sets, invoking sink callbacks
+// without accumulating full CollectResult slices in memory.
+func StreamCollectFromRules(
+	ctx context.Context,
+	rules []RuleJSON,
+	ruleSetRefs []RuleSetRef,
+	geo GeoPaths,
+	openJSON RuleSetJSONOpener,
+	sink CollectSink,
+) []error {
+	var errs []error
+	seen := &deduplicator{}
+	proxySetTags := make(map[string]string)
+
+	for i := range rules {
+		collectFromRuleStream(&rules[i], "", seen, sink, proxySetTags)
+	}
+	if len(proxySetTags) == 0 {
+		return errs
+	}
+
+	refsByTag := make(map[string]RuleSetRef, len(ruleSetRefs))
+	for _, ref := range ruleSetRefs {
+		refsByTag[ref.Tag] = ref
+	}
+	for tag, outbound := range proxySetTags {
+		ref, ok := refsByTag[tag]
+		if !ok {
+			continue
+		}
+		if err := streamRuleSetRef(ctx, ref, outbound, geo, openJSON, seen, &sink); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func collectFromRuleStream(r *RuleJSON, parentOutbound string, seen *deduplicator, sink CollectSink, proxySetTags map[string]string) {
+	outbound := effectiveOutbound(r, parentOutbound)
+	if isProxyRoute(r, outbound) {
+		for _, cidr := range r.IPCIDR {
+			if c := normalizeCIDR(cidr); c != "" && seen.addCIDR(c) {
+				_ = sink.OnStaticCIDR(c)
+			}
+		}
+		for _, d := range r.DomainSuffix {
+			if d = cleanDomain(d); d != "" && seen.addDomainQuery(d, KindDomainSuffix, outbound) {
+				_ = sink.OnDomainQuery(DomainQuery{Matcher: d, Kind: KindDomainSuffix, Outbound: outbound})
+			}
+		}
+		for _, d := range r.Domain {
+			if d = cleanDomain(d); d != "" && seen.addDomainQuery(d, KindDomain, outbound) {
+				_ = sink.OnDomainQuery(DomainQuery{Matcher: d, Kind: KindDomain, Outbound: outbound})
+			}
+		}
+		for _, tag := range r.RuleSet {
+			if tag == "" {
+				continue
+			}
+			if _, ok := proxySetTags[tag]; !ok {
+				proxySetTags[tag] = outbound
+			}
+		}
+	}
+	for i := range r.Rules {
+		collectFromRuleStream(&r.Rules[i], outbound, seen, sink, proxySetTags)
+	}
+}
+
+func streamRuleSetRef(
+	ctx context.Context,
+	ref RuleSetRef,
+	outbound string,
+	geo GeoPaths,
+	openJSON RuleSetJSONOpener,
+	seen *deduplicator,
+	sink *CollectSink,
+) error {
+	if len(ref.DatTags) > 0 && ref.DatKind != "" {
+		return streamDatRuleSet(ref.DatKind, ref.DatTags, outbound, geo, seen, sink)
+	}
+	if len(ref.Rules) > 0 {
+		for _, ruleMap := range ref.Rules {
+			raw, err := json.Marshal(ruleMap)
+			if err != nil {
+				continue
+			}
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &m); err != nil {
+				continue
+			}
+			if err := streamExtractFromRuleMap(m, outbound, seen, sink); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if openJSON == nil {
+		jsonPath := resolveRuleSetJSONPath(ref)
+		if jsonPath == "" {
+			return nil
+		}
+		return streamRuleSetJSONFile(jsonPath, outbound, seen, sink)
+	}
+	path, cleanup, err := openJSON(ctx, ref)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if path == "" {
+		return nil
+	}
+	return streamRuleSetJSONFile(path, outbound, seen, sink)
+}
+
+func streamDatRuleSet(kind string, tags []string, outbound string, geo GeoPaths, seen *deduplicator, sink *CollectSink) error {
+	switch kind {
+	case "geosite":
+		for _, path := range geo.GeoSite {
+			for _, tag := range tags {
+				if err := hydraroute.StreamGeoSiteTagLines(path, tag, func(line string) error {
+					return ingestGeoSiteLine(line, outbound, seen, sink)
+				}); err != nil {
+					if strings.Contains(err.Error(), "not found") {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	case "geoip":
+		for _, path := range geo.GeoIP {
+			for _, tag := range tags {
+				if err := hydraroute.StreamGeoIPTagLines(path, tag, func(line string) error {
+					if c := normalizeCIDR(line); c != "" && seen.addCIDR(c) {
+						return sink.OnStaticCIDR(c)
+					}
+					return nil
+				}); err != nil {
+					if strings.Contains(err.Error(), "not found") {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func ingestGeoSiteLine(line, outbound string, seen *deduplicator, sink *CollectSink) error {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+	if strings.HasPrefix(line, "domain_regex:") || strings.HasPrefix(line, "domain_keyword:") {
+		return nil
+	}
+	kind := KindDomainSuffix
+	matcher := line
+	if strings.HasPrefix(line, "domain:") {
+		kind = KindDomain
+		matcher = strings.TrimSpace(strings.TrimPrefix(line, "domain:"))
+	} else if strings.HasPrefix(line, "suffix:") {
+		matcher = strings.TrimSpace(strings.TrimPrefix(line, "suffix:"))
+	}
+	if d := cleanDomain(matcher); d != "" && seen.addDomainQuery(d, kind, outbound) {
+		return sink.OnDomainQuery(DomainQuery{Matcher: d, Kind: kind, Outbound: outbound})
+	}
+	return nil
+}

--- a/internal/singbox/router/selective/collector_test.go
+++ b/internal/singbox/router/selective/collector_test.go
@@ -1,0 +1,361 @@
+package selective
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func matchersOf(res CollectResult) []string {
+	out := make([]string, 0, len(res.DomainQueries))
+	for _, q := range res.DomainQueries {
+		out = append(out, q.Matcher)
+	}
+	return out
+}
+
+func hasMatcher(res CollectResult, matcher string) bool {
+	return slices.Contains(matchersOf(res), matcher)
+}
+
+func proxyRule(r RuleJSON) RuleJSON {
+	r.Action = "route"
+	if r.Outbound == "" {
+		r.Outbound = "proxy"
+	}
+	return r
+}
+
+func mustWriteJSON(t *testing.T, dir, name string, v any) string {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// ── normalizeCIDR ─────────────────────────────────────────────────────────────
+
+func TestNormalizeCIDR_ValidCIDR(t *testing.T) {
+	if got := normalizeCIDR("10.0.0.0/8"); got != "10.0.0.0/8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeCIDR_HostBitsMasked(t *testing.T) {
+	// net.ParseCIDR canonicalises: 10.0.0.1/8 → 10.0.0.0/8
+	if got := normalizeCIDR("10.0.0.1/8"); got != "10.0.0.0/8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeCIDR_BareIP(t *testing.T) {
+	if got := normalizeCIDR("1.2.3.4"); got != "1.2.3.4/32" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeCIDR_IPv6Rejected(t *testing.T) {
+	if got := normalizeCIDR("::1/128"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestNormalizeCIDR_Garbage(t *testing.T) {
+	if got := normalizeCIDR("not-an-ip"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+// ── cleanDomain ───────────────────────────────────────────────────────────────
+
+func TestCleanDomain_StripLeadingDot(t *testing.T) {
+	if got := cleanDomain(".example.com"); got != "example.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCleanDomain_StripWildcard(t *testing.T) {
+	if got := cleanDomain("*.example.com"); got != "example.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCleanDomain_Lowercase(t *testing.T) {
+	if got := cleanDomain("EXAMPLE.COM"); got != "example.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// ── CollectFromRules — direct rules ───────────────────────────────────────────
+
+func TestCollectFromRules_IPCIDRExtracted(t *testing.T) {
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{IPCIDR: []string{"1.2.3.0/24", "5.6.7.8"}}),
+	}
+	res := CollectFromRules(rules, nil)
+	if !slices.Contains(res.CIDRs, "1.2.3.0/24") {
+		t.Errorf("missing CIDR 1.2.3.0/24, got %v", res.CIDRs)
+	}
+	if !slices.Contains(res.CIDRs, "5.6.7.8/32") {
+		t.Errorf("missing CIDR 5.6.7.8/32, got %v", res.CIDRs)
+	}
+}
+
+func TestCollectFromRules_DomainsExtracted(t *testing.T) {
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{DomainSuffix: []string{"example.com", ".foo.com"}}),
+		proxyRule(RuleJSON{Domain: []string{"*.bar.com", "baz.com"}}),
+	}
+	res := CollectFromRules(rules, nil)
+	for _, want := range []string{"example.com", "foo.com", "bar.com", "baz.com"} {
+		if !hasMatcher(res, want) {
+			t.Errorf("missing domain %q, got %v", want, res.DomainQueries)
+		}
+	}
+}
+
+func TestCollectFromRules_IPv6Skipped(t *testing.T) {
+	rules := []RuleJSON{proxyRule(RuleJSON{IPCIDR: []string{"::1/128", "10.0.0.1/32"}})}
+	res := CollectFromRules(rules, nil)
+	if slices.Contains(res.CIDRs, "::1/128") {
+		t.Errorf("IPv6 should be skipped, got %v", res.CIDRs)
+	}
+	if !slices.Contains(res.CIDRs, "10.0.0.1/32") {
+		t.Errorf("missing 10.0.0.1/32, got %v", res.CIDRs)
+	}
+}
+
+func TestCollectFromRules_DeduplicatesCIDRs(t *testing.T) {
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{IPCIDR: []string{"1.2.3.0/24", "1.2.3.0/24"}}),
+	}
+	res := CollectFromRules(rules, nil)
+	count := 0
+	for _, c := range res.CIDRs {
+		if c == "1.2.3.0/24" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 occurrence of 1.2.3.0/24, got %d", count)
+	}
+}
+
+func TestCollectFromRules_DeduplicatesDomains(t *testing.T) {
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{DomainSuffix: []string{"example.com"}}),
+		proxyRule(RuleJSON{DomainSuffix: []string{"example.com"}}),
+	}
+	res := CollectFromRules(rules, nil)
+	count := 0
+	for _, q := range res.DomainQueries {
+		if q.Matcher == "example.com" && q.Kind == KindDomainSuffix {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 suffix query for example.com, got %d", count)
+	}
+}
+
+func TestCollectFromRules_NestedLogicalRules(t *testing.T) {
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{
+			Rules: []RuleJSON{
+				{IPCIDR: []string{"10.20.30.0/24"}},
+				{DomainSuffix: []string{"nested.com"}},
+			},
+		}),
+	}
+	res := CollectFromRules(rules, nil)
+	if !slices.Contains(res.CIDRs, "10.20.30.0/24") {
+		t.Errorf("nested CIDR not collected, got %v", res.CIDRs)
+	}
+	if !hasMatcher(res, "nested.com") {
+		t.Errorf("nested domain not collected, got %v", res.DomainQueries)
+	}
+}
+
+func TestCollectFromRules_DirectRulesSkipped(t *testing.T) {
+	rules := []RuleJSON{
+		{Action: "route", Outbound: "direct", DomainSuffix: []string{"github.com"}, IPCIDR: []string{"1.1.1.1"}},
+	}
+	res := CollectFromRules(rules, nil)
+	if len(res.CIDRs) != 0 || len(res.DomainQueries) != 0 {
+		t.Fatalf("direct rules must not populate ipset, got %+v", res)
+	}
+}
+
+func TestCollectFromRules_UnreferencedRuleSetsSkipped(t *testing.T) {
+	refs := []RuleSetRef{
+		{
+			Tag:  "orphan",
+			Type: "inline",
+			Rules: []map[string]interface{}{
+				{"domain_suffix": []interface{}{"orphan.example"}},
+			},
+		},
+	}
+	res := CollectFromRules(nil, refs)
+	if len(res.CIDRs) != 0 || len(res.DomainQueries) != 0 {
+		t.Fatalf("unreferenced rule sets must be ignored, got %+v", res)
+	}
+}
+
+func TestCollectFromRules_EmptyRules(t *testing.T) {
+	res := CollectFromRules(nil, nil)
+	if len(res.CIDRs) != 0 || len(res.DomainQueries) != 0 || len(res.Errors) != 0 {
+		t.Errorf("expected empty result, got %+v", res)
+	}
+}
+
+// ── CollectFromRules — inline rule set ────────────────────────────────────────
+
+func TestCollectFromRules_RuleSetRefInMemoryRules(t *testing.T) {
+	refs := []RuleSetRef{
+		{
+			Tag:  "custom-1",
+			Type: "inline",
+			Rules: []map[string]interface{}{
+				{"domain_suffix": []interface{}{"2ip.ru"}},
+				{"ip_cidr": []interface{}{"203.0.113.0/24"}},
+			},
+		},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"custom-1"}}),
+	}, refs)
+	if !hasMatcher(res, "2ip.ru") {
+		t.Errorf("missing in-memory domain, got %v", res.DomainQueries)
+	}
+	if !slices.Contains(res.CIDRs, "203.0.113.0/24") {
+		t.Errorf("missing in-memory CIDR, got %v", res.CIDRs)
+	}
+}
+
+// When a ref carries in-memory rules, the on-disk JSON is ignored entirely.
+func TestCollectFromRules_RuleSetRefInMemoryRulesIgnoresDisk(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteJSON(t, dir, "custom-1.json", ruleSetSourceJSON{
+		Version: 1,
+		Rules:   []map[string]interface{}{{"domain_suffix": []interface{}{"from-disk.example"}}},
+	})
+	refs := []RuleSetRef{
+		{
+			Tag:       "custom-1",
+			Type:      "inline",
+			InlineDir: dir,
+			Rules:     []map[string]interface{}{{"domain_suffix": []interface{}{"from-memory.example"}}},
+		},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"custom-1"}}),
+	}, refs)
+	if !hasMatcher(res, "from-memory.example") {
+		t.Errorf("expected in-memory domain, got %v", res.DomainQueries)
+	}
+	if hasMatcher(res, "from-disk.example") {
+		t.Errorf("on-disk domain should be ignored when Rules present, got %v", res.DomainQueries)
+	}
+}
+
+func TestCollectFromRules_InlineRuleSet(t *testing.T) {
+	dir := t.TempDir()
+	src := ruleSetSourceJSON{
+		Version: 5,
+		Rules: []map[string]interface{}{
+			{"ip_cidr": []interface{}{"192.168.100.0/24"}},
+			{"domain_suffix": []interface{}{"inline-domain.com"}},
+		},
+	}
+	mustWriteJSON(t, dir, "myset.json", src)
+
+	refs := []RuleSetRef{
+		{Tag: "myset", Type: "inline", InlineDir: dir},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"myset"}}),
+	}, refs)
+	if !slices.Contains(res.CIDRs, "192.168.100.0/24") {
+		t.Errorf("missing CIDR from inline ruleset, got %v", res.CIDRs)
+	}
+	if !hasMatcher(res, "inline-domain.com") {
+		t.Errorf("missing domain from inline ruleset, got %v", res.DomainQueries)
+	}
+}
+
+func TestCollectFromRules_LocalRuleSet(t *testing.T) {
+	dir := t.TempDir()
+	src := ruleSetSourceJSON{
+		Version: 5,
+		Rules: []map[string]interface{}{
+			{"ip_cidr": []interface{}{"172.16.0.0/12"}},
+		},
+	}
+	srsPath := filepath.Join(dir, "local-set.srs")
+	mustWriteJSON(t, dir, "local-set.json", src)
+
+	refs := []RuleSetRef{
+		{Tag: "local-set", Type: "local", Path: srsPath},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"local-set"}}),
+	}, refs)
+	if !slices.Contains(res.CIDRs, "172.16.0.0/12") {
+		t.Errorf("missing CIDR from local ruleset, got %v", res.CIDRs)
+	}
+}
+
+func TestCollectFromRules_MissingRuleSetFileSkipped(t *testing.T) {
+	refs := []RuleSetRef{
+		{Tag: "nonexistent", Type: "inline", InlineDir: "/tmp/nonexistent-dir-xyz"},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"nonexistent"}}),
+	}, refs)
+	if len(res.Errors) != 0 {
+		t.Errorf("expected no errors for missing file, got %v", res.Errors)
+	}
+}
+
+func TestCollectFromRules_RemoteRuleSetNoDir_Skipped(t *testing.T) {
+	refs := []RuleSetRef{
+		{Tag: "google", Type: "remote"},
+	}
+	res := CollectFromRules([]RuleJSON{
+		proxyRule(RuleJSON{RuleSet: []string{"google"}}),
+	}, refs)
+	if len(res.Errors) != 0 || len(res.CIDRs) != 0 {
+		t.Errorf("expected empty result for remote with no DatDir, got %+v", res)
+	}
+}
+
+func TestCollectFromRules_RuleSetAndProxyRuleCombined(t *testing.T) {
+	dir := t.TempDir()
+	src := ruleSetSourceJSON{
+		Version: 5,
+		Rules:   []map[string]interface{}{{"ip_cidr": []interface{}{"203.0.113.0/24"}}},
+	}
+	mustWriteJSON(t, dir, "my-set.json", src)
+
+	rules := []RuleJSON{
+		proxyRule(RuleJSON{IPCIDR: []string{"8.8.8.8"}, RuleSet: []string{"my-set"}}),
+	}
+	refs := []RuleSetRef{{Tag: "my-set", Type: "inline", InlineDir: dir}}
+
+	res := CollectFromRules(rules, refs)
+	if !slices.Contains(res.CIDRs, "8.8.8.8/32") {
+		t.Errorf("missing proxy rule CIDR, got %v", res.CIDRs)
+	}
+	if !slices.Contains(res.CIDRs, "203.0.113.0/24") {
+		t.Errorf("missing ruleset CIDR, got %v", res.CIDRs)
+	}
+}

--- a/internal/singbox/router/selective/conntrack.go
+++ b/internal/singbox/router/selective/conntrack.go
@@ -1,0 +1,117 @@
+package selective
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+)
+
+// conntrackBinaryPaths lists candidate absolute paths for the conntrack
+// binary (from the conntrack-tools package), searched in preference order.
+var conntrackBinaryPaths = []string{
+	"/opt/sbin/conntrack",
+	"/usr/sbin/conntrack",
+	"/sbin/conntrack",
+}
+
+// ConntrackBinary returns the path to the conntrack binary, or "" when not
+// found. The conntrack package is optional — without it the selective guard
+// guard still applies to NEW connections, it just can't evict already-tracked
+// ones (changes take effect only once the old flow expires).
+func ConntrackBinary() string {
+	for _, p := range conntrackBinaryPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// IsConntrackAvailable reports whether the conntrack binary is present.
+func IsConntrackAvailable() bool { return ConntrackBinary() != "" }
+
+// FlushConntrackForCIDRs evicts existing conntrack entries whose destination
+// matches the given CIDRs/IPs so that flows established BEFORE the ipset was
+// populated are re-evaluated against the selective guard immediately.
+//
+// Only /32 host entries are flushed; broader static CIDRs are skipped.
+func FlushConntrackForCIDRs(ctx context.Context, cidrs []string, errFn func(ip, err string)) (flushed int, available bool) {
+	bin := ConntrackBinary()
+	if bin == "" {
+		return 0, false
+	}
+	for _, raw := range cidrs {
+		dest := conntrackDestArg(raw)
+		if dest == "" {
+			continue
+		}
+		// `conntrack -D -d <ip[/mask]>` deletes flows matching the destination.
+		res, err := sysexec.Run(ctx, bin, "-D", "-d", dest)
+		if err != nil {
+			combined := ""
+			if res != nil {
+				combined = res.Stdout + res.Stderr
+			}
+			// "0 flow entries have been deleted" is reported on stderr with a
+			// non-zero exit — not an error worth surfacing.
+			if strings.Contains(combined, "0 flow entries") {
+				continue
+			}
+			if errFn != nil {
+				errFn(dest, err.Error())
+			}
+			continue
+		}
+		flushed++
+	}
+	return flushed, true
+}
+
+// conntrackDestArg returns the -d argument for conntrack -D: /32 hosts only.
+func conntrackDestArg(raw string) string {
+	entry := normalizeEntry(raw)
+	if entry == "" {
+		return ""
+	}
+	_, ipnet, err := net.ParseCIDR(entry)
+	if err != nil {
+		return ""
+	}
+	ones, bits := ipnet.Mask.Size()
+	if bits != 32 || ones != 32 {
+		return ""
+	}
+	return entry
+}
+
+// singleHostIP returns the bare IPv4 address for a "/32" CIDR or a bare IPv4
+// literal, or "" for anything broader or non-IPv4.
+func singleHostIP(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if ip, ipnet, err := net.ParseCIDR(raw); err == nil {
+		ones, bits := ipnet.Mask.Size()
+		if bits != 32 || ones != 32 {
+			return "" // broader than /32 — skip
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+		return ""
+	}
+	if ip := net.ParseIP(raw); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	}
+	return ""
+}
+
+// conntrackHint is a stable string the builder can attach to progress when
+// conntrack is missing, explaining why a routing change may lag.
+const conntrackHint = "conntrack не установлен: смена маршрута применится к новым соединениям; для мгновенного эффекта после полной пересборки установите пакет (opkg install conntrack)"

--- a/internal/singbox/router/selective/conntrack_test.go
+++ b/internal/singbox/router/selective/conntrack_test.go
@@ -1,0 +1,41 @@
+package selective
+
+import "testing"
+
+func TestSingleHostIP(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"188.40.167.82/32", "188.40.167.82"},
+		{"188.40.167.82", "188.40.167.82"},
+		{" 10.0.0.1/32 ", "10.0.0.1"},
+		{"142.250.0.0/15", ""}, // broader than /32 — skipped
+		{"10.0.0.0/8", ""},
+		{"::1/128", ""}, // IPv6 — skipped
+		{"2001:db8::1", ""},
+		{"not-an-ip", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := singleHostIP(c.in); got != c.want {
+			t.Errorf("singleHostIP(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// When the conntrack binary is absent the flush is a no-op and reports
+// available=false (so callers can surface an install hint) without erroring.
+func TestFlushConntrackForCIDRs_NoBinary(t *testing.T) {
+	saved := conntrackBinaryPaths
+	conntrackBinaryPaths = []string{"/nonexistent/conntrack-xyz"}
+	t.Cleanup(func() { conntrackBinaryPaths = saved })
+
+	flushed, available := FlushConntrackForCIDRs(t.Context(), []string{"188.40.167.82/32"}, nil)
+	if available {
+		t.Error("expected available=false when binary absent")
+	}
+	if flushed != 0 {
+		t.Errorf("expected 0 flushed, got %d", flushed)
+	}
+}

--- a/internal/singbox/router/selective/deps_check.go
+++ b/internal/singbox/router/selective/deps_check.go
@@ -1,0 +1,189 @@
+// Package selective implements the selective-bypass feature for the sing-box
+// TProxy router: only traffic whose destination IP is listed in the
+// AWGM-SELECTIVE ipset reaches sing-box; all other traffic bypasses it
+// entirely (RETURN → WAN).
+package selective
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
+)
+
+// ipsetBinaryPaths lists candidate absolute paths for the ipset binary,
+// searched in order. Entware installs to /opt/sbin; system may have
+// /usr/sbin or /sbin.
+var ipsetBinaryPaths = []string{
+	"/opt/sbin/ipset",
+	"/usr/sbin/ipset",
+	"/sbin/ipset",
+}
+
+// IPSetBinary returns the path to the installed ipset binary, or ""
+// when not found. Scans candidate paths in preference order.
+func IPSetBinary() string {
+	for _, p := range ipsetBinaryPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// IsIPSetAvailable reports whether the ipset binary is present on the router.
+func IsIPSetAvailable() bool {
+	return IPSetBinary() != ""
+}
+
+// xtSetModuleName is the kernel module name for iptables ipset matching.
+const xtSetModuleName = "xt_set"
+
+// IsXtSetAvailable reports whether the xt_set kernel module is currently
+// loaded OR available as a .ko file that can be loaded.
+// NOT cached — called at status-check time, result must reflect reality
+// after module load attempts.
+func IsXtSetAvailable() bool {
+	if isModuleLoaded(xtSetModuleName) {
+		return true
+	}
+	kernel := osdetect.KernelRelease()
+	if kernel == "" {
+		return false
+	}
+	path := filepath.Join("/lib/modules", kernel, xtSetModuleName+".ko")
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// isModuleLoaded checks /proc/modules for the given module name.
+// Identical to the helper in iptables.go; duplicated to keep the
+// selective package self-contained and avoid an internal import cycle.
+func isModuleLoaded(name string) bool {
+	data, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		return false
+	}
+	prefix := name + " "
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureXtSetModule attempts to load xt_set.ko via insmod. Soft-fail by
+// design: if the module is built into the kernel there is no .ko file but
+// it still works; a hard error here would be a false positive. The caller
+// (builder) logs the warning and continues — the real failure surfaces at
+// iptables-restore COMMIT time with a concrete message.
+func EnsureXtSetModule(ctx context.Context) error {
+	if isModuleLoaded(xtSetModuleName) {
+		return nil
+	}
+	kernel := osdetect.KernelRelease()
+	if kernel == "" {
+		return nil // soft-fail: can't determine kernel version
+	}
+	path := filepath.Join("/lib/modules", kernel, xtSetModuleName+".ko")
+	if _, err := os.Stat(path); err != nil {
+		return nil // soft-fail: .ko absent → assume built-in or unavailable
+	}
+	_, err := sysexec.Run(ctx, "insmod", path)
+	return err
+}
+
+// InstallIPSet runs `opkg install ipset` and streams output lines to
+// progressFn (called once per line, nil = silent). Returns the first
+// non-zero exit error, or nil on success.
+func InstallIPSet(ctx context.Context, progressFn func(line string)) error {
+	opkg, err := findOpkg()
+	if err != nil {
+		return err
+	}
+	// We use RunWithOptions with a long timeout — opkg downloads packages
+	// and can take 30-60s on slow WAN.
+	res, err := sysexec.RunWithOptions(ctx, opkg, []string{"install", "ipset"},
+		sysexec.Options{Timeout: 120e9}) // 120s
+	if res != nil && progressFn != nil {
+		combined := res.Stdout
+		if res.Stderr != "" {
+			combined += res.Stderr
+		}
+		for _, line := range strings.Split(combined, "\n") {
+			if l := strings.TrimSpace(line); l != "" {
+				progressFn(l)
+			}
+		}
+	}
+	if err != nil {
+		return sysexec.FormatError(res, err)
+	}
+	// Invalidate the cached result so subsequent IsIPSetAvailable calls
+	// reflect the newly installed binary.
+	resetIPSetCache()
+
+	// Best-effort: also install conntrack so a routing change takes effect
+	// immediately (existing flows get evicted) instead of waiting for old
+	// connections to expire. Failure here is non-fatal — the selective guard
+	// works without it, just with delayed effect on established flows.
+	if !IsConntrackAvailable() {
+		_ = InstallConntrackTools(ctx, progressFn)
+	}
+	return nil
+}
+
+// InstallConntrackTools installs the conntrack userspace binary via opkg.
+// Keenetic Entware ships it as package "conntrack"; some feeds use
+// "conntrack-tools" instead — we try both.
+func InstallConntrackTools(ctx context.Context, progressFn func(line string)) error {
+	opkg, err := findOpkg()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range []string{"conntrack", "conntrack-tools"} {
+		if err := opkgInstall(ctx, opkg, pkg, progressFn); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("opkg install conntrack: package not found in feed")
+}
+
+func opkgInstall(ctx context.Context, opkg, pkg string, progressFn func(line string)) error {
+	res, err := sysexec.RunWithOptions(ctx, opkg, []string{"install", pkg},
+		sysexec.Options{Timeout: 120e9})
+	if res != nil && progressFn != nil {
+		combined := res.Stdout
+		if res.Stderr != "" {
+			combined += res.Stderr
+		}
+		for _, line := range strings.Split(combined, "\n") {
+			if l := strings.TrimSpace(line); l != "" {
+				progressFn(l)
+			}
+		}
+	}
+	if err != nil {
+		return sysexec.FormatError(res, err)
+	}
+	return nil
+}
+
+// resetIPSetCache is kept for API compatibility with tests but is now a no-op
+// since IsXtSetAvailable no longer caches.
+func resetIPSetCache() {}
+
+// findOpkg returns the absolute path to opkg, or an error if not found.
+func findOpkg() (string, error) {
+	for _, p := range []string{"/opt/bin/opkg", "/usr/bin/opkg", "/bin/opkg"} {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", ErrOpkgNotFound
+}

--- a/internal/singbox/router/selective/errors.go
+++ b/internal/singbox/router/selective/errors.go
@@ -1,0 +1,14 @@
+package selective
+
+import "errors"
+
+// ErrOpkgNotFound is returned when opkg is not present on the router.
+var ErrOpkgNotFound = errors.New("opkg not found: cannot install ipset without a package manager")
+
+// ErrIPSetNotAvailable is returned when ipset binary is absent and the
+// caller cannot proceed without it.
+var ErrIPSetNotAvailable = errors.New("ipset binary not found: install the ipset package via opkg")
+
+// ErrXtSetNotAvailable is returned when xt_set kernel module is absent,
+// meaning iptables -m set rules cannot be applied.
+var ErrXtSetNotAvailable = errors.New("kernel module xt_set not found: iptables ipset matching unavailable")

--- a/internal/singbox/router/selective/ipset.go
+++ b/internal/singbox/router/selective/ipset.go
@@ -1,0 +1,210 @@
+package selective
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+)
+
+const (
+	// SetName is the ipset name used for the AWGM selective bypass filter.
+	SetName = "AWGM-SELECTIVE"
+
+	// setMaxElem is the maximum number of entries in the ipset.
+	// hash:net on Keenetic kernels supports up to ~1M entries; 262144
+	// is a safe ceiling that covers all realistic rule-set sizes without
+	// consuming excessive kernel memory.
+	setMaxElem = 262144
+)
+
+// ipsetBin returns the path to ipset, or an error if not available.
+func ipsetBin() (string, error) {
+	p := IPSetBinary()
+	if p == "" {
+		return "", ErrIPSetNotAvailable
+	}
+	return p, nil
+}
+
+// CreateSet creates the AWGM-SELECTIVE ipset (hash:net) if it does not
+// already exist. Idempotent — "set with the same name already exists" is
+// silently ignored.
+func CreateSet(ctx context.Context) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin,
+		"create", SetName, "hash:net",
+		"maxelem", fmt.Sprintf("%d", setMaxElem),
+		"family", "inet",
+	)
+	if err != nil {
+		// "set with the same name already exists" → idempotent success
+		combined := ""
+		if res != nil {
+			combined = res.Stdout + res.Stderr
+		}
+		if strings.Contains(combined, "already exists") {
+			return nil
+		}
+		return sysexec.FormatError(res, fmt.Errorf("ipset create: %w", err))
+	}
+	return nil
+}
+
+// DestroySet removes the AWGM-SELECTIVE ipset. Idempotent — "set does not
+// exist" is silently ignored (set was never created or already cleaned up).
+func DestroySet(ctx context.Context) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin, "destroy", SetName)
+	if err != nil {
+		combined := ""
+		if res != nil {
+			combined = res.Stdout + res.Stderr
+		}
+		if strings.Contains(combined, "does not exist") || strings.Contains(combined, "not found") {
+			return nil
+		}
+		return sysexec.FormatError(res, fmt.Errorf("ipset destroy: %w", err))
+	}
+	return nil
+}
+
+// FlushSet removes all entries from AWGM-SELECTIVE without deleting the set
+// itself. Idempotent — if the set does not exist, it is created first.
+func FlushSet(ctx context.Context) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin, "flush", SetName)
+	if err != nil {
+		combined := ""
+		if res != nil {
+			combined = res.Stdout + res.Stderr
+		}
+		if strings.Contains(combined, "does not exist") || strings.Contains(combined, "not found") {
+			// Set was not created yet — create it and return; it will be
+			// populated by a subsequent AddEntries call.
+			return CreateSet(ctx)
+		}
+		return sysexec.FormatError(res, fmt.Errorf("ipset flush: %w", err))
+	}
+	return nil
+}
+
+// SetExists reports whether the AWGM-SELECTIVE ipset currently exists in
+// the kernel. Uses `ipset list -name` which is fast (no entry output).
+func SetExists(ctx context.Context) bool {
+	bin, err := ipsetBin()
+	if err != nil {
+		return false
+	}
+	res, err := sysexec.Run(ctx, bin, "list", "-name")
+	if err != nil || res == nil {
+		return false
+	}
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		if strings.TrimSpace(line) == SetName {
+			return true
+		}
+	}
+	return false
+}
+
+// EntryCount returns the number of entries in the AWGM-SELECTIVE ipset,
+// or 0 if the set does not exist or the count cannot be determined.
+func EntryCount(ctx context.Context) int {
+	bin, err := ipsetBin()
+	if err != nil {
+		return 0
+	}
+	res, err := sysexec.Run(ctx, bin, "list", SetName)
+	if err != nil || res == nil {
+		return 0
+	}
+	count := 0
+	inMembers := false
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "Members:" {
+			inMembers = true
+			continue
+		}
+		if inMembers && line != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// ListEntries returns every member CIDR currently in AWGM-SELECTIVE.
+// Returns nil when the set does not exist.
+func ListEntries(ctx context.Context) ([]string, error) {
+	bin, err := ipsetBin()
+	if err != nil {
+		return nil, err
+	}
+	res, err := sysexec.Run(ctx, bin, "list", SetName)
+	if err != nil || res == nil {
+		return nil, err
+	}
+	var out []string
+	inMembers := false
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "Members:" {
+			inMembers = true
+			continue
+		}
+		if !inMembers || line == "" {
+			continue
+		}
+		if entry := normalizeEntry(line); entry != "" {
+			out = append(out, entry)
+		}
+	}
+	return out, nil
+}
+
+// AddEntries bulk-adds CIDRs/IPs to the AWGM-SELECTIVE set using
+// `ipset restore` piped input for efficiency (one syscall for all entries
+// instead of N `ipset add` calls). Each entry is validated as a CIDR or
+// bare IPv4 before submission; invalid entries are silently skipped.
+//
+// The set must already exist (call CreateSet or FlushSet first).
+func AddEntries(ctx context.Context, cidrs []string) error {
+	return chunkedAddToSet(ctx, SetName, cidrs)
+}
+
+// normalizeEntry canonicalises a CIDR or bare IPv4 address for ipset.
+// Returns "" for anything that is not a valid IPv4 address or CIDR.
+// IPv6 is not supported — sing-box TProxy on Keenetic is IPv4-only.
+func normalizeEntry(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// Try CIDR first.
+	if _, ipnet, err := net.ParseCIDR(raw); err == nil {
+		if ipnet.IP.To4() == nil {
+			return "" // IPv6 — skip
+		}
+		return ipnet.String() // canonical form (e.g. "10.0.0.0/8")
+	}
+	// Try bare IP.
+	if ip := net.ParseIP(raw); ip != nil {
+		if ip.To4() == nil {
+			return "" // IPv6 — skip
+		}
+		return ip.To4().String() + "/32"
+	}
+	return ""
+}

--- a/internal/singbox/router/selective/ipset_entries.go
+++ b/internal/singbox/router/selective/ipset_entries.go
@@ -1,0 +1,32 @@
+package selective
+
+// BuildIpsetEntries merges static CIDRs and per-domain resolved IPs into the
+// deduplicated list passed to ipset restore. Host routes stay /32 — widening
+// to /24 pulled unrelated neighbours into sing-box and broke selective bypass.
+func BuildIpsetEntries(static []string, domainResults []DomainResolveResult) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(raw string) {
+		entry := normalizeEntry(raw)
+		if entry == "" {
+			return
+		}
+		if _, ok := seen[entry]; ok {
+			return
+		}
+		seen[entry] = struct{}{}
+		out = append(out, entry)
+	}
+	for _, c := range static {
+		add(c)
+	}
+	for _, dr := range domainResults {
+		if dr.Error != "" {
+			continue
+		}
+		for _, ip := range dr.IPs {
+			add(ip)
+		}
+	}
+	return out
+}

--- a/internal/singbox/router/selective/ipset_entries_test.go
+++ b/internal/singbox/router/selective/ipset_entries_test.go
@@ -1,0 +1,44 @@
+package selective
+
+import "testing"
+
+func TestBuildIpsetEntries_DedupesHosts(t *testing.T) {
+	static := []string{"192.168.1.0/24"}
+	domains := []DomainResolveResult{
+		{
+			Matcher: "deepl.com",
+			Kind:    "suffix",
+			CDN:     true,
+			IPs:     []string{"104.18.36.122/32", "104.18.39.209/32"},
+		},
+		{
+			Matcher: "2ip.ru",
+			Kind:    "suffix",
+			CDN:     false,
+			IPs:     []string{"188.40.167.82/32"},
+		},
+	}
+	got := BuildIpsetEntries(static, domains)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 entries, got %v", got)
+	}
+	seen := map[string]bool{}
+	for _, e := range got {
+		seen[e] = true
+	}
+	if !seen["192.168.1.0/24"] || !seen["104.18.36.122/32"] || !seen["104.18.39.209/32"] || !seen["188.40.167.82/32"] {
+		t.Fatalf("unexpected set: %v", got)
+	}
+}
+
+func TestConntrackDestArg(t *testing.T) {
+	if got := conntrackDestArg("8.47.69.0/24"); got != "" {
+		t.Fatalf("expected skip for /24, got %q", got)
+	}
+	if got := conntrackDestArg("1.2.3.4/32"); got != "1.2.3.4/32" {
+		t.Fatalf("got %q", got)
+	}
+	if got := conntrackDestArg("10.0.0.0/8"); got != "" {
+		t.Fatalf("expected skip for /8, got %q", got)
+	}
+}

--- a/internal/singbox/router/selective/ipset_staging.go
+++ b/internal/singbox/router/selective/ipset_staging.go
@@ -1,0 +1,158 @@
+package selective
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+)
+
+// StagingSetName is the scratch ipset populated during rebuild and atomically
+// swapped with SetName when the pipeline completes.
+const StagingSetName = "AWGM-SELECTIVE-STG"
+
+// IpsetChunkSize is how many entries are batched into one ipset restore call.
+const IpsetChunkSize = 512
+
+var ipsetChunkPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, IpsetChunkSize*32)
+		return &b
+	},
+}
+
+// EnsureStagingSet creates the staging set (empty) if missing.
+func EnsureStagingSet(ctx context.Context) error {
+	return createNamedSet(ctx, StagingSetName)
+}
+
+// FlushStagingSet removes all members from the staging set.
+func FlushStagingSet(ctx context.Context) error {
+	return flushNamedSet(ctx, StagingSetName)
+}
+
+// SwapWithStaging atomically exchanges live and staging ipset contents.
+func SwapWithStaging(ctx context.Context) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	if err := EnsureStagingSet(ctx); err != nil {
+		return err
+	}
+	if err := CreateSet(ctx); err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin, "swap", SetName, StagingSetName)
+	if err != nil {
+		return sysexec.FormatError(res, fmt.Errorf("ipset swap: %w", err))
+	}
+	return nil
+}
+
+// ChunkedAddStaging appends entries to the staging set in restore batches.
+func ChunkedAddStaging(ctx context.Context, cidrs []string) error {
+	return chunkedAddToSet(ctx, StagingSetName, cidrs)
+}
+
+// ChunkedAddLive appends entries to the live set (CDN refresh path).
+func ChunkedAddLive(ctx context.Context, cidrs []string) error {
+	return chunkedAddToSet(ctx, SetName, cidrs)
+}
+
+func chunkedAddToSet(ctx context.Context, setName string, cidrs []string) error {
+	if len(cidrs) == 0 {
+		return nil
+	}
+	for i := 0; i < len(cidrs); i += IpsetChunkSize {
+		end := i + IpsetChunkSize
+		if end > len(cidrs) {
+			end = len(cidrs)
+		}
+		if err := addEntriesToSet(ctx, setName, cidrs[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addEntriesToSet(ctx context.Context, setName string, cidrs []string) error {
+	if len(cidrs) == 0 {
+		return nil
+	}
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	bufPtr := ipsetChunkPool.Get().(*[]byte)
+	b := bytes.NewBuffer((*bufPtr)[:0])
+	defer func() {
+		*bufPtr = b.Bytes()[:0]
+		ipsetChunkPool.Put(bufPtr)
+	}()
+
+	valid := 0
+	for _, raw := range cidrs {
+		entry := normalizeEntry(raw)
+		if entry == "" {
+			continue
+		}
+		fmt.Fprintf(b, "add %s %s\n", setName, entry)
+		valid++
+	}
+	if valid == 0 {
+		return nil
+	}
+	res, err := sysexec.RunWithOptions(ctx, bin, []string{"restore", "-exist"},
+		sysexec.Options{Stdin: b, Timeout: 60e9})
+	if err != nil {
+		return sysexec.FormatError(res, fmt.Errorf("ipset restore: %w", err))
+	}
+	return nil
+}
+
+func createNamedSet(ctx context.Context, name string) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin,
+		"create", name, "hash:net",
+		"maxelem", fmt.Sprintf("%d", setMaxElem),
+		"family", "inet",
+	)
+	if err != nil {
+		combined := ""
+		if res != nil {
+			combined = res.Stdout + res.Stderr
+		}
+		if strings.Contains(combined, "already exists") {
+			return nil
+		}
+		return sysexec.FormatError(res, fmt.Errorf("ipset create %s: %w", name, err))
+	}
+	return nil
+}
+
+func flushNamedSet(ctx context.Context, name string) error {
+	bin, err := ipsetBin()
+	if err != nil {
+		return err
+	}
+	res, err := sysexec.Run(ctx, bin, "flush", name)
+	if err != nil {
+		combined := ""
+		if res != nil {
+			combined = res.Stdout + res.Stderr
+		}
+		if strings.Contains(combined, "does not exist") || strings.Contains(combined, "not found") {
+			return createNamedSet(ctx, name)
+		}
+		return sysexec.FormatError(res, fmt.Errorf("ipset flush %s: %w", name, err))
+	}
+	return nil
+}
+

--- a/internal/singbox/router/selective/ipset_test.go
+++ b/internal/singbox/router/selective/ipset_test.go
@@ -1,0 +1,138 @@
+package selective
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── normalizeEntry ────────────────────────────────────────────────────────────
+
+func TestNormalizeEntry_ValidCIDR(t *testing.T) {
+	if got := normalizeEntry("10.0.0.0/8"); got != "10.0.0.0/8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeEntry_BareIPBecomesSlash32(t *testing.T) {
+	if got := normalizeEntry("1.2.3.4"); got != "1.2.3.4/32" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeEntry_CanonicalisesCIDR(t *testing.T) {
+	// Host bits should be masked: 10.0.0.1/8 → 10.0.0.0/8
+	if got := normalizeEntry("10.0.0.1/8"); got != "10.0.0.0/8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestNormalizeEntry_IPv6Rejected(t *testing.T) {
+	if got := normalizeEntry("::1/128"); got != "" {
+		t.Errorf("expected empty for IPv6, got %q", got)
+	}
+}
+
+func TestNormalizeEntry_IPv6BareRejected(t *testing.T) {
+	if got := normalizeEntry("fe80::1"); got != "" {
+		t.Errorf("expected empty for IPv6, got %q", got)
+	}
+}
+
+func TestNormalizeEntry_GarbageRejected(t *testing.T) {
+	if got := normalizeEntry("not-an-ip"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestNormalizeEntry_EmptyString(t *testing.T) {
+	if got := normalizeEntry(""); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestNormalizeEntry_Whitespace(t *testing.T) {
+	if got := normalizeEntry("  1.2.3.4  "); got != "1.2.3.4/32" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// ── IPSetBinary path detection ────────────────────────────────────────────────
+
+func TestIPSetBinary_ReturnsPresentPath(t *testing.T) {
+	// Override the candidate paths with a guaranteed-present binary.
+	original := ipsetBinaryPaths
+	ipsetBinaryPaths = []string{"/usr/bin/env"} // always exists
+	defer func() { ipsetBinaryPaths = original }()
+
+	if got := IPSetBinary(); got != "/usr/bin/env" {
+		t.Errorf("expected /usr/bin/env, got %q", got)
+	}
+	if !IsIPSetAvailable() {
+		t.Error("IsIPSetAvailable() should be true when binary exists")
+	}
+}
+
+func TestIPSetBinary_ReturnsEmptyWhenNotFound(t *testing.T) {
+	original := ipsetBinaryPaths
+	ipsetBinaryPaths = []string{"/nonexistent/path/ipset-xyz"}
+	defer func() { ipsetBinaryPaths = original }()
+
+	if got := IPSetBinary(); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+	if IsIPSetAvailable() {
+		t.Error("IsIPSetAvailable() should be false when binary missing")
+	}
+}
+
+// ── AddEntries — batch input format ──────────────────────────────────────────
+// We can't call the real `ipset` in unit tests, but we can verify the
+// batch restore input that would be piped to it.
+
+func buildRestoreInput_AddEntries(cidrs []string) string {
+	// Reproduce the batch format from AddEntries without calling ipset.
+	var sb strings.Builder
+	for _, raw := range cidrs {
+		entry := normalizeEntry(raw)
+		if entry == "" {
+			continue
+		}
+		sb.WriteString("add " + SetName + " " + entry + "\n")
+	}
+	return sb.String()
+}
+
+func TestAddEntries_BatchFormat(t *testing.T) {
+	input := buildRestoreInput_AddEntries([]string{"1.2.3.0/24", "5.6.7.8", "invalid"})
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (invalid skipped), got %d:\n%s", len(lines), input)
+	}
+	if !strings.Contains(lines[0], "1.2.3.0/24") {
+		t.Errorf("line 0: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "5.6.7.8/32") {
+		t.Errorf("line 1: %q", lines[1])
+	}
+}
+
+func TestAddEntries_EmptyInput_NoOutput(t *testing.T) {
+	input := buildRestoreInput_AddEntries(nil)
+	if input != "" {
+		t.Errorf("expected empty output for nil input, got %q", input)
+	}
+}
+
+func TestAddEntries_AllInvalid_NoOutput(t *testing.T) {
+	input := buildRestoreInput_AddEntries([]string{"::1", "garbage", ""})
+	if input != "" {
+		t.Errorf("expected empty output for all-invalid input, got %q", input)
+	}
+}
+
+func TestAddEntries_SetNameInOutput(t *testing.T) {
+	input := buildRestoreInput_AddEntries([]string{"10.0.0.1"})
+	if !strings.Contains(input, SetName) {
+		t.Errorf("expected %q in output, got %q", SetName, input)
+	}
+}

--- a/internal/singbox/router/selective/json_ruleset_stream.go
+++ b/internal/singbox/router/selective/json_ruleset_stream.go
@@ -1,0 +1,141 @@
+package selective
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+)
+
+// streamRuleSetJSONFile walks rules in a rule-set source JSON without loading
+// the entire file when domain_suffix arrays are large.
+func streamRuleSetJSONFile(path string, outbound string, seen *deduplicator, sink *CollectSink) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, _ := keyTok.(string)
+		if key != "rules" {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+			continue
+		}
+		arrTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if d, ok := arrTok.(json.Delim); !ok || d != '[' {
+			continue
+		}
+		for dec.More() {
+			var rule map[string]json.RawMessage
+			if err := dec.Decode(&rule); err != nil {
+				return err
+			}
+			if err := streamExtractFromRuleMap(rule, outbound, seen, sink); err != nil {
+				return err
+			}
+		}
+		if _, err := dec.Token(); err != nil { // ]
+			return err
+		}
+	}
+	return nil
+}
+
+func streamExtractFromRuleMap(rule map[string]json.RawMessage, outbound string, seen *deduplicator, sink *CollectSink) error {
+	if raw, ok := rule["ip_cidr"]; ok {
+		if err := streamStringArray(raw, func(s string) error {
+			if c := normalizeCIDR(s); c != "" && seen.addCIDR(c) {
+				return sink.OnStaticCIDR(c)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	for _, key := range []string{"domain_suffix", "domain"} {
+		raw, ok := rule[key]
+		if !ok {
+			continue
+		}
+		kind := KindDomain
+		if key == "domain_suffix" {
+			kind = KindDomainSuffix
+		}
+		if err := streamStringArray(raw, func(s string) error {
+			if d := cleanDomain(s); d != "" && seen.addDomainQuery(d, kind, outbound) {
+				return sink.OnDomainQuery(DomainQuery{Matcher: d, Kind: kind, Outbound: outbound})
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func streamStringArray(raw json.RawMessage, fn func(string) error) error {
+	raw = json.RawMessage(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return nil
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return err
+		}
+		return fn(s)
+	}
+	if raw[0] != '[' {
+		return nil
+	}
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	if tok, err := dec.Token(); err != nil {
+		return err
+	} else if d, ok := tok.(json.Delim); !ok || d != '[' {
+		return nil
+	}
+	for dec.More() {
+		var s string
+		if err := dec.Decode(&s); err != nil {
+			return err
+		}
+		if err := fn(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	var skip json.RawMessage
+	return dec.Decode(&skip)
+}
+
+// streamSRSJSONFile reads decompiled SRS JSON from a file path line-by-line rule.
+func streamSRSJSONFile(path string, outbound string, seen *deduplicator, sink *CollectSink) error {
+	return streamRuleSetJSONFile(path, outbound, seen, sink)
+}
+
+// noop closer for io usage
+var _ io.Closer = (*os.File)(nil)

--- a/internal/singbox/router/selective/resolver.go
+++ b/internal/singbox/router/selective/resolver.go
@@ -1,0 +1,614 @@
+package selective
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
+)
+
+// maxConcurrentResolves caps the number of simultaneous DNS goroutines
+// to avoid flooding the DNS server on large domain lists.
+const maxConcurrentResolves = 10
+
+// dnsQueryTimeout is the per-UDP-query budget. Keenetic often blocks public
+// resolvers — 5s × many hosts × many servers made rebuilds feel hung.
+const dnsQueryTimeout = 2 * time.Second
+
+// dnsResolveRounds is how many parallel sampling rounds per host on local DNS.
+const dnsResolveRounds = 2
+
+// dnsResolveRoundsCDN is extra rounds on local+public DNS for CDN hosts only.
+const dnsResolveRoundsCDN = 3
+
+// maxHostsPerMatcher caps hostname expansion (suffix probes + CNAME targets)
+// so a single rule cannot explode rebuild time.
+const maxHostsPerMatcher = 48
+
+// publicDNSFallbacks are always unioned into the rebuild resolver set so we
+// sample more CDN edge addresses than a single upstream would return.
+var publicDNSFallbacks = []string{
+	"1.1.1.1",
+	"8.8.8.8",
+	"9.9.9.9",
+	"208.67.222.222",
+	"77.88.8.8",
+}
+
+// DNSServerSource is the interface the resolver uses to pull fallback DNS
+// server addresses from the NDMS router. DNSProxyStatusStore satisfies it.
+type DNSServerSource interface {
+	// List returns the raw bytes of /show/dns-proxy response.
+	List(ctx context.Context) ([]byte, error)
+}
+
+// dnsProxyStatusUpstream is the partial shape of one upstream entry in
+// the /show/dns-proxy JSON response. We only need the address field.
+type dnsProxyStatusUpstream struct {
+	Address string `json:"address"`
+}
+
+// dnsProxyStatusProxy is the partial shape of one dns-proxy group in
+// the /show/dns-proxy JSON response.
+type dnsProxyStatusProxy struct {
+	Upstreams []dnsProxyStatusUpstream `json:"upstreams"`
+}
+
+// dnsProxyStatusResponse is the root of the /show/dns-proxy JSON. The
+// router can return either an array of proxy groups or a single group.
+// We handle both.
+type dnsProxyStatusResponse struct {
+	// When the router returns an array at the top level.
+	groups []dnsProxyStatusProxy
+}
+
+// BuildDNSServers returns the deduplicated union of DNS resolvers used when
+// populating the selective ipset:
+//  1. sing-box router DNS servers (udp/tls/https/h3/quic with a server field)
+//  2. NDMS router upstreams (/show/dns-proxy)
+//  3. publicDNSFallbacks (1.1.1.1, 8.8.8.8, …)
+//
+// Unioning every source matters for CDN domains: each resolver may return a
+// different subset of anycast A records for the same hostname.
+func BuildDNSServers(ctx context.Context, singboxDNSServers []SingboxDNSServer, ndmsSource DNSServerSource) []string {
+	var seeds []string
+
+	for _, srv := range singboxDNSServers {
+		t := strings.ToLower(srv.Type)
+		if t != "udp" && t != "tls" && t != "https" && t != "h3" && t != "quic" {
+			continue
+		}
+		if srv.Server == "" {
+			continue
+		}
+		if addr := extractHost(srv.Server); addr != "" {
+			seeds = append(seeds, addr)
+		}
+	}
+
+	if ndmsSource != nil {
+		raw, err := ndmsSource.List(ctx)
+		if err == nil && len(raw) > 0 {
+			seeds = append(seeds, parseNDMSUpstreamAddresses(raw)...)
+		}
+	}
+
+	return augmentDNSServers(seeds)
+}
+
+// partitionDNSServers splits the rebuild resolver list into router/sing-box
+// upstreams vs public fallbacks. Public resolvers are queried only during the
+// CDN extra pass — they are often unreachable from LAN and must not block the
+// initial resolve.
+func partitionDNSServers(servers []string) (primary, public []string) {
+	pub := make(map[string]struct{}, len(publicDNSFallbacks))
+	for _, p := range publicDNSFallbacks {
+		pub[p] = struct{}{}
+	}
+	for _, s := range servers {
+		s = extractHost(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := pub[s]; ok {
+			public = append(public, s)
+		} else {
+			primary = append(primary, s)
+		}
+	}
+	if len(primary) == 0 {
+		return public, nil
+	}
+	return primary, public
+}
+
+func augmentDNSServers(servers []string) []string {
+	seen := make(map[string]struct{}, len(servers)+len(publicDNSFallbacks))
+	var out []string
+	add := func(addr string) {
+		addr = extractHost(addr)
+		if addr == "" {
+			return
+		}
+		if _, ok := seen[addr]; ok {
+			return
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	for _, s := range servers {
+		add(s)
+	}
+	for _, s := range publicDNSFallbacks {
+		add(s)
+	}
+	return out
+}
+
+// SingboxDNSServer is a minimal view of a DNSServer from the router config,
+// carrying only the fields needed by BuildDNSServers. Exported so the router
+// adapter can pass DNS server list without importing router types.
+type SingboxDNSServer struct {
+	Tag    string
+	Type   string
+	Server string
+}
+
+// suffixResolvePrefixes are prepended to a domain_suffix matcher when building
+// DNS query hostnames. CDN-backed sites often serve content from these
+// subdomains while the rule only names the apex or suffix.
+var suffixResolvePrefixes = []string{
+	"www.",
+	"m.",
+	"cdn.",
+	"static.",
+	"media.",
+	"api.",
+	"img.",
+	"images.",
+	"image.",
+	"assets.",
+	"edge.",
+	"cache.",
+	"origin.",
+	"download.",
+	"files.",
+	"content.",
+	"lb.",
+	"mobile.",
+}
+
+// expandQueryHosts returns the hostnames to resolve for a rule matcher.
+// Exact domain rules query only the matcher; suffix rules also probe common
+// CDN / mobile subdomains so more of the site's address pool lands in ipset.
+func expandQueryHosts(matcher string, kind DomainKind) []string {
+	matcher = strings.TrimSpace(strings.ToLower(matcher))
+	if matcher == "" {
+		return nil
+	}
+	if kind == KindDomain {
+		return []string{matcher}
+	}
+
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(h string) {
+		h = strings.TrimSpace(strings.ToLower(h))
+		if h == "" {
+			return
+		}
+		if _, ok := seen[h]; ok {
+			return
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+
+	add(matcher)
+	for _, p := range suffixResolvePrefixes {
+		add(p + matcher)
+	}
+	return out
+}
+
+// ResolveProgressFn is called after each domain matcher finishes resolving.
+type ResolveProgressFn func(done, total int, matcher string)
+
+// ResolveHostProgressFn is called while resolving expanded hosts inside one matcher.
+type ResolveHostProgressFn func(matcher, host string, hostIndex, hostTotal int)
+
+// ResolveDomainQueries resolves each domain matcher to IPv4 /32 CIDRs and
+// returns structured per-matcher results plus a flat deduplicated IP list.
+func ResolveDomainQueries(ctx context.Context, queries []DomainQuery, dnsServers []string, errFn func(domain, err string), progressFn ResolveProgressFn, hostProgressFn ResolveHostProgressFn) ([]DomainResolveResult, []string) {
+	if len(queries) == 0 {
+		return nil, nil
+	}
+
+	sem := make(chan struct{}, maxConcurrentResolves)
+	results := make([]DomainResolveResult, len(queries))
+	var wg sync.WaitGroup
+	var doneCount atomic.Int32
+	total := len(queries)
+
+	for i, q := range queries {
+		wg.Add(1)
+		go func(idx int, query DomainQuery) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[idx] = resolveOneQuery(ctx, query, dnsServers, errFn, hostProgressFn)
+			if progressFn != nil {
+				n := int(doneCount.Add(1))
+				progressFn(n, total, query.Matcher)
+			}
+		}(i, q)
+	}
+	wg.Wait()
+
+	seen := make(map[string]struct{})
+	var flat []string
+	for _, r := range results {
+		for _, ip := range r.IPs {
+			if _, ok := seen[ip]; !ok {
+				seen[ip] = struct{}{}
+				flat = append(flat, ip)
+			}
+		}
+	}
+	return results, flat
+}
+
+func resolveOneQuery(ctx context.Context, query DomainQuery, dnsServers []string, errFn func(domain, err string), hostProgressFn ResolveHostProgressFn) DomainResolveResult {
+	primary, public := partitionDNSServers(dnsServers)
+	hosts := discoverQueryHosts(ctx, query.Matcher, query.Kind, primary)
+	seen := make(map[string]struct{})
+	var ips []string
+	var ipsMu sync.Mutex
+	add := func(list []string) {
+		ipsMu.Lock()
+		defer ipsMu.Unlock()
+		for _, ip := range list {
+			cidr := ip
+			if !strings.Contains(cidr, "/") {
+				cidr = ip + "/32"
+			}
+			if _, ok := seen[cidr]; ok {
+				continue
+			}
+			seen[cidr] = struct{}{}
+			ips = append(ips, cidr)
+		}
+	}
+
+	type hostResolve struct {
+		ips  []string
+		host string
+		err  error
+	}
+	resolved := make([]hostResolve, len(hosts))
+	var wg sync.WaitGroup
+	hostSem := make(chan struct{}, 6)
+	for i, host := range hosts {
+		wg.Add(1)
+		go func(i int, host string) {
+			defer wg.Done()
+			hostSem <- struct{}{}
+			defer func() { <-hostSem }()
+			if hostProgressFn != nil {
+				hostProgressFn(query.Matcher, host, i+1, len(hosts))
+			}
+			r, err := resolveHostIPv4Aggressive(ctx, host, primary, dnsResolveRounds, true)
+			resolved[i] = hostResolve{ips: r, host: host, err: err}
+		}(i, host)
+	}
+	wg.Wait()
+
+	var lastErr string
+	var cdnHosts []string
+	for _, r := range resolved {
+		if r.err != nil {
+			lastErr = r.err.Error()
+			continue
+		}
+		add(r.ips)
+		if containsCDNEdgeIP(r.ips) {
+			cdnHosts = append(cdnHosts, r.host)
+		}
+	}
+
+	if len(cdnHosts) > 0 && len(public) > 0 {
+		cdnServers := append(append([]string(nil), primary...), public...)
+		var cdnWg sync.WaitGroup
+		cdnSem := make(chan struct{}, 4)
+		for _, host := range cdnHosts {
+			cdnWg.Add(1)
+			go func(host string) {
+				defer cdnWg.Done()
+				cdnSem <- struct{}{}
+				defer func() { <-cdnSem }()
+				r, err := resolveHostIPv4Aggressive(ctx, host, cdnServers, dnsResolveRoundsCDN, false)
+				if err != nil {
+					return
+				}
+				add(r)
+			}(host)
+		}
+		cdnWg.Wait()
+	}
+
+	out := DomainResolveResult{
+		Matcher:    query.Matcher,
+		Kind:       string(query.Kind),
+		QueryHosts: hosts,
+		IPs:        ips,
+		CDN:        containsCDNEdgeIP(ips),
+		Outbound:   query.Outbound,
+	}
+	if len(ips) == 0 {
+		out.Error = lastErr
+		if out.Error == "" {
+			out.Error = "no A records"
+		}
+		if errFn != nil {
+			errFn(query.Matcher, out.Error)
+		}
+	}
+	return out
+}
+
+// discoverQueryHosts expands suffix probes and appends CNAME targets from the
+// first local resolver only (CNAME discovery is best-effort, not worth N×timeout).
+func discoverQueryHosts(ctx context.Context, matcher string, kind DomainKind, primaryDNS []string) []string {
+	seed := expandQueryHosts(matcher, kind)
+	seen := make(map[string]struct{}, len(seed))
+	out := make([]string, 0, len(seed))
+	add := func(h string) {
+		h = strings.TrimSpace(strings.ToLower(strings.TrimSuffix(h, ".")))
+		if h == "" || len(out) >= maxHostsPerMatcher {
+			return
+		}
+		if _, ok := seen[h]; ok {
+			return
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+	for _, h := range seed {
+		add(h)
+	}
+	for i := 0; i < len(out); i++ {
+		if len(out) >= maxHostsPerMatcher {
+			break
+		}
+		host := out[i]
+		if len(primaryDNS) == 0 {
+			break
+		}
+		cctx, cancel := context.WithTimeout(ctx, dnsQueryTimeout)
+		targets, err := httpclient.LookupCNAMETargetsViaDNS(cctx, host, primaryDNS[0], "")
+		cancel()
+		if err != nil {
+			continue
+		}
+		for _, cn := range targets {
+			add(cn)
+		}
+	}
+	return out
+}
+
+// resolveHostIPv4Aggressive unions A records from servers across several
+// parallel sampling rounds. When earlyExit is true, stops after the first
+// round that returned any address (fast path for non-CDN hosts).
+func resolveHostIPv4Aggressive(ctx context.Context, host string, servers []string, rounds int, earlyExit bool) ([]string, error) {
+	if rounds < 1 {
+		rounds = 1
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	var outMu sync.Mutex
+	addBare := func(ips []string) {
+		outMu.Lock()
+		defer outMu.Unlock()
+		for _, ip := range ips {
+			cidr := ip
+			if !strings.Contains(cidr, "/") {
+				cidr = ip + "/32"
+			}
+			if _, ok := seen[cidr]; ok {
+				continue
+			}
+			seen[cidr] = struct{}{}
+			out = append(out, cidr)
+		}
+	}
+
+	var customErr, sysErr error
+
+	for round := 0; round < rounds; round++ {
+		outMu.Lock()
+		before := len(out)
+		outMu.Unlock()
+		var wg sync.WaitGroup
+		var errMu sync.Mutex
+
+		if len(servers) > 0 {
+			for _, srv := range servers {
+				srv := strings.TrimSpace(srv)
+				if srv == "" {
+					continue
+				}
+				wg.Add(1)
+				go func(srv string) {
+					defer wg.Done()
+					qctx, cancel := context.WithTimeout(ctx, dnsQueryTimeout)
+					defer cancel()
+					ips, err := httpclient.LookupAllIPv4ForBind(qctx, host, []string{srv}, "")
+					if err != nil {
+						errMu.Lock()
+						if customErr == nil {
+							customErr = err
+						}
+						errMu.Unlock()
+						return
+					}
+					bare := make([]string, 0, len(ips))
+					for _, ip := range ips {
+						bare = append(bare, strings.TrimSuffix(ip, "/32"))
+					}
+					addBare(bare)
+				}(srv)
+			}
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			qctx, cancel := context.WithTimeout(ctx, dnsQueryTimeout)
+			defer cancel()
+			addrs, err := net.DefaultResolver.LookupHost(qctx, host)
+			if err != nil {
+				errMu.Lock()
+				if round == 0 && sysErr == nil {
+					sysErr = err
+				}
+				errMu.Unlock()
+				return
+			}
+			var v4 []string
+			for _, a := range addrs {
+				if ip := net.ParseIP(a); ip != nil && ip.To4() != nil {
+					v4 = append(v4, ip.To4().String())
+				}
+			}
+			addBare(v4)
+		}()
+		wg.Wait()
+
+		outMu.Lock()
+		gotNew := len(out) > before
+		outMu.Unlock()
+		if earlyExit && gotNew {
+			break
+		}
+	}
+
+	if len(out) == 0 {
+		switch {
+		case customErr != nil && sysErr != nil:
+			return nil, fmt.Errorf("%s; system: %s", customErr.Error(), sysErr.Error())
+		case customErr != nil:
+			return nil, customErr
+		case sysErr != nil:
+			return nil, sysErr
+		default:
+			return nil, fmt.Errorf("no A records")
+		}
+	}
+	return out, nil
+}
+
+// ResolveDomains is a compatibility wrapper that flattens ResolveDomainQueries.
+// Deprecated: prefer ResolveDomainQueries for structured output.
+func ResolveDomains(ctx context.Context, domains []string, dnsServers []string, errFn func(domain, err string)) []string {
+	queries := make([]DomainQuery, len(domains))
+	for i, d := range domains {
+		queries[i] = DomainQuery{Matcher: d, Kind: KindDomainSuffix}
+	}
+	_, flat := ResolveDomainQueries(ctx, queries, dnsServers, errFn, nil, nil)
+	return flat
+}
+
+// extractHost strips port and protocol scheme from a DNS server address,
+// returning a bare host (IP or hostname). Returns "" for empty or invalid input.
+//
+// Examples:
+//
+//	"8.8.8.8"         → "8.8.8.8"
+//	"8.8.8.8:53"      → "8.8.8.8"
+//	"tls://1.1.1.1"   → "1.1.1.1"
+//	"https://dns.example.com/dns-query" → "dns.example.com"
+func extractHost(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Strip scheme.
+	if idx := strings.Index(s, "://"); idx >= 0 {
+		s = s[idx+3:]
+	}
+	// Strip path.
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		s = s[:idx]
+	}
+	// Strip port.
+	host, _, err := net.SplitHostPort(s)
+	if err == nil {
+		return host
+	}
+	// No port — use as-is.
+	return s
+}
+
+// parseNDMSUpstreamAddresses parses the raw /show/dns-proxy JSON response
+// and extracts all upstream IP addresses. Returns nil on parse failure.
+func parseNDMSUpstreamAddresses(raw []byte) []string {
+	raw = trimBOM(raw)
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var addrs []string
+	seen := make(map[string]struct{})
+
+	addUpstream := func(addr string) {
+		host := extractHost(addr)
+		if host == "" {
+			return
+		}
+		if ip := net.ParseIP(host); ip == nil || ip.To4() == nil {
+			return // skip non-IPv4 upstream addresses
+		}
+		if _, ok := seen[host]; ok {
+			return
+		}
+		seen[host] = struct{}{}
+		addrs = append(addrs, host)
+	}
+
+	// Try array of proxy groups: [{upstreams:[{address:"..."},...]},...].
+	var proxies []dnsProxyStatusProxy
+	if err := json.Unmarshal(raw, &proxies); err == nil {
+		for _, p := range proxies {
+			for _, u := range p.Upstreams {
+				addUpstream(u.Address)
+			}
+		}
+		return addrs
+	}
+
+	// Try single proxy group: {upstreams:[{address:"..."},...], ...}.
+	var single dnsProxyStatusProxy
+	if err := json.Unmarshal(raw, &single); err == nil && len(single.Upstreams) > 0 {
+		for _, u := range single.Upstreams {
+			addUpstream(u.Address)
+		}
+		return addrs
+	}
+
+	return nil
+}
+
+// trimBOM strips a UTF-8 BOM if present (some NDMS endpoints include it).
+func trimBOM(b []byte) []byte {
+	if len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
+		return b[3:]
+	}
+	return b
+}

--- a/internal/singbox/router/selective/resolver_partition_test.go
+++ b/internal/singbox/router/selective/resolver_partition_test.go
@@ -1,0 +1,23 @@
+package selective
+
+import "testing"
+
+func TestPartitionDNSServers(t *testing.T) {
+	primary, public := partitionDNSServers([]string{"192.168.1.1", "1.1.1.1", "8.8.8.8", "9.9.9.9"})
+	if len(primary) != 1 || primary[0] != "192.168.1.1" {
+		t.Fatalf("primary = %v", primary)
+	}
+	if len(public) != 3 {
+		t.Fatalf("public = %v", public)
+	}
+}
+
+func TestPartitionDNSServers_OnlyPublic(t *testing.T) {
+	primary, public := partitionDNSServers([]string{"1.1.1.1", "8.8.8.8"})
+	if len(public) != 0 {
+		t.Fatalf("expected no separate public bucket, got %v", public)
+	}
+	if len(primary) != 2 {
+		t.Fatalf("primary = %v", primary)
+	}
+}

--- a/internal/singbox/router/selective/resolver_pipeline.go
+++ b/internal/singbox/router/selective/resolver_pipeline.go
@@ -1,0 +1,130 @@
+package selective
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// MatcherRecord is the slim DNS outcome for snapshot / SSE (no IP list).
+type MatcherRecord struct {
+	Matcher    string
+	Kind       DomainKind
+	QueryHosts []string
+	CDN        bool
+	Outbound   string
+	Error      string
+}
+
+// DomainQueryStreamSink receives per-matcher DNS outcomes during parallel resolve.
+type DomainQueryStreamSink struct {
+	OnIP     func(query DomainQuery, cidr string)
+	OnRecord func(query DomainQuery, rec MatcherRecord)
+}
+
+// ResolveDomainQueriesStream resolves matchers concurrently (same parallelism as
+// ResolveDomainQueries) but streams each /32 to onIP instead of retaining all IPs.
+func ResolveDomainQueriesStream(
+	ctx context.Context,
+	queries []DomainQuery,
+	dnsServers []string,
+	sink DomainQueryStreamSink,
+	progressFn ResolveProgressFn,
+	hostProgressFn ResolveHostProgressFn,
+) {
+	if len(queries) == 0 {
+		return
+	}
+
+	sem := make(chan struct{}, maxConcurrentResolves)
+	var wg sync.WaitGroup
+	var doneCount atomic.Int32
+	total := len(queries)
+
+	for _, q := range queries {
+		wg.Add(1)
+		go func(query DomainQuery) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			rec := ResolveOneQueryStream(ctx, query, dnsServers, func(cidr string) {
+				if sink.OnIP != nil {
+					sink.OnIP(query, cidr)
+				}
+			}, hostProgressFn)
+
+			if sink.OnRecord != nil {
+				sink.OnRecord(query, rec)
+			}
+			if progressFn != nil {
+				n := int(doneCount.Add(1))
+				progressFn(n, total, query.Matcher)
+			}
+		}(q)
+	}
+	wg.Wait()
+}
+
+// ResolveOneQueryStream resolves a single matcher, invoking onIP for each
+// discovered /32 (or wider static CIDR passed through) without retaining
+// the full IP list in the returned record.
+func ResolveOneQueryStream(
+	ctx context.Context,
+	query DomainQuery,
+	dnsServers []string,
+	onIP func(cidr string),
+	hostProgressFn ResolveHostProgressFn,
+) MatcherRecord {
+	ipsSink := func(list []string) {
+		if onIP == nil {
+			return
+		}
+		for _, ip := range list {
+			onIP(ip)
+		}
+	}
+	full := resolveOneQuery(ctx, query, dnsServers, nil, hostProgressFn)
+	ipsSink(full.IPs)
+	return MatcherRecord{
+		Matcher:    full.Matcher,
+		Kind:       DomainKind(full.Kind),
+		QueryHosts: full.QueryHosts,
+		CDN:        full.CDN,
+		Outbound:   full.Outbound,
+		Error:      full.Error,
+	}
+}
+
+// conntrackQueue collects /32 destinations for deferred flush.
+type conntrackQueue struct {
+	mu   sync.Mutex
+	ips  []string
+	seen map[string]struct{}
+}
+
+func newConntrackQueue() *conntrackQueue {
+	return &conntrackQueue{seen: make(map[string]struct{})}
+}
+
+func (q *conntrackQueue) Add(cidr string) {
+	cidr = normalizeEntry(cidr)
+	if cidr == "" || conntrackDestArg(cidr) == "" {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, ok := q.seen[cidr]; ok {
+		return
+	}
+	q.seen[cidr] = struct{}{}
+	q.ips = append(q.ips, cidr)
+}
+
+func (q *conntrackQueue) Drain() []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	out := q.ips
+	q.ips = nil
+	return out
+}

--- a/internal/singbox/router/selective/resolver_test.go
+++ b/internal/singbox/router/selective/resolver_test.go
@@ -1,0 +1,202 @@
+package selective
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// ── extractHost ───────────────────────────────────────────────────────────────
+
+func TestExtractHost_BareIP(t *testing.T) {
+	if got := extractHost("8.8.8.8"); got != "8.8.8.8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractHost_IPWithPort(t *testing.T) {
+	if got := extractHost("8.8.8.8:53"); got != "8.8.8.8" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractHost_TLSScheme(t *testing.T) {
+	if got := extractHost("tls://1.1.1.1"); got != "1.1.1.1" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractHost_HTTPSWithPath(t *testing.T) {
+	if got := extractHost("https://dns.example.com/dns-query"); got != "dns.example.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractHost_Empty(t *testing.T) {
+	if got := extractHost(""); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// ── parseNDMSUpstreamAddresses ────────────────────────────────────────────────
+
+func TestParseNDMSUpstreamAddresses_ArrayShape(t *testing.T) {
+	raw := []byte(`[{"upstreams":[{"address":"1.1.1.1"},{"address":"8.8.8.8"}]}]`)
+	got := parseNDMSUpstreamAddresses(raw)
+	if !slices.Contains(got, "1.1.1.1") || !slices.Contains(got, "8.8.8.8") {
+		t.Errorf("expected 1.1.1.1 and 8.8.8.8, got %v", got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_SingleShape(t *testing.T) {
+	raw := []byte(`{"upstreams":[{"address":"9.9.9.9"}]}`)
+	got := parseNDMSUpstreamAddresses(raw)
+	if !slices.Contains(got, "9.9.9.9") {
+		t.Errorf("expected 9.9.9.9, got %v", got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_DedupesAddresses(t *testing.T) {
+	raw := []byte(`[{"upstreams":[{"address":"1.1.1.1"},{"address":"1.1.1.1"}]}]`)
+	got := parseNDMSUpstreamAddresses(raw)
+	count := 0
+	for _, a := range got {
+		if a == "1.1.1.1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 occurrence of 1.1.1.1, got %d in %v", count, got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_SkipsIPv6(t *testing.T) {
+	raw := []byte(`[{"upstreams":[{"address":"::1"},{"address":"1.1.1.1"}]}]`)
+	got := parseNDMSUpstreamAddresses(raw)
+	for _, a := range got {
+		if a == "::1" {
+			t.Errorf("IPv6 should be skipped, got %v", got)
+		}
+	}
+	if !slices.Contains(got, "1.1.1.1") {
+		t.Errorf("expected 1.1.1.1, got %v", got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_BOM(t *testing.T) {
+	// Some NDMS firmwares include a UTF-8 BOM.
+	raw := append([]byte{0xEF, 0xBB, 0xBF}, `[{"upstreams":[{"address":"1.2.3.4"}]}]`...)
+	got := parseNDMSUpstreamAddresses(raw)
+	if !slices.Contains(got, "1.2.3.4") {
+		t.Errorf("expected 1.2.3.4, got %v", got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_EmptyResponse(t *testing.T) {
+	got := parseNDMSUpstreamAddresses(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestParseNDMSUpstreamAddresses_Garbage(t *testing.T) {
+	got := parseNDMSUpstreamAddresses([]byte(`not json`))
+	if len(got) != 0 {
+		t.Errorf("expected empty on garbage input, got %v", got)
+	}
+}
+
+// ── BuildDNSServers — priority logic ─────────────────────────────────────────
+
+type fakeDNSSource struct {
+	raw []byte
+	err error
+}
+
+func (f *fakeDNSSource) List(_ context.Context) ([]byte, error) {
+	return f.raw, f.err
+}
+
+func TestBuildDNSServers_UnionsSingboxNDMSAndPublic(t *testing.T) {
+	servers := []SingboxDNSServer{
+		{Tag: "google", Type: "udp", Server: "8.8.8.8"},
+	}
+	ndms := &fakeDNSSource{raw: []byte(`[{"upstreams":[{"address":"1.1.1.1"}]}]`)}
+	got := BuildDNSServers(context.Background(), servers, ndms)
+	for _, want := range []string{"8.8.8.8", "1.1.1.1", "9.9.9.9", "77.88.8.8"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected %s in union, got %v", want, got)
+		}
+	}
+}
+
+func TestBuildDNSServers_IncludesNDMSAndPublic(t *testing.T) {
+	servers := []SingboxDNSServer{
+		{Tag: "local", Type: "local", Server: ""},
+	}
+	ndms := &fakeDNSSource{raw: []byte(`[{"upstreams":[{"address":"9.9.9.9"}]}]`)}
+	got := BuildDNSServers(context.Background(), servers, ndms)
+	if !slices.Contains(got, "9.9.9.9") {
+		t.Errorf("expected NDMS 9.9.9.9, got %v", got)
+	}
+	if !slices.Contains(got, "1.1.1.1") {
+		t.Errorf("expected public fallback 1.1.1.1, got %v", got)
+	}
+}
+
+func TestExpandQueryHosts_Suffix(t *testing.T) {
+	hosts := expandQueryHosts("2ip.ru", KindDomainSuffix)
+	if !slices.Contains(hosts, "2ip.ru") || !slices.Contains(hosts, "www.2ip.ru") {
+		t.Fatalf("expected apex and www, got %v", hosts)
+	}
+	if !slices.Contains(hosts, "cdn.2ip.ru") {
+		t.Errorf("expected CDN probe host, got %v", hosts)
+	}
+}
+
+func TestExpandQueryHosts_Exact(t *testing.T) {
+	hosts := expandQueryHosts("www.example.com", KindDomain)
+	if len(hosts) != 1 || hosts[0] != "www.example.com" {
+		t.Fatalf("expected single exact host, got %v", hosts)
+	}
+}
+
+func TestBuildDNSServers_EmptyWhenOnlyGarbageNDMS(t *testing.T) {
+	got := BuildDNSServers(context.Background(), nil, &fakeDNSSource{raw: []byte(`[]`)})
+	// Public fallbacks are always present for rebuild sampling.
+	if len(got) < len(publicDNSFallbacks) {
+		t.Errorf("expected at least public fallbacks, got %v", got)
+	}
+}
+
+func TestBuildDNSServers_SkipsLocalAndFakeip(t *testing.T) {
+	servers := []SingboxDNSServer{
+		{Tag: "local", Type: "local", Server: ""},
+		{Tag: "fakeip", Type: "fakeip", Server: ""},
+		{Tag: "real", Type: "udp", Server: "1.0.0.1"},
+	}
+	got := BuildDNSServers(context.Background(), servers, nil)
+	if !slices.Contains(got, "1.0.0.1") {
+		t.Errorf("expected 1.0.0.1, got %v", got)
+	}
+	if !slices.Contains(got, "8.8.8.8") {
+		t.Errorf("expected public fallback 8.8.8.8, got %v", got)
+	}
+}
+
+func TestBuildDNSServers_StripsTLSScheme(t *testing.T) {
+	servers := []SingboxDNSServer{
+		{Tag: "dot", Type: "tls", Server: "tls://1.1.1.1"},
+	}
+	got := BuildDNSServers(context.Background(), servers, nil)
+	if !slices.Contains(got, "1.1.1.1") {
+		t.Errorf("expected 1.1.1.1 (stripped), got %v", got)
+	}
+}
+
+func TestBuildDNSServers_NilNDMSSource(t *testing.T) {
+	got := BuildDNSServers(context.Background(), nil, nil)
+	if len(got) < len(publicDNSFallbacks) {
+		t.Errorf("expected public fallbacks, got %v", got)
+	}
+}

--- a/internal/singbox/router/selective/route_acc.go
+++ b/internal/singbox/router/selective/route_acc.go
@@ -1,0 +1,59 @@
+package selective
+
+import (
+	"sync"
+)
+
+// RouteAccumulator groups /32 CIDRs by outbound for 19-selective-routes.json.
+// Only host routes are tracked — broader static CIDRs use ipset only.
+type RouteAccumulator struct {
+	mu         sync.Mutex
+	byOutbound map[string]map[string]struct{}
+}
+
+// NewRouteAccumulator constructs an empty accumulator.
+func NewRouteAccumulator() *RouteAccumulator {
+	return &RouteAccumulator{byOutbound: make(map[string]map[string]struct{})}
+}
+
+// Add records a CIDR for the given outbound when it is a /32 host route.
+func (a *RouteAccumulator) Add(outbound, cidr string) {
+	if a == nil || outbound == "" {
+		return
+	}
+	cidr = normalizeEntry(cidr)
+	if cidr == "" || !isHostCIDR(cidr) {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	set := a.byOutbound[outbound]
+	if set == nil {
+		set = make(map[string]struct{})
+		a.byOutbound[outbound] = set
+	}
+	set[cidr] = struct{}{}
+}
+
+// RulesByOutbound returns outbound → deduplicated /32 CIDR lists.
+func (a *RouteAccumulator) RulesByOutbound() map[string][]string {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make(map[string][]string, len(a.byOutbound))
+	for ob, set := range a.byOutbound {
+		list := make([]string, 0, len(set))
+		for c := range set {
+			list = append(list, c)
+		}
+		out[ob] = list
+	}
+	return out
+}
+
+func isHostCIDR(cidr string) bool {
+	dest := conntrackDestArg(cidr)
+	return dest != ""
+}

--- a/internal/singbox/router/selective/snapshot.go
+++ b/internal/singbox/router/selective/snapshot.go
@@ -1,0 +1,116 @@
+package selective
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// DomainResolveResult is one rule matcher resolved to IPv4 /32 CIDRs for ipset.
+type DomainResolveResult struct {
+	// Matcher is the domain or suffix as written in the routing rule (cleaned).
+	Matcher string `json:"matcher"`
+	// Kind is "domain" (exact) or "suffix" (domain_suffix).
+	Kind string `json:"kind"`
+	// QueryHosts lists every hostname that was queried (suffix rules expand to
+	// apex + common CDN subdomains).
+	QueryHosts []string `json:"queryHosts"`
+	// IPs are no longer persisted or returned via API (ipset holds them).
+	IPs []string `json:"ips,omitempty"`
+	// CDN is true when any resolved IP falls in a known anycast CDN prefix.
+	// Such matchers are included in the 20-minute background refresh loop.
+	CDN bool `json:"cdn,omitempty"`
+	// Outbound is the proxy outbound tag from the source route rule.
+	Outbound string `json:"outbound,omitempty"`
+	// Error is set when no IP could be resolved for any query host.
+	Error string `json:"error,omitempty"`
+}
+
+// RebuildSnapshot is the persisted outcome of the last successful ipset rebuild.
+// Written beside config.d (same parent dir as selective-last-rebuild) — NOT as
+// *.json inside config.d, or sing-box merge will try to decode it and FATAL.
+type RebuildSnapshot struct {
+	RebuiltAt            string                `json:"rebuiltAt"`
+	StaticCIDRs          []string              `json:"staticCidrs"`
+	DomainResults        []DomainResolveResult `json:"domainResults"`
+	EntryCount           int                   `json:"entryCount"`
+	StaticCIDRCount      int                   `json:"staticCidrCount,omitempty"`
+	DomainMatcherCount   int                   `json:"domainMatcherCount,omitempty"`
+	LastCDNRefresh       string                `json:"lastCDNRefresh,omitempty"`
+}
+
+// snapshotFileName has no .json suffix: sing-box -C config.d merges every
+// *.json in that directory; our metadata must not look like a config fragment.
+const snapshotFileName = "selective-snapshot"
+
+// legacySnapshotJSON is the old path (pre-2.14.2 fix) that broke sing-box startup.
+const legacySnapshotJSON = "selective-snapshot.json"
+
+func snapshotPath(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return filepath.Join(configDir, snapshotFileName)
+}
+
+func legacySnapshotPath(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return filepath.Join(configDir, legacySnapshotJSON)
+}
+
+// RemoveLegacySnapshotJSON deletes selective-snapshot.json from config.d if a
+// previous build left it there (sing-box FATAL: unknown field "rebuiltAt").
+func RemoveLegacySnapshotJSON(configDir string) {
+	p := legacySnapshotPath(configDir)
+	if p == "" {
+		return
+	}
+	_ = os.Remove(p)
+}
+
+// NeedsPopulation reports whether the selective ipset should be built on daemon
+// start: set missing, empty, or no successful rebuild marker on disk.
+func NeedsPopulation(ctx context.Context, configDir string) bool {
+	if !SetExists(ctx) || EntryCount(ctx) == 0 {
+		return true
+	}
+	return readLastRebuild(configDir).IsZero()
+}
+
+// NormalizeRebuildSnapshot ensures slice fields are non-nil so JSON encodes
+// [] instead of null (the frontend snapshot UI reads .length on these fields).
+func NormalizeRebuildSnapshot(snap *RebuildSnapshot) *RebuildSnapshot {
+	if snap == nil {
+		return nil
+	}
+	cp := *snap
+	if cp.StaticCIDRs == nil {
+		cp.StaticCIDRs = []string{}
+	}
+	if cp.DomainResults == nil {
+		cp.DomainResults = []DomainResolveResult{}
+	}
+	for i := range cp.DomainResults {
+		if cp.DomainResults[i].QueryHosts == nil {
+			cp.DomainResults[i].QueryHosts = []string{}
+		}
+		if cp.DomainResults[i].IPs == nil {
+			cp.DomainResults[i].IPs = []string{}
+		}
+	}
+	return &cp
+}
+
+func writeSnapshot(configDir string, snap RebuildSnapshot) {
+	summary := SnapshotSummary{
+		RebuiltAt:          snap.RebuiltAt,
+		EntryCount:         snap.EntryCount,
+		StaticCIDRCount:    len(snap.StaticCIDRs),
+		DomainMatcherCount: len(snap.DomainResults),
+		LastCDNRefresh:     snap.LastCDNRefresh,
+	}
+	writeSnapshotMeta(configDir, summary)
+	RemoveLegacySnapshotJSON(configDir)
+}

--- a/internal/singbox/router/selective/snapshot_ndjson.go
+++ b/internal/singbox/router/selective/snapshot_ndjson.go
@@ -1,0 +1,220 @@
+package selective
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// DomainMatcherRecord is one matcher persisted after rebuild (no IP list).
+type DomainMatcherRecord struct {
+	Matcher    string   `json:"matcher"`
+	Kind       string   `json:"kind"`
+	QueryHosts []string `json:"queryHosts"`
+	CDN        bool     `json:"cdn,omitempty"`
+	Outbound   string   `json:"outbound,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+// SnapshotSummary is the in-memory + on-disk metadata for the last rebuild.
+type SnapshotSummary struct {
+	RebuiltAt          string `json:"rebuiltAt"`
+	EntryCount         int    `json:"entryCount"`
+	StaticCIDRCount    int    `json:"staticCidrCount"`
+	DomainMatcherCount int    `json:"domainMatcherCount"`
+	LastCDNRefresh     string `json:"lastCDNRefresh,omitempty"`
+}
+
+const (
+	snapshotMetaFile  = "selective-snapshot-meta"
+	snapshotNDJSON    = "selective-snapshot.ndjson"
+	snapshotNDJSONTmp = "selective-snapshot.ndjson.tmp"
+)
+
+func snapshotMetaPath(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return filepath.Join(configDir, snapshotMetaFile)
+}
+
+func snapshotNDJSONPath(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return filepath.Join(configDir, snapshotNDJSON)
+}
+
+// snapshotWriter streams matcher records to NDJSON during rebuild.
+type snapshotWriter struct {
+	configDir string
+	file      *os.File
+	enc       *json.Encoder
+	mu        *sync.Mutex
+}
+
+func newSnapshotWriter(configDir string) (*snapshotWriter, error) {
+	p := snapshotNDJSONPath(configDir)
+	if p == "" {
+		return &snapshotWriter{}, nil
+	}
+	tmp := filepath.Join(filepath.Dir(p), snapshotNDJSONTmp)
+	f, err := os.Create(tmp)
+	if err != nil {
+		return nil, err
+	}
+	return &snapshotWriter{configDir: configDir, file: f, enc: json.NewEncoder(f), mu: &sync.Mutex{}}, nil
+}
+
+func (w *snapshotWriter) WriteRecord(rec DomainMatcherRecord) error {
+	if w.enc == nil {
+		return nil
+	}
+	if w.mu != nil {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+	}
+	if rec.QueryHosts == nil {
+		rec.QueryHosts = []string{}
+	}
+	return w.enc.Encode(rec)
+}
+
+func (w *snapshotWriter) CloseAndCommit(summary SnapshotSummary) error {
+	if w.file == nil {
+		writeSnapshotMeta(w.configDir, summary)
+		return nil
+	}
+	if err := w.file.Close(); err != nil {
+		return err
+	}
+	w.file = nil
+	dst := snapshotNDJSONPath(w.configDir)
+	tmp := filepath.Join(filepath.Dir(dst), snapshotNDJSONTmp)
+	if err := os.Rename(tmp, dst); err != nil {
+		return err
+	}
+	writeSnapshotMeta(w.configDir, summary)
+	RemoveLegacySnapshotJSON(w.configDir)
+	return nil
+}
+
+func (w *snapshotWriter) Abort() {
+	if w.file != nil {
+		_ = w.file.Close()
+		w.file = nil
+	}
+	p := snapshotNDJSONPath(w.configDir)
+	if p != "" {
+		_ = os.Remove(filepath.Join(filepath.Dir(p), snapshotNDJSONTmp))
+	}
+}
+
+func writeSnapshotMeta(configDir string, summary SnapshotSummary) {
+	p := snapshotMetaPath(configDir)
+	if p == "" {
+		return
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(p, data, 0644)
+}
+
+func readSnapshotSummary(configDir string) *SnapshotSummary {
+	p := snapshotMetaPath(configDir)
+	if p == "" {
+		return nil
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	var s SnapshotSummary
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil
+	}
+	return &s
+}
+
+// ReadSnapshotMatchers reads up to limit matcher records starting at offset.
+func ReadSnapshotMatchers(configDir string, offset, limit int) ([]DomainMatcherRecord, int, error) {
+	p := snapshotNDJSONPath(configDir)
+	if p == "" {
+		return nil, 0, nil
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	var total int
+	var page []DomainMatcherRecord
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if total >= offset && len(page) < limit {
+			var rec DomainMatcherRecord
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				continue
+			}
+			if rec.QueryHosts == nil {
+				rec.QueryHosts = []string{}
+			}
+			page = append(page, rec)
+		}
+		total++
+	}
+	if err := sc.Err(); err != nil {
+		return nil, 0, err
+	}
+	return page, total, nil
+}
+
+// ForEachCDNMatcher scans NDJSON and invokes fn for CDN-flagged matchers.
+func ForEachCDNMatcher(configDir string, fn func(DomainMatcherRecord) error) error {
+	p := snapshotNDJSONPath(configDir)
+	if p == "" {
+		return nil
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var rec DomainMatcherRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if !rec.CDN || rec.Error != "" {
+			continue
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}

--- a/internal/singbox/router/selective/snapshot_test.go
+++ b/internal/singbox/router/selective/snapshot_test.go
@@ -1,0 +1,53 @@
+package selective
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSnapshotPath_NotJSONInConfigDir(t *testing.T) {
+	dir := "/opt/etc/awg-manager/singbox/config.d"
+	if filepath.Ext(snapshotPath(dir)) != "" {
+		t.Fatalf("snapshot must not use .json extension, got %q", snapshotPath(dir))
+	}
+}
+
+func TestRemoveLegacySnapshotJSON(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, legacySnapshotJSON)
+	if err := os.WriteFile(legacy, []byte(`{"rebuiltAt":"x"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	RemoveLegacySnapshotJSON(dir)
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("legacy snapshot json should be removed, stat err=%v", err)
+	}
+}
+
+func TestNormalizeRebuildSnapshot_NilSlices(t *testing.T) {
+	snap := NormalizeRebuildSnapshot(&RebuildSnapshot{
+		DomainResults: []DomainResolveResult{{
+			Matcher: "example.com",
+			Kind:    "suffix",
+		}},
+	})
+	if snap.StaticCIDRs == nil || snap.DomainResults[0].IPs == nil || snap.DomainResults[0].QueryHosts == nil {
+		t.Fatalf("expected empty slices, got %+v", snap)
+	}
+}
+
+func TestWriteSnapshot_RemovesLegacyJSON(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, legacySnapshotJSON)
+	if err := os.WriteFile(legacy, []byte(`{"rebuiltAt":"old"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshot(dir, RebuildSnapshot{RebuiltAt: "2026-01-01T00:00:00Z", EntryCount: 1})
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatal("legacy file still present after writeSnapshot")
+	}
+	if _, err := os.Stat(snapshotMetaPath(dir)); err != nil {
+		t.Fatalf("meta snapshot missing: %v", err)
+	}
+}

--- a/internal/singbox/router/selective_adapter.go
+++ b/internal/singbox/router/selective_adapter.go
@@ -1,0 +1,186 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+)
+
+// selectiveBuilderAdapter implements SelectiveBuilder by pulling the current
+// router config (rules + rule-sets) and DNS servers from the live service,
+// then delegating to the underlying selective.Builder.
+type selectiveBuilderAdapter struct {
+	svc *ServiceImpl
+	b   *selective.Builder
+}
+
+// NewSelectiveBuilderAdapter constructs a SelectiveBuilder backed by svc and b.
+func NewSelectiveBuilderAdapter(svc *ServiceImpl, b *selective.Builder) SelectiveBuilder {
+	return &selectiveBuilderAdapter{svc: svc, b: b}
+}
+
+// Rebuild loads the current router config from disk, derives rule-set JSON
+// paths, and calls the underlying Builder.Rebuild.
+func (a *selectiveBuilderAdapter) Rebuild(ctx context.Context) error {
+	cfg, err := a.svc.loadRouterConfig()
+	if err != nil {
+		return err
+	}
+	cfg = a.svc.ruleSetMaterializer().restoreConfig(cfg)
+
+	rules := rulesAsSelectiveJSON(cfg.Route.Rules)
+
+	configDir := ""
+	if a.svc.deps.Singbox != nil {
+		configDir = a.svc.deps.Singbox.ConfigDir()
+	}
+	refs := a.svc.enrichSelectiveRuleSetRefs(ctx, ruleSetRefsFromConfig(cfg, configDir), cfg)
+	singboxDNS := singboxDNSServersFromConfig(cfg)
+
+	a.svc.appLog.Info("selective-rebuild", "",
+		fmt.Sprintf("starting rebuild: %d rules, %d rule-sets, %d dns-servers",
+			len(rules), len(refs), len(singboxDNS)),
+	)
+
+	if err := a.b.Rebuild(ctx, rules, refs, singboxDNS, nil); err != nil {
+		return err
+	}
+	a.syncRoutesAfterRebuild(ctx)
+	return nil
+}
+
+func (a *selectiveBuilderAdapter) syncRoutesAfterRebuild(ctx context.Context) {
+	if _, err := a.svc.stripLegacySelectiveRulesFromRouter(ctx); err != nil {
+		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
+	}
+	routes := a.b.LastIPRulesByOutbound()
+	entryCount := selective.EntryCount(ctx)
+	if entryCount > 0 && len(routes) == 0 {
+		a.svc.appLog.Warn("selective-rebuild", "routes",
+			fmt.Sprintf("ipset has %d entries but no /32 overlay routes — traffic may reach sing-box yet exit via route.final", entryCount))
+	}
+	if err := a.svc.syncSelectiveRoutesSlot(ctx, routes); err != nil {
+		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
+		return
+	}
+	if err := a.svc.orchestratorApplyNow(); err != nil {
+		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
+	}
+}
+
+// RefreshCDN incrementally refreshes ipset entries for CDN-flagged domain matchers.
+func (a *selectiveBuilderAdapter) RefreshCDN(ctx context.Context) error {
+	configDir := ""
+	if a.svc.deps.Singbox != nil {
+		configDir = a.svc.deps.Singbox.ConfigDir()
+	}
+	queries, err := selective.CDNQueriesFromConfigDir(configDir)
+	if err != nil || len(queries) == 0 {
+		return err
+	}
+
+	cfg, err := a.svc.loadRouterConfig()
+	if err != nil {
+		return err
+	}
+	cfg = a.svc.ruleSetMaterializer().restoreConfig(cfg)
+	singboxDNS := singboxDNSServersFromConfig(cfg)
+
+	if err := a.b.RefreshCDNMatchers(ctx, queries, singboxDNS); err != nil {
+		return err
+	}
+	a.syncRoutesAfterRebuild(ctx)
+	return nil
+}
+
+func rulesAsSelectiveJSON(rules []Rule) []selective.RuleJSON {
+	userRules, _ := stripSelectiveManagedRules(rules)
+	out := make([]selective.RuleJSON, len(userRules))
+	for i, r := range userRules {
+		out[i] = selective.RuleJSON{
+			Action:       r.Action,
+			Outbound:     r.Outbound,
+			IPCIDR:       r.IPCIDR,
+			Domain:       r.Domain,
+			DomainSuffix: r.DomainSuffix,
+			RuleSet:      r.RuleSet,
+			Rules:        rulesAsSelectiveJSON(r.Rules),
+		}
+	}
+	return out
+}
+
+func ruleSetRefsFromConfig(cfg *RouterConfig, configDir string) []selective.RuleSetRef {
+	if cfg == nil {
+		return nil
+	}
+	inlineDir := filepath.Join(configDir, "rule-sets", "inline")
+	datDir := filepath.Join(configDir, "rule-sets", "dat")
+
+	refs := make([]selective.RuleSetRef, 0, len(cfg.Route.RuleSet))
+	for _, rs := range cfg.Route.RuleSet {
+		ref := selective.RuleSetRef{
+			Tag:       rs.Tag,
+			Type:      rs.Type,
+			Path:      rs.Path,
+			URL:       rs.URL,
+			Format:    rs.Format,
+			InlineDir: inlineDir,
+			DatDir:    datDir,
+		}
+		if kind, tags, ok := parseDatRuleSetURL(rs.URL); ok {
+			ref.DatKind = kind
+			ref.DatTags = tags
+		}
+		if len(rs.Rules) > 0 {
+			ref.Rules = append(ref.Rules, rs.Rules...)
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func singboxDNSServersFromConfig(cfg *RouterConfig) []selective.SingboxDNSServer {
+	if cfg == nil {
+		return nil
+	}
+	out := make([]selective.SingboxDNSServer, 0, len(cfg.DNS.Servers))
+	for _, srv := range cfg.DNS.Servers {
+		out = append(out, selective.SingboxDNSServer{
+			Tag:    srv.Tag,
+			Type:   srv.Type,
+			Server: srv.Server,
+		})
+	}
+	return out
+}
+
+// OpenSelectiveRuleSetJSON implements selective.RuleSetJSONOpener.
+func (s *ServiceImpl) OpenSelectiveRuleSetJSON(ctx context.Context, ref selective.RuleSetRef) (string, func(), error) {
+	return s.openSelectiveRuleSetJSON(ctx, ref)
+}
+
+func selectiveJSONPath(ref selective.RuleSetRef) string {
+	if ref.Path != "" {
+		if strings.HasSuffix(strings.ToLower(ref.Path), ".json") {
+			return ref.Path
+		}
+		return strings.TrimSuffix(ref.Path, ".srs") + ".json"
+	}
+	switch ref.Type {
+	case "inline":
+		if ref.InlineDir == "" {
+			return ""
+		}
+		return filepath.Join(ref.InlineDir, safeRuleSetFilename(ref.Tag)+".json")
+	case "remote":
+		if ref.DatDir == "" {
+			return ""
+		}
+		return filepath.Join(ref.DatDir, safeRuleSetFilename(ref.Tag)+".json")
+	}
+	return ""
+}

--- a/internal/singbox/router/selective_adapter_ruleset.go
+++ b/internal/singbox/router/selective_adapter_ruleset.go
@@ -1,0 +1,108 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+)
+
+// openSelectiveRuleSetJSON returns a streamable JSON file path for a rule-set ref.
+// SRS sources are decompiled to a temp file; callers must invoke cleanup when done.
+func (s *ServiceImpl) openSelectiveRuleSetJSON(ctx context.Context, ref selective.RuleSetRef) (string, func(), error) {
+	noop := func() {}
+
+	if jsonPath := selectiveJSONPath(ref); jsonPath != "" {
+		if _, err := os.Stat(jsonPath); err == nil {
+			return jsonPath, noop, nil
+		}
+	}
+
+	rs := ruleSetFromRef(ref)
+
+	if rs.Type == "inline" && ref.InlineDir != "" {
+		p := filepath.Join(ref.InlineDir, safeRuleSetFilename(rs.Tag)+".json")
+		if fileReadable(p) {
+			return p, noop, nil
+		}
+	}
+
+	if path := strings.TrimSpace(rs.Path); path != "" {
+		if strings.HasSuffix(strings.ToLower(path), ".json") && fileReadable(path) {
+			return path, noop, nil
+		}
+		if strings.HasSuffix(strings.ToLower(path), ".srs") {
+			return s.decompileSRSToTemp(s.singboxBinary(), path)
+		}
+	}
+
+	if rs.Type == "remote" && strings.TrimSpace(rs.URL) != "" {
+		if kind, tags, ok := parseDatRuleSetURL(rs.URL); ok {
+			jsonPath, err := s.ensureDatRuleSetJSONPath(ctx, ref.DatDir, kind, tags)
+			return jsonPath, noop, err
+		}
+		format := rs.Format
+		if format == "" {
+			format = inferFormat(rs.URL)
+		}
+		localPath, err := ruleSetDownload(ctx, rs.URL, format)
+		if err != nil {
+			return "", noop, fmt.Errorf("download: %w", err)
+		}
+		if strings.HasSuffix(strings.ToLower(localPath), ".json") || format == "source" {
+			return localPath, noop, nil
+		}
+		return s.decompileSRSToTemp(s.singboxBinary(), localPath)
+	}
+
+	if rs.Type == "remote" && ref.DatDir != "" {
+		p := filepath.Join(ref.DatDir, safeRuleSetFilename(rs.Tag)+".json")
+		if fileReadable(p) {
+			return p, noop, nil
+		}
+	}
+
+	return "", noop, nil
+}
+
+func (s *ServiceImpl) decompileSRSToTemp(binary, srsPath string) (string, func(), error) {
+	path, err := ruleSetDecompileToFile(binary, srsPath)
+	if err != nil {
+		return "", func() {}, err
+	}
+	return path, func() { _ = os.Remove(path) }, nil
+}
+
+func (s *ServiceImpl) ensureDatRuleSetJSONPath(ctx context.Context, datDir, kind string, tags []string) (string, error) {
+	if datDir == "" {
+		return "", fmt.Errorf("dat rule-set dir unavailable")
+	}
+	jsonPath := filepath.Join(datDir, datRuleSetBaseName(kind, tags)+".json")
+	if fileReadable(jsonPath) {
+		return jsonPath, nil
+	}
+	token, err := s.ensureDatRuleSetToken()
+	if err != nil {
+		return "", err
+	}
+	if _, err := s.DatRuleSetFile(ctx, kind, tags, token); err != nil {
+		return "", err
+	}
+	if !fileReadable(jsonPath) {
+		return "", fmt.Errorf("dat rule-set json missing after materialize: %s", jsonPath)
+	}
+	return jsonPath, nil
+}
+
+func ruleSetFromRef(ref selective.RuleSetRef) RuleSet {
+	return RuleSet{
+		Tag:    ref.Tag,
+		Type:   ref.Type,
+		Path:   ref.Path,
+		URL:    ref.URL,
+		Format: ref.Format,
+	}
+}

--- a/internal/singbox/router/selective_routes.go
+++ b/internal/singbox/router/selective_routes.go
@@ -1,0 +1,179 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+)
+
+const selectiveIPRuleManaged = "selective-ip"
+
+// selectiveRoutesSlot is the JSON shape for 19-selective-routes.json.
+// Only route.rules — never inbounds/outbounds; null slices in a merged
+// slot corrupt sing-box's outbounds array (unknown outbound type at index N).
+type selectiveRoutesSlot struct {
+	Route struct {
+		Rules []Rule `json:"rules"`
+	} `json:"route"`
+}
+
+func marshalSelectiveRoutesSlot(rules []Rule) ([]byte, error) {
+	slot := selectiveRoutesSlot{}
+	slot.Route.Rules = rules
+	return json.MarshalIndent(slot, "", "  ")
+}
+
+// buildSelectiveIPRules builds ip_cidr route rules from outbound-grouped /32 lists.
+func buildSelectiveIPRules(byOutbound map[string][]string) []Rule {
+	if len(byOutbound) == 0 {
+		return nil
+	}
+	out := make([]Rule, 0, len(byOutbound))
+	for ob, cidrs := range byOutbound {
+		out = append(out, Rule{
+			Action:   "route",
+			Outbound: ob,
+			IPCIDR:   cidrs,
+			// AwgmManaged intentionally omitted: 19-selective-routes.json is
+			// merged into sing-box config and must not contain unknown fields.
+		})
+	}
+	return out
+}
+
+// stripSelectiveManagedRules removes auto-generated selective-ip rules that were
+// mistakenly persisted into 20-router.json by an earlier build.
+func stripSelectiveManagedRules(rules []Rule) ([]Rule, bool) {
+	if len(rules) == 0 {
+		return rules, false
+	}
+	filtered := rules[:0]
+	changed := false
+	for _, r := range rules {
+		if r.AwgmManaged == selectiveIPRuleManaged {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered, changed
+}
+
+// stripLegacySelectiveRulesFromRouter removes managed selective-ip rules from
+// the user-visible router slot (20-router.json). Returns whether anything changed.
+func (s *ServiceImpl) stripLegacySelectiveRulesFromRouter(ctx context.Context) (bool, error) {
+	cfg, err := s.loadRouterConfig()
+	if err != nil {
+		return false, err
+	}
+	cfg = s.ruleSetMaterializer().restoreConfig(cfg)
+	filtered, changed := stripSelectiveManagedRules(cfg.Route.Rules)
+	if !changed {
+		return false, nil
+	}
+	cfg.Route.Rules = filtered
+	if err := s.persistConfigDirect(ctx, cfg); err != nil {
+		return false, err
+	}
+	s.emitCfgEvent("rules", cfg)
+	return true, nil
+}
+
+// syncSelectiveRoutesSlot writes ip_cidr overlay rules into 19-selective-routes.json
+// (merged by sing-box, invisible in the rules UI). Uses SaveSilent so no staging
+// draft / «Применить» banner appears after ipset rebuild.
+func (s *ServiceImpl) syncSelectiveRoutesSlot(ctx context.Context, byOutbound map[string][]string) error {
+	if s.deps.Orch == nil {
+		return nil
+	}
+	rules := buildSelectiveIPRules(byOutbound)
+	enable := len(rules) > 0
+	data, err := marshalSelectiveRoutesSlot(rules)
+	if err != nil {
+		return err
+	}
+	// Always rewrite the slot file so a legacy build's `"outbounds": null`
+	// cannot keep breaking sing-box check after rules are cleared.
+	if err := s.deps.Orch.SaveSilent(orchestrator.SlotSelectiveRoutes, data); err != nil {
+		return err
+	}
+	return s.deps.Orch.SetEnabledSilent(orchestrator.SlotSelectiveRoutes, enable)
+}
+
+// healLegacySelectiveRoutesSlotIfNeeded rewrites 19-selective-routes.json when an
+// older build left unsupported keys (outbounds/inbounds null, awgm_managed).
+func (s *ServiceImpl) healLegacySelectiveRoutesSlotIfNeeded(ctx context.Context) error {
+	if s.deps.Orch == nil {
+		return nil
+	}
+	path := filepath.Join(s.deps.Orch.ConfigDir(), "19-selective-routes.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	if !selectiveRoutesSlotNeedsHeal(data) {
+		return nil
+	}
+	var slot selectiveRoutesSlot
+	if err := json.Unmarshal(data, &slot); err != nil {
+		var legacy RouterConfig
+		if err2 := json.Unmarshal(data, &legacy); err2 != nil {
+			return s.syncSelectiveRoutesSlot(ctx, nil)
+		}
+		slot.Route.Rules = legacy.Route.Rules
+	}
+	for i := range slot.Route.Rules {
+		slot.Route.Rules[i].AwgmManaged = ""
+	}
+	fixed, err := marshalSelectiveRoutesSlot(slot.Route.Rules)
+	if err != nil {
+		return err
+	}
+	enable := len(slot.Route.Rules) > 0
+	if err := s.deps.Orch.SaveSilent(orchestrator.SlotSelectiveRoutes, fixed); err != nil {
+		return err
+	}
+	return s.deps.Orch.SetEnabledSilent(orchestrator.SlotSelectiveRoutes, enable)
+}
+
+func selectiveRoutesSlotNeedsHeal(data []byte) bool {
+	s := string(data)
+	return bytesContainsLegacyNullSlotKeys(data) ||
+		strings.Contains(s, `"awgm_managed"`)
+}
+
+func bytesContainsLegacyNullSlotKeys(data []byte) bool {
+	s := string(data)
+	return strings.Contains(s, `"outbounds"`) || strings.Contains(s, `"inbounds"`)
+}
+
+// disableSelectiveRoutesSlot turns off the overlay slot when selective bypass
+// is disabled.
+func (s *ServiceImpl) disableSelectiveRoutesSlot() error {
+	if s.deps.Orch == nil {
+		return nil
+	}
+	return s.deps.Orch.SetEnabledSilent(orchestrator.SlotSelectiveRoutes, false)
+}
+
+func normalizeSelectiveIPCIDR(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if _, ipnet, err := net.ParseCIDR(raw); err == nil {
+		if ipnet.IP.To4() == nil {
+			return ""
+		}
+		return ipnet.String()
+	}
+	if ip := net.ParseIP(raw); ip != nil && ip.To4() != nil {
+		return ip.To4().String() + "/32"
+	}
+	return ""
+}

--- a/internal/singbox/router/selective_routes_test.go
+++ b/internal/singbox/router/selective_routes_test.go
@@ -1,0 +1,134 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+)
+
+func TestBuildSelectiveIPRules_GroupsByOutbound(t *testing.T) {
+	rules := buildSelectiveIPRules(map[string][]string{
+		"awg-tunnel": {"188.40.167.82/32"},
+	})
+	if len(rules) != 1 {
+		t.Fatalf("got %d rules", len(rules))
+	}
+	if rules[0].Outbound != "awg-tunnel" || rules[0].IPCIDR[0] != "188.40.167.82/32" {
+		t.Fatalf("unexpected rule: %+v", rules[0])
+	}
+}
+
+func TestStripSelectiveManagedRules(t *testing.T) {
+	rules := []Rule{
+		{AwgmManaged: selectiveIPRuleManaged, Action: "route", Outbound: "x", IPCIDR: []string{"1.2.3.4/32"}},
+		{Action: "route", Outbound: "direct", DomainSuffix: []string{"example.com"}},
+	}
+	filtered, changed := stripSelectiveManagedRules(rules)
+	if !changed || len(filtered) != 1 || filtered[0].DomainSuffix[0] != "example.com" {
+		t.Fatalf("got %+v changed=%v", filtered, changed)
+	}
+}
+
+func TestMarshalSelectiveRoutesSlot_RouteOnly(t *testing.T) {
+	data, err := marshalSelectiveRoutesSlot(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"outbounds", "inbounds", "dns"} {
+		if _, ok := m[forbidden]; ok {
+			t.Fatalf("slot JSON must not contain %q: %s", forbidden, string(data))
+		}
+	}
+}
+
+func TestHealLegacySelectiveRoutesSlotIfNeeded(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	_ = orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotSelectiveRoutes, Filename: "19-selective-routes.json"})
+	_ = orch.SetEnabled(orchestrator.SlotSelectiveRoutes, true)
+
+	broken := []byte(`{
+  "inbounds": null,
+  "outbounds": null,
+  "route": {"rules": [{"action": "route", "outbound": "tun", "ip_cidr": ["1.2.3.4/32"]}]}
+}`)
+	if err := os.WriteFile(filepath.Join(dir, "19-selective-routes.json"), broken, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &ServiceImpl{deps: Deps{Orch: orch}}
+	if err := svc.healLegacySelectiveRoutesSlotIfNeeded(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	fixed, err := os.ReadFile(filepath.Join(dir, "19-selective-routes.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytesContainsLegacyNullSlotKeys(fixed) {
+		t.Fatalf("file still broken: %s", fixed)
+	}
+}
+
+func TestHealLegacySelectiveRoutesSlot_StripsAwgmManaged(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	_ = orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotSelectiveRoutes, Filename: "19-selective-routes.json"})
+	_ = orch.SetEnabled(orchestrator.SlotSelectiveRoutes, true)
+
+	broken := []byte(`{
+  "route": {"rules": [{"action": "route", "outbound": "tun", "ip_cidr": ["1.2.3.4/32"], "awgm_managed": "selective-ip"}]}
+}`)
+	if err := os.WriteFile(filepath.Join(dir, "19-selective-routes.json"), broken, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &ServiceImpl{deps: Deps{Orch: orch}}
+	if err := svc.healLegacySelectiveRoutesSlotIfNeeded(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	fixed, err := os.ReadFile(filepath.Join(dir, "19-selective-routes.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(fixed), "awgm_managed") {
+		t.Fatalf("awgm_managed still present: %s", fixed)
+	}
+}
+
+func TestStripLegacySelectiveRulesFromRouter(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	_ = orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotRouter, Filename: "20-router.json"})
+	_ = orch.SetEnabled(orchestrator.SlotRouter, true)
+
+	cfg := NewEmptyConfig()
+	cfg.Route.Rules = []Rule{
+		{AwgmManaged: selectiveIPRuleManaged, Action: "route", Outbound: "tun", IPCIDR: []string{"188.40.167.82/32"}},
+		{Action: "route", Outbound: "tun", DomainSuffix: []string{"2ip.ru"}},
+	}
+	svc := &ServiceImpl{deps: Deps{Orch: orch}}
+	if err := svc.persistConfigDirect(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := svc.stripLegacySelectiveRulesFromRouter(context.Background())
+	if err != nil || !changed {
+		t.Fatalf("strip: changed=%v err=%v", changed, err)
+	}
+	rules, err := svc.ListRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 1 || rules[0].DomainSuffix[0] != "2ip.ru" {
+		t.Fatalf("unexpected rules after strip: %+v", rules)
+	}
+}

--- a/internal/singbox/router/selective_ruleset_source.go
+++ b/internal/singbox/router/selective_ruleset_source.go
@@ -1,0 +1,191 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+)
+
+// enrichSelectiveRuleSetRefs attaches dat rule-set metadata from the live router
+// config. Matchers are streamed from disk via OpenRuleSetJSON during rebuild —
+// full rule-set JSON is not loaded into memory here.
+func (s *ServiceImpl) enrichSelectiveRuleSetRefs(ctx context.Context, refs []selective.RuleSetRef, cfg *RouterConfig) []selective.RuleSetRef {
+	if len(refs) == 0 || cfg == nil {
+		return refs
+	}
+	byTag := make(map[string]RuleSet, len(cfg.Route.RuleSet))
+	for _, rs := range cfg.Route.RuleSet {
+		byTag[rs.Tag] = rs
+	}
+	out := make([]selective.RuleSetRef, len(refs))
+	copy(out, refs)
+	for i := range out {
+		rs, ok := byTag[out[i].Tag]
+		if !ok {
+			continue
+		}
+		if kind, tags, ok := parseDatRuleSetURL(rs.URL); ok {
+			out[i].DatKind = kind
+			out[i].DatTags = tags
+		}
+		if out[i].URL == "" {
+			out[i].URL = rs.URL
+		}
+		if out[i].Format == "" {
+			out[i].Format = rs.Format
+		}
+		if len(rs.Rules) > 0 {
+			out[i].Rules = append(out[i].Rules, rs.Rules...)
+		}
+	}
+	return out
+}
+
+func (s *ServiceImpl) loadRuleSetSourceRules(ctx context.Context, rs RuleSet) ([]map[string]any, error) {
+	if len(rs.Rules) > 0 {
+		return rs.Rules, nil
+	}
+	raw, err := s.loadRuleSetSourceJSON(ctx, rs)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var src inlineRuleSetSource
+	if err := json.Unmarshal(raw, &src); err != nil {
+		return nil, fmt.Errorf("parse rule-set source: %w", err)
+	}
+	return src.Rules, nil
+}
+
+func (s *ServiceImpl) loadRuleSetSourceJSON(ctx context.Context, rs RuleSet) ([]byte, error) {
+	configDir := s.singboxConfigDir()
+	inlineDir := filepath.Join(configDir, "rule-sets", "inline")
+	datDir := filepath.Join(configDir, "rule-sets", "dat")
+
+	if rs.Type == "inline" {
+		if p := filepath.Join(inlineDir, safeRuleSetFilename(rs.Tag)+".json"); fileReadable(p) {
+			return os.ReadFile(p)
+		}
+	}
+
+	if rs.Path != "" {
+		if data, ok := readRuleSetJSONSibling(rs.Path); ok {
+			return data, nil
+		}
+	}
+
+	if rs.Type == "remote" && strings.TrimSpace(rs.URL) != "" {
+		if kind, tags, ok := parseDatRuleSetURL(rs.URL); ok {
+			return s.loadDatRuleSetSourceJSON(ctx, datDir, kind, tags)
+		}
+		return s.loadRemoteRuleSetSourceJSON(ctx, rs)
+	}
+
+	if rs.Type == "local" && rs.Path != "" {
+		if data, ok := readRuleSetJSONSibling(rs.Path); ok {
+			return data, nil
+		}
+	}
+
+	if rs.Type == "remote" && datDir != "" && configDir != "" {
+		p := filepath.Join(datDir, safeRuleSetFilename(rs.Tag)+".json")
+		if fileReadable(p) {
+			return os.ReadFile(p)
+		}
+	}
+
+	return nil, nil
+}
+
+func (s *ServiceImpl) singboxConfigDir() string {
+	if s.deps.Orch != nil {
+		return s.deps.Orch.ConfigDir()
+	}
+	if s.deps.Singbox != nil {
+		return s.deps.Singbox.ConfigDir()
+	}
+	return ""
+}
+
+func readRuleSetJSONSibling(path string) ([]byte, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, false
+	}
+	if strings.HasSuffix(strings.ToLower(path), ".json") {
+		data, err := os.ReadFile(path)
+		return data, err == nil
+	}
+	jsonPath := strings.TrimSuffix(path, ".srs") + ".json"
+	data, err := os.ReadFile(jsonPath)
+	return data, err == nil
+}
+
+func fileReadable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func parseDatRuleSetURL(rawURL string) (kind string, tags []string, ok bool) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u == nil {
+		return "", nil, false
+	}
+	if !strings.HasSuffix(u.Path, "/dat-srs") && !strings.HasSuffix(u.Path, "dat-srs") {
+		return "", nil, false
+	}
+	kind = strings.ToLower(strings.TrimSpace(u.Query().Get("kind")))
+	if kind != "geosite" && kind != "geoip" {
+		return "", nil, false
+	}
+	tags = dedupeStrings(u.Query()["tag"])
+	if len(tags) == 0 {
+		return "", nil, false
+	}
+	return kind, tags, true
+}
+
+func (s *ServiceImpl) loadDatRuleSetSourceJSON(ctx context.Context, datDir, kind string, tags []string) ([]byte, error) {
+	if datDir == "" {
+		return nil, fmt.Errorf("dat rule-set dir unavailable")
+	}
+	jsonPath := filepath.Join(datDir, datRuleSetBaseName(kind, tags)+".json")
+	if fileReadable(jsonPath) {
+		return os.ReadFile(jsonPath)
+	}
+	token, err := s.ensureDatRuleSetToken()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.DatRuleSetFile(ctx, kind, tags, token); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(jsonPath)
+}
+
+func datRuleSetBaseName(kind string, tags []string) string {
+	return safeRuleSetFilename(kind + "-" + strings.Join(tags, "-"))
+}
+
+func (s *ServiceImpl) loadRemoteRuleSetSourceJSON(ctx context.Context, rs RuleSet) ([]byte, error) {
+	format := rs.Format
+	if format == "" {
+		format = inferFormat(rs.URL)
+	}
+	path, err := ruleSetDownload(ctx, rs.URL, format)
+	if err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+	if strings.HasSuffix(strings.ToLower(path), ".json") || format == "source" {
+		return os.ReadFile(path)
+	}
+	return ruleSetDecompileExec(s.singboxBinary(), path)
+}

--- a/internal/singbox/router/selective_ruleset_source_test.go
+++ b/internal/singbox/router/selective_ruleset_source_test.go
@@ -1,0 +1,152 @@
+package router
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+)
+
+func TestParseDatRuleSetURL(t *testing.T) {
+	kind, tags, ok := parseDatRuleSetURL("http://127.0.0.1:8080/api/singbox/router/rulesets/dat-srs?kind=geosite&tag=GOOGLE&tag=YOUTUBE&token=x")
+	if !ok {
+		t.Fatal("expected dat URL to parse")
+	}
+	if kind != "geosite" || len(tags) != 2 || tags[0] != "GOOGLE" || tags[1] != "YOUTUBE" {
+		t.Fatalf("got kind=%q tags=%v", kind, tags)
+	}
+	if _, _, ok := parseDatRuleSetURL("https://example.com/geosite-youtube.srs"); ok {
+		t.Fatal("external URL must not parse as dat")
+	}
+}
+
+func TestOpenSelectiveRuleSetJSON_RemoteSRSStream(t *testing.T) {
+	origDL, origDT := ruleSetDownload, ruleSetDecompileToFile
+	t.Cleanup(func() { ruleSetDownload, ruleSetDecompileToFile = origDL, origDT })
+
+	ruleSetDownload = func(_ context.Context, url, _format string) (string, error) {
+		return "/tmp/fake-" + url + ".srs", nil
+	}
+	decompiled := t.TempDir() + "/decompiled.json"
+	if err := os.WriteFile(decompiled, []byte(`{"version":3,"rules":[{"domain_suffix":["only-ruleset.example"]}]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ruleSetDecompileToFile = func(_binary, _srsPath string) (string, error) {
+		return decompiled, nil
+	}
+
+	s := newTestService(t, Deps{})
+	path, cleanup, err := s.openSelectiveRuleSetJSON(context.Background(), selective.RuleSetRef{
+		Tag:    "geosite-example",
+		Type:   "remote",
+		Format: "binary",
+		URL:    "https://example.com/geosite-example.srs",
+	})
+	if err != nil {
+		t.Fatalf("openSelectiveRuleSetJSON: %v", err)
+	}
+	defer cleanup()
+	if path != decompiled {
+		t.Fatalf("path = %q want decompiled file", path)
+	}
+
+	var matchers []string
+	sink := selective.CollectSink{
+		OnDomainQuery: func(q selective.DomainQuery) error {
+			matchers = append(matchers, q.Matcher)
+			return nil
+		},
+	}
+	refs := []selective.RuleSetRef{{
+		Tag:  "geosite-example",
+		Type: "remote",
+		URL:  "https://example.com/geosite-example.srs",
+	}}
+	errs := selective.StreamCollectFromRules(context.Background(),
+		[]selective.RuleJSON{{Action: "route", Outbound: "proxy", RuleSet: []string{"geosite-example"}}},
+		refs, selective.GeoPaths{}, s.OpenSelectiveRuleSetJSON, sink)
+	if len(errs) > 0 {
+		t.Fatalf("stream collect errors: %v", errs)
+	}
+	if len(matchers) != 1 || matchers[0] != "only-ruleset.example" {
+		t.Fatalf("matchers = %v", matchers)
+	}
+}
+
+func TestEnrichSelectiveRuleSetRefs_DatKindOnly(t *testing.T) {
+	s := newTestService(t, Deps{})
+	cfg := &RouterConfig{Route: Route{
+		RuleSet: []RuleSet{{
+			Tag:  "dat-google",
+			Type: "remote",
+			URL:  "http://127.0.0.1:8080/api/singbox/router/rulesets/dat-srs?kind=geosite&tag=GOOGLE",
+		}},
+	}}
+	refs := s.enrichSelectiveRuleSetRefs(context.Background(), []selective.RuleSetRef{{
+		Tag:  "dat-google",
+		Type: "remote",
+	}}, cfg)
+	if len(refs) != 1 || refs[0].DatKind != "geosite" || len(refs[0].DatTags) != 1 || refs[0].DatTags[0] != "GOOGLE" {
+		t.Fatalf("dat metadata not enriched: %+v", refs[0])
+	}
+	if len(refs[0].Rules) != 0 {
+		t.Fatalf("rules must not be loaded into memory: %+v", refs[0].Rules)
+	}
+}
+
+func TestLoadRuleSetSourceRules_LocalJSONSibling(t *testing.T) {
+	dir := t.TempDir()
+	srsPath := filepath.Join(dir, "myset.srs")
+	jsonPath := filepath.Join(dir, "myset.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"version":3,"rules":[{"ip_cidr":["10.0.0.0/8"]}]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.WriteFile(srsPath, []byte("fake"), 0644)
+
+	s := newTestService(t, Deps{})
+	rules, err := s.loadRuleSetSourceRules(context.Background(), RuleSet{
+		Tag:    "myset",
+		Type:   "local",
+		Format: "binary",
+		Path:   srsPath,
+	})
+	if err != nil {
+		t.Fatalf("loadRuleSetSourceRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("rules = %+v", rules)
+	}
+}
+
+func TestLoadRuleSetSourceRules_RemoteDecompile(t *testing.T) {
+	origDL, origDC := ruleSetDownload, ruleSetDecompileExec
+	t.Cleanup(func() { ruleSetDownload, ruleSetDecompileExec = origDL, origDC })
+
+	ruleSetDownload = func(_ context.Context, url, _format string) (string, error) {
+		return "/tmp/fake-" + strings.TrimPrefix(url, "https://") + ".srs", nil
+	}
+	ruleSetDecompileExec = func(_binary, _srsPath string) ([]byte, error) {
+		return []byte(`{"version":3,"rules":[{"domain_suffix":["example.com"]}]}`), nil
+	}
+
+	s := newTestService(t, Deps{})
+	rules, err := s.loadRuleSetSourceRules(context.Background(), RuleSet{
+		Tag:    "geosite-example",
+		Type:   "remote",
+		Format: "binary",
+		URL:    "https://example.com/geosite-example.srs",
+	})
+	if err != nil {
+		t.Fatalf("loadRuleSetSourceRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("rules len = %d", len(rules))
+	}
+	suffixes, _ := rules[0]["domain_suffix"].([]interface{})
+	if len(suffixes) != 1 || suffixes[0] != "example.com" {
+		t.Fatalf("domain_suffix = %v", rules[0]["domain_suffix"])
+	}
+}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -17,7 +17,9 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/presets"
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/tunnel"
 )
@@ -306,6 +308,22 @@ type Deps struct {
 	// ranges, tun addrs, MTU, DHCP pool). Zero-value in tests; defaults
 	// wired in cmd/awg-manager. Consumed by Slice 1D Enable.
 	FakeIPTun FakeIPTunParams
+
+	// SelectiveBuilder handles ipset population for the selective-bypass
+	// feature. When non-nil and SingboxRouterSettings.SelectiveBypass is
+	// true, reconcileInstalled calls Rebuild after every iptables install
+	// that changes rules/rule-sets. When nil the feature is disabled.
+	SelectiveBuilder SelectiveBuilder
+
+	// NDMSDNSSource provides fallback DNS server addresses (NDMS router
+	// upstreams) for the selective-bypass domain resolver. Optional — nil
+	// means only sing-box DNS servers and the system resolver are used.
+	NDMSDNSSource SelectiveDNSSource
+
+	// ClashHealthy probes sing-box's Clash API (127.0.0.1:9099). Optional —
+	// when set, tproxy readiness treats a healthy Clash endpoint as equivalent
+	// to the procfs socket probe (same signal the Operator uses after start).
+	ClashHealthy func() bool
 }
 
 // routerLoggerAdapter narrows *logging.ScopedLogger to the wanLogger
@@ -337,7 +355,10 @@ type ServiceImpl struct {
 	// Enable/Disable (which SwitchRoutingMode composes) take mu themselves, so
 	// holding mu across the whole switch would self-deadlock.
 	transitionMu            sync.Mutex
-	currentMark             string              // last-installed iptables mark; used by Reconcile to detect change
+	// transitionReadinessProgress emits readiness heartbeats during
+	// waitForSingbox while SwitchRoutingMode is in flight (nil otherwise).
+	transitionReadinessProgress func(message string)
+	currentMark                 string // last-installed iptables mark; used by Reconcile to detect change
 	currentWANIPs           []string            // last-collected WAN IPs; used by Reconcile to detect change
 	currentLANBridges       []LANBridgeDNSRedir // last-discovered LAN-bridge (name, ndnproxy port) pairs; reconcile triggers re-install when this changes (e.g. NDMS hotspot reconfigured, bridge added/removed, port reassigned)
 	currentBypassPresets    []string
@@ -352,6 +373,10 @@ type ServiceImpl struct {
 	// first reconcileInstalled or Enable install forces a full re-install.
 	// After Install succeeds the flag is set to true until Disable resets it.
 	netfilterStateKnown bool
+
+	// selective tracking
+	currentSelectiveBypass bool   // last-applied value of SelectiveBypass
+	currentRulesHash       string // hash of rules+ruleSets used for last ipset rebuild
 
 	// inspectCache backs the route-inspector's rule_set match path. Lazy
 	// constructed on first Inspect call so dev-machine builds (no
@@ -375,6 +400,12 @@ func NewService(d Deps) *ServiceImpl {
 	// creates it on first Enable.
 	refreshNetfilterHookIfPresent()
 	return &ServiceImpl{deps: d, appLog: appLog}
+}
+
+// SetSelectiveBuilder wires the selective-bypass builder post-construction.
+// Called after NewService because the adapter needs a *ServiceImpl reference.
+func (s *ServiceImpl) SetSelectiveBuilder(b SelectiveBuilder) {
+	s.deps.SelectiveBuilder = b
 }
 
 func (s *ServiceImpl) routerConfigPath() string {
@@ -519,6 +550,15 @@ func (s *ServiceImpl) persistConfigDirect(ctx context.Context, cfg *RouterConfig
 		return err
 	}
 	return nil
+}
+
+// orchestratorApplyNow flushes any debounced reload and applies config.d to
+// sing-box immediately. No-op when Orch is nil (tests).
+func (s *ServiceImpl) orchestratorApplyNow() error {
+	if s.deps.Orch == nil {
+		return nil
+	}
+	return s.deps.Orch.ReloadNow()
 }
 
 // prepareNetfilter runs the common netfilter preflight: xt_TPROXY module
@@ -723,10 +763,22 @@ func (s *ServiceImpl) waitForSingbox(ctx context.Context, timeout time.Duration)
 	}
 
 	deadline := time.Now().Add(timeout)
+	start := time.Now()
+	lastHeartbeat := time.Time{}
 	const pollInterval = 100 * time.Millisecond
 	for {
 		if s.singboxReady(ctx, fakeIP) {
 			return nil
+		}
+		if fn := s.transitionReadinessProgress; fn != nil && time.Since(lastHeartbeat) >= 2*time.Second {
+			elapsed := time.Since(start).Round(time.Second)
+			running, _ := s.deps.Singbox.IsRunning()
+			msg := fmt.Sprintf("запуск sing-box… %s", elapsed)
+			if running {
+				msg = fmt.Sprintf("sing-box работает, ожидаем inbounds… %s", elapsed)
+			}
+			fn(msg)
+			lastHeartbeat = time.Now()
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("sing-box did not come up within %s", timeout)
@@ -762,7 +814,13 @@ func (s *ServiceImpl) singboxReady(_ context.Context, fakeIP bool) bool {
 		return false
 	}
 	if !fakeIP {
-		return singboxListeningProbe()
+		if singboxListeningProbe() {
+			return true
+		}
+		if s.deps.ClashHealthy != nil && s.deps.ClashHealthy() {
+			return true
+		}
+		return false
 	}
 	// Only iface is needed for the carrier gate; dnsAddr/fakeipNet (which the
 	// demoted DNS probe used) are derived later in enableFakeIPTun for the
@@ -850,7 +908,10 @@ func (s *ServiceImpl) persistConfig(ctx context.Context, cfg *RouterConfig) erro
 		return fmt.Errorf("%s", cleanValidateError(err))
 	}
 	if running, _ := s.deps.Singbox.IsRunning(); running {
-		if err := s.deps.Singbox.Reload(); err != nil {
+		heavyop.Default.Lock()
+		err := s.deps.Singbox.Reload()
+		heavyop.Default.Unlock()
+		if err != nil {
 			return err
 		}
 	}
@@ -988,6 +1049,9 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	if err := s.persistConfigDirect(ctx, cfg); err != nil {
 		return err
 	}
+	if err := s.orchestratorApplyNow(); err != nil {
+		return fmt.Errorf("orchestrator reload after enable: %w", err)
+	}
 
 	// Wait for sing-box to be listening before iptables start redirecting
 	// traffic to its TPROXY/REDIRECT ports. HARD fail (issue #221): if
@@ -1041,6 +1105,16 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 
 	bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
 	bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+
+	// Pre-create the AWGM-SELECTIVE ipset (empty) before iptables-restore
+	// when selective bypass is enabled. iptables-restore fails immediately
+	// if the set referenced in -m set --match-set doesn't exist yet.
+	if sr.SelectiveBypass {
+		if err := ensureSelectiveSetExists(ctx); err != nil {
+			s.appLog.Warn("selective", "", fmt.Sprintf("pre-create ipset failed: %v", err))
+		}
+	}
+
 	if err := s.deps.IPTables.Install(ctx, RestoreInputSpec{
 		PolicyMark:        mark,
 		MatchAll:          !policyMode,
@@ -1050,6 +1124,7 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 		BypassTCPPorts:    bypassTCP,
 		BypassCIDRs:       bypassSubnets,
 		IngressInterfaces: ingress,
+		SelectiveIPSet:    sr.SelectiveBypass,
 	}); err != nil {
 		// Stop sing-box from listening on the now-orphan TPROXY port,
 		// but DO NOT corrupt the persisted user config. With orchestrator
@@ -1462,6 +1537,19 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	if err != nil {
 		return err
 	}
+	if sr.SelectiveBypass {
+		if err := s.validateSelectiveBypassSettings(ctx, sr); err != nil {
+			s.appLog.Warn("selective", "", err.Error()+"; disabling selective bypass")
+			settings, loadErr := s.deps.Settings.Load()
+			if loadErr == nil {
+				settings.SingboxRouter.SelectiveBypass = false
+				if saveErr := s.deps.Settings.Save(settings); saveErr != nil {
+					s.appLog.Warn("selective", "", "failed to persist selective bypass disable: "+saveErr.Error())
+				}
+			}
+			sr.SelectiveBypass = false
+		}
+	}
 	policyMode := sr.DeviceMode == "" || sr.DeviceMode == "policy"
 	mark := ""
 	if policyMode {
@@ -1492,6 +1580,9 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	bypassExtraChanged := s.currentBypassExtraPorts != sr.BypassExtraPorts
 	bypassSubnetsChanged := s.currentBypassExtraSubnets != sr.BypassExtraSubnets
 
+	// Selective-bypass change detection.
+	selectiveChanged := s.currentSelectiveBypass != sr.SelectiveBypass
+
 	// After a daemon restart or upgrade the old awg-manager process died
 	// with no chance to run Uninstall, so stale AWGM chains, ip rules
 	// and ip routes may remain from the old process. netfilterStateKnown
@@ -1507,7 +1598,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// during an NDMS reload must not trigger a needless rebuild.
 	_, jumps, probeErr := s.deps.IPTables.Probe(ctx)
 	jumpsMissing := probeErr == nil && !jumps
-	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged
+	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged || selectiveChanged
 
 	if needsInstall {
 		if forceInitialSync {
@@ -1518,6 +1609,21 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 
 		if err := s.prepareNetfilter(ctx); err != nil {
 			return err
+		}
+
+		// If selective-bypass is enabled, the ipset MUST exist before
+		// iptables-restore runs — iptables-restore fails with "Set
+		// AWGM-SELECTIVE doesn't exist" if the set was never created.
+		// Create it empty now; it will be populated by the async rebuild
+		// triggered below. An empty set means no traffic is selectively
+		// intercepted yet, which is safe: the engine will fill it shortly.
+		if sr.SelectiveBypass {
+			if err := ensureSelectiveSetExists(ctx); err != nil {
+				s.appLog.Warn("selective", "", fmt.Sprintf("pre-create ipset failed: %v", err))
+				// Don't abort — if xt_set is missing, iptables-restore will
+				// surface a clear error; if ipset isn't installed but SelectiveBypass
+				// was somehow set, same. Proceed and let Install fail gracefully.
+			}
 		}
 
 		bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
@@ -1532,6 +1638,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 			BypassTCPPorts:    bypassTCP,
 			BypassCIDRs:       bypassSubnets,
 			IngressInterfaces: ingress,
+			SelectiveIPSet:    sr.SelectiveBypass,
 		}); err != nil {
 			s.mu.Unlock()
 			return err
@@ -1543,8 +1650,23 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 		s.currentBypassExtraPorts = sr.BypassExtraPorts
 		s.currentBypassExtraSubnets = sr.BypassExtraSubnets
 		s.currentIngress = ingress
+		s.currentSelectiveBypass = sr.SelectiveBypass
 		s.netfilterStateKnown = true
 		s.mu.Unlock()
+
+		// If selective mode is being disabled, destroy the ipset so it
+		// doesn't linger in kernel memory.
+		if !sr.SelectiveBypass {
+			if err := destroySelectiveSet(ctx); err != nil {
+				s.appLog.Warn("selective", "", fmt.Sprintf("destroy ipset after disable: %v", err))
+			}
+			if err := s.disableSelectiveRoutesSlot(); err != nil {
+				s.appLog.Warn("selective", "", fmt.Sprintf("disable selective routes slot: %v", err))
+			}
+			if _, err := s.stripLegacySelectiveRulesFromRouter(ctx); err != nil {
+				s.appLog.Warn("selective", "", fmt.Sprintf("strip legacy selective rules: %v", err))
+			}
+		}
 	}
 
 	// Self-heal: a previous Install rollback or upgrade hop may
@@ -1552,6 +1674,20 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// it idempotently so sing-box keeps listening on TPROXYPort.
 	if err := s.healTProxyInbound(ctx, sr.UDPTimeout); err != nil {
 		s.appLog.Warn("heal-tproxy", "", err.Error())
+	}
+
+	// Selective-bypass: rebuild on first Enable, when toggled on, or on daemon
+	// start only if the ipset was never populated yet. Rule changes trigger
+	// rebuild explicitly via staging Apply (frontend) — no periodic refresh.
+	if sr.SelectiveBypass && s.deps.SelectiveBuilder != nil {
+		configDir := ""
+		if s.deps.Singbox != nil {
+			configDir = s.deps.Singbox.ConfigDir()
+		}
+		needsInitialBuild := selective.NeedsPopulation(ctx, configDir)
+		if selectiveChanged || (forceInitialSync && needsInitialBuild) {
+			s.triggerSelectiveRebuild(ctx)
+		}
 	}
 	return nil
 }
@@ -1711,7 +1847,9 @@ func (s *ServiceImpl) ListRules(ctx context.Context) ([]Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.ruleSetMaterializer().restoreConfig(cfg).Route.Rules, nil
+	rules := s.ruleSetMaterializer().restoreConfig(cfg).Route.Rules
+	filtered, _ := stripSelectiveManagedRules(rules)
+	return filtered, nil
 }
 
 func (s *ServiceImpl) AddRule(ctx context.Context, r Rule) error {
@@ -1731,12 +1869,18 @@ func (s *ServiceImpl) MoveRule(ctx context.Context, from, to int) error {
 }
 
 func (s *ServiceImpl) SetRouteFinal(ctx context.Context, tag string) error {
-	return s.withConfig(ctx, "route", func(c *RouterConfig) error {
+	if err := s.withConfig(ctx, "route", func(c *RouterConfig) error {
 		if !s.isKnownOutboundTag(ctx, tag, c) {
 			return fmt.Errorf("unknown outbound tag %q for route.final", tag)
 		}
 		return c.SetRouteFinal(tag)
-	})
+	}); err != nil {
+		return err
+	}
+	if tag != "direct" {
+		return s.disableSelectiveBypassIfEnabled(ctx)
+	}
+	return nil
 }
 
 // isKnownOutboundTag returns true if tag is a sing-box built-in or matches
@@ -1899,6 +2043,9 @@ func (s *ServiceImpl) GetSettings(ctx context.Context) (storage.SingboxRouterSet
 func (s *ServiceImpl) UpdateSettings(ctx context.Context, sr storage.SingboxRouterSettings) error {
 	normalized, err := NormalizeSingboxRouterSettings(sr)
 	if err != nil {
+		return err
+	}
+	if err := s.validateSelectiveBypassSettings(ctx, normalized); err != nil {
 		return err
 	}
 	settings, err := s.deps.Settings.Load()
@@ -2477,6 +2624,7 @@ func (s *ServiceImpl) StagingStatus(ctx context.Context) StagingStatus {
 // success it emits "singbox.router.staging" + "singbox.router.rules" SSE
 // invalidations.
 func (s *ServiceImpl) ApplyStaging(ctx context.Context) (orchestrator.ValidationResult, error) {
+	_ = s.healLegacySelectiveRoutesSlotIfNeeded(ctx)
 	res, err := s.deps.Orch.ApplyDraft(orchestrator.SlotRouter)
 	if err == nil && res.Ok() {
 		s.emitStagingEvent("applied")

--- a/internal/singbox/router/service_selective.go
+++ b/internal/singbox/router/service_selective.go
@@ -1,0 +1,188 @@
+package router
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+)
+
+// routeFinalAllowsSelectiveBypass reports whether route.final is compatible
+// with selective ipset bypass. Empty final is treated as direct (same as UI).
+func routeFinalAllowsSelectiveBypass(final string) bool {
+	return final == "" || final == "direct"
+}
+
+func (s *ServiceImpl) validateSelectiveBypassSettings(ctx context.Context, sr storage.SingboxRouterSettings) error {
+	if !sr.SelectiveBypass {
+		return nil
+	}
+	if sr.RoutingMode != "tproxy" {
+		return fmt.Errorf("selectiveBypass only applies to routingMode %q", "tproxy")
+	}
+	cfg, err := s.loadRouterConfig()
+	if err != nil {
+		return fmt.Errorf("selectiveBypass: load router config: %w", err)
+	}
+	if !routeFinalAllowsSelectiveBypass(cfg.Route.Final) {
+		return fmt.Errorf(
+			"selectiveBypass requires route.final %q (current %q): catch-all proxy routing sends all traffic through sing-box and conflicts with selective ipset bypass",
+			"direct", cfg.Route.Final,
+		)
+	}
+	return nil
+}
+
+// disableSelectiveBypassIfEnabled turns off selectiveBypass in persisted settings
+// and reconciles netfilter. No-op when already disabled.
+func (s *ServiceImpl) disableSelectiveBypassIfEnabled(ctx context.Context) error {
+	if s.deps.Settings == nil {
+		return nil
+	}
+	settings, err := s.deps.Settings.Load()
+	if err != nil {
+		return err
+	}
+	if !settings.SingboxRouter.SelectiveBypass {
+		return nil
+	}
+	settings.SingboxRouter.SelectiveBypass = false
+	if err := s.deps.Settings.Save(settings); err != nil {
+		return err
+	}
+	s.appLog.Info("selective", "", "selective bypass disabled because route.final is not direct")
+	return s.Reconcile(ctx)
+}
+
+// SelectiveBuilder is the interface the router service uses to rebuild the
+// AWGM-SELECTIVE ipset when selective-bypass is enabled.
+// *selective.Builder satisfies it; tests pass a stub.
+type SelectiveBuilder interface {
+	// Rebuild populates the AWGM-SELECTIVE ipset from the current rules
+	// and rule sets. The call is blocking; progress events are delivered
+	// via the underlying ProgressFn wired at construction time.
+	Rebuild(ctx context.Context) error
+	// RefreshCDN incrementally adds newly resolved CDN matcher IPs without
+	// flushing ipset or evicting conntrack (safe for background refresh).
+	RefreshCDN(ctx context.Context) error
+}
+
+// SelectiveDNSSource provides raw /show/dns-proxy bytes for the selective
+// domain resolver fallback path. *ndmsquery.DNSProxyStatusStore satisfies it.
+type SelectiveDNSSource interface {
+	List(ctx context.Context) ([]byte, error)
+}
+
+// rulesHash returns a short SHA-256 hex digest over the JSON serialisation
+// of the route rules and rule sets. Used to detect whether a reconcile
+// needs to trigger an ipset rebuild.
+func rulesHash(rules []Rule, ruleSets []RuleSet) string {
+	h := sha256.New()
+	enc := json.NewEncoder(h)
+	_ = enc.Encode(rules)
+	_ = enc.Encode(ruleSets)
+	return fmt.Sprintf("%x", h.Sum(nil))[:16]
+}
+
+// triggerSelectiveRebuild triggers a non-blocking ipset rebuild when
+// selective-bypass is enabled and the builder is wired. Errors are
+// logged but do not fail the reconcile — a stale ipset is better than
+// breaking connectivity altogether.
+//
+// Note: uses context.Background() so the rebuild is NOT cancelled when the
+// parent reconcile/enable context finishes. The rebuild can outlive the
+// reconcile call (DNS resolution, ipset populate) and must not be cancelled
+// mid-way — a partial ipset is worse than none.
+func (s *ServiceImpl) triggerSelectiveRebuild(_ context.Context) {
+	if s.deps.SelectiveBuilder == nil {
+		return
+	}
+	go func() {
+		if err := s.deps.SelectiveBuilder.Rebuild(context.Background()); err != nil {
+			s.appLog.Warn("selective-rebuild", "", fmt.Sprintf("ipset rebuild failed: %v", err))
+		}
+	}()
+}
+
+// ensureSelectiveSetExists creates the AWGM-SELECTIVE ipset (empty) if it
+// does not already exist. Called before IPTables.Install when SelectiveBypass
+// is true so that iptables-restore never references a non-existent set.
+// Returns nil when ipset is not installed — the Install call will fail anyway
+// with a meaningful error from the xt_set module check.
+func ensureSelectiveSetExists(ctx context.Context) error {
+	// Try to load xt_set kernel module before creating the set — without it
+	// iptables -m set rules will be rejected at COMMIT time.
+	if err := selective.EnsureXtSetModule(ctx); err != nil {
+		// soft-fail: module may be built-in even without .ko
+		_ = err
+	}
+
+	bin := selectiveIPSetBinary()
+	if bin == "" {
+		return nil // ipset not installed — let IPTables.Install surface the real error
+	}
+	out, err := runIPSet(ctx, bin, "create", selectiveSetName, "hash:net",
+		"maxelem", "262144", "family", "inet")
+	if err != nil {
+		// "set with the same name already exists" → idempotent, not an error
+		if containsAny(out, "already exists") {
+			return nil
+		}
+		return fmt.Errorf("ipset create %s: %w (output: %s)", selectiveSetName, err, out)
+	}
+	return nil
+}
+
+// destroySelectiveSet is a thin wrapper that calls ipset destroy without
+// importing the selective sub-package into service.go. It uses the
+// selectiveSetName constant already defined in iptables.go.
+func destroySelectiveSet(ctx context.Context) error {
+	bin := selectiveIPSetBinary()
+	if bin == "" {
+		return nil // ipset not installed — nothing to destroy
+	}
+	res, err := runIPSet(ctx, bin, "destroy", selectiveSetName)
+	if err != nil {
+		if res != "" && (containsAny(res, "does not exist", "not found")) {
+			return nil
+		}
+		return fmt.Errorf("ipset destroy %s: %w", selectiveSetName, err)
+	}
+	return nil
+}
+
+// selectiveIPSetBinary returns the path to ipset or "".
+// Mirrors selective.IPSetBinary without importing the sub-package.
+func selectiveIPSetBinary() string {
+	for _, p := range []string{"/opt/sbin/ipset", "/usr/sbin/ipset", "/sbin/ipset"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// runIPSet executes ipset with the given args and returns (combined output, error).
+func runIPSet(ctx context.Context, bin string, args ...string) (string, error) {
+	res, err := sysexec.Run(ctx, bin, args...)
+	out := ""
+	if res != nil {
+		out = res.Stdout + res.Stderr
+	}
+	return out, err
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -478,6 +478,111 @@ func TestUpdateSettings_MalformedSubnet_RejectedBeforeSaveAndInstall(t *testing.
 	}
 }
 
+func TestUpdateSettings_SelectiveBypassRejectedWhenFinalNotDirect(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	cfg := NewEmptyConfig()
+	cfg.Route.Final = "my-vpn"
+	cfg.Outbounds = append(cfg.Outbounds, Outbound{Tag: "my-vpn", Type: "direct"})
+	if err := svc.persistConfig(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	err := svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		PolicyName:      "Policy0",
+		WANAutoDetect:   true,
+		SelectiveBypass: true,
+	})
+	if err == nil {
+		t.Fatal("expected UpdateSettings to reject selectiveBypass when route.final is not direct")
+	}
+	if !strings.Contains(err.Error(), "selectiveBypass") {
+		t.Errorf("error should mention selectiveBypass, got %q", err.Error())
+	}
+	all, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatalf("settingsStore.Load: %v", err)
+	}
+	if all.SingboxRouter.SelectiveBypass {
+		t.Error("selectiveBypass must not be persisted when validation fails")
+	}
+}
+
+func TestSetRouteFinal_DisablesSelectiveBypass(t *testing.T) {
+	singbox := newTestSingbox(t)
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		PolicyName:      "Policy0",
+		SelectiveBypass: true,
+	})
+	svc := &ServiceImpl{
+		deps: Deps{
+			Singbox:  singbox,
+			Settings: settingsStore,
+			IPTables: newStubIPTables(func(_ context.Context, _ string) error { return nil }),
+			SubscriptionComposites: NewSubscriptionCompositesAdapter(
+				&fakeSubscriptionSource{tags: []string{"sub-test"}},
+			),
+		},
+	}
+	cfg := NewEmptyConfig()
+	if err := svc.persistConfig(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.SetRouteFinal(context.Background(), "sub-test"); err != nil {
+		t.Fatalf("SetRouteFinal(sub-test): %v", err)
+	}
+	all, err := settingsStore.Load()
+	if err != nil {
+		t.Fatalf("settingsStore.Load: %v", err)
+	}
+	if all.SingboxRouter.SelectiveBypass {
+		t.Error("expected selectiveBypass disabled after setting route.final to non-direct")
+	}
+}
+
+func TestReconcileInstalled_SelectiveSelfHealWhenFinalNotDirect(t *testing.T) {
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		Enabled:         true,
+		PolicyName:      "Policy0",
+		WANAutoDetect:   true,
+		SelectiveBypass: true,
+	})
+	ipt := newStubIPTables(func(_ context.Context, _ string) error { return nil })
+	svc, _ := newOrchedTestService(t)
+	svc.deps.Settings = settingsStore
+	svc.deps.Policies = &fakeAccessPolicyProvider{mark: "0xffffaaa"}
+	svc.deps.IPTables = ipt
+	svc.deps.WANIPCollector = &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}}
+	svc.deps.NetfilterPreflight = func(context.Context) error { return nil }
+	svc.currentSelectiveBypass = true
+
+	cfg := NewEmptyConfig()
+	cfg.Route.Final = "my-vpn"
+	cfg.Outbounds = append(cfg.Outbounds, Outbound{Tag: "my-vpn", Type: "direct"})
+	if err := svc.persistConfig(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.reconcileInstalled(context.Background(), storage.SingboxRouterSettings{
+		Enabled:         true,
+		PolicyName:      "Policy0",
+		WANAutoDetect:   true,
+		SelectiveBypass: true,
+	}); err != nil {
+		t.Fatalf("reconcileInstalled: %v", err)
+	}
+	all, err := settingsStore.Load()
+	if err != nil {
+		t.Fatalf("settingsStore.Load: %v", err)
+	}
+	if all.SingboxRouter.SelectiveBypass {
+		t.Error("expected self-heal to disable selectiveBypass in settings")
+	}
+	if svc.currentSelectiveBypass {
+		t.Error("expected currentSelectiveBypass=false after self-heal reconcile")
+	}
+}
+
 // TestReconcileInstalled_MalformedSubnet_RejectedBeforeInstall guards the second
 // Install entry point. reconcileInstalled re-Normalizes the settings it is
 // handed (e.g. a hand-edited settings.json read from disk), so a malformed

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -66,6 +66,7 @@ type Rule struct {
 	Mode         string   `json:"mode,omitempty"`
 	Rules        []Rule   `json:"rules,omitempty"`
 	DomainSuffix []string `json:"domain_suffix,omitempty"`
+	Domain       []string `json:"domain,omitempty"`
 	IPCIDR       []string `json:"ip_cidr,omitempty"`
 	SourceIPCIDR []string `json:"source_ip_cidr,omitempty"`
 	Port         []int    `json:"port,omitempty"`
@@ -84,6 +85,10 @@ type Rule struct {
 	IPIsPrivate *bool  `json:"ip_is_private,omitempty"`
 	Action      string `json:"action,omitempty"`
 	Outbound    string `json:"outbound,omitempty"`
+	// AwgmManaged marks auto-generated route rules owned by AWG Manager.
+	// "selective-ip" rules map resolved domain IPs to proxy outbounds for
+	// selective TPROXY mode; they are replaced on each ipset rebuild.
+	AwgmManaged string `json:"awgm_managed,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler for Rule. It accepts both

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -146,6 +146,14 @@ type SingboxRouterSettings struct {
 	// (DefaultUDPTimeout). Увеличение помогает при работе игр и других UDP-приложений,
 	// которые могут молчать дольше стандартных 3 минут.
 	UDPTimeout string `json:"udpTimeout,omitempty"`
+	// SelectiveBypass, when true, installs an iptables -m set guard in front
+	// of the TPROXY/REDIRECT catch-all rules so only traffic whose destination
+	// IP is present in the AWGM-SELECTIVE ipset reaches sing-box. All other
+	// traffic bypasses sing-box entirely (RETURN → WAN). The ipset is built
+	// from ip_cidr matchers and resolved domain_suffix/domain entries across
+	// all active router rules and their rule sets. Only meaningful when
+	// RoutingMode == "tproxy" and ipset + xt_set are available on the router.
+	SelectiveBypass bool `json:"selectiveBypass,omitempty"`
 }
 
 // ManagedServer represents the user-created WireGuard server interface.

--- a/internal/sys/httpclient/dns.go
+++ b/internal/sys/httpclient/dns.go
@@ -55,6 +55,74 @@ func LookupIPv4ForBind(ctx context.Context, host string, dnsServers []string, bi
 	return "", fmt.Errorf("httpclient: no IPv4 address for %q", host)
 }
 
+// LookupAllIPv4ForBind resolves host to ALL of its IPv4 addresses. Server and
+// bind semantics match LookupIPv4ForBind, but every A record found is returned
+// (deduplicated) instead of just the first. This matters for the selective
+// ipset: a domain may serve several A records (CDN, round-robin) and the client
+// can connect to any of them — the set must contain all so none leak past the
+// guard. Returns an error only when nothing could be resolved.
+func LookupAllIPv4ForBind(ctx context.Context, host string, dnsServers []string, bindIface string) ([]string, error) {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return nil, fmt.Errorf("httpclient: empty host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return []string{ip4.String()}, nil
+		}
+		return nil, fmt.Errorf("httpclient: non-IPv4 literal %q", host)
+	}
+
+	if len(dnsServers) > 0 {
+		var lastErr error
+		for _, srv := range dnsServers {
+			srv = strings.TrimSpace(srv)
+			if srv == "" {
+				continue
+			}
+			ips, err := lookupAllAViaDNS(ctx, host, srv, bindIface, 0)
+			if err == nil && len(ips) > 0 {
+				return ips, nil
+			}
+			if err != nil {
+				lastErr = err
+			}
+		}
+		if lastErr != nil {
+			return nil, fmt.Errorf("httpclient: tunnel DNS lookup %q: %w", host, lastErr)
+		}
+		return nil, fmt.Errorf("httpclient: no A record in DNS response for %q", host)
+	}
+
+	addrs, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
+	if err != nil {
+		return nil, fmt.Errorf("httpclient: system DNS lookup %q: %w", host, err)
+	}
+	out := dedupeIPv4(addrs)
+	if len(out) == 0 {
+		return nil, fmt.Errorf("httpclient: no IPv4 address for %q", host)
+	}
+	return out, nil
+}
+
+func dedupeIPv4(ips []net.IP) []string {
+	seen := make(map[string]struct{}, len(ips))
+	var out []string
+	for _, ip := range ips {
+		ip4 := ip.To4()
+		if ip4 == nil {
+			continue
+		}
+		s := ip4.String()
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
 func lookupAViaDNS(ctx context.Context, host, dnsServer, bindIface string, depth int) (string, error) {
 	if depth > 5 {
 		return "", fmt.Errorf("CNAME chain too deep for %q", host)
@@ -168,6 +236,181 @@ func parseDNSARecord(ctx context.Context, pkt []byte, dnsServer, bindIface strin
 		return lookupAViaDNS(ctx, cname, dnsServer, bindIface, depth+1)
 	}
 	return "", fmt.Errorf("no A record in DNS response")
+}
+
+// lookupAllAViaDNS is the multi-record sibling of lookupAViaDNS: it returns
+// every A record in the response (following a single CNAME chain) rather than
+// stopping at the first.
+// LookupCNAMETargetsViaDNS returns CNAME target hostnames from the answer
+// section for host (not followed). Useful for discovering CDN origin names
+// that should be resolved into ipset entries.
+func LookupCNAMETargetsViaDNS(ctx context.Context, host, dnsServer, bindIface string) ([]string, error) {
+	pkt, err := exchangeDNS(ctx, host, dnsServer, bindIface)
+	if err != nil {
+		return nil, err
+	}
+	return parseDNSCNAMETargets(pkt)
+}
+
+func lookupAllAViaDNS(ctx context.Context, host, dnsServer, bindIface string, depth int) ([]string, error) {
+	if depth > 5 {
+		return nil, fmt.Errorf("CNAME chain too deep for %q", host)
+	}
+	pkt, err := exchangeDNS(ctx, host, dnsServer, bindIface)
+	if err != nil {
+		return nil, err
+	}
+	return parseAllDNSARecords(ctx, pkt, dnsServer, bindIface, depth)
+}
+
+func exchangeDNS(ctx context.Context, host, dnsServer, bindIface string) ([]byte, error) {
+	query, err := encodeDNSQuery(host)
+	if err != nil {
+		return nil, err
+	}
+
+	d := bindDialer(bindIface, 5*time.Second)
+	conn, err := d.DialContext(ctx, "udp4", net.JoinHostPort(dnsServer, "53"))
+	if err != nil {
+		return nil, fmt.Errorf("dial DNS %s: %w", dnsServer, err)
+	}
+	defer conn.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	}
+
+	if _, err := conn.Write(query); err != nil {
+		return nil, fmt.Errorf("write DNS query: %w", err)
+	}
+
+	buf := make([]byte, 1500)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, fmt.Errorf("read DNS response: %w", err)
+	}
+	return buf[:n], nil
+}
+
+// parseDNSCNAMETargets collects every CNAME rdata hostname in the answer section.
+func parseDNSCNAMETargets(pkt []byte) ([]string, error) {
+	if len(pkt) < 12 {
+		return nil, fmt.Errorf("short DNS packet")
+	}
+	if pkt[3]&0x0f != 0 {
+		return nil, fmt.Errorf("DNS error rcode %d", pkt[3]&0x0f)
+	}
+	ancount := int(binary.BigEndian.Uint16(pkt[6:8]))
+	off := 12
+	off, err := skipDNSName(pkt, off)
+	if err != nil {
+		return nil, err
+	}
+	if off+4 > len(pkt) {
+		return nil, fmt.Errorf("truncated DNS question")
+	}
+	off += 4
+
+	seen := make(map[string]struct{})
+	var out []string
+	for i := 0; i < ancount; i++ {
+		off, err = skipDNSName(pkt, off)
+		if err != nil {
+			return nil, err
+		}
+		if off+10 > len(pkt) {
+			return nil, fmt.Errorf("truncated DNS answer header")
+		}
+		rrType := binary.BigEndian.Uint16(pkt[off : off+2])
+		rdLen := int(binary.BigEndian.Uint16(pkt[off+8 : off+10]))
+		rdataOff := off + 10
+		off = rdataOff + rdLen
+		if off > len(pkt) {
+			return nil, fmt.Errorf("truncated DNS rdata")
+		}
+		if rrType != 5 { // CNAME
+			continue
+		}
+		target, err := decodeDNSName(pkt, rdataOff)
+		if err != nil || target == "" {
+			continue
+		}
+		target = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(target)), ".")
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+// parseAllDNSARecords collects every A record in the answer section. If the
+// answer carries only CNAMEs, it follows the first one (bounded by depth).
+func parseAllDNSARecords(ctx context.Context, pkt []byte, dnsServer, bindIface string, depth int) ([]string, error) {
+	if len(pkt) < 12 {
+		return nil, fmt.Errorf("short DNS packet")
+	}
+	if pkt[3]&0x0f != 0 {
+		return nil, fmt.Errorf("DNS error rcode %d", pkt[3]&0x0f)
+	}
+	ancount := int(binary.BigEndian.Uint16(pkt[6:8]))
+	off := 12
+	off, err := skipDNSName(pkt, off)
+	if err != nil {
+		return nil, err
+	}
+	if off+4 > len(pkt) {
+		return nil, fmt.Errorf("truncated DNS question")
+	}
+	off += 4
+
+	var ips []string
+	var cname string
+	for i := 0; i < ancount; i++ {
+		off, err = skipDNSName(pkt, off)
+		if err != nil {
+			return nil, err
+		}
+		if off+10 > len(pkt) {
+			return nil, fmt.Errorf("truncated DNS answer header")
+		}
+		rrType := binary.BigEndian.Uint16(pkt[off : off+2])
+		rdLen := int(binary.BigEndian.Uint16(pkt[off+8 : off+10]))
+		rdataOff := off + 10
+		off = rdataOff + rdLen
+		if off > len(pkt) {
+			return nil, fmt.Errorf("truncated DNS rdata")
+		}
+		switch rrType {
+		case 1: // A
+			if rdLen == 4 {
+				ips = append(ips, net.IP(pkt[rdataOff:rdataOff+4]).String())
+			}
+		case 5: // CNAME
+			if cname == "" {
+				cname, _ = decodeDNSName(pkt, rdataOff)
+			}
+		}
+	}
+	if len(ips) > 0 {
+		seen := make(map[string]struct{}, len(ips))
+		out := ips[:0]
+		for _, ip := range ips {
+			if _, ok := seen[ip]; ok {
+				continue
+			}
+			seen[ip] = struct{}{}
+			out = append(out, ip)
+		}
+		return out, nil
+	}
+	if cname != "" {
+		return lookupAllAViaDNS(ctx, cname, dnsServer, bindIface, depth+1)
+	}
+	return nil, fmt.Errorf("no A record in DNS response")
 }
 
 func skipDNSName(pkt []byte, off int) (int, error) {

--- a/internal/sys/httpclient/dns_test.go
+++ b/internal/sys/httpclient/dns_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -29,17 +30,6 @@ func TestEncodeDNSQuery(t *testing.T) {
 	}
 }
 
-func TestParseDNSARecord_directA(t *testing.T) {
-	pkt := buildDNSResponse(1, net.IPv4(1, 2, 3, 4).To4())
-	ip, err := parseDNSARecord(context.Background(), pkt, "1.1.1.1", "", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ip != "1.2.3.4" {
-		t.Fatalf("ip = %q, want 1.2.3.4", ip)
-	}
-}
-
 func buildDNSResponse(rrType uint16, rdata []byte) []byte {
 	q := []byte{7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0}
 	ansName := []byte{0xc0, 0x0c}
@@ -62,4 +52,39 @@ func buildDNSResponse(rrType uint16, rdata []byte) []byte {
 	off += len(ansName)
 	copy(out[off:], ansTail)
 	return out
+}
+
+func TestParseDNSARecord_directA(t *testing.T) {
+	pkt := buildDNSResponse(1, net.IPv4(1, 2, 3, 4).To4())
+	ip, err := parseDNSARecord(context.Background(), pkt, "1.1.1.1", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ip != "1.2.3.4" {
+		t.Fatalf("ip = %q, want 1.2.3.4", ip)
+	}
+}
+
+func buildDNSCNAMEResponse(target string) []byte {
+	return buildDNSResponse(5, encodeDNSNameBytes(target))
+}
+
+func encodeDNSNameBytes(name string) []byte {
+	var out []byte
+	for _, label := range strings.Split(strings.TrimSuffix(name, "."), ".") {
+		out = append(out, byte(len(label)))
+		out = append(out, label...)
+	}
+	return append(out, 0)
+}
+
+func TestParseDNSCNAMETargets(t *testing.T) {
+	pkt := buildDNSCNAMEResponse("d111111.cloudfront.net")
+	got, err := parseDNSCNAMETargets(pkt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "d111111.cloudfront.net" {
+		t.Fatalf("got %v", got)
+	}
 }

--- a/scripts/build-ipk.sh
+++ b/scripts/build-ipk.sh
@@ -4,189 +4,198 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+ALL_ARCHES=(mipsel-3.4 mips-3.4 aarch64-3.10)
+
 # Read version from VERSION file
 VERSION=$(cat "$PROJECT_ROOT/VERSION" 2>/dev/null || echo "0.1.0")
 
-# Parse arguments
-if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+# Usage:
+#   ./scripts/build-ipk.sh                         → all arches, VERSION from file
+#   ./scripts/build-ipk.sh <arch>                  → one arch
+#   ./scripts/build-ipk.sh <version>               → all arches
+#   ./scripts/build-ipk.sh <version> <arch|all>    → one arch or all
+#   ./scripts/build-ipk.sh all                     → all arches
+BUILD_ALL=0
+ENTWARE_ARCH=""
+
+if [[ $# -eq 0 ]]; then
+    BUILD_ALL=1
+elif [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     VERSION="$1"
-    ENTWARE_ARCH="${2:-mipsel-3.4}"
+    if [[ -z "${2:-}" || "$2" == "all" ]]; then
+        BUILD_ALL=1
+    else
+        ENTWARE_ARCH="$2"
+    fi
+elif [[ "$1" == "all" ]]; then
+    BUILD_ALL=1
 else
-    ENTWARE_ARCH="${1:-mipsel-3.4}"
+    ENTWARE_ARCH="$1"
 fi
 
-echo "Building awg-manager IPK package"
-echo "Version: $VERSION"
-echo "Architecture: $ENTWARE_ARCH"
+build_ipk_one() {
+    local ENTWARE_ARCH="$1"
 
-# Extract Go arch from entware arch
-case "$ENTWARE_ARCH" in
-    mipsel-*)
-        GO_ARCH="mipsle"
-        PKG_ARCH="$ENTWARE_ARCH"
-        AWG_ARCH="mipsle"
-        KMOD_ARCH="mipsel"
-        ;;
-    mips-*)
-        GO_ARCH="mips"
-        PKG_ARCH="$ENTWARE_ARCH"
-        AWG_ARCH="mips"
-        KMOD_ARCH="mips"
-        ;;
-    aarch64-*)
-        GO_ARCH="arm64"
-        PKG_ARCH="$ENTWARE_ARCH"
-        AWG_ARCH="arm64"
-        KMOD_ARCH="arm64"
-        ;;
-    *)
-        echo "Unknown architecture: $ENTWARE_ARCH"
-        exit 1
-        ;;
-esac
+    echo ""
+    echo "========================================"
+    echo "Building awg-manager IPK package"
+    echo "Version: $VERSION"
+    echo "Architecture: $ENTWARE_ARCH"
+    echo "========================================"
 
-cd "$PROJECT_ROOT"
+    local GO_ARCH PKG_ARCH AWG_ARCH KMOD_ARCH
+    case "$ENTWARE_ARCH" in
+        mipsel-*)
+            GO_ARCH="mipsle"
+            PKG_ARCH="$ENTWARE_ARCH"
+            AWG_ARCH="mipsle"
+            KMOD_ARCH="mipsel"
+            ;;
+        mips-*)
+            GO_ARCH="mips"
+            PKG_ARCH="$ENTWARE_ARCH"
+            AWG_ARCH="mips"
+            KMOD_ARCH="mips"
+            ;;
+        aarch64-*)
+            GO_ARCH="arm64"
+            PKG_ARCH="$ENTWARE_ARCH"
+            AWG_ARCH="arm64"
+            KMOD_ARCH="arm64"
+            ;;
+        *)
+            echo "Unknown architecture: $ENTWARE_ARCH"
+            exit 1
+            ;;
+    esac
 
-# Check for amneziawg binaries
-AWG_CLI_BIN="prebuilt/bin/awg-${AWG_ARCH}"
+    cd "$PROJECT_ROOT"
 
-if [[ ! -f "$AWG_CLI_BIN" ]]; then
-    echo "ERROR: Missing $AWG_CLI_BIN"
-    echo "Please place awg CLI binary for ${AWG_ARCH} architecture in prebuilt/bin/"
-    exit 1
-fi
-
-# Kernel modules are bundled per-model from prebuilt/kmod/.
-# At runtime, the daemon selects the correct .ko for the detected router model.
-
-# Clean previous builds
-rm -rf build/ipk build/bin
-mkdir -p build/ipk build/bin dist
-
-# Build frontend
-if [[ "${SKIP_FRONTEND_BUILD:-0}" == "1" ]]; then
-    if [[ ! -f "$PROJECT_ROOT/frontend/build/index.html.gz" && ! -f "$PROJECT_ROOT/frontend/build/index.html" ]]; then
-        echo "ERROR: SKIP_FRONTEND_BUILD=1 but frontend/build/index.html(.gz) is missing"
+    local AWG_CLI_BIN="prebuilt/bin/awg-${AWG_ARCH}"
+    if [[ ! -f "$AWG_CLI_BIN" ]]; then
+        echo "ERROR: Missing $AWG_CLI_BIN"
+        echo "Please place awg CLI binary for ${AWG_ARCH} architecture in prebuilt/bin/"
         exit 1
     fi
-    echo "Using existing frontend build: frontend/build/"
-else
-    echo "Building frontend..."
-    "$SCRIPT_DIR/build-frontend.sh"
-fi
 
-# Build backend (export VERSION so build-backend.sh uses it)
-echo ""
-echo "Building backend..."
-VERSION="$VERSION" ENTWARE_ARCH="$ENTWARE_ARCH" "$SCRIPT_DIR/build-backend.sh" "$GO_ARCH"
+    # Kernel modules are bundled per-model from prebuilt/kmod/.
+    # At runtime, the daemon selects the correct .ko for the detected router model.
 
-# Create IPK structure
-IPK_ROOT="build/ipk"
-mkdir -p "$IPK_ROOT/CONTROL"
-mkdir -p "$IPK_ROOT/opt/bin"
-mkdir -p "$IPK_ROOT/opt/sbin"
-mkdir -p "$IPK_ROOT/opt/etc/init.d"
-mkdir -p "$IPK_ROOT/opt/etc/awg-manager"
-for hook in iflayerchanged ifcreated ifdestroyed ifipchanged; do
-    mkdir -p "$IPK_ROOT/opt/etc/ndm/${hook}.d"
-done
+    rm -rf build/ipk build/bin
+    mkdir -p build/ipk build/bin dist
 
-# Copy binaries
-cp build/bin/awg-manager "$IPK_ROOT/opt/bin/"
-cp "$AWG_CLI_BIN" "$IPK_ROOT/opt/sbin/awg"
-chmod +x "$IPK_ROOT/opt/sbin/awg"
+    if [[ "${SKIP_FRONTEND_BUILD:-0}" == "1" ]]; then
+        if [[ ! -f "$PROJECT_ROOT/frontend/build/index.html.gz" && ! -f "$PROJECT_ROOT/frontend/build/index.html" ]]; then
+            echo "ERROR: SKIP_FRONTEND_BUILD=1 but frontend/build/index.html(.gz) is missing"
+            exit 1
+        fi
+        echo "Using existing frontend build: frontend/build/"
+    else
+        echo "Building frontend..."
+        "$SCRIPT_DIR/build-frontend.sh"
+    fi
 
-# Bundle kernel modules (filtered by architecture)
-KMOD_VERSION=$(grep 'ExpectedKmodVersion' internal/sys/kmod/download.go | grep -oP '"[^"]+"' | tr -d '"')
-BUNDLED_DIR="$IPK_ROOT/opt/etc/awg-manager/modules/bundled"
-KMOD_COUNT=0
+    echo ""
+    echo "Building backend..."
+    VERSION="$VERSION" ENTWARE_ARCH="$ENTWARE_ARCH" "$SCRIPT_DIR/build-backend.sh" "$GO_ARCH"
 
-if ls "$PROJECT_ROOT/prebuilt/kmod"/amneziawg-*.ko &>/dev/null; then
-    mkdir -p "$BUNDLED_DIR"
-    for ko in "$PROJECT_ROOT/prebuilt/kmod"/amneziawg-*.ko; do
-        filetype=$(file -b "$ko")
-        match=false
+    local IPK_ROOT="build/ipk"
+    mkdir -p "$IPK_ROOT/CONTROL"
+    mkdir -p "$IPK_ROOT/opt/bin"
+    mkdir -p "$IPK_ROOT/opt/sbin"
+    mkdir -p "$IPK_ROOT/opt/etc/init.d"
+    mkdir -p "$IPK_ROOT/opt/etc/awg-manager"
+    for hook in iflayerchanged ifcreated ifdestroyed ifipchanged; do
+        mkdir -p "$IPK_ROOT/opt/etc/ndm/${hook}.d"
+    done
+
+    cp build/bin/awg-manager "$IPK_ROOT/opt/bin/"
+    cp "$AWG_CLI_BIN" "$IPK_ROOT/opt/sbin/awg"
+    chmod +x "$IPK_ROOT/opt/sbin/awg"
+
+    local KMOD_VERSION
+    KMOD_VERSION=$(grep 'ExpectedKmodVersion' internal/sys/kmod/download.go | grep -oP '"[^"]+"' | tr -d '"')
+    local BUNDLED_DIR="$IPK_ROOT/opt/etc/awg-manager/modules/bundled"
+    local KMOD_COUNT=0
+
+    if ls "$PROJECT_ROOT/prebuilt/kmod"/amneziawg-*.ko &>/dev/null; then
+        mkdir -p "$BUNDLED_DIR"
+        for ko in "$PROJECT_ROOT/prebuilt/kmod"/amneziawg-*.ko; do
+            local filetype
+            filetype=$(file -b "$ko")
+            local match=false
+            case "$ENTWARE_ARCH" in
+                mipsel-3.4)   [[ "$filetype" == *"LSB"*"MIPS"* ]] && match=true ;;
+                mips-3.4)     [[ "$filetype" == *"MSB"*"MIPS"* ]] && match=true ;;
+                aarch64-3.10) [[ "$filetype" == *"aarch64"* ]]     && match=true ;;
+            esac
+            if $match; then
+                cp "$ko" "$BUNDLED_DIR/"
+                KMOD_COUNT=$((KMOD_COUNT + 1))
+            fi
+        done
+        if [[ $KMOD_COUNT -gt 0 ]]; then
+            echo "$KMOD_VERSION" > "$BUNDLED_DIR/version"
+            echo "Bundled $KMOD_COUNT kernel modules (kmod $KMOD_VERSION) for $ENTWARE_ARCH"
+        else
+            echo "WARNING: No kernel modules matched architecture $ENTWARE_ARCH"
+            rmdir "$BUNDLED_DIR" 2>/dev/null || true
+        fi
+    else
+        echo "WARNING: No prebuilt/kmod/*.ko files found, IPK will have no bundled modules"
+    fi
+
+    local AWG_PROXY_DIR="$IPK_ROOT/opt/etc/awg-manager/modules"
+    local AWG_PROXY_COUNT=0
+    local AWG_PROXY_DEFAULT
+
+    case "$ENTWARE_ARCH" in
+        mipsel-3.4) AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-mt7621.ko" ;;
+        mips-3.4)   AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-mips.ko" ;;
+        aarch64-3.10) AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-arm64.ko" ;;
+    esac
+    if [[ -f "$AWG_PROXY_DEFAULT" ]]; then
+        mkdir -p "$AWG_PROXY_DIR"
+        cp "$AWG_PROXY_DEFAULT" "$AWG_PROXY_DIR/awg_proxy.ko"
+        AWG_PROXY_COUNT=$((AWG_PROXY_COUNT + 1))
+        echo "Bundled awg_proxy.ko default ($(basename "$AWG_PROXY_DEFAULT"))"
+    else
+        echo "WARNING: $AWG_PROXY_DEFAULT not found, IPK will have no awg_proxy module"
+    fi
+
+    for EXTRA_KO in kmod/awg-proxy/out/awg_proxy-*.ko; do
+        [[ -f "$EXTRA_KO" ]] || continue
+        case "$(basename "$EXTRA_KO")" in
+            awg_proxy-mips.ko|awg_proxy-arm64.ko) continue ;;
+        esac
+        local filetype
+        filetype=$(file -b "$EXTRA_KO")
+        local match=false
         case "$ENTWARE_ARCH" in
             mipsel-3.4)   [[ "$filetype" == *"LSB"*"MIPS"* ]] && match=true ;;
             mips-3.4)     [[ "$filetype" == *"MSB"*"MIPS"* ]] && match=true ;;
             aarch64-3.10) [[ "$filetype" == *"aarch64"* ]]     && match=true ;;
         esac
         if $match; then
-            cp "$ko" "$BUNDLED_DIR/"
-            KMOD_COUNT=$((KMOD_COUNT + 1))
+            local KONAME
+            KONAME=$(basename "$EXTRA_KO" .ko | sed 's/awg_proxy-//')
+            mkdir -p "$AWG_PROXY_DIR"
+            cp "$EXTRA_KO" "$AWG_PROXY_DIR/awg_proxy-${KONAME}.ko"
+            AWG_PROXY_COUNT=$((AWG_PROXY_COUNT + 1))
+            echo "Bundled awg_proxy override: ${KONAME}"
         fi
     done
-    if [[ $KMOD_COUNT -gt 0 ]]; then
-        echo "$KMOD_VERSION" > "$BUNDLED_DIR/version"
-        echo "Bundled $KMOD_COUNT kernel modules (kmod $KMOD_VERSION) for $ENTWARE_ARCH"
-    else
-        echo "WARNING: No kernel modules matched architecture $ENTWARE_ARCH"
-        rmdir "$BUNDLED_DIR" 2>/dev/null || true
-    fi
-else
-    echo "WARNING: No prebuilt/kmod/*.ko files found, IPK will have no bundled modules"
-fi
 
-# Bundle awg_proxy.ko kernel modules (NativeWG obfuscation proxy)
-# Modules are installed to /opt/etc/awg-manager/modules/ alongside amneziawg.ko.
-# For mipsel: SoC-specific (mt7621, mt7628) + per-model (KN-1011 HIGHMEM).
-# For mips/arm64: single arch default copied as awg_proxy.ko.
-AWG_PROXY_DIR="$IPK_ROOT/opt/etc/awg-manager/modules"
-AWG_PROXY_COUNT=0
+    echo "Total awg_proxy modules bundled: $AWG_PROXY_COUNT"
 
-# 1. Arch default (awg_proxy.ko) — for mips/arm64 fallback, for mipsel = copy of mt7621
-case "$ENTWARE_ARCH" in
-    mipsel-3.4) AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-mt7621.ko" ;;
-    mips-3.4)   AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-mips.ko" ;;
-    aarch64-3.10) AWG_PROXY_DEFAULT="kmod/awg-proxy/out/awg_proxy-arm64.ko" ;;
-esac
-if [[ -f "$AWG_PROXY_DEFAULT" ]]; then
-    mkdir -p "$AWG_PROXY_DIR"
-    cp "$AWG_PROXY_DEFAULT" "$AWG_PROXY_DIR/awg_proxy.ko"
-    AWG_PROXY_COUNT=$((AWG_PROXY_COUNT + 1))
-    echo "Bundled awg_proxy.ko default ($(basename "$AWG_PROXY_DEFAULT"))"
-else
-    echo "WARNING: $AWG_PROXY_DEFAULT not found, IPK will have no awg_proxy module"
-fi
+    cp entware/files/etc/init.d/* "$IPK_ROOT/opt/etc/init.d/"
 
-# 2. SoC-specific and per-model overrides (filtered by ELF architecture)
-for EXTRA_KO in kmod/awg-proxy/out/awg_proxy-*.ko; do
-    [[ -f "$EXTRA_KO" ]] || continue
-    # Skip arch defaults (already handled above)
-    case "$(basename "$EXTRA_KO")" in
-        awg_proxy-mips.ko|awg_proxy-arm64.ko) continue ;;
-    esac
-    filetype=$(file -b "$EXTRA_KO")
-    match=false
-    case "$ENTWARE_ARCH" in
-        mipsel-3.4)   [[ "$filetype" == *"LSB"*"MIPS"* ]] && match=true ;;
-        mips-3.4)     [[ "$filetype" == *"MSB"*"MIPS"* ]] && match=true ;;
-        aarch64-3.10) [[ "$filetype" == *"aarch64"* ]]     && match=true ;;
-    esac
-    if $match; then
-        KONAME=$(basename "$EXTRA_KO" .ko | sed 's/awg_proxy-//')
-        mkdir -p "$AWG_PROXY_DIR"
-        cp "$EXTRA_KO" "$AWG_PROXY_DIR/awg_proxy-${KONAME}.ko"
-        AWG_PROXY_COUNT=$((AWG_PROXY_COUNT + 1))
-        echo "Bundled awg_proxy override: ${KONAME}"
-    fi
-done
+    for hook in iflayerchanged ifcreated ifdestroyed ifipchanged; do
+        cp internal/ndms/events/hook-script.sh \
+            "$IPK_ROOT/opt/etc/ndm/${hook}.d/50-awg-manager.sh"
+    done
 
-echo "Total awg_proxy modules bundled: $AWG_PROXY_COUNT"
-
-# Copy init script (lighttpd config is generated dynamically)
-cp entware/files/etc/init.d/* "$IPK_ROOT/opt/etc/init.d/"
-
-# Copy unified hook script into every NDMS hook directory we use.
-# Source file is internal/ndms/events/hook-script.sh (also used as
-# //go:embed for the Installer component at runtime).
-for hook in iflayerchanged ifcreated ifdestroyed ifipchanged; do
-    cp internal/ndms/events/hook-script.sh \
-        "$IPK_ROOT/opt/etc/ndm/${hook}.d/50-awg-manager.sh"
-done
-
-# Generate control file
-cat > "$IPK_ROOT/CONTROL/control" << EOF
+    cat > "$IPK_ROOT/CONTROL/control" << EOF
 Package: awg-manager
 Version: ${VERSION}
 Depends: iptables, ip-full, wireguard-tools
@@ -199,40 +208,54 @@ Description: AmneziaWG tunnel manager with web interface
  Includes bundled kernel modules.
 EOF
 
-# Copy control scripts
-cp entware/control/postinst "$IPK_ROOT/CONTROL/"
-cp entware/control/prerm "$IPK_ROOT/CONTROL/"
-chmod 755 "$IPK_ROOT/CONTROL/postinst"
-chmod 755 "$IPK_ROOT/CONTROL/prerm"
+    cp entware/control/postinst "$IPK_ROOT/CONTROL/"
+    cp entware/control/prerm "$IPK_ROOT/CONTROL/"
+    chmod 755 "$IPK_ROOT/CONTROL/postinst"
+    chmod 755 "$IPK_ROOT/CONTROL/prerm"
 
-# Build IPK
-echo ""
-echo "Creating IPK package..."
+    echo ""
+    echo "Creating IPK package..."
 
-IPK_DIR="$PROJECT_ROOT/build/ipk"
+    local IPK_DIR="$PROJECT_ROOT/build/ipk"
 
-# debian-binary
-echo "2.0" > "$IPK_DIR/debian-binary"
+    echo "2.0" > "$IPK_DIR/debian-binary"
 
-# control.tar.gz - without ./ prefix
-cd "$IPK_DIR/CONTROL"
-tar --numeric-owner --owner=0 --group=0 -czf "$IPK_DIR/control.tar.gz" \
-    control postinst prerm
+    cd "$IPK_DIR/CONTROL"
+    tar --numeric-owner --owner=0 --group=0 -czf "$IPK_DIR/control.tar.gz" \
+        control postinst prerm
 
-# data.tar.gz - with ./opt prefix
-cd "$IPK_DIR"
-tar --numeric-owner --owner=0 --group=0 -czf "$IPK_DIR/data.tar.gz" \
-    ./opt
+    cd "$IPK_DIR"
+    tar --numeric-owner --owner=0 --group=0 -czf "$IPK_DIR/data.tar.gz" \
+        ./opt
 
-# IPK as gzip tar archive (Entware format)
-cd "$IPK_DIR"
-rm -f "$PROJECT_ROOT/dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk"
-tar --numeric-owner --owner=0 --group=0 -czf "$PROJECT_ROOT/dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk" \
-    ./debian-binary ./data.tar.gz ./control.tar.gz
+    cd "$IPK_DIR"
+    rm -f "$PROJECT_ROOT/dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk"
+    tar --numeric-owner --owner=0 --group=0 -czf "$PROJECT_ROOT/dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk" \
+        ./debian-binary ./data.tar.gz ./control.tar.gz
 
-# Cleanup
-rm -f "$IPK_DIR/debian-binary" "$IPK_DIR/control.tar.gz" "$IPK_DIR/data.tar.gz"
+    rm -f "$IPK_DIR/debian-binary" "$IPK_DIR/control.tar.gz" "$IPK_DIR/data.tar.gz"
 
-echo ""
-echo "IPK package created: dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk"
-ls -la "$PROJECT_ROOT/dist/"*.ipk
+    echo ""
+    echo "IPK package created: dist/awg-manager_${VERSION}_${PKG_ARCH}-kn.ipk"
+}
+
+if [[ "$BUILD_ALL" -eq 1 ]]; then
+    echo "Building awg-manager IPK for all architectures"
+    echo "Version: $VERSION"
+    echo "Architectures: ${ALL_ARCHES[*]}"
+    first=1
+    for arch in "${ALL_ARCHES[@]}"; do
+        if [[ $first -eq 1 ]]; then
+            first=0
+            build_ipk_one "$arch"
+        else
+            SKIP_FRONTEND_BUILD=1 build_ipk_one "$arch"
+        fi
+    done
+    echo ""
+    echo "All IPK packages:"
+    ls -la "$PROJECT_ROOT/dist/"*.ipk
+else
+    build_ipk_one "$ENTWARE_ARCH"
+    ls -la "$PROJECT_ROOT/dist/"*.ipk
+fi


### PR DESCRIPTION
В tproxy-режиме в sing-box уходит только трафик к IP из правил маршрутизации (домены резолвятся, ip_cidr — как есть); остальное идёт в WAN мимо sing-box. iptables-guard в mangle/nat, сбор matcher'ов только для non-direct outbound

Сильно упрощает жизнь sing-box'у и, тем самым, роутеру в принципе, т.к. без этой настройки просто бешенный спам всего трафика, 90% которого направляется в direct и, как показывает практика, заставляет периодически ломаться соединениям, особенно если в настроив маршрутизацию начнёте играть/стримить и т.д.

Не идеальный алгоритм для решения проблемы с CDN, есть что улучшить в будущем.

Настройка находится в "Параметры sing-box":
<img width="396" height="414" alt="image" src="https://github.com/user-attachments/assets/f18ac339-1d81-486f-98f6-392b7deb5f67" />

Позволяет просмотреть имеющиеся списки:
<img width="572" height="447" alt="image" src="https://github.com/user-attachments/assets/9ae234dc-e529-4874-b3b3-8757330adab9" />

После применения изменений, идёт пересборка ipset:
<img width="584" height="301" alt="image" src="https://github.com/user-attachments/assets/c7154155-e88a-43c2-a1d3-a8564849ea5a" />
<img width="569" height="645" alt="image" src="https://github.com/user-attachments/assets/539a5190-94f3-4a74-9155-5b10050f8972" />
<img width="575" height="826" alt="image" src="https://github.com/user-attachments/assets/6aae63e3-1c5c-4863-979d-eb6d67e249ba" />

**Нюансы**:

1. Готовые наборы (rule sets) разбиваются и статичные адреса из них попадают в ipset как есть, домены же тоже резолвятся.
2. Домены резолвятся с приоритетом на DNS сервера в настройках sin-box'а, если же их нет, то берутся DNS сервера из NDMS.
3. Домены с CDN помечаются и раз в 20 минут на фоне происходит рефреш ipset списка с повторным резолвом этих доменов.
