### PR TITLE
Refactor persisted stores and clean up unused components

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -63,6 +62,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/sys/env"
 	"github.com/hoaxisr/awg-manager/internal/sys/kmod"
 	"github.com/hoaxisr/awg-manager/internal/sys/ndmsinfo"
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
 	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
 	"github.com/hoaxisr/awg-manager/internal/terminal"
 	"github.com/hoaxisr/awg-manager/internal/testing"
@@ -1288,7 +1288,7 @@ func main() {
 
 	// Determine bind IP from settings
 	bindIface := settings.Server.Interface
-	ip := getInterfaceIP(bindIface)
+	ip := netif.FirstIPv4(bindIface)
 	if ip == "" {
 		fmt.Fprintf(os.Stderr, "Warning: could not get IP for interface %s, binding to all interfaces\n", bindIface)
 		ip = "0.0.0.0"
@@ -1296,7 +1296,7 @@ func main() {
 
 	// Get port from settings, with fallback logic
 	selectedPort := settings.Server.Port
-	if selectedPort == 0 || !isPortFree(selectedPort) {
+	if selectedPort == 0 || !server.IsPortFree(selectedPort) {
 		var err error
 		selectedPort, err = srv.FindFreePort(settings.Server.Port)
 		if err != nil {
@@ -1713,39 +1713,6 @@ func populateWANModel(ctx context.Context, queries *ndmsquery.Queries, model *wa
 	appLog.Info("populate-wan", "", fmt.Sprintf("WAN model populated, count=%d ifaces=[%s]", len(interfaces), strings.Join(ifaceList, " ")))
 }
 
-// getInterfaceIP returns the first IPv4 address of the given interface.
-func getInterfaceIP(ifaceName string) string {
-	iface, err := net.InterfaceByName(ifaceName)
-	if err != nil {
-		return ""
-	}
-
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return ""
-	}
-
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok {
-			if ip4 := ipnet.IP.To4(); ip4 != nil {
-				return ip4.String()
-			}
-		}
-	}
-	return ""
-}
-
-// isPortFree checks if a port is available for binding.
-func isPortFree(port int) bool {
-	addr := fmt.Sprintf(":%d", port)
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return false
-	}
-	ln.Close()
-	return true
-}
-
 // getUptime reads system uptime in seconds from /proc/uptime.
 // Returns 0 on error (treated as non-boot scenario).
 func getUptime() float64 {
@@ -1951,7 +1918,7 @@ func getServiceEndpoint(dataDir string) (string, int) {
 	}
 
 	// Use br0 (LAN bridge) for display — this is what the user connects from
-	host := getInterfaceIP("br0")
+	host := netif.FirstIPv4(storage.DefaultInterface)
 	if host == "" {
 		host = "192.168.1.1"
 	}

--- a/frontend/src/lib/stores/compactLayout.ts
+++ b/frontend/src/lib/stores/compactLayout.ts
@@ -1,43 +1,13 @@
-import { browser } from '$app/environment';
-import { writable } from 'svelte/store';
 import type { UsageLevel } from '$lib/types/usageLevel';
+import { createPersistedFlag } from './persisted';
 
-const storageKey = 'awg-manager-compact-layout';
+const store = createPersistedFlag('awg-manager-compact-layout', false);
 
-function readStored(): boolean {
-	if (!browser) return false;
-	try {
-		return localStorage.getItem(storageKey) === 'true';
-	} catch {
-		return false;
-	}
-}
-
-function writeStored(enabled: boolean): void {
-	if (!browser) return;
-	try {
-		localStorage.setItem(storageKey, enabled ? 'true' : 'false');
-	} catch {
-		/* ignore quota / private mode */
-	}
-}
-
-function createCompactLayoutStore() {
-	const { subscribe, set } = writable<boolean>(readStored());
-
-	return {
-		subscribe,
-		init() {
-			set(readStored());
-		},
-		setEnabled(enabled: boolean) {
-			set(enabled);
-			writeStored(enabled);
-		},
-	};
-}
-
-export const compactLayout = createCompactLayoutStore();
+export const compactLayout = {
+	subscribe: store.subscribe,
+	init: store.init,
+	setEnabled: store.set,
+};
 
 /** Базовый режим — всегда; расширенный/продвинутый — по выбору пользователя. */
 export function isCompactLayoutActive(level: UsageLevel, userEnabled: boolean): boolean {

--- a/frontend/src/lib/stores/developFeedbackFab.ts
+++ b/frontend/src/lib/stores/developFeedbackFab.ts
@@ -1,28 +1,9 @@
-import { writable } from 'svelte/store';
+import { createPersistedFlag } from './persisted';
 
-const STORAGE_KEY = 'awg-manager-develop-feedback-fab-visible';
-
-function readInitial(): boolean {
-	if (typeof localStorage === 'undefined') return true;
-	return localStorage.getItem(STORAGE_KEY) !== '0';
-}
-
-function persist(value: boolean) {
-	if (typeof localStorage === 'undefined') return;
-	localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
-}
-
-function createDevelopFeedbackFabVisible() {
-	const { subscribe, set, update } = writable<boolean>(readInitial());
-
-	return {
-		subscribe,
-		set(value: boolean) {
-			persist(value);
-			set(value);
-		},
-	};
-}
+const store = createPersistedFlag('awg-manager-develop-feedback-fab-visible', true);
 
 /** Whether the develop-channel feedback FAB is shown (persisted in localStorage). */
-export const developFeedbackFabVisible = createDevelopFeedbackFabVisible();
+export const developFeedbackFabVisible = {
+	subscribe: store.subscribe,
+	set: store.set,
+};

--- a/frontend/src/lib/stores/diagnosticsPrivacy.ts
+++ b/frontend/src/lib/stores/diagnosticsPrivacy.ts
@@ -1,40 +1,15 @@
-import { writable } from 'svelte/store';
+import { createPersistedFlag } from './persisted';
 
-const STORAGE_KEY = 'awgm.diagnostics.sanitizeLogs';
+const store = createPersistedFlag('awgm.diagnostics.sanitizeLogs', true);
 
-function readInitial(): boolean {
-  if (typeof localStorage === 'undefined') return true;
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (raw === null) return true;
-  return raw !== '0';
-}
-
-function persist(value: boolean) {
-  if (typeof localStorage === 'undefined') return;
-  localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
-}
-
-function createDiagnosticsSanitized() {
-  const { subscribe, set, update } = writable<boolean>(readInitial());
-
-  return {
-    subscribe,
-    set(value: boolean) {
-      persist(value);
-      set(value);
-    },
-    toggle() {
-      update((value) => {
-        const next = !value;
-        persist(next);
-        return next;
-      });
-    },
-  };
-}
-
-export const diagnosticsSanitized = createDiagnosticsSanitized();
+export const diagnosticsSanitized = {
+	subscribe: store.subscribe,
+	set: store.set,
+	toggle() {
+		store.update((value) => !value);
+	},
+};
 
 export function toggleDiagnosticsSanitized() {
-  diagnosticsSanitized.toggle();
+	diagnosticsSanitized.toggle();
 }

--- a/frontend/src/lib/stores/experimentalSettingsUnlocked.ts
+++ b/frontend/src/lib/stores/experimentalSettingsUnlocked.ts
@@ -1,35 +1,12 @@
-import { writable } from 'svelte/store';
+import { createPersistedFlag } from './persisted';
 
-const STORAGE_KEY = 'awg-manager-experimental-settings-unlocked';
-
-function readInitial(): boolean {
-	if (typeof localStorage === 'undefined') return false;
-	return localStorage.getItem(STORAGE_KEY) === '1';
-}
-
-function persist(value: boolean) {
-	if (typeof localStorage === 'undefined') return;
-	localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
-}
-
-function createExperimentalSettingsUnlocked() {
-	const { subscribe, set, update } = writable<boolean>(readInitial());
-
-	return {
-		subscribe,
-		toggle() {
-			update((current) => {
-				const next = !current;
-				persist(next);
-				return next;
-			});
-		},
-		set(value: boolean) {
-			persist(value);
-			set(value);
-		},
-	};
-}
+const store = createPersistedFlag('awg-manager-experimental-settings-unlocked', false);
 
 /** Hidden «Экспериментальное» block in settings — toggled via version-badge easter egg. */
-export const experimentalSettingsUnlocked = createExperimentalSettingsUnlocked();
+export const experimentalSettingsUnlocked = {
+	subscribe: store.subscribe,
+	set: store.set,
+	toggle() {
+		store.update((current) => !current);
+	},
+};

--- a/frontend/src/lib/stores/peerSort.ts
+++ b/frontend/src/lib/stores/peerSort.ts
@@ -1,90 +1,27 @@
-import { writable } from 'svelte/store';
-import { browser } from '$app/environment';
 import { PEER_SORT_DEFAULTS, type PeerSortKey } from '$lib/utils/peerSort';
 import { cycleTableSort } from '$lib/utils/tableSort';
+import { createSortStore, type SortState } from './sortStore';
 
-const storageKey = 'awg-manager-peer-sort';
+export type PeerSortState = SortState<PeerSortKey>;
 
-const VALID_KEYS = new Set<PeerSortKey>(['name', 'traffic', 'ip', 'endpoint', 'online', 'handshake']);
+const store = createSortStore<PeerSortKey>(
+	'awg-manager-peer-sort',
+	['name', 'traffic', 'ip', 'endpoint', 'online', 'handshake'],
+	PEER_SORT_DEFAULTS,
+);
 
-export interface PeerSortState {
-	sortBy: PeerSortKey | null;
-	sortAsc: boolean;
-}
-
-function defaultState(): PeerSortState {
-	return { sortBy: null, sortAsc: true };
-}
-
-function getInitial(): PeerSortState {
-	if (!browser) return defaultState();
-	try {
-		const raw = localStorage.getItem(storageKey);
-		if (!raw) return defaultState();
-		const parsed: unknown = JSON.parse(raw);
-		if (!parsed || typeof parsed !== 'object') return defaultState();
-		const { sortBy, sortAsc } = parsed as Partial<PeerSortState>;
-		if (sortBy !== null && sortBy !== undefined && !VALID_KEYS.has(sortBy)) return defaultState();
-		return {
-			sortBy: sortBy ?? null,
-			sortAsc:
-				typeof sortAsc === 'boolean'
-					? sortAsc
-					: sortBy != null
-						? PEER_SORT_DEFAULTS[sortBy]
-						: true,
-		};
-	} catch {
-		return defaultState();
-	}
-}
-
-function persist(state: PeerSortState) {
-	if (!browser) return;
-	try {
-		localStorage.setItem(storageKey, JSON.stringify(state));
-	} catch {
-		// quota / private-mode: silently ignore
-	}
-}
-
-function createPeerSortStore() {
-	const { subscribe, set, update } = writable<PeerSortState>(getInitial());
-
-	return {
-		subscribe,
-		setSort(sortBy: PeerSortKey | null, sortAsc: boolean) {
-			const next: PeerSortState = { sortBy, sortAsc };
-			persist(next);
-			set(next);
-		},
-		setSortBy(key: PeerSortKey | null) {
-			update((s) => {
-				if (s.sortBy === key) return s;
-				const next: PeerSortState = {
-					sortBy: key,
-					sortAsc: true,
-				};
-				persist(next);
-				return next;
-			});
-		},
-		toggleSort(key: PeerSortKey) {
-			update((state) => {
-				const next = cycleTableSort(state, key);
-				persist(next);
-				return next;
-			});
-		},
-		toggleDir() {
-			update((s) => {
-				if (s.sortBy === null) return s;
-				const next: PeerSortState = { ...s, sortAsc: !s.sortAsc };
-				persist(next);
-				return next;
-			});
-		},
-	};
-}
-
-export const peerSort = createPeerSortStore();
+export const peerSort = {
+	subscribe: store.subscribe,
+	setSort(sortBy: PeerSortKey | null, sortAsc: boolean) {
+		store.mutate(() => ({ sortBy, sortAsc }));
+	},
+	setSortBy(key: PeerSortKey | null) {
+		store.mutate((s) => (s.sortBy === key ? s : { sortBy: key, sortAsc: true }));
+	},
+	toggleSort(key: PeerSortKey) {
+		store.mutate((state) => cycleTableSort(state, key));
+	},
+	toggleDir() {
+		store.mutate((s) => (s.sortBy === null ? s : { ...s, sortAsc: !s.sortAsc }));
+	},
+};

--- a/frontend/src/lib/stores/persisted.ts
+++ b/frontend/src/lib/stores/persisted.ts
@@ -1,0 +1,74 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export interface PersistedStoreOptions<T> {
+	/** Value used before hydration (SSR) and when nothing valid is stored. */
+	defaultValue: T;
+	/** Turn a raw localStorage string into T. Return defaultValue for junk. */
+	deserialize: (raw: string) => T;
+	/** Turn T into the string persisted to localStorage. */
+	serialize: (value: T) => string;
+}
+
+/**
+ * createPersistedStore is the single localStorage-backed writable used by the
+ * small UI-preference stores. It centralises the browser guard, the
+ * try/catch around a potentially-throwing localStorage (quota / private mode)
+ * and the read-on-construct + explicit init() re-read that individual stores
+ * used to hand-roll, each with slightly different guards and encodings.
+ */
+export function createPersistedStore<T>(storageKey: string, opts: PersistedStoreOptions<T>) {
+	function read(): T {
+		if (!browser) return opts.defaultValue;
+		try {
+			const raw = localStorage.getItem(storageKey);
+			return raw === null ? opts.defaultValue : opts.deserialize(raw);
+		} catch {
+			return opts.defaultValue;
+		}
+	}
+
+	function persist(value: T): void {
+		if (!browser) return;
+		try {
+			localStorage.setItem(storageKey, opts.serialize(value));
+		} catch {
+			/* ignore quota / private mode */
+		}
+	}
+
+	const { subscribe, set, update } = writable<T>(read());
+
+	return {
+		subscribe,
+		set(value: T) {
+			persist(value);
+			set(value);
+		},
+		update(fn: (current: T) => T) {
+			update((current) => {
+				const next = fn(current);
+				persist(next);
+				return next;
+			});
+		},
+		/** Re-read from localStorage — used by stores initialised before hydration. */
+		init() {
+			set(read());
+		},
+	};
+}
+
+/**
+ * createPersistedFlag is the boolean specialisation of createPersistedStore.
+ * It writes the canonical '1'/'0' but reads liberally so preferences persisted
+ * by the older stores (which variously used 'true'/'false' or '1'/'0') keep
+ * working across an upgrade instead of silently resetting to defaultValue.
+ */
+export function createPersistedFlag(storageKey: string, defaultValue: boolean) {
+	return createPersistedStore<boolean>(storageKey, {
+		defaultValue,
+		deserialize: (raw) => raw === '1' || raw === 'true',
+		serialize: (value) => (value ? '1' : '0'),
+	});
+}

--- a/frontend/src/lib/stores/serviceLetterIcons.ts
+++ b/frontend/src/lib/stores/serviceLetterIcons.ts
@@ -1,42 +1,10 @@
-import { browser } from '$app/environment';
-import { writable } from 'svelte/store';
+import { createPersistedFlag } from './persisted';
 
-const storageKey = 'awg-manager-service-letter-icons';
-
-function readStored(): boolean {
-	if (!browser) return true;
-	try {
-		const raw = localStorage.getItem(storageKey);
-		if (raw === null) return true;
-		return raw === 'true';
-	} catch {
-		return true;
-	}
-}
-
-function writeStored(enabled: boolean): void {
-	if (!browser) return;
-	try {
-		localStorage.setItem(storageKey, enabled ? 'true' : 'false');
-	} catch {
-		/* ignore quota / private mode */
-	}
-}
-
-function createServiceLetterIconsStore() {
-	const { subscribe, set } = writable<boolean>(readStored());
-
-	return {
-		subscribe,
-		init() {
-			set(readStored());
-		},
-		setEnabled(enabled: boolean) {
-			set(enabled);
-			writeStored(enabled);
-		},
-	};
-}
+const store = createPersistedFlag('awg-manager-service-letter-icons', true);
 
 /** User preference: colored monogram tiles when no custom / brand icon applies. */
-export const serviceLetterIcons = createServiceLetterIconsStore();
+export const serviceLetterIcons = {
+	subscribe: store.subscribe,
+	init: store.init,
+	setEnabled: store.set,
+};

--- a/frontend/src/lib/stores/settingsSectionIconMode.ts
+++ b/frontend/src/lib/stores/settingsSectionIconMode.ts
@@ -1,5 +1,4 @@
-import { browser } from '$app/environment';
-import { writable } from 'svelte/store';
+import { createPersistedStore } from './persisted';
 
 export type SettingsSectionIconMode = 'strict' | 'harmonious' | 'vivid';
 
@@ -9,45 +8,20 @@ export const SETTINGS_SECTION_ICON_MODE_LABELS: Record<SettingsSectionIconMode, 
 	vivid: 'Красочная',
 };
 
-const storageKey = 'awg-manager-settings-section-icon-mode';
 const DEFAULT_MODE: SettingsSectionIconMode = 'harmonious';
 
-function isValidMode(value: string | null): value is SettingsSectionIconMode {
+function isValidMode(value: string): value is SettingsSectionIconMode {
 	return value === 'strict' || value === 'harmonious' || value === 'vivid';
 }
 
-function readStored(): SettingsSectionIconMode {
-	if (!browser) return DEFAULT_MODE;
-	try {
-		const raw = localStorage.getItem(storageKey);
-		return isValidMode(raw) ? raw : DEFAULT_MODE;
-	} catch {
-		return DEFAULT_MODE;
-	}
-}
+const store = createPersistedStore<SettingsSectionIconMode>('awg-manager-settings-section-icon-mode', {
+	defaultValue: DEFAULT_MODE,
+	deserialize: (raw) => (isValidMode(raw) ? raw : DEFAULT_MODE),
+	serialize: (mode) => mode,
+});
 
-function writeStored(mode: SettingsSectionIconMode): void {
-	if (!browser) return;
-	try {
-		localStorage.setItem(storageKey, mode);
-	} catch {
-		/* ignore quota / private mode */
-	}
-}
-
-function createSettingsSectionIconModeStore() {
-	const { subscribe, set } = writable<SettingsSectionIconMode>(readStored());
-
-	return {
-		subscribe,
-		init() {
-			set(readStored());
-		},
-		setMode(mode: SettingsSectionIconMode) {
-			set(mode);
-			writeStored(mode);
-		},
-	};
-}
-
-export const settingsSectionIconMode = createSettingsSectionIconModeStore();
+export const settingsSectionIconMode = {
+	subscribe: store.subscribe,
+	init: store.init,
+	setMode: store.set,
+};

--- a/frontend/src/lib/stores/sortStore.ts
+++ b/frontend/src/lib/stores/sortStore.ts
@@ -1,0 +1,74 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export interface SortState<T extends string> {
+	sortBy: T | null;
+	sortAsc: boolean;
+}
+
+/**
+ * createSortStore is the shared localStorage-backed core for table-sort
+ * preferences. Both peerSort and the tunnel/subscription table sorts used to
+ * duplicate this getInitial/persist/defaultState block verbatim; they now
+ * layer their own mutators on top of `mutate`.
+ *
+ * `defaults[key]` supplies the initial direction when a persisted state names
+ * a column but omits (or corrupts) its sortAsc flag.
+ */
+export function createSortStore<T extends string>(
+	storageKey: string,
+	validKeys: readonly T[],
+	defaults: Record<T, boolean>,
+) {
+	const valid = new Set<T>(validKeys);
+
+	function defaultState(): SortState<T> {
+		return { sortBy: null, sortAsc: true };
+	}
+
+	function getInitial(): SortState<T> {
+		if (!browser) return defaultState();
+		try {
+			const raw = localStorage.getItem(storageKey);
+			if (!raw) return defaultState();
+			const parsed = JSON.parse(raw) as Partial<SortState<T>> | null;
+			if (!parsed || typeof parsed !== 'object') return defaultState();
+			const sortBy = parsed.sortBy ?? null;
+			if (sortBy !== null && !valid.has(sortBy)) return defaultState();
+			return {
+				sortBy,
+				sortAsc:
+					typeof parsed.sortAsc === 'boolean'
+						? parsed.sortAsc
+						: sortBy !== null
+							? defaults[sortBy]
+							: true,
+			};
+		} catch {
+			return defaultState();
+		}
+	}
+
+	function persist(state: SortState<T>): void {
+		if (!browser) return;
+		try {
+			localStorage.setItem(storageKey, JSON.stringify(state));
+		} catch {
+			// ignore quota / private mode
+		}
+	}
+
+	const { subscribe, update } = writable<SortState<T>>(getInitial());
+
+	return {
+		subscribe,
+		/** Apply a pure transition to the current state and persist the result. */
+		mutate(fn: (state: SortState<T>) => SortState<T>) {
+			update((state) => {
+				const next = fn(state);
+				persist(next);
+				return next;
+			});
+		},
+	};
+}

--- a/frontend/src/lib/stores/tunnelTableSort.ts
+++ b/frontend/src/lib/stores/tunnelTableSort.ts
@@ -1,74 +1,27 @@
-import { writable } from 'svelte/store';
-import { browser } from '$app/environment';
 import {
 	AWG_TUNNEL_SORT_DEFAULTS,
 	SINGBOX_TUNNEL_SORT_DEFAULTS,
 	SUBSCRIPTION_SORT_DEFAULTS,
 } from '$lib/utils/tunnelTableSort';
 import { cycleTableSort } from '$lib/utils/tableSort';
+import { createSortStore, type SortState } from './sortStore';
 
 export type AwgTunnelSortKey = 'name' | 'status' | 'endpoint' | 'traffic' | 'handshake';
 export type SingboxTunnelSortKey = 'delay' | 'name' | 'protocol' | 'server' | 'running' | 'traffic' | 'ping';
 export type SubscriptionSortKey = 'delay' | 'label' | 'mode' | 'active' | 'traffic' | 'updated' | 'ping';
 
-export interface TunnelTableSortState<T extends string> {
-	sortBy: T | null;
-	sortAsc: boolean;
-}
+export type TunnelTableSortState<T extends string> = SortState<T>;
 
 function createTunnelTableSortStore<T extends string>(
 	storageKey: string,
 	validKeys: readonly T[],
 	defaults: Record<T, boolean>,
 ) {
-	const valid = new Set(validKeys);
-
-	function defaultState(): TunnelTableSortState<T> {
-		return { sortBy: null, sortAsc: true };
-	}
-
-	function getInitial(): TunnelTableSortState<T> {
-		if (!browser) return defaultState();
-		try {
-			const raw = localStorage.getItem(storageKey);
-			if (!raw) return defaultState();
-			const parsed = JSON.parse(raw) as Partial<TunnelTableSortState<T>> | null;
-			if (!parsed || typeof parsed !== 'object') return defaultState();
-			const sortBy = parsed.sortBy ?? null;
-			if (sortBy !== null && !valid.has(sortBy)) return defaultState();
-			return {
-				sortBy,
-				sortAsc:
-					typeof parsed.sortAsc === 'boolean'
-						? parsed.sortAsc
-						: sortBy !== null
-							? defaults[sortBy]
-							: true,
-			};
-		} catch {
-			return defaultState();
-		}
-	}
-
-	function persist(state: TunnelTableSortState<T>): void {
-		if (!browser) return;
-		try {
-			localStorage.setItem(storageKey, JSON.stringify(state));
-		} catch {
-			// ignore storage issues
-		}
-	}
-
-	const { subscribe, update } = writable<TunnelTableSortState<T>>(getInitial());
-
+	const store = createSortStore<T>(storageKey, validKeys, defaults);
 	return {
-		subscribe,
+		subscribe: store.subscribe,
 		toggleSort(key: T) {
-			update((state) => {
-				const next = cycleTableSort(state, key);
-				persist(next);
-				return next;
-			});
+			store.mutate((state) => cycleTableSort(state, key));
 		},
 	};
 }

--- a/frontend/src/routes/diagnostics/ChecksTab.svelte
+++ b/frontend/src/routes/diagnostics/ChecksTab.svelte
@@ -6,6 +6,7 @@
 	import { developFeedbackIncidentPending } from '$lib/stores/developFeedbackIncident';
 	import type { DiagnosticsTargetSeed } from '$lib/stores/diagnostics';
 	import { notifications } from '$lib/stores/notifications';
+	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { DiagEvent } from '$lib/types';
 	import {
 		ChecksToolbar,
@@ -233,31 +234,8 @@
 		].join('\n');
 	}
 
-	async function copyText(text: string): Promise<boolean> {
-		if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-			try {
-				await navigator.clipboard.writeText(text);
-				return true;
-			} catch {
-				// Fall back to execCommand below.
-			}
-		}
-		if (typeof document === 'undefined') return false;
-		const textarea = document.createElement('textarea');
-		textarea.value = text;
-		textarea.setAttribute('readonly', '');
-		textarea.style.position = 'fixed';
-		textarea.style.left = '-9999px';
-		document.body.appendChild(textarea);
-		textarea.select();
-		let copied = false;
-		try {
-			copied = document.execCommand('copy');
-		} catch {
-			copied = false;
-		}
-		document.body.removeChild(textarea);
-		return copied;
+	function copyText(text: string): Promise<boolean> {
+		return copyToClipboard(text);
 	}
 
 	function openPendingIssueWindow(): Window | null {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -63,6 +63,7 @@
 		Power,
 	} from "lucide-svelte";
 	import { downloadErrorToText } from "$lib/utils/downloadError";
+	import { copyToClipboard } from "$lib/utils/clipboard";
 
 	const expandUsageLevel = $derived($page.url.searchParams.has('mode'));
 	const highlightFeedbackFab = $derived($page.url.searchParams.has('feedbackFab'));
@@ -367,42 +368,7 @@ $effect(() => {
 			notifications.info("Сначала сгенерируйте API ключ");
 			return;
 		}
-		const fallbackCopy = (text: string): boolean => {
-			try {
-				const textarea = document.createElement("textarea");
-				textarea.value = text;
-				textarea.setAttribute("readonly", "");
-				textarea.style.position = "fixed";
-				textarea.style.top = "-1000px";
-				textarea.style.left = "-1000px";
-				textarea.style.opacity = "0";
-				document.body.appendChild(textarea);
-				textarea.focus();
-				textarea.select();
-				textarea.setSelectionRange(0, textarea.value.length);
-				const copied = document.execCommand("copy");
-				document.body.removeChild(textarea);
-				return copied;
-			} catch {
-				return false;
-			}
-		};
-
-		let copied = false;
-		try {
-			if (navigator.clipboard?.writeText) {
-				await navigator.clipboard.writeText(key);
-				copied = true;
-			}
-		} catch {
-			copied = false;
-		}
-
-		if (!copied) {
-			copied = fallbackCopy(key);
-		}
-
-		if (copied) {
+		if (await copyToClipboard(key)) {
 			notifications.success("API ключ скопирован в буфер обмена");
 		} else {
 			notifications.error("Не удалось скопировать API ключ");

--- a/internal/api/amnezia_cp.go
+++ b/internal/api/amnezia_cp.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/downloader"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
 )
 
 const amneziaCPOrigin = "https://cp.amnezia.org"
@@ -49,16 +50,27 @@ func configureAmneziaCPTransport(tr *http.Transport) {
 	applyAmneziaCPTimeouts(tr)
 }
 
+// newAmneziaCPTransport builds the direct-WAN fallback transport on the
+// canonical httpclient base so it inherits the pinned HTTP/1.1 ALPN and the
+// ForceAttemptHTTP2=false guard (cp.amnezia.org's Fastly front returns
+// EOF/"malformed HTTP response" on h2 — the exact failure httpclient exists
+// to prevent). Env proxy + amnezia dialer/timeouts are layered on top.
+func newAmneziaCPTransport() *http.Transport {
+	tr, err := httpclient.NewTransport(httpclient.TransportConfig{})
+	if err != nil || tr == nil {
+		tr = &http.Transport{}
+	}
+	tr.Proxy = http.ProxyFromEnvironment
+	configureAmneziaCPTransport(tr)
+	return tr
+}
+
 // Dedicated HTTP client for cp.amnezia.org: disable connection reuse — idle TLS sessions
 // behind CDN occasionally stall until DefaultTransport idle timeout / Client.Timeout (~45s),
 // which matches user-visible "every paste hangs ~40s after warm-up".
 func newAmneziaCPHTTPClient() *http.Client {
-	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-	}
-	configureAmneziaCPTransport(tr)
 	return &http.Client{
-		Transport: tr,
+		Transport: newAmneziaCPTransport(),
 		Timeout:   45 * time.Second,
 	}
 }
@@ -111,9 +123,7 @@ func (h *AmneziaCPHandler) downloadClient(ctx context.Context) (*downloader.Leas
 		// Preserve the lease's bind dialer + ALPN pin; only adjust timeouts.
 		applyAmneziaCPTimeouts(tr)
 	} else if client.Transport == nil {
-		tr := &http.Transport{Proxy: http.ProxyFromEnvironment}
-		configureAmneziaCPTransport(tr)
-		client.Transport = tr
+		client.Transport = newAmneziaCPTransport()
 	}
 
 	return lease, client, lease.Route, nil

--- a/internal/api/clientroutes.go
+++ b/internal/api/clientroutes.go
@@ -117,9 +117,8 @@ func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request
 	if !ok {
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	route.ID = id
@@ -149,9 +148,8 @@ func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if err := h.svc.Delete(r.Context(), id); err != nil {
@@ -181,9 +179,8 @@ func (h *ClientRouteHandler) HandleToggle(w http.ResponseWriter, r *http.Request
 	if !ok {
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if err := h.svc.SetEnabled(r.Context(), id, req.Enabled); err != nil {

--- a/internal/api/control.go
+++ b/internal/api/control.go
@@ -92,9 +92,8 @@ func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -145,9 +144,8 @@ func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -198,9 +196,8 @@ func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -305,9 +302,8 @@ func (h *ControlHandler) ToggleEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -363,9 +359,8 @@ func (h *ControlHandler) ToggleDefaultRoute(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {

--- a/internal/api/deviceproxy.go
+++ b/internal/api/deviceproxy.go
@@ -375,9 +375,8 @@ func (h *DeviceProxyHandler) GetInstanceRuntime(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -409,9 +408,8 @@ func (h *DeviceProxyHandler) SelectInstanceRuntime(w http.ResponseWriter, r *htt
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -481,9 +479,8 @@ func (h *DeviceProxyHandler) GetInstance(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -558,9 +555,8 @@ func (h *DeviceProxyHandler) DeleteInstance(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	applied, err := h.svc.DeleteInstance(r.Context(), id)
@@ -619,9 +615,8 @@ func (h *DeviceProxyHandler) CheckInstanceExternalIP(w http.ResponseWriter, r *h
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	service := r.URL.Query().Get("service")

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -172,9 +172,8 @@ func (h *DNSRouteHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -234,9 +233,8 @@ func (h *DNSRouteHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	list.ID = id
@@ -271,9 +269,8 @@ func (h *DNSRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -393,9 +390,8 @@ func (h *DNSRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -71,6 +71,21 @@ func parseJSON[T any](w http.ResponseWriter, r *http.Request, method string) (T,
 	return dst, true
 }
 
+// requireQueryID reads the "id" query parameter. When it is absent it writes
+// the canonical 400 MISSING_ID response and returns ("", false); callers bail
+// out on false. Centralising this makes a missing id a consistent 400 across
+// every handler that requires one — several previously forgot the guard and
+// passed an empty id straight to the service, which surfaced as a 500 (or a
+// 200 with the wrong scope) instead.
+func requireQueryID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		response.Error(w, "missing id parameter", "MISSING_ID")
+		return "", false
+	}
+	return id, true
+}
+
 // decodeBody reads and JSON-decodes the request body into dst for handlers
 // that write their own error responses (they typically map the returned
 // error to response.BadRequest). It shares readJSONBody with parseJSON, so

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -3,6 +3,8 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -10,6 +12,39 @@ import (
 )
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// errEmptyBody / errInvalidJSON are the two "the payload is bad JSON" cases
+// readJSONBody reports. A body-read failure (oversized, connection reset) is
+// returned verbatim so callers can distinguish it (INVALID_BODY) from a
+// malformed/absent payload (INVALID_JSON).
+var (
+	errEmptyBody   = errors.New("empty request body")
+	errInvalidJSON = errors.New("invalid JSON")
+)
+
+// readJSONBody is the single JSON request-body reader shared by parseJSON and
+// decodeBody. It size-caps r.Body, strips a UTF-8 BOM and surrounding
+// whitespace, rejects an empty payload and unmarshals into dst.
+//
+// An empty (or whitespace-only) body is an error, NOT a silent zero-value
+// success — that previously let Add/Update requests with no payload through
+// as if they carried a valid object.
+func readJSONBody(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	raw = bytes.TrimSpace(raw)
+	raw = bytes.TrimPrefix(raw, utf8BOM)
+	if len(raw) == 0 {
+		return errEmptyBody
+	}
+	if err := json.Unmarshal(raw, dst); err != nil {
+		return fmt.Errorf("%w: %v", errInvalidJSON, err)
+	}
+	return nil
+}
 
 // parseJSON guards method + reads the request body into T. On any
 // error — wrong method, body-read failure, decode failure — it writes
@@ -25,21 +60,21 @@ func parseJSON[T any](w http.ResponseWriter, r *http.Request, method string) (T,
 		response.MethodNotAllowed(w)
 		return dst, false
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
-	raw, err := io.ReadAll(r.Body)
-	if err != nil {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "invalid body", "INVALID_BODY")
-		return dst, false
-	}
-	raw = bytes.TrimSpace(raw)
-	raw = bytes.TrimPrefix(raw, utf8BOM)
-	if len(raw) == 0 {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "invalid JSON", "INVALID_JSON")
-		return dst, false
-	}
-	if err := json.Unmarshal(raw, &dst); err != nil {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "invalid JSON", "INVALID_JSON")
+	if err := readJSONBody(w, r, &dst); err != nil {
+		if errors.Is(err, errEmptyBody) || errors.Is(err, errInvalidJSON) {
+			response.ErrorWithStatus(w, http.StatusBadRequest, "invalid JSON", "INVALID_JSON")
+		} else {
+			response.ErrorWithStatus(w, http.StatusBadRequest, "invalid body", "INVALID_BODY")
+		}
 		return dst, false
 	}
 	return dst, true
+}
+
+// decodeBody reads and JSON-decodes the request body into dst for handlers
+// that write their own error responses (they typically map the returned
+// error to response.BadRequest). It shares readJSONBody with parseJSON, so
+// an empty body is rejected here too rather than decoding to a zero value.
+func decodeBody(r *http.Request, dst any) error {
+	return readJSONBody(nil, r, dst)
 }

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -99,6 +99,25 @@ func TestParseJSON_Malformed(t *testing.T) {
 	}
 }
 
+func TestDecodeBody_EmptyBodyRejected(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	var got parsePayload
+	if err := decodeBody(req, &got); err == nil {
+		t.Fatal("decodeBody(empty) = nil error, want empty-body error")
+	}
+}
+
+func TestDecodeBody_Valid(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"ok"}`))
+	var got parsePayload
+	if err := decodeBody(req, &got); err != nil {
+		t.Fatalf("decodeBody error = %v, want nil", err)
+	}
+	if got.Name != "ok" {
+		t.Fatalf("Name = %q, want %q", got.Name, "ok")
+	}
+}
+
 func TestParseJSON_OversizedBody(t *testing.T) {
 	body := strings.Repeat("x", maxBodySize+1)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -1437,19 +1436,6 @@ func (h *SingboxRouterHandler) SetRouteFinal(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	response.Success(w, map[string]bool{"ok": true})
-}
-
-func decodeBody(r *http.Request, dst any) error {
-	r.Body = http.MaxBytesReader(nil, r.Body, 1<<20)
-	defer r.Body.Close()
-	raw, err := io.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	if len(raw) == 0 {
-		return nil
-	}
-	return json.Unmarshal(raw, dst)
 }
 
 // GetStaging returns the current draft state for the router slot.

--- a/internal/api/staticroute.go
+++ b/internal/api/staticroute.go
@@ -170,9 +170,8 @@ func (h *StaticRouteHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -205,9 +204,8 @@ func (h *StaticRouteHandler) SetEnabled(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "Missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -652,9 +652,8 @@ func (h *SubscriptionHandler) Get(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	sub, err := h.svc.Get(id)
@@ -684,7 +683,10 @@ func (h *SubscriptionHandler) Update(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
+	id, ok := requireQueryID(w, r)
+	if !ok {
+		return
+	}
 	var req UpdateSubscriptionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		response.ErrorWithStatus(w, http.StatusBadRequest, "bad request body", "INVALID_JSON")
@@ -739,9 +741,8 @@ func (h *SubscriptionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.BadRequest(w, "id required")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if sub, err := h.svc.Get(id); err == nil {
@@ -811,7 +812,10 @@ func (h *SubscriptionHandler) ActiveMember(w http.ResponseWriter, r *http.Reques
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
+	id, ok := requireQueryID(w, r)
+	if !ok {
+		return
+	}
 	h.log.Info("subscription-active-member", id, "requested via API")
 	var req ActiveMemberRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -851,9 +855,8 @@ func (h *SubscriptionHandler) ActiveNow(w http.ResponseWriter, r *http.Request) 
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	h.log.Info("subscription-active-now", id, "requested via API")
@@ -888,9 +891,8 @@ func (h *SubscriptionHandler) GetStream(w http.ResponseWriter, r *http.Request) 
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 
@@ -960,7 +962,10 @@ func (h *SubscriptionHandler) OrphansDelete(w http.ResponseWriter, r *http.Reque
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
+	id, ok := requireQueryID(w, r)
+	if !ok {
+		return
+	}
 	h.log.Info("subscription-orphans-delete", id, "requested via API")
 	if err := h.svc.DeleteOrphans(r.Context(), id); err != nil {
 		response.InternalError(w, err.Error())
@@ -977,9 +982,8 @@ func (h *SubscriptionHandler) RejectedToInfo(w http.ResponseWriter, r *http.Requ
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	var req MoveRejectedToInfoRequest
@@ -1012,9 +1016,8 @@ func (h *SubscriptionHandler) InfoRemove(w http.ResponseWriter, r *http.Request)
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	var req RemoveInfoItemRequest
@@ -1059,9 +1062,8 @@ func (h *SubscriptionHandler) AddMember(w http.ResponseWriter, r *http.Request) 
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	h.log.Info("subscription-member-add", id, "requested via API")
@@ -1110,9 +1112,8 @@ func (h *SubscriptionHandler) RemoveMember(w http.ResponseWriter, r *http.Reques
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	h.log.Info("subscription-member-remove", id, "requested via API")
@@ -1164,9 +1165,8 @@ func (h *SubscriptionHandler) ExcludeMembers(w http.ResponseWriter, r *http.Requ
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	h.log.Info("subscription-member-exclude", id, "requested via API")
@@ -1204,9 +1204,8 @@ func (h *SubscriptionHandler) RestoreMembers(w http.ResponseWriter, r *http.Requ
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	h.log.Info("subscription-member-restore", id, "requested via API")

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/sys/kmod"
 	"github.com/hoaxisr/awg-manager/internal/sys/ndmsinfo"
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
 	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
 	"github.com/hoaxisr/awg-manager/internal/sys/routerclock"
 	"github.com/hoaxisr/awg-manager/internal/sys/routerinfo"
@@ -429,7 +429,7 @@ func (h *SystemHandler) Info(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Router LAN IP (from br0 interface)
-	routerIP := getBr0IP()
+	routerIP := netif.FirstIPv4(storage.DefaultInterface)
 
 	info := h.buildSystemInfo(disableMemorySaving, gcMemLimit, gogc, kernelModuleExists, kernelModuleLoaded, kernelModuleModel, kernelModuleVersion, isAarch64, activeBackendType, routerIP)
 
@@ -635,26 +635,6 @@ func evalNativewg(hasWireguardComponent, supportsASC, awgProxyLoaded bool) (avai
 func nativewgStatus() (available bool, reason string) {
 	_, err := os.Stat("/proc/awg_proxy/version")
 	return evalNativewg(ndmsinfo.HasWireguardComponent(), ndmsinfo.SupportsWireguardASC(), err == nil)
-}
-
-// getBr0IP returns the first IPv4 address of the br0 (Bridge0) interface.
-func getBr0IP() string {
-	iface, err := net.InterfaceByName("br0")
-	if err != nil {
-		return ""
-	}
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return ""
-	}
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok {
-			if ip4 := ipnet.IP.To4(); ip4 != nil {
-				return ip4.String()
-			}
-		}
-	}
-	return ""
 }
 
 // wanInterfaceJSON is the JSON response for a single WAN interface.

--- a/internal/api/testing.go
+++ b/internal/api/testing.go
@@ -114,9 +114,8 @@ func (h *TestingHandler) CheckIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -171,9 +170,8 @@ func (h *TestingHandler) CheckConnectivity(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -225,9 +223,8 @@ func (h *TestingHandler) SpeedTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {

--- a/internal/api/tunnels.go
+++ b/internal/api/tunnels.go
@@ -796,9 +796,8 @@ func (h *TunnelsHandler) Traffic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	// Read-only handler reading an in-memory map: tolerate non-AWG ids
@@ -849,9 +848,8 @@ func (h *TunnelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -1000,9 +998,8 @@ func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -1192,9 +1189,8 @@ func (h *TunnelsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -1265,9 +1261,8 @@ func (h *TunnelsHandler) Export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {
@@ -1357,9 +1352,8 @@ func (h *TunnelsHandler) ReplaceConf(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	id := r.URL.Query().Get("id")
-	if id == "" {
-		response.Error(w, "missing id parameter", "MISSING_ID")
+	id, ok := requireQueryID(w, r)
+	if !ok {
 		return
 	}
 	if !isValidTunnelID(id) {

--- a/internal/auth/keenetic.go
+++ b/internal/auth/keenetic.go
@@ -9,13 +9,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
 )
 
 const (
@@ -48,7 +48,7 @@ func NewKeeneticClient() *KeeneticClient {
 // resolveAddr detects router IP (br0) and HTTP port (RCI) once.
 func (c *KeeneticClient) resolveAddr() {
 	c.routerAddrOnce.Do(func() {
-		ip := getBr0IP()
+		ip := netif.FirstIPv4("br0")
 		if ip == "" {
 			ip = "192.168.1.1"
 		}
@@ -88,28 +88,6 @@ func getHTTPPort() int {
 	}
 
 	return 80
-}
-
-// getBr0IP returns the first IPv4 address of br0 interface.
-func getBr0IP() string {
-	iface, err := net.InterfaceByName("br0")
-	if err != nil {
-		return ""
-	}
-
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return ""
-	}
-
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok {
-			if ip4 := ipnet.IP.To4(); ip4 != nil {
-				return ip4.String()
-			}
-		}
-	}
-	return ""
 }
 
 // Authenticate verifies credentials against Keenetic router.
@@ -234,4 +212,3 @@ func (c *KeeneticClient) postAuth(ctx context.Context, authURL, login, hashedPas
 
 	return nil
 }
-

--- a/internal/dnscheck/ensure_iphost_test.go
+++ b/internal/dnscheck/ensure_iphost_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
 )
 
 type fakeNDMS struct {
@@ -108,7 +110,7 @@ func TestCreateIPHost_InvalidatesCacheOnSuccess(t *testing.T) {
 // must NOT issue a create POST — that's what triggered NDMS to log
 // 'Core::Configurator: not found: "ip/host/awgm-dnscheck.test"'.
 func TestEnsureIPHost_SkipsPostWhenAlreadyCorrect(t *testing.T) {
-	routerIP := getBr0IP()
+	routerIP := netif.FirstIPv4("br0")
 	if routerIP == "" {
 		t.Skip("no br0 IP on this test host")
 	}

--- a/internal/dnscheck/service.go
+++ b/internal/dnscheck/service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/ndms"
 	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
 )
 
 const probeDomain = "awgm-dnscheck.test"
@@ -93,7 +93,7 @@ func NewService(
 // 'Core::Configurator: not found: "ip/host/awgm-dnscheck.test"' because
 // it resolved the leaf path before creating.
 func (s *Service) EnsureIPHost(ctx context.Context) {
-	routerIP := getBr0IP()
+	routerIP := netif.FirstIPv4("br0")
 	if routerIP == "" {
 		s.appLog.Warn("ensure-ip-host", probeDomain, "br0 has no IPv4, skipping")
 		return
@@ -318,29 +318,4 @@ func (s *Service) resolveHostname(ctx context.Context, ip string) string {
 		}
 	}
 	return ip
-}
-
-// getBr0IP returns the first IPv4 address of the br0 interface.
-func getBr0IP() string {
-	iface, err := net.InterfaceByName("br0")
-	if err != nil {
-		return ""
-	}
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return ""
-	}
-	for _, addr := range addrs {
-		var ip net.IP
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		}
-		if ip != nil && ip.To4() != nil {
-			return ip.To4().String()
-		}
-	}
-	return ""
 }

--- a/internal/hydraroute/confgen.go
+++ b/internal/hydraroute/confgen.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 // Paths are package-level vars so tests can override them via t.TempDir().
@@ -88,13 +90,5 @@ func WriteWholeFile(filePath, content string) error {
 }
 
 func atomicWrite(filePath, content string) error {
-	tmpPath := filePath + ".awgm.tmp"
-	if err := os.WriteFile(tmpPath, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("hydraroute: write tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, filePath); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("hydraroute: rename tmp: %w", err)
-	}
-	return nil
+	return storage.AtomicWrite(filePath, []byte(content))
 }

--- a/internal/hydraroute/geodata.go
+++ b/internal/hydraroute/geodata.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
 	"github.com/hoaxisr/awg-manager/internal/sys/httpdownload"
 )
 
@@ -966,7 +967,16 @@ func downloadFileWithClient(ctx context.Context, client *http.Client, rawURL, de
 	req.Header.Set("User-Agent", "curl/8.7.1")
 
 	if client == nil {
-		client = &http.Client{}
+		// Build the direct-download fallback on the canonical httpclient base
+		// so it inherits the pinned HTTP/1.1 ALPN + ForceAttemptHTTP2=false —
+		// geo mirrors like raw.githubusercontent.com return EOF/malformed h2
+		// otherwise (the failure httpclient exists to prevent).
+		tr, terr := httpclient.NewTransport(httpclient.TransportConfig{})
+		if terr != nil || tr == nil {
+			client = &http.Client{}
+		} else {
+			client = &http.Client{Transport: tr}
+		}
 	}
 
 	resp, err := client.Do(req)

--- a/internal/ndms/events/installer.go
+++ b/internal/ndms/events/installer.go
@@ -2,9 +2,10 @@ package events
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 //go:embed hook-script.sh
@@ -57,7 +58,7 @@ func (i *Installer) Install() error {
 			continue
 		}
 
-		if err := writeAtomic(path, []byte(hookScriptContent)); err != nil {
+		if err := storage.AtomicWrite(path, []byte(hookScriptContent)); err != nil {
 			i.Log.Warnf("install hook %s: write: %v", hook, err)
 			if firstErr == nil {
 				firstErr = err
@@ -72,28 +73,4 @@ func (i *Installer) Install() error {
 		}
 	}
 	return firstErr
-}
-
-// writeAtomic writes to a sibling tmp file then renames.
-func writeAtomic(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, "hook-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create tmp: %w", err)
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("write tmp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("close tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename: %w", err)
-	}
-	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -372,18 +372,18 @@ func generateInstanceID() string {
 // Priority: 1) preferred port from settings, 2) default port (2222), 3) fallback range (8080-8090).
 func (s *Server) FindFreePort(preferredPort int) (int, error) {
 	// Try preferred port from settings
-	if preferredPort > 0 && preferredPort <= 65535 && isPortFree(preferredPort) {
+	if preferredPort > 0 && preferredPort <= 65535 && IsPortFree(preferredPort) {
 		return preferredPort, nil
 	}
 
 	// Try default port (2222)
-	if isPortFree(DefaultPort) {
+	if IsPortFree(DefaultPort) {
 		return DefaultPort, nil
 	}
 
 	// Fallback to range 8080-8090
 	for port := FallbackPortStart; port <= FallbackPortEnd; port++ {
-		if isPortFree(port) {
+		if IsPortFree(port) {
 			return port, nil
 		}
 	}
@@ -391,7 +391,8 @@ func (s *Server) FindFreePort(preferredPort int) (int, error) {
 	return 0, fmt.Errorf("no free port: %d occupied, fallback range %d-%d also occupied", DefaultPort, FallbackPortStart, FallbackPortEnd)
 }
 
-func isPortFree(port int) bool {
+// IsPortFree reports whether a TCP port is available for binding.
+func IsPortFree(port int) bool {
 	addr := fmt.Sprintf(":%d", port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 func NewEmptyConfig() *RouterConfig {
@@ -65,11 +67,7 @@ func SaveConfig(path string, cfg *RouterConfig) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".new"
-	if err := os.WriteFile(tmp, raw, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return storage.AtomicWrite(path, raw)
 }
 
 func (c *RouterConfig) AddRuleSet(rs RuleSet) error {

--- a/internal/singbox/router/inspector_ruleset.go
+++ b/internal/singbox/router/inspector_ruleset.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
 )
 
 // ruleSetCacheTTL is how long a downloaded remote rule-set stays valid in
@@ -78,7 +80,18 @@ func (c *ruleSetCache) urlLock(url string) *sync.Mutex {
 
 // httpClient is package-level so tests can swap it via the unexported
 // ruleSetHTTPClient hook. Do not swap from tests using t.Parallel().
-var ruleSetHTTPClient = &http.Client{Timeout: ruleSetDownloadTimeout}
+// Built on the canonical httpclient base for the pinned HTTP/1.1 ALPN +
+// ForceAttemptHTTP2=false — rule-set mirrors like raw.githubusercontent.com
+// return EOF/malformed h2 otherwise.
+var ruleSetHTTPClient = newRuleSetHTTPClient()
+
+func newRuleSetHTTPClient() *http.Client {
+	c := &http.Client{Timeout: ruleSetDownloadTimeout}
+	if tr, err := httpclient.NewTransport(httpclient.TransportConfig{}); err == nil && tr != nil {
+		c.Transport = tr
+	}
+	return c
+}
 
 // getOrDownload returns the local file path for url, downloading and
 // caching it on first call (or after the TTL expires). Format only

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1649,7 +1649,7 @@ func (s *ServiceImpl) RenameExternalOutboundTag(ctx context.Context, oldTag, new
 	if data, ok, err := rewriteRouterConfigOutboundRefs(disabledPath, oldTag, newTag); err != nil {
 		return err
 	} else if ok {
-		if err := writeRouterConfigAtomic(disabledPath, data); err != nil {
+		if err := storage.AtomicWrite(disabledPath, data); err != nil {
 			return err
 		}
 		changed = true
@@ -1692,18 +1692,6 @@ func rewriteRouterConfigOutboundRefs(path, oldTag, newTag string) ([]byte, bool,
 		return nil, false, err
 	}
 	return data, true, nil
-}
-
-func writeRouterConfigAtomic(path string, data []byte) error {
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
 }
 
 func (s *ServiceImpl) ListRules(ctx context.Context) ([]Rule, error) {

--- a/internal/sys/netif/netif.go
+++ b/internal/sys/netif/netif.go
@@ -1,0 +1,32 @@
+// Package netif provides small network-interface helpers shared across the
+// daemon, replacing several copy-pasted getBr0IP/getInterfaceIP functions.
+package netif
+
+import "net"
+
+// FirstIPv4 returns the first IPv4 address (dotted-decimal) assigned to iface,
+// or "" if the interface is absent or has no IPv4. Handles both *net.IPNet
+// (the usual case) and *net.IPAddr address shapes.
+func FirstIPv4(iface string) string {
+	ni, err := net.InterfaceByName(iface)
+	if err != nil {
+		return ""
+	}
+	addrs, err := ni.Addrs()
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip != nil && ip.To4() != nil {
+			return ip.To4().String()
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
This PR consolidates localStorage-backed store patterns into reusable utilities, removes unused UI components and debug files, and fixes a subscription excluded members visibility bug.

## Key Changes

### Store Refactoring
- **New `persisted.ts`**: Generic `createPersistedStore` and `createPersistedFlag` utilities for localStorage-backed stores with SSR safety
- **New `sortStore.ts`**: Shared `createSortStore` for table sort preferences (replaces duplicated logic)
- Migrated existing stores to use new utilities:
  - `peerSort.ts` → uses `createSortStore`
  - `tunnelTableSort.ts` → uses `createSortStore`
  - `settingsSectionIconMode.ts`, `serviceLetterIcons.ts`, `diagnosticsPrivacy.ts`, `compactLayout.ts`, `experimentalSettingsUnlocked.ts`, `developFeedbackFab.ts` → use `createPersistedFlag`

### Component & File Cleanup
- **Removed unused Svelte components**:
  - `SpeedTestCard.svelte` (speed test UI)
  - `GeoTagBrowserModal.svelte` (geo tag browser)
  - `DiagnosticsTestList.svelte` (diagnostics test list)
  - `AddServerModal.svelte` (server addition modal)
  - `SaveStatusIndicator.svelte` (save status UI)
  - `StatRow.svelte` (stat tiles)
  - `SimpleMatchersEditModal.svelte` (matcher editor)
  - `CatalogPresetRow.svelte` (catalog preset row)
  - `SubscriptionList.svelte` (subscription list)
  - `SingboxTunnelDetails.svelte` (singbox details)
  - `TunnelListColumnHeader.svelte` (column header)
  - `TunnelFieldLabel.svelte` (field label)
  - And several test files and helper scripts

- **Removed debug/generated files**:
  - `debug.md` (IPK build guide)
  - `scripts/generate-tabler-icons.mjs` (icon generation script)
  - `frontend/scripts/tabler-icons.json` (generated icon list)
  - `frontend/src/lib/components/ui/tabler-icons.ts` (auto-generated)
  - `.build-warnings.txt` (build output)
  - Legacy kernel module binaries in `kmod/awg-proxy/out/`

### Bug Fixes
- **Subscription excluded members**: Fixed visibility of excluded servers after exclusion ([#383](https://github.com/hoaxisr/awg-manager/issues/383))
  - Added `buildExcludedDTO` helper in `subscription.go` to properly serialize excluded tags and members
  - Updated subscription stream response to include excluded data

### Backend Improvements
- **New `netif` package**: Centralized network interface helpers (replaces copy-pasted `getBr0IP`/`getInterfaceIP` functions)
- **Error handling**: Enhanced `helpers.go` with `errEmptyBody` and `errInvalidJSON` constants for better payload validation
- **Code cleanup**: Removed unused imports (`net`, `sync`, `io`, `strings`) and dead code across multiple files
- **Test updates**: Removed obsolete test cases and updated diagnostics tests to use new `TestResult` structure

### Configuration & Environment
- **`.env.example`**: Added comments explaining local dev setup
- **`.gitignore`**: Added `.env` and `.build-warnings.txt` to ignored files
- **Version bump**: 2.15.0 → 2.15.1

## Implementation Details
- All persisted stores now follow a consistent pattern with `defaultValue`, `deserialize`, and `serialize` callbacks
- SSR-safe: stores use `browser` check before accessing localStorage
- Removed icon generation pipeline (Tabler icons now managed differently)
- Cleaned up unused API endpoints and handlers

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg