### PR TITLE
fix(selective): асинхронная пересборка ipset (504 за nginx), гейты с дедлайном, надёжная репопуляция после ребута

### DIFF
--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { api } from './client';
+import { api, ApiGatewayError } from './client';
 
 describe('ApiClient error shape', () => {
 	const originalFetch = globalThis.fetch;
@@ -95,5 +95,85 @@ describe('ApiClient error shape', () => {
 		expect(url.searchParams.getAll('subgroup')).toEqual(['inbound', 'dns']);
 		expect(url.searchParams.get('limit')).toBe('200');
 		expect(url.searchParams.get('offset')).toBe('0');
+	});
+});
+
+describe('ApiClient gateway/HTML error classification', () => {
+	const originalFetch = globalThis.fetch;
+
+	const NGINX_504 =
+		'<html>\r\n<head><title>504 Gateway Time-out</title></head>\r\n' +
+		'<body>\r\n<center><h1>504 Gateway Time-out</h1></center>\r\n' +
+		'<hr><center>nginx</center>\r\n</body>\r\n</html>';
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function mockResponse(status: number, body: string, contentType: string) {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(body, { status, headers: { 'Content-Type': contentType } }),
+		);
+	}
+
+	async function catchFrom(promise: Promise<unknown>): Promise<unknown> {
+		try {
+			await promise;
+		} catch (e) {
+			return e;
+		}
+		return undefined;
+	}
+
+	it('classifies nginx 504 HTML as ApiGatewayError without leaking markup', async () => {
+		mockResponse(504, NGINX_504, 'text/html');
+		const err = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect(err).toBeInstanceOf(ApiGatewayError);
+		const gw = err as ApiGatewayError;
+		expect(gw.status).toBe(504);
+		expect(gw.code).toBe('GATEWAY_ERROR');
+		expect(gw.message).toBe(
+			'Шлюз не дождался ответа от роутера (504). Операция может продолжаться в фоне.',
+		);
+		expect(gw.message).not.toContain('<');
+	});
+
+	it('classifies 502 HTML as ApiGatewayError', async () => {
+		mockResponse(502, '<html><body>502 Bad Gateway</body></html>', 'text/html');
+		const err = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect(err).toBeInstanceOf(ApiGatewayError);
+		expect((err as ApiGatewayError).status).toBe(502);
+		expect((err as ApiGatewayError).message).not.toContain('<');
+	});
+
+	it('classifies non-JSON 503 as ApiGatewayError, keeps JSON 503 message intact', async () => {
+		mockResponse(503, '<html><body>503</body></html>', 'text/html');
+		const gw = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect(gw).toBeInstanceOf(ApiGatewayError);
+		expect((gw as ApiGatewayError).status).toBe(503);
+
+		mockResponse(503, JSON.stringify({ error: true, message: 'идёт операция' }), 'application/json');
+		const jsonErr = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect(jsonErr).toBeInstanceOf(Error);
+		expect(jsonErr).not.toBeInstanceOf(ApiGatewayError);
+		expect((jsonErr as Error).message).toBe('идёт операция');
+	});
+
+	it('never includes HTML body for non-gateway statuses', async () => {
+		mockResponse(500, '<html><body>Internal Server Error</body></html>', 'text/html');
+		const err = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect(err).toBeInstanceOf(Error);
+		expect(err).not.toBeInstanceOf(ApiGatewayError);
+		expect((err as Error).message).toBe('Ошибка сервера (500)');
+	});
+
+	it('keeps plain-text bodies in the message for non-gateway statuses', async () => {
+		mockResponse(500, 'boom from upstream', 'text/plain');
+		const err = await catchFrom(api.singboxRouterSelectiveRebuild());
+		expect((err as Error).message).toBe('Ошибка сервера (500): boom from upstream');
 	});
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -125,6 +125,28 @@ interface ApiResponse<T> {
 	code?: string;
 }
 
+/**
+ * Ошибка уровня шлюза (nginx перед awg-manager): 502/503/504 без JSON-тела.
+ * Отдельный класс, чтобы вызывающие могли отличить «шлюз не дождался ответа»
+ * (операция может продолжаться в фоне) от настоящей ошибки приложения.
+ */
+export class ApiGatewayError extends Error {
+	readonly code = 'GATEWAY_ERROR';
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = 'ApiGatewayError';
+		this.status = status;
+	}
+}
+
+const GATEWAY_MESSAGES: Record<number, string> = {
+	502: 'Шлюз не смог получить ответ от роутера (502). Операция может продолжаться в фоне.',
+	503: 'Сервер временно недоступен (503). Операция может продолжаться в фоне.',
+	504: 'Шлюз не дождался ответа от роутера (504). Операция может продолжаться в фоне.',
+};
+
 class ApiClient {
 	private baseUrl = '/api';
 	private onUnauthorized?: () => void;
@@ -179,20 +201,32 @@ class ApiClient {
 
 		// Handle 503 Service Unavailable — preserve server message when present.
 		if (response.status === 503) {
-			let message = 'Сервер временно недоступен';
 			if (contentType.includes('application/json')) {
+				let message = 'Сервер временно недоступен';
 				try {
 					const body = (await response.json()) as ApiResponse<unknown>;
 					if (body.message) message = body.message;
 				} catch {
 					// keep default
 				}
+				throw new Error(message);
 			}
-			throw new Error(message);
+			// Non-JSON 503 — страница шлюза (nginx), разметку не показываем.
+			throw new ApiGatewayError(GATEWAY_MESSAGES[503], 503);
 		}
 
 		if (!contentType.includes('application/json')) {
 			const text = await response.text();
+			// Gateway-ошибки (nginx перед awg-manager) отдают HTML-страницы —
+			// классифицируем по статусу и никогда не показываем разметку.
+			if (response.status in GATEWAY_MESSAGES) {
+				throw new ApiGatewayError(GATEWAY_MESSAGES[response.status], response.status);
+			}
+			const looksLikeHtml =
+				contentType.includes('text/html') || text.trimStart().startsWith('<');
+			if (looksLikeHtml) {
+				throw new Error(`Ошибка сервера (${response.status})`);
+			}
 			throw new Error(`Ошибка сервера (${response.status}): ${text.substring(0, 100)}`);
 		}
 
@@ -2228,6 +2262,13 @@ class ApiClient {
 		return this.request('/singbox/router/selective/install-conntrack', { method: 'POST' });
 	}
 
+	/**
+	 * Запускает пересборку ipset. Бэкенд отвечает 202 Accepted сразу —
+	 * data это текущий статус с rebuilding: true («запущено», не «завершено»);
+	 * реальное завершение приходит по SSE singbox-router:selective-progress /
+	 * selective-status. Повторный POST во время пересборки тоже вернёт 202,
+	 * не запуская вторую.
+	 */
 	async singboxRouterSelectiveRebuild(): Promise<SelectiveStatus> {
 		return this.request('/singbox/router/selective/rebuild', { method: 'POST' });
 	}

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { SideDrawer, Toggle, Button, Badge, StatusDot, Modal } from '$lib/components/ui';
-  import { api } from '$lib/api/client';
+  import { api, ApiGatewayError } from '$lib/api/client';
   import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
   import { modeSwitch, modeSwitchBusy } from '$lib/stores/modeSwitch';
   import { singboxStatus } from '$lib/stores/singbox';
@@ -168,6 +168,10 @@
 
   let selectiveStatus = $derived($selectiveBypassStatus);
   let selectiveStatusLoaded = $derived(selectiveStatus !== null);
+  // Пересборка в процессе: локальный флаг покрывает HTTP round-trip (202),
+  // status.rebuilding — фон после ответа и «страница открыта во время пересборки».
+  // Сбрасывается по SSE selective-status с rebuilding: false.
+  let rebuildInFlight = $derived(rebuilding || (selectiveStatus?.rebuilding ?? false));
   let selectiveIpsetOk = $derived(selectiveStatus?.available ?? false);
   let selectiveSnapshot = $derived(selectiveStatus?.snapshot ?? null);
   let hasSnapshot = $derived(
@@ -200,11 +204,31 @@
     rebuilding = true;
     selectiveBypass.resetProgress();
     selectiveBypass.requestModal();
+    const epochBefore = selectiveBypass.statusEpoch();
     try {
+      // 202 Accepted = «запущено», не «завершено»: статус приходит с
+      // rebuilding: true, а завершение доскажут SSE-события
+      // selective-progress / selective-status (модалка закрывается по ним).
       const status = await api.singboxRouterSelectiveRebuild();
-      selectiveBypass.applyStatus(status);
+      // Мгновенно упавшая пересборка публикует терминальный SSE
+      // selective-status РАНЬШЕ, чем разрешится 202 — не затираем более
+      // свежее состояние устаревшим телом ответа (иначе кнопка залипает
+      // в «Пересборка…»).
+      if (selectiveBypass.statusEpoch() === epochBefore) {
+        selectiveBypass.applyStatus(status);
+      }
     } catch (e) {
-      notifications.error('Не удалось пересобрать ipset: ' + (e instanceof Error ? e.message : String(e)));
+      if (e instanceof ApiGatewayError) {
+        // Шлюз (nginx) не дождался ответа, но пересборка продолжается на
+        // сервере — без тоста об ошибке, прогресс доедет по SSE.
+        console.warn('selective rebuild: gateway error, rebuild continues in background', e);
+      } else if ((e as { body?: { code?: string } })?.body?.code === 'OPERATION_IN_PROGRESS') {
+        // 409: сейчас применяется конфигурация sing-box — честный тост
+        // вместо сырого «занято: …».
+        notifications.error('Пересборка недоступна: применяется конфигурация sing-box. Повторите позже.');
+      } else {
+        notifications.error('Не удалось пересобрать ipset: ' + (e instanceof Error ? e.message : String(e)));
+      }
     } finally {
       rebuilding = false;
     }
@@ -396,8 +420,8 @@
             </Button>
           {/if}
 
-          <Button variant="ghost" size="sm" fullWidth loading={rebuilding} onclick={triggerRebuild}>
-            {rebuilding ? 'Пересборка…' : 'Пересобрать ipset'}
+          <Button variant="ghost" size="sm" fullWidth loading={rebuildInFlight} onclick={triggerRebuild}>
+            {rebuildInFlight ? 'Пересборка…' : 'Пересобрать ipset'}
           </Button>
         {:else}
           <!-- Доступно, но выключено -->

--- a/frontend/src/lib/components/sb-router/selectiveRebuildTrigger.ts
+++ b/frontend/src/lib/components/sb-router/selectiveRebuildTrigger.ts
@@ -14,8 +14,11 @@ import { selectiveBypass } from '$lib/stores/selectiveBypass';
 
 /**
  * Trigger an ipset rebuild if the router settings have selectiveBypass enabled.
- * Errors are silently swallowed — a stale ipset is preferable to surfacing an
- * extra error notification after a successful rule save.
+ * The POST is async: the backend answers 202 immediately (status with
+ * rebuilding: true) and completion arrives via SSE. Errors — including gateway
+ * timeouts (ApiGatewayError), after which the rebuild keeps running server-side
+ * — are silently swallowed: a stale ipset is preferable to surfacing an extra
+ * error notification after a successful rule save.
  */
 export async function triggerSelectiveRebuildIfEnabled(): Promise<void> {
   const settings = get(singboxRouter.settings);

--- a/frontend/src/lib/stores/selectiveBypass.ts
+++ b/frontend/src/lib/stores/selectiveBypass.ts
@@ -12,13 +12,21 @@ function createSelectiveBypassStore() {
 	// Set to true by explicit triggers (Apply button, engine enable) to request
 	// the global modal open. The modal clears this on close.
 	const modalRequested = writable(false);
+	// Monotonic counter bumped on every applyStatus. Lets callers detect that
+	// a NEWER status (e.g. a terminal SSE event) landed while their request
+	// was in flight, so they can skip applying a stale response body.
+	let epoch = 0;
 
 	return {
 		status,
 		progress,
 		modalRequested,
 		applyStatus(data: SelectiveStatus) {
+			epoch++;
 			status.set(data);
+		},
+		statusEpoch(): number {
+			return epoch;
 		},
 		applyProgress(data: SelectiveProgress) {
 			progress.set(data);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2066,6 +2066,10 @@ export interface SelectiveStatus {
 	installing: boolean;
 	/** Mirrors SingboxRouterSettings.selectiveBypass. */
 	enabled: boolean;
+	/** True while an ipset rebuild is running. POST /selective/rebuild отвечает
+	 *  202 сразу (data = статус с rebuilding: true); завершение приходит по SSE
+	 *  singbox-router:selective-progress / selective-status. */
+	rebuilding?: boolean;
 	/** Current number of entries in AWGM-SELECTIVE ipset. 0 when set doesn't exist. */
 	entryCount: number;
 	/** RFC3339 timestamp of the last successful rebuild. Empty if never rebuilt. */

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -46,7 +46,7 @@ type LoggingSettingsDTO struct {
 	Enabled           bool   `json:"enabled" example:"true"`
 	MaxAge            int    `json:"maxAge" example:"2"`
 	LogLevel          string `json:"logLevel" example:"info"`
-	SingboxLogLevel   string `json:"singboxLogLevel" example:"trace" enums:"trace,debug,info,warn,error,fatal,panic"`
+	SingboxLogLevel   string `json:"singboxLogLevel" example:"info" enums:"trace,debug,info,warn,error,fatal,panic"`
 	AppMaxEntries     int    `json:"appMaxEntries" example:"5000"`
 	SingboxMaxEntries int    `json:"singboxMaxEntries" example:"5000"`
 }

--- a/internal/api/singbox_selective.go
+++ b/internal/api/singbox_selective.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
@@ -26,6 +28,10 @@ type SelectiveStatusData struct {
 	ConntrackAvailable bool `json:"conntrackAvailable"`
 	// Installing is true while opkg install ipset is running.
 	Installing bool `json:"installing"`
+	// Rebuilding is true while an ipset rebuild is in flight (POST /rebuild
+	// responds 202 and runs the rebuild in the background; completion is
+	// delivered via the singbox-router:selective-status SSE event).
+	Rebuilding bool `json:"rebuilding"`
 	// Enabled mirrors SingboxRouterSettings.SelectiveBypass.
 	Enabled bool `json:"enabled"`
 	// EntryCount is the current number of entries in the AWGM-SELECTIVE ipset.
@@ -117,9 +123,19 @@ type SelectiveHandler struct {
 	// check-and-set atomic so two concurrent InstallDeps requests cannot
 	// both slip past the guard and race opkg against itself.
 	installing atomic.Bool
+	// rebuilding serializes handler-launched ipset rebuilds the same way:
+	// a concurrent POST /rebuild (nginx retry after 504, second tab) gets
+	// 202 + rebuilding:true instead of a duplicate background run.
+	rebuilding atomic.Bool
 	builder    SelectiveRebuildTriggerer
 	status     SelectiveStatusProvider
 }
+
+// rebuildTimeout is the overall backstop for one background ipset rebuild.
+const rebuildTimeout = 10 * time.Minute
+
+// installTimeout is the overall backstop for one opkg install run.
+const installTimeout = 10 * time.Minute
 
 // SelectiveRebuildTriggerer is the narrow interface the handler needs from
 // the router service to force an ipset rebuild. Implemented by a wrapper
@@ -134,6 +150,9 @@ type SelectiveStatusProvider interface {
 	LastRebuild() string
 	LastError() string
 	LastSnapshot() *selective.RebuildSnapshot
+	// Rebuilding reports a rebuild in flight regardless of who started it
+	// (this handler or the boot/reconcile auto-rebuild).
+	Rebuilding() bool
 }
 
 // NewSelectiveHandler creates a new handler. configDir is the sing-box config.d
@@ -151,6 +170,12 @@ func NewSelectiveHandler(settings *storage.SettingsStore, configDir string, buil
 //	@Success		200	{object}	SelectiveStatusData
 //	@Router			/singbox/router/selective/status [get]
 func (h *SelectiveHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
+	response.Success(w, h.statusData(r.Context()))
+}
+
+// statusData assembles the SelectiveStatusData payload shared by GetStatus
+// and the 202 responses of Rebuild/InstallDeps.
+func (h *SelectiveHandler) statusData(ctx context.Context) SelectiveStatusData {
 	enabled := false
 	if h.settings != nil {
 		if settings, err := h.settings.Get(); err == nil {
@@ -160,27 +185,30 @@ func (h *SelectiveHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 
 	// EntryCount already returns 0 when the set does not exist — no separate
 	// SetExists fork needed on this per-status-request path.
-	entryCount := selective.EntryCount(r.Context())
+	entryCount := selective.EntryCount(ctx)
 
 	lastRebuild, lastError := "", ""
+	rebuilding := h.rebuilding.Load()
 	var snapshot *selective.RebuildSnapshot
 	if h.status != nil {
 		lastRebuild = h.status.LastRebuild()
 		lastError = h.status.LastError()
 		snapshot = h.status.LastSnapshot()
+		rebuilding = rebuilding || h.status.Rebuilding()
 	}
 
-	response.Success(w, SelectiveStatusData{
+	return SelectiveStatusData{
 		Available:          selective.IsIPSetAvailable(),
 		XtSetAvailable:     selective.IsXtSetAvailable(),
 		ConntrackAvailable: selective.IsConntrackAvailable(),
 		Installing:         h.installing.Load(),
+		Rebuilding:         rebuilding,
 		Enabled:            enabled,
 		EntryCount:         entryCount,
 		LastRebuild:        lastRebuild,
 		LastError:          lastError,
 		Snapshot:           selectiveSnapshotDTO(snapshot),
-	})
+	}
 }
 
 // SelectiveSnapshotMatchersData is the payload for GET .../snapshot/matchers.
@@ -261,7 +289,10 @@ func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
 
 	// Detach cancellation: a client disconnect must not SIGKILL opkg in the
 	// middle of a package transaction (same rationale as Rebuild below).
-	ctx := context.WithoutCancel(r.Context())
+	// The timeout backstops a wedged opkg (dead mirror) so the request —
+	// still synchronous — cannot hang forever.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), installTimeout)
+	defer cancel()
 	if err := selective.InstallIPSet(ctx, nil); err != nil { // progress delivered via SSE by the builder
 		response.InternalError(w, "ipset installation failed: "+err.Error())
 		return
@@ -298,8 +329,10 @@ func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Reque
 	}
 	defer h.installing.Store(false)
 
-	// Detach cancellation — see InstallDeps.
-	if err := selective.InstallConntrackTools(context.WithoutCancel(r.Context()), nil); err != nil {
+	// Detach cancellation + backstop — see InstallDeps.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), installTimeout)
+	defer cancel()
+	if err := selective.InstallConntrackTools(ctx, nil); err != nil {
 		response.InternalError(w, "conntrack installation failed: "+err.Error())
 		return
 	}
@@ -307,13 +340,20 @@ func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Reque
 }
 
 // Rebuild handles POST /api/singbox/router/selective/rebuild.
-// Forces an immediate ipset rebuild from current rules.
+// Starts an ipset rebuild in the background and responds 202 immediately:
+// a full rebuild (DNS resolve over thousands of matchers) easily exceeds the
+// ~60s proxy_read_timeout of the Keenetic nginx reverse proxy, and a
+// synchronous handler handed the browser nginx's stock 504 page while the
+// rebuild kept running. Progress/completion reach the UI via the
+// singbox-router:selective-progress / selective-status SSE events.
 //
-//	@Summary		Force ipset rebuild
+//	@Summary		Force ipset rebuild (asynchronous)
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SelectiveStatusData
+//	@Success		202	{object}	SelectiveStatusData	"rebuild started (or already running); rebuilding reflects live state"
+//	@Failure		409	{object}	APIErrorEnvelope	"sing-box config apply in progress"
+//	@Failure		503	{object}	APIErrorEnvelope	"builder not configured"
 //	@Router			/singbox/router/selective/rebuild [post]
 func (h *SelectiveHandler) Rebuild(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -324,13 +364,61 @@ func (h *SelectiveHandler) Rebuild(w http.ResponseWriter, r *http.Request) {
 		response.ErrorWithStatus(w, http.StatusServiceUnavailable, "selective builder not configured", "NOT_CONFIGURED")
 		return
 	}
-	// Detach cancellation: a client disconnecting mid-rebuild must not abort
-	// the populate (a partial ipset is worse than a stale one). We still wait
-	// synchronously so the response carries the fresh status.
-	ctx := context.WithoutCancel(r.Context())
-	if err := h.builder.Rebuild(ctx); err != nil {
-		response.InternalError(w, "ipset rebuild failed: "+err.Error())
-		return
+	// Pre-checks run BEFORE the CAS so the guard flips only at the point of
+	// no return: flipping first and then bailing (already-rebuilding, gate
+	// held) would let a concurrent request see the flag, answer 202
+	// «rebuilding» and piggyback on a run that never starts.
+	for {
+		if h.status != nil && h.status.Rebuilding() {
+			// A rebuild is already in flight (boot/reconcile auto-rebuild or
+			// one launched via the adapter) — it serves the same intent.
+			h.respondRebuildAccepted(w, r)
+			return
+		}
+		if !heavyop.Default.TryLock() {
+			// A sing-box config apply holds the heavy-op gate: fail fast with
+			// an honest 409 instead of accepting work that would only queue
+			// behind the apply.
+			response.ErrorWithStatus(w, http.StatusConflict, selective.ErrBusy.Error(), "OPERATION_IN_PROGRESS")
+			return
+		}
+		heavyop.Default.Unlock()
+		if h.rebuilding.CompareAndSwap(false, true) {
+			break
+		}
+		if h.rebuilding.Load() {
+			// Concurrent POST (nginx retry, second tab) owns a live run — it
+			// already serves the user's intent, don't start a second one.
+			h.respondRebuildAccepted(w, r)
+			return
+		}
+		// The concurrent run ended between the CAS and the Load — re-run the
+		// pre-checks and try to own a fresh run.
 	}
-	h.GetStatus(w, r)
+
+	// Point of no return: the flag is ours and the goroutine below is the
+	// only thing that clears it.
+	// Detach cancellation: a client disconnecting mid-rebuild must not abort
+	// the populate (a partial ipset is worse than a stale one). The timeout
+	// backstops a wedged rebuild so the flag cannot stay latched forever.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), rebuildTimeout)
+	go func() {
+		defer cancel()
+		defer h.rebuilding.Store(false)
+		// Errors are already surfaced by the builder: terminal
+		// selective-progress/selective-status SSE events plus lastError in
+		// the status payload.
+		_ = h.builder.Rebuild(ctx)
+	}()
+
+	h.respondRebuildAccepted(w, r)
+}
+
+// respondRebuildAccepted writes the 202 payload with the LIVE rebuilding
+// flag: on the launch path h.rebuilding is already set, and on the piggyback
+// paths the live value is the honest one — forcing true here could overwrite
+// a terminal state the UI already received via SSE (an instantly-failed run
+// would otherwise leave the button stuck at «Пересборка…»).
+func (h *SelectiveHandler) respondRebuildAccepted(w http.ResponseWriter, r *http.Request) {
+	response.Accepted(w, h.statusData(r.Context()))
 }

--- a/internal/api/singbox_selective_test.go
+++ b/internal/api/singbox_selective_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
+)
+
+// blockingRebuildTriggerer blocks each Rebuild until release is signalled.
+type blockingRebuildTriggerer struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingRebuildTriggerer) Rebuild(ctx context.Context) error {
+	b.calls.Add(1)
+	b.started <- struct{}{}
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+type stubSelectiveStatus struct {
+	rebuilding bool
+}
+
+func (s *stubSelectiveStatus) LastRebuild() string                      { return "" }
+func (s *stubSelectiveStatus) LastError() string                        { return "" }
+func (s *stubSelectiveStatus) LastSnapshot() *selective.RebuildSnapshot { return nil }
+func (s *stubSelectiveStatus) Rebuilding() bool                         { return s.rebuilding }
+
+func postRebuild(t *testing.T, h *SelectiveHandler) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/singbox/router/selective/rebuild", nil)
+	h.Rebuild(rr, req)
+	return rr
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+func TestSelectiveRebuild_Returns202AndRunsInBackground(t *testing.T) {
+	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{})
+
+	rr := postRebuild(t, h)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("first POST: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"rebuilding":true`) {
+		t.Fatalf("first POST body missing rebuilding:true: %s", rr.Body.String())
+	}
+	<-b.started
+
+	// Concurrent POST (nginx retry / second tab): 202 again, NO second run.
+	rr2 := postRebuild(t, h)
+	if rr2.Code != http.StatusAccepted || !strings.Contains(rr2.Body.String(), `"rebuilding":true`) {
+		t.Fatalf("concurrent POST: code=%d body=%s", rr2.Code, rr2.Body.String())
+	}
+	if got := b.calls.Load(); got != 1 {
+		t.Fatalf("concurrent POST started a duplicate rebuild: calls=%d", got)
+	}
+
+	close(b.release)
+	waitFor(t, "rebuilding flag clear", func() bool { return !h.rebuilding.Load() })
+
+	// Flag cleared — a new POST starts a fresh run.
+	rr3 := postRebuild(t, h)
+	if rr3.Code != http.StatusAccepted {
+		t.Fatalf("post-completion POST: code=%d", rr3.Code)
+	}
+	<-b.started
+	if got := b.calls.Load(); got != 2 {
+		t.Fatalf("expected second rebuild after completion, calls=%d", got)
+	}
+	waitFor(t, "second run finish", func() bool { return !h.rebuilding.Load() })
+}
+
+func TestSelectiveRebuild_409WhenHeavyOpGateHeld(t *testing.T) {
+	if !heavyop.Default.TryLock() {
+		t.Fatal("heavyop gate unexpectedly held")
+	}
+	defer heavyop.Default.Unlock()
+
+	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{})
+
+	rr := postRebuild(t, h)
+	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "OPERATION_IN_PROGRESS") {
+		t.Fatalf("gate-held POST: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if b.calls.Load() != 0 {
+		t.Fatal("rebuild must not start while heavyop gate is held")
+	}
+	if h.rebuilding.Load() {
+		t.Fatal("rebuilding flag must be released on 409")
+	}
+}
+
+func TestSelectiveRebuild_202WhenAutoRebuildInFlight(t *testing.T) {
+	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{rebuilding: true})
+
+	rr := postRebuild(t, h)
+	if rr.Code != http.StatusAccepted || !strings.Contains(rr.Body.String(), `"rebuilding":true`) {
+		t.Fatalf("auto-rebuild POST: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if b.calls.Load() != 0 {
+		t.Fatal("handler must not stack a second rebuild on the boot auto-rebuild")
+	}
+	if h.rebuilding.Load() {
+		t.Fatal("rebuilding flag must be released when piggybacking")
+	}
+}
+
+func TestSelectiveRebuild_MethodAndConfigGuards(t *testing.T) {
+	h := NewSelectiveHandler(nil, "", nil, &stubSelectiveStatus{})
+
+	rr := httptest.NewRecorder()
+	h.Rebuild(rr, httptest.NewRequest(http.MethodGet, "/singbox/router/selective/rebuild", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET rebuild: code=%d", rr.Code)
+	}
+
+	rr = postRebuild(t, h)
+	if rr.Code != http.StatusServiceUnavailable || !strings.Contains(rr.Body.String(), "NOT_CONFIGURED") {
+		t.Fatalf("nil builder POST: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSelectiveGetStatus_ReportsRebuilding(t *testing.T) {
+	st := &stubSelectiveStatus{}
+	h := NewSelectiveHandler(nil, "", nil, st)
+
+	rr := httptest.NewRecorder()
+	h.GetStatus(rr, httptest.NewRequest(http.MethodGet, "/singbox/router/selective/status", nil))
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"rebuilding":false`) {
+		t.Fatalf("idle status: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	st.rebuilding = true
+	rr = httptest.NewRecorder()
+	h.GetStatus(rr, httptest.NewRequest(http.MethodGet, "/singbox/router/selective/status", nil))
+	if !strings.Contains(rr.Body.String(), `"rebuilding":true`) {
+		t.Fatalf("in-flight status body: %s", rr.Body.String())
+	}
+}

--- a/internal/ndms/transport/client.go
+++ b/internal/ndms/transport/client.go
@@ -221,7 +221,7 @@ func (c *Client) PostBatch(ctx context.Context, commands []any) ([]json.RawMessa
 func (c *Client) postJSON(ctx context.Context, payload any) (json.RawMessage, error) {
 	start := time.Now()
 	defer c.recordPerf(start, "POST", "/")
-	if err := c.sem.Acquire(ctx); err != nil {
+	if err := c.sem.acquireWithBackstop(ctx); err != nil {
 		c.appLog.Error("POST", "/", fmt.Sprintf("semaphore: %v", err))
 		return nil, fmt.Errorf("rci POST: %w", err)
 	}
@@ -313,7 +313,7 @@ func bypassBatch(path string) bool {
 func (c *Client) getRawDirect(ctx context.Context, path string) ([]byte, error) {
 	start := time.Now()
 	defer c.recordPerf(start, "GET", path)
-	if err := c.sem.Acquire(ctx); err != nil {
+	if err := c.sem.acquireWithBackstop(ctx); err != nil {
 		c.appLog.Error("GET", path, fmt.Sprintf("semaphore: %v", err))
 		return nil, fmt.Errorf("rci GET %s: %w", path, err)
 	}
@@ -348,7 +348,7 @@ func (c *Client) getRawDirect(ctx context.Context, path string) ([]byte, error) 
 // Use instead of GetRaw when the caller immediately decodes the body (e.g.
 // json.NewDecoder) and does not need to retain the raw bytes.
 func (c *Client) GetStream(ctx context.Context, path string, fn func(io.Reader) error) error {
-	if err := c.sem.Acquire(ctx); err != nil {
+	if err := c.sem.acquireWithBackstop(ctx); err != nil {
 		c.appLog.Error("GET", path, fmt.Sprintf("semaphore: %v", err))
 		return fmt.Errorf("rci GET %s: %w", path, err)
 	}

--- a/internal/ndms/transport/semaphore.go
+++ b/internal/ndms/transport/semaphore.go
@@ -1,6 +1,9 @@
 package transport
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Semaphore is a channel-backed bounded concurrency gate. Acquire blocks
 // until a slot is free or ctx is cancelled; Release returns a slot.
@@ -25,6 +28,24 @@ func (s *Semaphore) Acquire(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// semAcquireBackstop bounds a deadline-less wait for an RCI slot. Callers
+// passing context.Background() (boot paths, background loops) must not queue
+// forever behind a wedged request.
+const semAcquireBackstop = 60 * time.Second
+
+// acquireWithBackstop is Acquire with semAcquireBackstop applied ONLY when
+// ctx carries no deadline of its own — explicitly-set deadlines (shorter or
+// longer) are honored as-is. The backstop covers just the slot wait, never
+// the request that follows.
+func (s *Semaphore) acquireWithBackstop(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); ok {
+		return s.Acquire(ctx)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, semAcquireBackstop)
+	defer cancel()
+	return s.Acquire(waitCtx)
 }
 
 // Release returns a slot. Panics if called without a matching Acquire.

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -29,6 +29,20 @@ func Success(w http.ResponseWriter, data interface{}) {
 	enc.Encode(resp)
 }
 
+// Accepted writes a 202 success response with optional data. Used by
+// endpoints that start background work and return before it completes.
+func Accepted(w http.ResponseWriter, data interface{}) {
+	resp := APIResponse{Success: true}
+	if data != nil {
+		resp.Data = data
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.Encode(resp)
+}
+
 // Error writes an error response with message and code.
 // Format: {error: true, message: "...", code: "..."}
 func Error(w http.ResponseWriter, message, code string) {

--- a/internal/singbox/heavyop/gate.go
+++ b/internal/singbox/heavyop/gate.go
@@ -1,27 +1,57 @@
 // Package heavyop serializes memory-heavy sing-box work (ipset rebuild, config apply).
 package heavyop
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // Gate ensures selective ipset rebuild and sing-box config apply/reload do not run concurrently.
+// Channel-backed (not sync.Mutex) so acquisition can be bounded by a context.
 type Gate struct {
-	mu sync.Mutex
+	once sync.Once
+	ch   chan struct{}
 }
 
 // Default is the process-wide gate shared by orchestrator reload and selective rebuild.
 var Default Gate
 
+func (g *Gate) sem() chan struct{} {
+	g.once.Do(func() { g.ch = make(chan struct{}, 1) })
+	return g.ch
+}
+
 // Lock blocks until no other heavy operation is running.
 func (g *Gate) Lock() {
-	g.mu.Lock()
+	g.sem() <- struct{}{}
+}
+
+// LockWithContext blocks until the gate is acquired or ctx ends.
+// Returns ctx.Err() when the deadline expires or ctx is cancelled first.
+func (g *Gate) LockWithContext(ctx context.Context) error {
+	select {
+	case g.sem() <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Unlock releases the gate.
 func (g *Gate) Unlock() {
-	g.mu.Unlock()
+	select {
+	case <-g.sem():
+	default:
+		panic("heavyop: Unlock of unlocked Gate")
+	}
 }
 
 // TryLock reports whether the gate was acquired without blocking.
 func (g *Gate) TryLock() bool {
-	return g.mu.TryLock()
+	select {
+	case g.sem() <- struct{}{}:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/singbox/heavyop/gate_test.go
+++ b/internal/singbox/heavyop/gate_test.go
@@ -1,0 +1,61 @@
+package heavyop
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGateLockWithContext_AcquiresWhenFree(t *testing.T) {
+	var g Gate
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := g.LockWithContext(ctx); err != nil {
+		t.Fatalf("LockWithContext on free gate: %v", err)
+	}
+	g.Unlock()
+}
+
+func TestGateLockWithContext_DeadlineWhileHeld(t *testing.T) {
+	var g Gate
+	g.Lock()
+	defer g.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := g.LockWithContext(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestGateLockWithContext_SucceedsAfterUnlock(t *testing.T) {
+	var g Gate
+	g.Lock()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		g.Unlock()
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := g.LockWithContext(ctx); err != nil {
+		t.Fatalf("LockWithContext after Unlock: %v", err)
+	}
+	g.Unlock()
+}
+
+func TestGateTryLock(t *testing.T) {
+	var g Gate
+	if !g.TryLock() {
+		t.Fatal("TryLock on free gate must succeed")
+	}
+	if g.TryLock() {
+		t.Fatal("TryLock on held gate must fail")
+	}
+	g.Unlock()
+	if !g.TryLock() {
+		t.Fatal("TryLock after Unlock must succeed")
+	}
+	g.Unlock()
+}

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -128,7 +128,7 @@ func normalizeSingboxLogLevel(v string) string {
 	if _, ok := singboxAllowedLogLevels[normalized]; ok {
 		return normalized
 	}
-	return "trace"
+	return "info"
 }
 
 // Operator is the high-level facade for sing-box integration.
@@ -265,7 +265,7 @@ type OperatorDeps struct {
 	// that pre-date this field).
 	IsNDMSProxyEnabled func() bool
 	// SingboxLogLevel returns desired sing-box log.level from settings.
-	// Optional; defaults to "trace".
+	// Optional; defaults to "info".
 	SingboxLogLevel func() string
 }
 
@@ -286,7 +286,7 @@ func NewOperator(d OperatorDeps) *Operator {
 	if err := MigrateLegacyConfigDir(dir); err != nil {
 		log.Warn("singbox config.d migration", "err", err)
 	}
-	desiredSingboxLogLevel := normalizeSingboxLogLevel("trace")
+	desiredSingboxLogLevel := normalizeSingboxLogLevel("info")
 	if d.SingboxLogLevel != nil {
 		desiredSingboxLogLevel = normalizeSingboxLogLevel(d.SingboxLogLevel())
 	}
@@ -527,7 +527,7 @@ func (o *Operator) tunnelsFile() string {
 // clashAPIAddr's 9099), which silently broke our LogForwarder /
 // DelayChecker on existing installs.
 func ensureBaseConfig(configDir string, loggers ...*slog.Logger) {
-	ensureBaseConfigWithLogLevel(configDir, "trace", loggers...)
+	ensureBaseConfigWithLogLevel(configDir, "info", loggers...)
 }
 
 func ensureBaseConfigWithLogLevel(configDir, desiredLogLevel string, loggers ...*slog.Logger) {
@@ -1205,7 +1205,7 @@ func patchTunnelsSlotEnsureNaiveUDPOverTCP(tunnelsPath string) {
 // freshBaseConfig returns the canonical base sing-box config. Single
 // source of truth for ensureBaseConfig (initial write + self-heal path).
 func freshBaseConfig() map[string]any {
-	return freshBaseConfigWithLogLevel("trace")
+	return freshBaseConfigWithLogLevel("info")
 }
 
 func freshBaseConfigWithLogLevel(logLevel string) map[string]any {

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -239,11 +239,11 @@ func TestEnsureBaseConfig_Idempotent(t *testing.T) {
 	if string(first) != string(second) {
 		t.Errorf("ensureBaseConfig not idempotent: first=%s second=%s", first, second)
 	}
-	// Default desired sing-box level is trace (when not explicitly provided).
+	// Default desired sing-box level is info (when not explicitly provided).
 	var m map[string]any
 	_ = json.Unmarshal(second, &m)
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level must be patched to trace, got %v", m["log"])
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level must be patched to info, got %v", m["log"])
 	}
 }
 
@@ -267,9 +267,9 @@ func TestEnsureBaseConfig_PatchesStaleClashPort(t *testing.T) {
 	if clash["external_controller"] != "127.0.0.1:9099" {
 		t.Errorf("expected port 9099, got %v", clash["external_controller"])
 	}
-	// Desired level defaults to trace.
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level want trace, got %v", m["log"])
+	// Desired level defaults to info.
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level want info, got %v", m["log"])
 	}
 	if m["dns"].(map[string]any)["final"] != "my-dns" {
 		t.Errorf("dns.final lost: %v", m["dns"])
@@ -302,8 +302,8 @@ func TestEnsureBaseConfig_NoClashApiBlockUntouched(t *testing.T) {
 	if _, has := m["experimental"]; has {
 		t.Errorf("experimental block must NOT be re-added, got %s", raw)
 	}
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level want trace, got %v", m["log"])
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level want info, got %v", m["log"])
 	}
 	route, ok := m["route"].(map[string]any)
 	if !ok {
@@ -318,7 +318,7 @@ func TestEnsureBaseConfig_PatchesStaleLogLevel(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
 	_ = os.MkdirAll(configDir, 0755)
-	stale := `{"log":{"level":"info","timestamp":true},"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"}}}`
+	stale := `{"log":{"level":"debug","timestamp":true},"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"}}}`
 	basePath := filepath.Join(configDir, "00-base.json")
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
@@ -329,8 +329,8 @@ func TestEnsureBaseConfig_PatchesStaleLogLevel(t *testing.T) {
 	if err := json.Unmarshal(raw, &m); err != nil {
 		t.Fatal(err)
 	}
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level should be heal-patched to trace, got %v", m["log"])
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level should be heal-patched to info, got %v", m["log"])
 	}
 }
 
@@ -338,7 +338,9 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
 	_ = os.MkdirAll(configDir, 0755)
-	// User-chosen debug — heal must NOT reduce verbosity.
+	// ensureBaseConfig force-syncs log.level to the desired default; the
+	// settings-driven wiring (NewOperator + SingboxLogLevel) preserves an
+	// explicit user choice, this legacy path always applies the default.
 	custom := `{"log":{"level":"debug","timestamp":true},"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"}}}`
 	basePath := filepath.Join(configDir, "00-base.json")
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
@@ -348,8 +350,8 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level want trace, got %v", m["log"])
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level want info, got %v", m["log"])
 	}
 }
 
@@ -564,7 +566,7 @@ func TestEnsureBaseConfig_MaterialisesMissingRouteBlock(t *testing.T) {
 	if m["dns"].(map[string]any)["strategy"] != "prefer_ipv4" {
 		t.Errorf("dns.strategy must be migrated ipv4_only→prefer_ipv4: %v", m["dns"])
 	}
-	if m["log"].(map[string]any)["level"] != "trace" {
+	if m["log"].(map[string]any)["level"] != "info" {
 		t.Errorf("log.level lost: %v", m["log"])
 	}
 }
@@ -737,8 +739,8 @@ func TestEnsureBaseConfig_PatchesRelativeCachePath(t *testing.T) {
 	if cf["path"] != defaultCacheDBPath {
 		t.Errorf("expected %s, got %v", defaultCacheDBPath, cf["path"])
 	}
-	if m["log"].(map[string]any)["level"] != "trace" {
-		t.Errorf("log.level want trace, got %v", m["log"])
+	if m["log"].(map[string]any)["level"] != "info" {
+		t.Errorf("log.level want info, got %v", m["log"])
 	}
 }
 

--- a/internal/singbox/router/selective/builder.go
+++ b/internal/singbox/router/selective/builder.go
@@ -59,12 +59,73 @@ type BuilderConfig struct {
 type Builder struct {
 	cfg BuilderConfig
 
-	mu          sync.Mutex
-	opMu        sync.Mutex
+	mu sync.Mutex
+	// opCh is a 1-slot semaphore serializing Rebuild vs RefreshCDNMatchers.
+	// Channel-backed (lazy-init via opOnce so &Builder{} in tests still works)
+	// because acquisition must be boundable by a context — see acquireOp.
+	opOnce      sync.Once
+	opCh        chan struct{}
+	rebuilding  atomic.Bool
 	lastRebuild time.Time
 	lastError   string
 	summary     *SnapshotSummary
 	routes      map[string][]string
+}
+
+func (b *Builder) opSem() chan struct{} {
+	b.opOnce.Do(func() { b.opCh = make(chan struct{}, 1) })
+	return b.opCh
+}
+
+// acquireOp takes the builder op slot, giving up when ctx ends.
+func (b *Builder) acquireOp(ctx context.Context) error {
+	select {
+	case b.opSem() <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// tryAcquireOp takes the builder op slot without blocking.
+func (b *Builder) tryAcquireOp() bool {
+	select {
+	case b.opSem() <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *Builder) releaseOp() {
+	select {
+	case <-b.opSem():
+	default:
+		panic("selective: releaseOp without matching acquire")
+	}
+}
+
+// Rebuilding reports whether a full Rebuild is currently in flight
+// (including waiting on the heavy-op gate).
+func (b *Builder) Rebuilding() bool {
+	return b.rebuilding.Load()
+}
+
+// TryBeginRun marks a rebuild run as in flight, returning false when another
+// run already owns the flag. Callers that do expensive pre-work before
+// Rebuild proper (the router adapter loads config and materializes rule sets
+// for seconds) must mark the run at THEIR entry so both the API handler's
+// duplicate check (Rebuilding) and the builder's own dedupe see it from the
+// start — otherwise a user POST in that window launches a second full run.
+// A successful TryBeginRun must be paired with EndRun and the actual work
+// routed through RebuildOwnedRun.
+func (b *Builder) TryBeginRun() bool {
+	return b.rebuilding.CompareAndSwap(false, true)
+}
+
+// EndRun clears the in-flight marker taken by TryBeginRun.
+func (b *Builder) EndRun() {
+	b.rebuilding.Store(false)
 }
 
 // NewBuilder constructs a Builder with the given configuration.
@@ -144,6 +205,8 @@ func summaryToLegacyAPI(s *SnapshotSummary) *RebuildSnapshot {
 }
 
 // Rebuild streams matchers → DNS → staging ipset → atomic swap.
+// It begins its own run; callers that already marked the run via TryBeginRun
+// (the router adapter) must call RebuildOwnedRun instead.
 func (b *Builder) Rebuild(
 	ctx context.Context,
 	rules []RuleJSON,
@@ -151,19 +214,40 @@ func (b *Builder) Rebuild(
 	singboxDNS []SingboxDNSServer,
 	fn ProgressFn,
 ) error {
-	heavyop.Default.Lock()
-	defer heavyop.Default.Unlock()
-	b.opMu.Lock()
-	defer b.opMu.Unlock()
-
-	emit := func(p Progress) {
-		if fn != nil {
-			fn(p)
-		}
-		if b.cfg.Bus != nil {
-			b.cfg.Bus.Publish("singbox-router:selective-progress", p)
-		}
+	if !b.TryBeginRun() {
+		return b.fail(ctx, b.emitter(fn), fmt.Errorf("selective: %w", ErrBusy))
 	}
+	defer b.EndRun()
+	return b.RebuildOwnedRun(ctx, rules, ruleSetRefs, singboxDNS, fn)
+}
+
+// RebuildOwnedRun is Rebuild for a caller that already owns the run marker
+// (TryBeginRun returned true). The caller is responsible for EndRun.
+func (b *Builder) RebuildOwnedRun(
+	ctx context.Context,
+	rules []RuleJSON,
+	ruleSetRefs []RuleSetRef,
+	singboxDNS []SingboxDNSServer,
+	fn ProgressFn,
+) error {
+	emit := b.emitter(fn)
+
+	// Gate acquisition rides on the RUN's own context (the API background run
+	// caps it at 10 minutes, the boot auto-rebuild likewise): at boot the
+	// orchestrator can legitimately hold the gate 60+ seconds (sing-box cold
+	// start readiness floor), and a short hard sub-timeout here made the
+	// one-shot boot rebuild give up — leaving a reboot-emptied ipset
+	// unpopulated (silent WAN leak). Fast-fail UX for manual rebuilds is
+	// provided by the API handler's TryLock pre-check; in-run waiting can be
+	// patient.
+	if err := heavyop.Default.LockWithContext(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: %w", ErrBusy))
+	}
+	defer heavyop.Default.Unlock()
+	if err := b.acquireOp(ctx); err != nil {
+		return b.fail(ctx, emit, fmt.Errorf("selective: %w", ErrBusy))
+	}
+	defer b.releaseOp()
 
 	emit(Progress{Phase: PhaseCollecting, Message: "Сбор IP-адресов и доменов из правил маршрутизации…"})
 
@@ -331,6 +415,26 @@ func (b *Builder) Rebuild(
 	emit(Progress{Phase: PhaseDone, Message: doneMsg, Current: entryCount, Total: entryCount})
 	b.publishStatus(true, entryCount)
 	return nil
+}
+
+// emitter wraps the optional per-call ProgressFn with the SSE bus publish.
+func (b *Builder) emitter(fn ProgressFn) func(Progress) {
+	return func(p Progress) {
+		if fn != nil {
+			fn(p)
+		}
+		if b.cfg.Bus != nil {
+			b.cfg.Bus.Publish("singbox-router:selective-progress", p)
+		}
+	}
+}
+
+// FailRebuild records err as the last rebuild error and emits the terminal
+// progress + status events. For wrappers that fail before Rebuild proper runs
+// (config load, rule-set restore) — the UI must still see a final event to
+// close its progress view.
+func (b *Builder) FailRebuild(ctx context.Context, err error) error {
+	return b.fail(ctx, b.emitter(nil), err)
 }
 
 func (b *Builder) fail(ctx context.Context, emit func(Progress), err error) error {

--- a/internal/singbox/router/selective/cdn_refresh.go
+++ b/internal/singbox/router/selective/cdn_refresh.go
@@ -41,28 +41,16 @@ func (b *Builder) RefreshCDNMatchers(
 	if len(queries) == 0 {
 		return 0, nil
 	}
-	if !heavyop.Default.TryLock() {
-		if b.cfg.Log != nil {
-			b.cfg.Log.Info("selective-cdn-refresh", "", "skipped: sing-box apply or rebuild in progress")
-		}
-		return 0, nil
-	}
-	defer heavyop.Default.Unlock()
-	if !b.opMu.TryLock() {
+	if !b.tryAcquireOp() {
 		if b.cfg.Log != nil {
 			b.cfg.Log.Info("selective-cdn-refresh", "", "skipped: full rebuild in progress")
 		}
 		return 0, nil
 	}
-	defer b.opMu.Unlock()
-
-	if err := CreateSet(ctx); err != nil {
-		return 0, fmt.Errorf("selective cdn refresh: create set: %w", err)
-	}
+	defer b.releaseOp()
 
 	dnsServers := BuildDNSServers(ctx, singboxDNS, b.cfg.DNSSource)
 	fullProbes := fullProbeFlags(queries)
-	var added, addFailed int
 	// Freshly resolved IPs must ALSO reach the routes overlay: the ipset only
 	// decides what is intercepted, while 19-selective-routes.json decides
 	// where it goes. An IP present in the set but absent from the overlay is
@@ -70,30 +58,56 @@ func (b *Builder) RefreshCDNMatchers(
 	// exactly the leak this refresh exists to prevent.
 	acc := NewRouteAccumulator()
 
+	// Resolve phase — DNS I/O and in-memory buffering only, NO heavy-op gate:
+	// holding the gate across this multi-minute loop made the rebuild API's
+	// TryLock pre-check answer every manual rebuild with a misleading 409
+	// «применяется конфигурация sing-box».
+	type matcherCIDRs struct {
+		matcher string
+		cidrs   []string
+	}
+	var pending []matcherCIDRs
 	for qi, q := range queries {
-		var chunk []string
-		flush := func() {
-			if len(chunk) == 0 {
-				return
-			}
-			if err := ChunkedAddLive(ctx, chunk); err != nil {
-				addFailed += len(chunk)
-				if b.cfg.Log != nil {
-					b.cfg.Log.Warn("selective-cdn-refresh", q.Matcher, err.Error())
-				}
-			} else {
-				added += len(chunk)
-			}
-			chunk = chunk[:0]
-		}
+		var cidrs []string
 		ResolveOneQueryStream(ctx, q, dnsServers, func(cidr string) {
-			chunk = append(chunk, cidr)
+			cidrs = append(cidrs, cidr)
 			acc.Add(q.Outbound, cidr)
-			if len(chunk) >= IpsetChunkSize {
-				flush()
-			}
 		}, nil, fullProbes[qi])
-		flush()
+		if len(cidrs) > 0 {
+			pending = append(pending, matcherCIDRs{matcher: q.Matcher, cidrs: cidrs})
+		}
+	}
+
+	// Mutation phase — the heavy-op gate is held ONLY around the ipset writes.
+	var added, addFailed int
+	if len(pending) > 0 {
+		if !heavyop.Default.TryLock() {
+			if b.cfg.Log != nil {
+				b.cfg.Log.Info("selective-cdn-refresh", "", "skipped ipset update: sing-box apply or rebuild in progress")
+			}
+			return 0, nil
+		}
+		err := func() error {
+			defer heavyop.Default.Unlock()
+			if err := CreateSet(ctx); err != nil {
+				return fmt.Errorf("selective cdn refresh: create set: %w", err)
+			}
+			for _, p := range pending {
+				// ChunkedAddLive batches internally (IpsetChunkSize per restore).
+				if err := ChunkedAddLive(ctx, p.cidrs); err != nil {
+					addFailed += len(p.cidrs)
+					if b.cfg.Log != nil {
+						b.cfg.Log.Warn("selective-cdn-refresh", p.matcher, err.Error())
+					}
+				} else {
+					added += len(p.cidrs)
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	entries := EntryCount(ctx)

--- a/internal/singbox/router/selective/errors.go
+++ b/internal/singbox/router/selective/errors.go
@@ -12,3 +12,8 @@ var ErrIPSetNotAvailable = errors.New("ipset binary not found: install the ipset
 // ErrXtSetNotAvailable is returned when xt_set kernel module is absent,
 // meaning iptables -m set rules cannot be applied.
 var ErrXtSetNotAvailable = errors.New("kernel module xt_set not found: iptables ipset matching unavailable")
+
+// ErrBusy is returned when the heavy-op gate (sing-box config apply / another
+// rebuild) could not be acquired within the bounded wait. The API maps it to
+// an OPERATION_IN_PROGRESS conflict instead of hanging the request.
+var ErrBusy = errors.New("занято: применяется конфигурация sing-box")

--- a/internal/singbox/router/selective/resolver.go
+++ b/internal/singbox/router/selective/resolver.go
@@ -92,7 +92,12 @@ func BuildDNSServers(ctx context.Context, singboxDNSServers []SingboxDNSServer, 
 	}
 
 	if ndmsSource != nil {
-		raw, err := ndmsSource.List(ctx)
+		// Best-effort: NDMS RCI can stall on a loaded router (cold boot). The
+		// discovery only widens the resolver union — bound it so a hung
+		// /show/dns-proxy call cannot delay the whole rebuild.
+		ndmsCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		raw, err := ndmsSource.List(ndmsCtx)
+		cancel()
 		if err == nil && len(raw) > 0 {
 			seeds = append(seeds, parseNDMSUpstreamAddresses(raw)...)
 		}

--- a/internal/singbox/router/selective/route_acc.go
+++ b/internal/singbox/router/selective/route_acc.go
@@ -1,6 +1,7 @@
 package selective
 
 import (
+	"sort"
 	"sync"
 )
 
@@ -35,7 +36,10 @@ func (a *RouteAccumulator) Add(outbound, cidr string) {
 	set[cidr] = struct{}{}
 }
 
-// RulesByOutbound returns outbound → deduplicated /32 CIDR lists.
+// RulesByOutbound returns outbound → deduplicated /32 CIDR lists. Each list
+// is sorted so the marshalled routes slot is byte-stable across rebuilds —
+// the caller diffs slot bytes to decide whether sing-box needs a reload, and
+// random map order would report «changed» on every identical rebuild.
 func (a *RouteAccumulator) RulesByOutbound() map[string][]string {
 	if a == nil {
 		return nil
@@ -48,6 +52,7 @@ func (a *RouteAccumulator) RulesByOutbound() map[string][]string {
 		for c := range set {
 			list = append(list, c)
 		}
+		sort.Strings(list)
 		out[ob] = list
 	}
 	return out

--- a/internal/singbox/router/selective/snapshot.go
+++ b/internal/singbox/router/selective/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // DomainResolveResult is one rule matcher resolved to IPv4 /32 CIDRs for ipset.
@@ -30,13 +31,13 @@ type DomainResolveResult struct {
 // Written beside config.d (same parent dir as selective-last-rebuild) — NOT as
 // *.json inside config.d, or sing-box merge will try to decode it and FATAL.
 type RebuildSnapshot struct {
-	RebuiltAt            string                `json:"rebuiltAt"`
-	StaticCIDRs          []string              `json:"staticCidrs"`
-	DomainResults        []DomainResolveResult `json:"domainResults"`
-	EntryCount           int                   `json:"entryCount"`
-	StaticCIDRCount      int                   `json:"staticCidrCount,omitempty"`
-	DomainMatcherCount   int                   `json:"domainMatcherCount,omitempty"`
-	LastCDNRefresh       string                `json:"lastCDNRefresh,omitempty"`
+	RebuiltAt          string                `json:"rebuiltAt"`
+	StaticCIDRs        []string              `json:"staticCidrs"`
+	DomainResults      []DomainResolveResult `json:"domainResults"`
+	EntryCount         int                   `json:"entryCount"`
+	StaticCIDRCount    int                   `json:"staticCidrCount,omitempty"`
+	DomainMatcherCount int                   `json:"domainMatcherCount,omitempty"`
+	LastCDNRefresh     string                `json:"lastCDNRefresh,omitempty"`
 }
 
 // snapshotFileName has no .json suffix: sing-box -C config.d merges every
@@ -71,12 +72,39 @@ func RemoveLegacySnapshotJSON(configDir string) {
 }
 
 // NeedsPopulation reports whether the selective ipset should be built on daemon
-// start: set missing, empty, or no successful rebuild marker on disk.
+// start: set missing, no successful rebuild marker on disk, or an empty set the
+// last rebuild expected to have entries. An empty set whose persisted snapshot
+// says the last rebuild produced 0 entries was built empty deliberately (user
+// has no IP/domain matchers) — re-running a full rebuild on every daemon start
+// for that case is pure boot-time contention.
 func NeedsPopulation(ctx context.Context, configDir string) bool {
-	if !SetExists(ctx) || EntryCount(ctx) == 0 {
+	if !SetExists(ctx) {
 		return true
 	}
-	return readLastRebuild(configDir).IsZero()
+	return needsPopulationForExistingSet(EntryCount(ctx), readLastRebuild(configDir), readSnapshotSummary(configDir))
+}
+
+// needsPopulationForExistingSet is the NeedsPopulation decision once the set
+// is known to exist. Split out so the empty-set logic is testable without a
+// live ipset.
+func needsPopulationForExistingSet(entryCount int, lastRebuild time.Time, summary *SnapshotSummary) bool {
+	if lastRebuild.IsZero() {
+		return true
+	}
+	if entryCount > 0 {
+		return false
+	}
+	// Empty set: intentional ONLY when the last rebuild had nothing
+	// configured at all (no static CIDRs, no domain matchers). A summary
+	// with matchers but 0 entries means the rebuild «succeeded» during a
+	// DNS/WAN outage (resolve failures are not errors) — treating that as
+	// deliberate would leave the set empty forever and leak proxied traffic
+	// via WAN. No snapshot, or one that expected entries, means the set lost
+	// its contents — rebuild in all these cases.
+	return summary == nil ||
+		summary.EntryCount != 0 ||
+		summary.StaticCIDRCount > 0 ||
+		summary.DomainMatcherCount > 0
 }
 
 // NormalizeRebuildSnapshot ensures slice fields are non-nil so JSON encodes

--- a/internal/singbox/router/selective/snapshot_test.go
+++ b/internal/singbox/router/selective/snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestSnapshotPath_NotJSONInConfigDir(t *testing.T) {
@@ -34,6 +35,43 @@ func TestNormalizeRebuildSnapshot_NilSlices(t *testing.T) {
 	})
 	if snap.StaticCIDRs == nil || snap.DomainResults[0].IPs == nil || snap.DomainResults[0].QueryHosts == nil {
 		t.Fatalf("expected empty slices, got %+v", snap)
+	}
+}
+
+func TestNeedsPopulationForExistingSet(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name        string
+		entryCount  int
+		lastRebuild time.Time
+		summary     *SnapshotSummary
+		want        bool
+	}{
+		{"no rebuild marker", 0, time.Time{}, nil, true},
+		{"populated set", 42, now, &SnapshotSummary{EntryCount: 42}, false},
+		{"deliberately empty build", 0, now, &SnapshotSummary{EntryCount: 0}, false},
+		{"empty set but snapshot expected entries", 0, now, &SnapshotSummary{EntryCount: 17}, true},
+		{"empty set without snapshot", 0, now, nil, true},
+		// A 0-entry rebuild with matchers configured is an outage artifact
+		// (DNS resolve failures are not rebuild errors), not a deliberate
+		// empty set — boot repopulation must fire.
+		{"0-entry build with domain matchers", 0, now, &SnapshotSummary{EntryCount: 0, DomainMatcherCount: 12}, true},
+		{"0-entry build with static cidrs", 0, now, &SnapshotSummary{EntryCount: 0, StaticCIDRCount: 3}, true},
+		{"0-entry build with both configured", 0, now, &SnapshotSummary{EntryCount: 0, StaticCIDRCount: 3, DomainMatcherCount: 12}, true},
+	}
+	for _, tc := range cases {
+		if got := needsPopulationForExistingSet(tc.entryCount, tc.lastRebuild, tc.summary); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNeedsPopulationForExistingSet_EmptyIntentionalFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	writeLastRebuild(dir, time.Now())
+	writeSnapshotMeta(dir, SnapshotSummary{RebuiltAt: "2026-01-01T00:00:00Z", EntryCount: 0})
+	if needsPopulationForExistingSet(0, readLastRebuild(dir), readSnapshotSummary(dir)) {
+		t.Fatal("deliberately-empty set must not re-trigger a boot rebuild")
 	}
 }
 

--- a/internal/singbox/router/selective_adapter.go
+++ b/internal/singbox/router/selective_adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 )
@@ -15,19 +16,41 @@ import (
 type selectiveBuilderAdapter struct {
 	svc *ServiceImpl
 	b   *selective.Builder
+	// applyNow applies config.d to sing-box (svc.orchestratorApplyNow);
+	// injectable for tests.
+	applyNow func() error
+	// lastApplyFailed remembers a failed applyNow: disk state ≠ running
+	// sing-box after a failed apply, so the next rebuild must re-apply even
+	// when the routes slot is byte-identical — otherwise a retry rebuild
+	// becomes a no-op forever and loses its self-heal role.
+	lastApplyFailed atomic.Bool
 }
 
 // NewSelectiveBuilderAdapter constructs a SelectiveBuilder backed by svc and b.
 func NewSelectiveBuilderAdapter(svc *ServiceImpl, b *selective.Builder) SelectiveBuilder {
-	return &selectiveBuilderAdapter{svc: svc, b: b}
+	return &selectiveBuilderAdapter{svc: svc, b: b, applyNow: svc.orchestratorApplyNow}
 }
 
 // Rebuild loads the current router config from disk, derives rule-set JSON
-// paths, and calls the underlying Builder.Rebuild.
+// paths, and calls the underlying Builder.RebuildOwnedRun.
 func (a *selectiveBuilderAdapter) Rebuild(ctx context.Context) error {
+	// Mark the run BEFORE the config pre-work below (seconds of disk I/O and
+	// rule-set materialization): both the API handler's duplicate check
+	// (status.Rebuilding) and the builder's own dedupe must see this run from
+	// adapter entry, or a user POST in that window starts a second full run
+	// that dies with a spurious ErrBusy SSE error.
+	if !a.b.TryBeginRun() {
+		a.svc.appLog.Info("selective-rebuild", "", "rebuild already in flight — skipping duplicate run")
+		return nil
+	}
+	defer a.b.EndRun()
+
 	cfg, err := a.svc.loadRouterConfig()
 	if err != nil {
-		return err
+		// FailRebuild publishes the terminal progress/status SSE events —
+		// the rebuild API responds 202 before the work runs, so an early
+		// failure here is otherwise invisible to the UI.
+		return a.b.FailRebuild(ctx, fmt.Errorf("selective: load router config: %w", err))
 	}
 	cfg = a.svc.ruleSetMaterializer().restoreConfig(cfg)
 
@@ -45,7 +68,7 @@ func (a *selectiveBuilderAdapter) Rebuild(ctx context.Context) error {
 			len(rules), len(refs), len(singboxDNS)),
 	)
 
-	if err := a.b.Rebuild(ctx, rules, refs, singboxDNS, nil); err != nil {
+	if err := a.b.RebuildOwnedRun(ctx, rules, refs, singboxDNS, nil); err != nil {
 		return err
 	}
 	a.syncRoutesAfterRebuild(ctx)
@@ -62,13 +85,30 @@ func (a *selectiveBuilderAdapter) syncRoutesAfterRebuild(ctx context.Context) {
 		a.svc.appLog.Warn("selective-rebuild", "routes",
 			fmt.Sprintf("ipset has %d entries but no /32 overlay routes — traffic may reach sing-box yet exit via route.final", entryCount))
 	}
-	if err := a.svc.syncSelectiveRoutesSlot(ctx, routes); err != nil {
+	changed, err := a.svc.syncSelectiveRoutesSlot(ctx, routes)
+	if err != nil {
 		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
 		return
 	}
-	if err := a.svc.orchestratorApplyNow(); err != nil {
-		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
+	a.applyRoutesSlot(changed)
+}
+
+// applyRoutesSlot reloads sing-box when the routes slot changed OR the
+// previous apply failed (byte-equal slot on disk says nothing about the
+// running process in that case).
+func (a *selectiveBuilderAdapter) applyRoutesSlot(changed bool) {
+	if !changed && !a.lastApplyFailed.Load() {
+		// Routes overlay identical to what sing-box already runs — a SIGHUP
+		// here would only drop live proxied connections for nothing.
+		a.svc.appLog.Info("selective-rebuild", "routes", "overlay routes unchanged — skipping sing-box reload")
+		return
 	}
+	if err := a.applyNow(); err != nil {
+		a.lastApplyFailed.Store(true)
+		a.svc.appLog.Warn("selective-rebuild", "routes", err.Error())
+		return
+	}
+	a.lastApplyFailed.Store(false)
 }
 
 // RefreshCDN incrementally refreshes ipset entries for CDN-flagged domain matchers.

--- a/internal/singbox/router/selective_adapter_test.go
+++ b/internal/singbox/router/selective_adapter_test.go
@@ -1,0 +1,50 @@
+package router
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestApplyRoutesSlot_RetriesAfterFailedApply guards the rebuild's self-heal
+// role: a byte-identical routes slot normally skips the sing-box reload, but
+// after a FAILED apply the disk state says nothing about the running process
+// — the next rebuild must re-apply even when nothing changed on disk.
+func TestApplyRoutesSlot_RetriesAfterFailedApply(t *testing.T) {
+	var calls int
+	failNext := true
+	a := &selectiveBuilderAdapter{
+		svc: &ServiceImpl{},
+		applyNow: func() error {
+			calls++
+			if failNext {
+				return errors.New("sighup failed")
+			}
+			return nil
+		},
+	}
+
+	// Changed slot, apply fails → sticky failure flag set.
+	a.applyRoutesSlot(true)
+	if calls != 1 {
+		t.Fatalf("changed slot: applyNow calls = %d, want 1", calls)
+	}
+	if !a.lastApplyFailed.Load() {
+		t.Fatal("failed apply must set lastApplyFailed")
+	}
+
+	// Identical rebuild (changed=false) after a failed apply must still apply.
+	failNext = false
+	a.applyRoutesSlot(false)
+	if calls != 2 {
+		t.Fatalf("unchanged slot after failed apply: applyNow calls = %d, want 2", calls)
+	}
+	if a.lastApplyFailed.Load() {
+		t.Fatal("successful apply must clear lastApplyFailed")
+	}
+
+	// Once applied successfully, an unchanged slot skips the reload again.
+	a.applyRoutesSlot(false)
+	if calls != 2 {
+		t.Fatalf("unchanged slot after success: applyNow calls = %d, want 2", calls)
+	}
+}

--- a/internal/singbox/router/selective_routes.go
+++ b/internal/singbox/router/selective_routes.go
@@ -1,11 +1,13 @@
 package router
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
@@ -29,12 +31,22 @@ func marshalSelectiveRoutesSlot(rules []Rule) ([]byte, error) {
 }
 
 // buildSelectiveIPRules builds ip_cidr route rules from outbound-grouped /32 lists.
+// Output is canonical (sorted outbounds, sorted CIDRs): syncSelectiveRoutesSlot
+// byte-compares the marshalled slot to skip the sing-box reload, so identical
+// inputs must always marshal identically regardless of map iteration order.
 func buildSelectiveIPRules(byOutbound map[string][]string) []Rule {
 	if len(byOutbound) == 0 {
 		return nil
 	}
-	out := make([]Rule, 0, len(byOutbound))
-	for ob, cidrs := range byOutbound {
+	outbounds := make([]string, 0, len(byOutbound))
+	for ob := range byOutbound {
+		outbounds = append(outbounds, ob)
+	}
+	sort.Strings(outbounds)
+	out := make([]Rule, 0, len(outbounds))
+	for _, ob := range outbounds {
+		cidrs := append([]string(nil), byOutbound[ob]...)
+		sort.Strings(cidrs)
 		out = append(out, Rule{
 			Action:   "route",
 			Outbound: ob,
@@ -87,22 +99,42 @@ func (s *ServiceImpl) stripLegacySelectiveRulesFromRouter(ctx context.Context) (
 // syncSelectiveRoutesSlot writes ip_cidr overlay rules into 19-selective-routes.json
 // (merged by sing-box, invisible in the rules UI). Uses SaveSilent so no staging
 // draft / «Применить» banner appears after ipset rebuild.
-func (s *ServiceImpl) syncSelectiveRoutesSlot(ctx context.Context, byOutbound map[string][]string) error {
+//
+// Returns changed=false when the merged config is already in the target shape
+// (byte-equal active slot, same enabled state — mirrors the 20-router.json
+// diff in persistConfigDirect) so the caller can skip the sing-box reload: an
+// unconditional SIGHUP after every manual rebuild drops all proxied
+// connections even when zero routes changed.
+func (s *ServiceImpl) syncSelectiveRoutesSlot(ctx context.Context, byOutbound map[string][]string) (bool, error) {
 	if s.deps.Orch == nil {
-		return nil
+		return false, nil
 	}
 	rules := buildSelectiveIPRules(byOutbound)
 	enable := len(rules) > 0
 	data, err := marshalSelectiveRoutesSlot(rules)
 	if err != nil {
-		return err
+		return false, err
+	}
+	// The merged config only sees the ACTIVE file: enabled ⇒ byte-equal active
+	// file is a no-op; disabled ⇒ absent active file is a no-op regardless of
+	// any parked disabled/ copy.
+	activePath := filepath.Join(s.deps.Orch.ConfigDir(), "19-selective-routes.json")
+	existing, readErr := os.ReadFile(activePath)
+	var unchanged bool
+	if enable {
+		unchanged = readErr == nil && bytes.Equal(existing, data)
+	} else {
+		unchanged = os.IsNotExist(readErr)
 	}
 	// Always rewrite the slot file so a legacy build's `"outbounds": null`
 	// cannot keep breaking sing-box check after rules are cleared.
 	if err := s.deps.Orch.SaveSilent(orchestrator.SlotSelectiveRoutes, data); err != nil {
-		return err
+		return false, err
 	}
-	return s.deps.Orch.SetEnabledSilent(orchestrator.SlotSelectiveRoutes, enable)
+	if err := s.deps.Orch.SetEnabledSilent(orchestrator.SlotSelectiveRoutes, enable); err != nil {
+		return false, err
+	}
+	return !unchanged, nil
 }
 
 // healLegacySelectiveRoutesSlotIfNeeded rewrites 19-selective-routes.json when an
@@ -123,7 +155,8 @@ func (s *ServiceImpl) healLegacySelectiveRoutesSlotIfNeeded(ctx context.Context)
 	if err := json.Unmarshal(data, &slot); err != nil {
 		var legacy RouterConfig
 		if err2 := json.Unmarshal(data, &legacy); err2 != nil {
-			return s.syncSelectiveRoutesSlot(ctx, nil)
+			_, err3 := s.syncSelectiveRoutesSlot(ctx, nil)
+			return err3
 		}
 		slot.Route.Rules = legacy.Route.Rules
 	}

--- a/internal/singbox/router/selective_routes_test.go
+++ b/internal/singbox/router/selective_routes_test.go
@@ -1,14 +1,17 @@
 package router
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 )
 
 func TestBuildSelectiveIPRules_GroupsByOutbound(t *testing.T) {
@@ -20,6 +23,32 @@ func TestBuildSelectiveIPRules_GroupsByOutbound(t *testing.T) {
 	}
 	if rules[0].Outbound != "awg-tunnel" || rules[0].IPCIDR[0] != "188.40.167.82/32" {
 		t.Fatalf("unexpected rule: %+v", rules[0])
+	}
+}
+
+// TestBuildSelectiveIPRules_DeterministicBytes guards the changed/unchanged
+// byte-compare in syncSelectiveRoutesSlot: marshalling the same accumulator
+// twice must be byte-identical, or every identical rebuild reports «changed»
+// and the skip-SIGHUP optimisation never fires.
+func TestBuildSelectiveIPRules_DeterministicBytes(t *testing.T) {
+	acc := selective.NewRouteAccumulator()
+	for i := 0; i < 60; i++ {
+		acc.Add("awg-a", fmt.Sprintf("10.0.%d.%d/32", i%7, i))
+		acc.Add("awg-b", fmt.Sprintf("172.16.%d.%d/32", i%5, i))
+		acc.Add("awg-c", fmt.Sprintf("192.168.%d.%d/32", i%3, i))
+	}
+	first, err := marshalSelectiveRoutesSlot(buildSelectiveIPRules(acc.RulesByOutbound()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		again, err := marshalSelectiveRoutesSlot(buildSelectiveIPRules(acc.RulesByOutbound()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first, again) {
+			t.Fatalf("marshal %d differs from first:\n%s\nvs\n%s", i, first, again)
+		}
 	}
 }
 
@@ -47,6 +76,63 @@ func TestMarshalSelectiveRoutesSlot_RouteOnly(t *testing.T) {
 		if _, ok := m[forbidden]; ok {
 			t.Fatalf("slot JSON must not contain %q: %s", forbidden, string(data))
 		}
+	}
+}
+
+func TestSyncSelectiveRoutesSlot_ReportsChangedOnlyOnDiff(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	_ = orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotSelectiveRoutes, Filename: "19-selective-routes.json"})
+
+	svc := &ServiceImpl{deps: Deps{Orch: orch}}
+	ctx := context.Background()
+	routes := map[string][]string{"tun": {"1.2.3.4/32"}}
+
+	changed, err := svc.syncSelectiveRoutesSlot(ctx, routes)
+	if err != nil || !changed {
+		t.Fatalf("first sync: changed=%v err=%v", changed, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "19-selective-routes.json")); err != nil {
+		t.Fatalf("active slot file missing: %v", err)
+	}
+
+	// Identical routes → byte-equal slot → no reload needed.
+	changed, err = svc.syncSelectiveRoutesSlot(ctx, routes)
+	if err != nil || changed {
+		t.Fatalf("no-op sync must report changed=false, got changed=%v err=%v", changed, err)
+	}
+
+	// Different routes → changed again.
+	changed, err = svc.syncSelectiveRoutesSlot(ctx, map[string][]string{"tun": {"5.6.7.8/32"}})
+	if err != nil || !changed {
+		t.Fatalf("diff sync: changed=%v err=%v", changed, err)
+	}
+}
+
+func TestSyncSelectiveRoutesSlot_EmptyRoutes(t *testing.T) {
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	_ = orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotSelectiveRoutes, Filename: "19-selective-routes.json"})
+
+	svc := &ServiceImpl{deps: Deps{Orch: orch}}
+	ctx := context.Background()
+
+	// Never-enabled slot + zero routes: already in target shape, no reload.
+	changed, err := svc.syncSelectiveRoutesSlot(ctx, nil)
+	if err != nil || changed {
+		t.Fatalf("empty sync on empty slot: changed=%v err=%v", changed, err)
+	}
+
+	// Enable with routes, then clear them: slot disable IS a config change.
+	if changed, err = svc.syncSelectiveRoutesSlot(ctx, map[string][]string{"tun": {"1.2.3.4/32"}}); err != nil || !changed {
+		t.Fatalf("populate: changed=%v err=%v", changed, err)
+	}
+	if changed, err = svc.syncSelectiveRoutesSlot(ctx, nil); err != nil || !changed {
+		t.Fatalf("clear: changed=%v err=%v", changed, err)
+	}
+	// And clearing again is a no-op.
+	if changed, err = svc.syncSelectiveRoutesSlot(ctx, nil); err != nil || changed {
+		t.Fatalf("second clear: changed=%v err=%v", changed, err)
 	}
 }
 

--- a/internal/singbox/router/service_selective.go
+++ b/internal/singbox/router/service_selective.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -106,17 +107,27 @@ type SelectiveDNSSource interface {
 // Note: uses context.Background() so the rebuild is NOT cancelled when the
 // parent reconcile/enable context finishes. The rebuild can outlive the
 // reconcile call (DNS resolution, ipset populate) and must not be cancelled
-// mid-way — a partial ipset is worse than none.
+// mid-way — a partial ipset is worse than none. The generous timeout both
+// backstops a wedged run and lets the in-run heavy-op gate acquire wait out
+// a boot-time orchestrator apply (60+ s sing-box cold-start readiness floor)
+// instead of giving up and leaving a reboot-emptied ipset unpopulated.
 func (s *ServiceImpl) triggerSelectiveRebuild(_ context.Context) {
 	if s.deps.SelectiveBuilder == nil {
 		return
 	}
 	go func() {
-		if err := s.deps.SelectiveBuilder.Rebuild(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), selectiveRebuildTimeout)
+		defer cancel()
+		if err := s.deps.SelectiveBuilder.Rebuild(ctx); err != nil {
 			s.appLog.Warn("selective-rebuild", "", fmt.Sprintf("ipset rebuild failed: %v", err))
 		}
 	}()
 }
+
+// selectiveRebuildTimeout is the overall backstop for one auto-triggered
+// ipset rebuild (boot/reconcile path). Mirrors the API handler's
+// rebuildTimeout.
+const selectiveRebuildTimeout = 10 * time.Minute
 
 // ensureSelectiveSetExists creates the AWGM-SELECTIVE ipset (empty) if it
 // does not already exist. Called before IPTables.Install when SelectiveBypass

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	CurrentSchemaVersion        = 27
+	CurrentSchemaVersion        = 28
 	DefaultPort                 = 2222
 	DefaultInterface            = "br0"
 	DefaultPingCheckTarget      = "8.8.8.8"
@@ -157,6 +157,9 @@ func (s *SettingsStore) Load() (*Settings, error) {
 		}
 		if settings.SchemaVersion < 27 {
 			s.migrateToV27(&settings)
+		}
+		if settings.SchemaVersion < 28 {
+			s.migrateToV28(&settings)
 		}
 	}
 
@@ -487,6 +490,19 @@ func (s *SettingsStore) migrateToV27(settings *Settings) {
 		settings.SingboxRouter.RoutingMode = "tproxy"
 	}
 	settings.SchemaVersion = 27
+}
+
+// migrateToV28 remaps Logging.SingboxLogLevel "trace" → "info" one-time.
+// migrateToV21 stamped the then-default "trace" on every existing install, so
+// on upgrade "trace" is overwhelmingly the old default, not a user choice —
+// it self-inflicted hundreds of journal lines per minute on low-RAM routers.
+// The rare user who deliberately picked trace has to re-enable it once;
+// levels chosen after v21 (debug, warn, …) are left untouched.
+func (s *SettingsStore) migrateToV28(settings *Settings) {
+	if settings.Logging.SingboxLogLevel == "trace" {
+		settings.Logging.SingboxLogLevel = "info"
+	}
+	settings.SchemaVersion = 28
 }
 
 // dedupManagedServers returns servers with duplicate InterfaceName entries

--- a/internal/storage/settings_test.go
+++ b/internal/storage/settings_test.go
@@ -603,6 +603,31 @@ func TestMigrateToV23SetsStableChannel(t *testing.T) {
 	}
 }
 
+func TestMigrateToV28RemapsTraceToInfo(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"trace", "info"}, // v21-stamped default, not a user choice
+		{"debug", "debug"},
+		{"warn", "warn"},
+		{"info", "info"},
+		{"", ""}, // left for downstream defaulting
+	}
+	for _, tc := range cases {
+		var s Settings
+		s.SchemaVersion = 27
+		s.Logging.SingboxLogLevel = tc.in
+		(&SettingsStore{}).migrateToV28(&s)
+		if s.Logging.SingboxLogLevel != tc.want {
+			t.Errorf("migrateToV28(%q) SingboxLogLevel = %q, want %q", tc.in, s.Logging.SingboxLogLevel, tc.want)
+		}
+		if s.SchemaVersion != 28 {
+			t.Errorf("SchemaVersion = %d, want 28", s.SchemaVersion)
+		}
+	}
+}
+
 func TestSettingsStore_SetSingboxCreateNDMSProxy_PersistsAtomic(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := NewSettingsStore(tmpDir)
@@ -735,8 +760,8 @@ func TestMigrateToV27_SetsRoutingModeTproxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if s.SchemaVersion != 27 {
-		t.Fatalf("schema = %d, want 27", s.SchemaVersion)
+	if s.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("schema = %d, want %d", s.SchemaVersion, CurrentSchemaVersion)
 	}
 	if s.SingboxRouter.RoutingMode != "tproxy" {
 		t.Fatalf("routingMode = %q, want tproxy", s.SingboxRouter.RoutingMode)
@@ -757,8 +782,8 @@ func TestMigrateToV27_PreservesExistingMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if s.SchemaVersion != 27 {
-		t.Fatalf("schema = %d, want 27", s.SchemaVersion)
+	if s.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("schema = %d, want %d", s.SchemaVersion, CurrentSchemaVersion)
 	}
 	if s.SingboxRouter.RoutingMode != "fakeip-tun" {
 		t.Fatalf("existing routingMode must be preserved, got %q", s.SingboxRouter.RoutingMode)

--- a/internal/storage/singbox_loglevel.go
+++ b/internal/storage/singbox_loglevel.go
@@ -2,7 +2,10 @@ package storage
 
 import "strings"
 
-const DefaultSingboxLogLevel = "trace"
+// DefaultSingboxLogLevel is "info": the old "trace" default self-inflicted
+// hundreds of journal lines per minute on low-RAM routers. Explicitly
+// configured "trace" keeps working.
+const DefaultSingboxLogLevel = "info"
 
 var validSingboxLogLevels = map[string]struct{}{
 	"trace": {},

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -248,7 +248,7 @@ type LoggingSettings struct {
 	Enabled           bool   `json:"enabled"`           // default: false
 	MaxAge            int    `json:"maxAge"`            // hours, default: 2 (shared by both buffers)
 	LogLevel          string `json:"logLevel"`          // "warn", "info", "full", "debug"; default: "info"
-	SingboxLogLevel   string `json:"singboxLogLevel"`   // "trace", "debug", "info", "warn", "error", "fatal", "panic"; default: "trace"
+	SingboxLogLevel   string `json:"singboxLogLevel"`   // "trace", "debug", "info", "warn", "error", "fatal", "panic"; default: "info"
 	AppMaxEntries     int    `json:"appMaxEntries"`     // app-bucket buffer cap, default: 5000
 	SingboxMaxEntries int    `json:"singboxMaxEntries"` // singbox-bucket buffer cap, default: 5000
 }


### PR DESCRIPTION
## Проблема

Пользователь за реверс-прокси Keenetic nginx получает при «Пересобрать ipset»:

> Не удалось пересобрать ipset: Ошибка сервера (504): \<html\> \<head\>\<title\>504 Gateway Time-out\</title\>…

Диагностика: Hopper KN-3811, OS 5.1 preview, 2 минуты после ребута, load 3.81. Обработчик `POST /api/singbox/router/selective/rebuild` был полностью синхронным и без дедлайна; на холодном старте он встал в очередь за автопересборкой бута и оркестратором на безлимитных мьютексах, nginx не дождался ~60 с (`proxy_read_timeout`) и отдал свою HTML-страницу 504, которую фронтенд показал как есть. Сама пересборка при этом продолжалась на роутере (`context.WithoutCancel`).

## Фикс

**Эндпоинт пересборки**
- `POST .../selective/rebuild` теперь отвечает **202** сразу (живой статус + `rebuilding`), работа идёт в фоне с 10-минутным дедлайном; повторный POST (nginx-retry, вторая вкладка) подхватывает идущую пересборку, а не ставит вторую в очередь; занятый heavy-op гейт — честный 409 `OPERATION_IN_PROGRESS`
- завершение — через существующие SSE-события selective progress/status; отказ до старта билдера теперь тоже публикует терминальное событие; порядок pre-check'ов и CAS исключает «обещали 202, а пересборка не запустилась»

**Гейты и конкуренция**
- `heavyop.LockWithContext`; билдер ждёт гейт с дедлайном своего запуска, а не жёсткие 30 с — one-shot бут-пересборка больше не сдаётся, пока sing-box холодно стартует (это оставляло опустошённый ребутом ipset пустым — тихая утечка в WAN)
- дедуп запусков начинается с входа в адаптер (закрыто окно гонки пользовательской и бут-пересборки со спурией «занято»)
- CDN-refresh держит гейт только на фазу мутации ipset, а не на минуты резолвинга — ручная пересборка больше не ловит 409 за ним
- RCI-семафор получает backstop 60 с для вызовов без дедлайна (3 места)

**Корректность пропуска no-op перезагрузки**
- слот selective-маршрутов маршалится детерминированно (сортировка outbound'ов и CIDR) — byte-diff, пропускающий SIGHUP sing-box, реально срабатывает
- неудачный apply запоминается и форсирует применение при следующей пересборке даже при неизменных байтах (самолечение сохранено)

**Репопуляция после ребута**
- «намеренно пустой» набор не триггерит пересборку на каждом буте, но только если снапшот подтверждает ноль настроенных матчеров; «успешная» пересборка с 0 записей при отказе DNS не отравляет маркер — бут-репопуляция сработает

**Логи**
- лог-уровень sing-box по умолчанию `info` (был `trace`, в т.ч. fallback), миграция v28 одноразово перемапливает `trace`→`info`, проштампованный миграцией v21 (на роутере из репорта было 720 warn/мин)

**Фронтенд**
- HTML шлюза (502/503/504) больше не попадает в тосты — классифицированная ошибка «Шлюз не дождался ответа от роутера (504). Операция может продолжаться в фоне.»; при gateway-timeout прогресс-UI остаётся открытым
- 202 = «запущено», завершение по SSE; `rebuilding` переживает перезагрузку страницы; epoch-guard не даёт устаревшему телу 202 перезаписать терминальный статус, пришедший раньше

## Проверки

- `go vet ./...`, `go test ./...` — чисто; `-race` на затронутых пакетах — чисто (один pre-existing race в `TestRouterSwitchMode_CallsService` воспроизводится на чистом HEAD)
- кросс-компиляция mips/mipsle (softfloat) + arm64, CGO off
- svelte-check 0/0, client-тесты 8/8 (+5 новых на классификатор)
- новые тесты: 202/дедуп/409/сброс флага, LockWithContext, детерминизм marshal, self-heal apply, decision-table NeedsPopulation, миграция v28
- два независимых ревью-прохода по difу (конкурентность + совместимость/регрессии): 10 находок, все исправлены до пуша

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_