### PR TITLE
Фиксы открытых bug-issue: #428, #426, #420

### DIFF
--- a/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
+++ b/frontend/src/lib/components/subscriptions/AddTunnelWizard.svelte
@@ -203,9 +203,19 @@
 		previewing = true;
 		error = '';
 		try {
-			previewMembers = await api.previewSubscription({
+			const members = await api.previewSubscription({
 				url,
 				headers: parseHeadersText(headersText),
+			});
+			// Дедуп по key обязателен: список рендерится keyed each'ем по
+			// member.key, и дубликат ключа роняет рендер (each_key_duplicate) —
+			// модалка замирает на «Загрузка...» (issue #428). Бэкенд уже
+			// дедуплицирует, это страховка от старых бэкендов и иных источников.
+			const seen = new Set<string>();
+			previewMembers = (members ?? []).filter((m) => {
+				if (seen.has(m.key)) return false;
+				seen.add(m.key);
+				return true;
 			});
 			excludedKeys = new Set();
 			urlStep = 'preview';

--- a/frontend/src/lib/stores/singboxRouter.ts
+++ b/frontend/src/lib/stores/singboxRouter.ts
@@ -153,6 +153,18 @@ function createSingboxRouterStore() {
 		}
 	}
 
+	// reloadSettings is the settings counterpart of reloadStatus: a light
+	// primer for consumers that need routingMode before any sing-box tab has
+	// run loadAll (issue #420 — the tab bar mutes the dormant TProxy/FakeIP
+	// chip from `enabled && routingMode`, so both must be primed on page load).
+	async function reloadSettings(): Promise<void> {
+		try {
+			settings.set(await api.singboxRouterGetSettings());
+		} catch {
+			return;
+		}
+	}
+
 	function applyStatus(data: SingboxRouterStatus): void {
 		status.set(data);
 	}
@@ -205,6 +217,7 @@ function createSingboxRouterStore() {
 		error: { subscribe: error.subscribe },
 		loadAll,
 		reloadStatus,
+		reloadSettings,
 		loadStaging,
 		loadRulesSnapshot,
 		applyStatus,

--- a/frontend/src/routes/routing/+page.svelte
+++ b/frontend/src/routes/routing/+page.svelte
@@ -52,6 +52,11 @@
         // immediately on page load instead of waiting for the next polling
         // tick after the user actually clicks into the sing-box sub-tab.
         void singboxRouterStore.reloadStatus();
+        // Settings must be primed too (issue #420): the TProxy/FakeIP chip
+        // mute-XOR reads `enabled && routingMode`, and routingMode lives in
+        // settings. Without this the dormant mode's chip rendered as active
+        // until the user first visited a sing-box tab (which runs loadAll).
+        void singboxRouterStore.reloadSettings();
     });
     onDestroy(() => {
         unsubRouting?.();

--- a/internal/api/control.go
+++ b/internal/api/control.go
@@ -108,6 +108,10 @@ func (h *ControlHandler) Start(w http.ResponseWriter, r *http.Request) {
 	if errors.Is(err, tunnel.ErrAlreadyRunning) {
 		err = nil // tunnel already running — user's intent fulfilled
 	}
+	if errors.Is(err, tunnel.ErrOperationInProgress) {
+		response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "OPERATION_IN_PROGRESS")
+		return
+	}
 	if err != nil {
 		h.log.Warn("start", id, "Failed to start tunnel: "+err.Error())
 		response.Error(w, err.Error(), "START_FAILED")
@@ -157,6 +161,11 @@ func (h *ControlHandler) Stop(w http.ResponseWriter, r *http.Request) {
 		Type:   orchestrator.EventStop,
 		Tunnel: id,
 	}); err != nil {
+		if errors.Is(err, tunnel.ErrOperationInProgress) {
+			// Busy lock — nothing was attempted, do NOT flip Enabled.
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "OPERATION_IN_PROGRESS")
+			return
+		}
 		// Always sync Enabled=false — user's intent is "OFF" regardless of current state.
 		// ErrNotRunning means tunnel is already stopped/disabled, but we still want Enabled=false
 		// so it doesn't auto-start on boot.
@@ -209,6 +218,10 @@ func (h *ControlHandler) Restart(w http.ResponseWriter, r *http.Request) {
 		Type:   orchestrator.EventRestart,
 		Tunnel: id,
 	}); err != nil {
+		if errors.Is(err, tunnel.ErrOperationInProgress) {
+			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "OPERATION_IN_PROGRESS")
+			return
+		}
 		h.log.Warn("restart", id, "Failed to restart tunnel: "+err.Error())
 		response.Error(w, err.Error(), "RESTART_FAILED")
 		return

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -329,22 +329,50 @@ func (o *Orchestrator) HandleEvent(ctx context.Context, event Event) error {
 		return o.executeActionsGrouped(ctx, actions)
 	}
 
-	// Single-tunnel event: lock that tunnel
-	o.lockTunnel(tunnelID)
+	// Single-tunnel event: lock that tunnel. Bounded acquisition (issue
+	// #426): if a previous operation wedged (dead endpoint, slow NDMS), an
+	// unbounded mutex made every subsequent start/stop/replace request
+	// queue forever — piling up stale actions that then executed one after
+	// another and kept the tunnel wedged until the daemon was restarted.
+	// Failing fast with ErrOperationInProgress gives the UI an honest,
+	// retryable "операция уже выполняется" instead of a hung request.
+	if err := o.lockTunnel(ctx, tunnelID); err != nil {
+		return err
+	}
 	defer o.unlockTunnel(tunnelID)
 	return o.executeActions(ctx, actions)
 }
 
-// lockTunnel acquires the per-tunnel mutex.
-func (o *Orchestrator) lockTunnel(tunnelID string) {
-	mu, _ := o.tunnelMu.LoadOrStore(tunnelID, &sync.Mutex{})
-	mu.(*sync.Mutex).Lock()
+// tunnelLockTimeout bounds how long a caller waits for a busy tunnel's
+// execution lock before giving up with ErrOperationInProgress. Long enough
+// to ride out a normal start/stop sequence ahead in the queue, short enough
+// that the HTTP caller gets an answer instead of a hung request.
+const tunnelLockTimeout = 15 * time.Second
+
+// lockTunnel acquires the per-tunnel execution semaphore. Gives up when ctx
+// is cancelled (client disconnected) or after tunnelLockTimeout.
+func (o *Orchestrator) lockTunnel(ctx context.Context, tunnelID string) error {
+	semAny, _ := o.tunnelMu.LoadOrStore(tunnelID, make(chan struct{}, 1))
+	sem := semAny.(chan struct{})
+	timer := time.NewTimer(tunnelLockTimeout)
+	defer timer.Stop()
+	select {
+	case sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("%w (%s)", tunnel.ErrOperationInProgress, tunnelID)
+	case <-timer.C:
+		return fmt.Errorf("%w (%s)", tunnel.ErrOperationInProgress, tunnelID)
+	}
 }
 
-// unlockTunnel releases the per-tunnel mutex.
+// unlockTunnel releases the per-tunnel execution semaphore.
 func (o *Orchestrator) unlockTunnel(tunnelID string) {
-	if mu, ok := o.tunnelMu.Load(tunnelID); ok {
-		mu.(*sync.Mutex).Unlock()
+	if semAny, ok := o.tunnelMu.Load(tunnelID); ok {
+		select {
+		case <-semAny.(chan struct{}):
+		default: // already released / entry recreated after cleanup — no-op
+		}
 	}
 }
 
@@ -358,6 +386,17 @@ func (o *Orchestrator) cleanupTunnelLock(tunnelID string) {
 func (o *Orchestrator) executeActions(ctx context.Context, actions []Action) error {
 	var firstErr error
 	for _, action := range actions {
+		// Abandoned caller (client disconnected / request deadline) — stop
+		// BETWEEN actions, never mid-action, so each executed step is whole.
+		// Any partially-applied sequence is healed by the reconcile loop;
+		// grinding through the rest of a stale queue while holding the
+		// tunnel lock is what wedged the UI in issue #426.
+		if err := ctx.Err(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			break
+		}
 		if err := o.executeOne(ctx, action); err != nil {
 			o.appLog.Warn("execute-action", action.Tunnel, fmt.Sprintf("action type %d failed: %s", action.Type, err.Error()))
 			if firstErr == nil {
@@ -420,7 +459,12 @@ func (o *Orchestrator) executeGroup(ctx context.Context, group []Action) error {
 	if tid == "" {
 		return o.executeActions(ctx, group)
 	}
-	o.lockTunnel(tid)
+	// Bounded like the single-tunnel path: a wedged tunnel skips its group
+	// (logged via firstErr) instead of stalling the whole boot/reconnect
+	// sweep behind one dead endpoint.
+	if err := o.lockTunnel(ctx, tid); err != nil {
+		return err
+	}
 	defer o.unlockTunnel(tid)
 	return o.executeActions(ctx, group)
 }

--- a/internal/orchestrator/tunnel_lock_test.go
+++ b/internal/orchestrator/tunnel_lock_test.go
@@ -1,0 +1,71 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/tunnel"
+)
+
+// Issue #426: the per-tunnel execution lock must be bounded. A wedged
+// operation used to make every subsequent start/stop/replace request block
+// on a bare mutex forever — the UI showed «Операция уже выполняется» until
+// the daemon was restarted.
+func TestLockTunnel_BusyFailsFastOnCtxCancel(t *testing.T) {
+	o := &Orchestrator{}
+
+	if err := o.lockTunnel(context.Background(), "tun_a"); err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := o.lockTunnel(ctx, "tun_a")
+	if !errors.Is(err, tunnel.ErrOperationInProgress) {
+		t.Fatalf("busy lock: err = %v, want ErrOperationInProgress", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("busy lock waited %s — must give up with the caller's ctx", elapsed)
+	}
+
+	// Release → the tunnel is lockable again (no leaked state).
+	o.unlockTunnel("tun_a")
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	if err := o.lockTunnel(ctx2, "tun_a"); err != nil {
+		t.Fatalf("relock after unlock: %v", err)
+	}
+	o.unlockTunnel("tun_a")
+}
+
+// Different tunnels never contend with each other.
+func TestLockTunnel_IndependentPerTunnel(t *testing.T) {
+	o := &Orchestrator{}
+	if err := o.lockTunnel(context.Background(), "tun_a"); err != nil {
+		t.Fatalf("lock a: %v", err)
+	}
+	defer o.unlockTunnel("tun_a")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := o.lockTunnel(ctx, "tun_b"); err != nil {
+		t.Fatalf("lock b must not contend with a: %v", err)
+	}
+	o.unlockTunnel("tun_b")
+}
+
+// Double-unlock (or unlock after cleanupTunnelLock) must be a harmless no-op.
+func TestUnlockTunnel_Idempotent(t *testing.T) {
+	o := &Orchestrator{}
+	if err := o.lockTunnel(context.Background(), "tun_a"); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	o.unlockTunnel("tun_a")
+	o.unlockTunnel("tun_a") // must not panic or corrupt the semaphore
+	if err := o.lockTunnel(context.Background(), "tun_a"); err != nil {
+		t.Fatalf("relock: %v", err)
+	}
+	o.unlockTunnel("tun_a")
+}

--- a/internal/singbox/subscription/preview_test.go
+++ b/internal/singbox/subscription/preview_test.go
@@ -1,0 +1,66 @@
+package subscription
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Issue #428: a feed listing the same endpoint twice (identical identity,
+// different labels) produced duplicate preview keys. The frontend renders the
+// preview with a keyed each over member.key, so a duplicate key crashed the
+// render (each_key_duplicate) and froze the add-subscription wizard on
+// «Загрузка...». PreviewURL must dedupe by key exactly like ApplyDiff does
+// on refresh (SkippedDuplicate) — the refresh creates one member anyway.
+func TestPreviewURL_DedupesByExclusionKey(t *testing.T) {
+	const link = "vless://11111111-2222-3333-4444-555555555555@a.example.com:443?security=tls&sni=a.example.com&type=tcp"
+	body := link + "#Server%20A\n" + link + "#Server%20A%20(backup)\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	svc := NewService(nil, nil)
+	members, err := svc.PreviewURL(context.Background(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("PreviewURL: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 deduped member, got %d: %+v", len(members), members)
+	}
+	seen := map[string]struct{}{}
+	for _, m := range members {
+		if m.Key == "" {
+			t.Errorf("member has empty key: %+v", m)
+		}
+		if _, dup := seen[m.Key]; dup {
+			t.Errorf("duplicate preview key %q", m.Key)
+		}
+		seen[m.Key] = struct{}{}
+	}
+}
+
+// Distinct endpoints must NOT be collapsed by the dedupe.
+func TestPreviewURL_KeepsDistinctMembers(t *testing.T) {
+	body := "vless://11111111-2222-3333-4444-555555555555@a.example.com:443?security=tls&type=tcp#A\n" +
+		"vless://11111111-2222-3333-4444-555555555555@b.example.com:443?security=tls&type=tcp#B\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	svc := NewService(nil, nil)
+	members, err := svc.PreviewURL(context.Background(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("PreviewURL: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d: %+v", len(members), members)
+	}
+	if members[0].Key == members[1].Key {
+		t.Fatalf("distinct servers must have distinct keys, both %q", members[0].Key)
+	}
+}

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -1175,10 +1175,21 @@ func (s *Service) PreviewURL(ctx context.Context, url string, headers []Header) 
 	parts := partitionParsedOutbounds("preview", parseRes.Outbounds)
 	out := make([]PreviewMember, 0, len(parts.Valid))
 	keys := chooseKeys(parts.Valid)
+	// Dedupe by exclusion key, mirroring ApplyDiff's SkippedDuplicate: a
+	// byte-identical duplicate in the feed becomes ONE member on refresh, so
+	// the preview must not list it twice either. Issue #428: duplicate keys
+	// also crash the frontend's keyed list (each_key_duplicate) and freeze
+	// the add-subscription wizard on «Загрузка...».
+	seen := make(map[string]struct{}, len(parts.Valid))
 	for i, p := range parts.Valid {
+		key := suffixOf(keys[i])
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
 		mi := toMemberInfo(StableTag("preview00", p), p) // tag игнорируется, берём поля
 		out = append(out, PreviewMember{
-			Key: suffixOf(keys[i]), Label: mi.Label, Protocol: mi.Protocol,
+			Key: key, Label: mi.Label, Protocol: mi.Protocol,
 			Server: mi.Server, Port: mi.Port, SNI: mi.SNI,
 			Transport: mi.Transport, Security: mi.Security,
 		})

--- a/internal/tunnel/errors.go
+++ b/internal/tunnel/errors.go
@@ -71,4 +71,3 @@ func NewOpError(op, tunnelID, component string, err error) *OpError {
 		Err:       err,
 	}
 }
-

--- a/internal/tunnel/errors.go
+++ b/internal/tunnel/errors.go
@@ -22,6 +22,11 @@ var (
 	// ErrTransitioning indicates the tunnel is currently starting or stopping.
 	ErrTransitioning = errors.New("tunnel is transitioning")
 
+	// ErrOperationInProgress indicates another lifecycle operation currently
+	// holds the tunnel's execution lock (issue #426). Callers surface it as a
+	// retryable 409 instead of queueing behind the lock indefinitely.
+	ErrOperationInProgress = errors.New("операция с туннелем уже выполняется — дождитесь завершения предыдущей")
+
 	// ErrAddressInUse indicates the tunnel address is already assigned to a system interface.
 	ErrAddressInUse = errors.New("address already in use")
 


### PR DESCRIPTION
## Summary

Три открытых issue с тегом bug, по фиксу на коммит.

## Key Changes

### #428 — вечная «Загрузка...» при добавлении sing-box подписки по URL
Фид с одним и тем же эндпоинтом под разными лейблами давал дубликаты `Key` в ответе `/subscriptions/preview` (label не входит в identity-ключ). Список превью рендерится keyed each'ем по `member.key` — на дубликате Svelte 5 роняет рендер (`each_key_duplicate`), и мастер замирает на «Загрузка...» при успешном 200. Падение воспроизведено vitest-репродукцией.

- `PreviewURL` дедуплицирует по exclusion-ключу зеркально `ApplyDiff.SkippedDuplicate` — refresh всё равно создаёт одного участника на такие дубли (+2 Go-теста)
- страховочная дедупликация в `fetchPreview` мастера (старые бэкенды)

Fixes #428

### #426 — «Операция уже выполняется» до перезапуска AWGM
Per-tunnel замок оркестратора был голым `sync.Mutex`: одна заклинившая операция (замена конфига мёртвого туннеля) заставляла каждый следующий start/stop/replace вставать в очередь навсегда, после чего устаревшие действия доигрывались по одному — туннель оставался заклиненным до перезапуска демона.

- замок стал канальным семафором с ограниченным захватом: отмена контекста (F5/уход клиента) или 15с ожидания → типизированная `tunnel.ErrOperationInProgress` (+3 теста)
- API Start/Stop/Restart отвечают честным 409 `OPERATION_IN_PROGRESS`; Stop при этом не трогает `Enabled`
- `executeActions` прерывает очередь между действиями при отменённом контексте — частичные последовательности долечивает reconcile
- boot/reconnect-свипы пропускают заклиненный туннель вместо остановки всей группы

Fixes #426

### #420 — «активный» шрифт выключенной вкладки Sing-box: FakeIP
Mute-XOR вкладок TProxy/FakeIP вычисляется из `enabled && routingMode`, но `routingMode` живёт в settings, которые грузились только при заходе на SB-вкладку — до этого спящая вкладка рендерилась активным шрифтом.

- в сторе появился лёгкий `reloadSettings()` (зеркало `reloadStatus`), страница маршрутизации праймит оба значения на mount

Fixes #420

## Верификация
`go vet` + полный Go-тестсьют — зелёные; кросс-компиляция mips/mipsle/arm64 — OK; svelte-check — 0 ошибок; 1149 frontend-тестов; +5 новых регрессионных тестов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_