### PR TITLE
feat(router): QoS-маршрутизация по DSCP-меткам (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Новые возможности
+
+- **QoS-классы по DSCP в sb-router** ([#371](https://github.com/hoaxisr/awg-manager/issues/371)) — трафик, помеченный DSCP-кодами (0-63, до 8 классов), направляется в отдельные выходы sing-box: классификация через iptables `-m dscp` в цепочках AWGM (per-class TPROXY/REDIRECT-порты 51281+/51301+), пары inbound'ов `tproxy-qos-N`/`redirect-qos-N` и управляемые правила маршрутизации по `inbound`. Классы редактируются в настройках sb-router (`qosClasses`); доступность xt_dscp отражается в статусе (`xtDscpAvailable`), при отсутствии модуля ядра или расширения iptables функция мягко отключается, не ломая движок.
+
 ## [2.15.1] - 2026-06-26
 
 ### Исправления

--- a/frontend/src/lib/components/sb-router/QosHelpModal.svelte
+++ b/frontend/src/lib/components/sb-router/QosHelpModal.svelte
@@ -1,0 +1,182 @@
+<!--
+  «Как пометить трафик на ПК» — компактная справка для QoS/DSCP-классов
+  (issue #371). PowerShell-политика QoS с подставленным DSCP выбранного
+  класса, reg add для недоменных/мульти-NIC машин и короткие заметки про
+  Linux / macOS / Wi-Fi WMM.
+-->
+<script lang="ts">
+  import { Copy } from 'lucide-svelte';
+  import { Modal, IconButton } from '$lib/components/ui';
+  import { notifications } from '$lib/stores/notifications';
+  import { copyToClipboard } from '$lib/utils/clipboard';
+  import type { SingboxQosClass } from '$lib/types';
+
+  interface Props {
+    open: boolean;
+    /** Настроенные классы — для подстановки DSCP/имени в сниппеты. */
+    classes: SingboxQosClass[];
+    onclose: () => void;
+  }
+  let { open, classes, onclose }: Props = $props();
+
+  let selectedIdx = $state(0);
+  // Сброс выбора при переоткрытии / изменении списка.
+  $effect(() => {
+    if (!open || selectedIdx >= classes.length) selectedIdx = 0;
+  });
+
+  const selected = $derived<SingboxQosClass | null>(classes[selectedIdx] ?? null);
+  // Без настроенных классов подставляем рабочий пример (DSCP 46, «Пример»):
+  // копируемая команда должна оставаться валидной — никаких <плейсхолдеров>
+  // в тексте под кнопкой «Копировать».
+  const dscpValue = $derived(selected ? String(selected.dscp) : '46');
+  const policyName = $derived.by(() => {
+    if (!selected) return 'AWGM-Пример';
+    const raw = selected.name.trim().replace(/"/g, '');
+    return `AWGM-${raw || 'class'}`;
+  });
+
+  const psSnippet = $derived(
+    `New-NetQosPolicy -Name "${policyName}" -AppPathNameMatchCondition "app.exe" -DSCPAction ${dscpValue} -NetworkProfile All`,
+  );
+  const regSnippet =
+    'reg add "HKLM\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\QoS" /v "Do not use NLA" /t REG_SZ /d 1 /f';
+  const linuxSnippet = $derived(
+    `iptables -t mangle -A OUTPUT -m owner --uid-owner <uid> -j DSCP --set-dscp ${dscpValue}`,
+  );
+
+  async function copy(text: string) {
+    const ok = await copyToClipboard(text);
+    if (ok) notifications.success('Скопировано в буфер обмена');
+    else notifications.error('Не удалось скопировать');
+  }
+</script>
+
+<Modal {open} title="Как пометить трафик на ПК" size="md" {onclose}>
+  <div class="body">
+    {#if classes.length === 0}
+      <p class="hint">
+        Команды ниже — пример с DSCP 46. Добавьте класс, чтобы получить готовую
+        команду под него.
+      </p>
+    {/if}
+
+    {#if classes.length > 1}
+      <label class="field">
+        <span class="lbl">Класс</span>
+        <select class="inp" bind:value={selectedIdx}>
+          {#each classes as cls, idx (idx)}
+            <option value={idx}>DSCP {cls.dscp} — {cls.name || 'без названия'}</option>
+          {/each}
+        </select>
+      </label>
+    {/if}
+
+    <section class="block">
+      <div class="blk-cap">Windows — политика QoS (PowerShell от администратора)</div>
+      <div class="code-row">
+        <pre class="code">{psSnippet}</pre>
+        <IconButton size="sm" ariaLabel="Копировать команду PowerShell" title="Копировать" onclick={() => void copy(psSnippet)}>
+          <Copy size={14} />
+        </IconButton>
+      </div>
+      <p class="hint">
+        Замените <code class="mono">app.exe</code> на имя исполняемого файла программы,
+        чей трафик нужно пометить.
+      </p>
+    </section>
+
+    <section class="block">
+      <div class="blk-cap">Недоменные / мульти-NIC машины</div>
+      <div class="code-row">
+        <pre class="code">{regSnippet}</pre>
+        <IconButton size="sm" ariaLabel="Копировать команду reg add" title="Копировать" onclick={() => void copy(regSnippet)}>
+          <Copy size={14} />
+        </IconButton>
+      </div>
+      <p class="hint">
+        Без этого ключа Windows вне домена (или с несколькими сетевыми адаптерами)
+        может игнорировать политику QoS. После добавления перезагрузите ПК.
+      </p>
+    </section>
+
+    <section class="block">
+      <div class="blk-cap">Заметки</div>
+      <ul class="notes">
+        <li>
+          Linux: <code class="mono">{linuxSnippet}</code>
+        </li>
+        <li>macOS: пометка DSCP для приложений не поддерживается системно.</li>
+        <li>Wi-Fi (WMM) может перезаписать DSCP-метку — проверяйте по кабелю.</li>
+      </ul>
+    </section>
+  </div>
+</Modal>
+
+<style>
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .lbl { font-size: 11px; color: var(--text-muted); font-weight: 500; }
+  .inp {
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    font-size: 12.5px;
+    font-family: inherit;
+  }
+  .block { display: flex; flex-direction: column; gap: 6px; }
+  .blk-cap {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+  .code-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .code {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .hint { margin: 0; font-size: 11.5px; color: var(--text-muted); line-height: 1.4; }
+  .notes {
+    margin: 0;
+    padding-left: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  code.mono {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 3px;
+    color: var(--text-secondary);
+    word-break: break-all;
+  }
+</style>

--- a/frontend/src/lib/components/sb-router/QosSettingsCard.svelte
+++ b/frontend/src/lib/components/sb-router/QosSettingsCard.svelte
@@ -1,0 +1,331 @@
+<!--
+  QoS-маршрутизация (DSCP) — issue #371. Секция настроек движка sing-box
+  (StatusDrawer, expert): таблица классов DSCP → outbound. Сохранение идёт
+  через тот же auto-save пайплайн, что и остальные настройки дровера
+  (onPatch → applyPatch → mergeAndSaveSettings → PUT /singbox/router/settings).
+
+  Семантика: работает только в режиме TProxy (не fakeip-tun); трафик с меткой
+  DSCP N уходит в outbound класса, минуя остальные правила маршрутизации.
+-->
+<script lang="ts">
+  import { Plus, Trash2, TriangleAlert } from 'lucide-svelte';
+  import { Toggle, Button, Dropdown, IconButton, type DropdownOption } from '$lib/components/ui';
+  import { notifications } from '$lib/stores/notifications';
+  import type { OutboundGroup } from '$lib/components/routing/singboxRouter/outboundOptions';
+  import type { SingboxQosClass, SingboxRouterSettings, SingboxRouterStatus } from '$lib/types';
+  import IssueRow from './IssueRow.svelte';
+  import QosHelpModal from './QosHelpModal.svelte';
+  import {
+    QOS_MAX_CLASSES,
+    QOS_DSCP_MIN,
+    QOS_DSCP_MAX,
+    QOS_NAME_MAX,
+    clampDscp,
+    normalizeQosClasses,
+    addQosClass,
+    isDscpTaken,
+    updateQosClass,
+    removeQosClass,
+    resolveOutboundOptions,
+    createSaveQueue,
+  } from './qosClasses';
+
+  interface Props {
+    cfg: SingboxRouterSettings;
+    status: SingboxRouterStatus | null;
+    outboundOptions: OutboundGroup[];
+    /** Может вернуть Promise — карточка ждёт его для сериализации PUT-ов. */
+    onPatch: (patch: Partial<SingboxRouterSettings>) => void | Promise<void>;
+  }
+  let { cfg, status, outboundOptions, onPatch }: Props = $props();
+
+  // Оптимистичный черновик поверх cfg: коммиты применяются к нему сразу
+  // (иначе коммит, сделанный пока предыдущий PUT в полёте, считался бы от
+  // устаревшего cfg и потерял бы прошлое изменение). Сбрасывается, когда
+  // очередь сохранений опустела: после успеха cfg уже перезагружен и равен
+  // черновику; после ошибки cfg не изменился — строки откатываются к
+  // сохранённой правде (значения инпутов перерисуются из cfg).
+  let draft = $state<SingboxQosClass[] | null>(null);
+
+  // mock-api / легаси-payload без qosClasses → пустой список (undefined-safe).
+  const classes = $derived(draft ?? normalizeQosClasses(cfg.qosClasses));
+  // Классы применимы только в TProxy; отсутствующий routingMode = легаси tproxy.
+  const locked = $derived((cfg.routingMode ?? 'tproxy') === 'fakeip-tun');
+  // Строго false: undefined (мок/старый бэкенд) — неизвестно, баннер не показываем.
+  const xtDscpMissing = $derived(status?.xtDscpAvailable === false);
+  const atCap = $derived(classes.length >= QOS_MAX_CLASSES);
+
+  // Тот же формат опций, что у RuleEditModal: группы из
+  // singboxRouter.options (buildOutboundOptions) → плоский DropdownOption[].
+  const outboundDropdownOptions = $derived<DropdownOption[]>(
+    outboundOptions.flatMap((g) =>
+      g.items.map((i) => ({ value: i.value, label: i.label, group: g.group })),
+    ),
+  );
+  // Новый класс по умолчанию направляем в первый туннель (не direct):
+  // класс с outbound=direct не имеет смысла для «направить в туннель».
+  const defaultOutbound = $derived(
+    outboundDropdownOptions.find((o) => o.value !== 'direct')?.value
+      ?? outboundDropdownOptions[0]?.value
+      ?? 'direct',
+  );
+
+  let helpOpen = $state(false);
+
+  // Один PUT в полёте, следующие коммиты коалесцируются (последний снапшот
+  // побеждает — он полный список, собранный поверх предыдущих). Когда
+  // очередь опустела — сбрасываем черновик: UI ресинкается со стором.
+  const enqueueSave = createSaveQueue<SingboxQosClass[]>(
+    (next) => onPatch({ qosClasses: next }),
+    () => {
+      draft = null;
+    },
+  );
+
+  function commit(next: SingboxQosClass[]) {
+    draft = next;
+    enqueueSave(next);
+  }
+
+  function handleAdd() {
+    const next = addQosClass(classes, defaultOutbound);
+    if (!next) return;
+    commit(next);
+  }
+
+  // DSCP/название коммитятся только на blur (Enter → blur → коммит):
+  // событие change у number-инпута стреляет на каждый клик по стрелкам —
+  // это устраивало PUT-шторм с промежуточными значениями.
+  function handleDscpCommit(e: Event, idx: number) {
+    const input = e.currentTarget as HTMLInputElement;
+    const parsed = clampDscp(Number(input.value));
+    if (isDscpTaken(classes, idx, parsed)) {
+      notifications.error(`DSCP ${parsed} уже используется другим классом`);
+      input.value = String(classes[idx].dscp);
+      return;
+    }
+    input.value = String(parsed);
+    if (parsed === classes[idx].dscp) return;
+    commit(updateQosClass(classes, idx, { dscp: parsed }));
+  }
+
+  function handleNameCommit(e: Event, idx: number) {
+    const input = e.currentTarget as HTMLInputElement;
+    const name = input.value.slice(0, QOS_NAME_MAX);
+    input.value = name;
+    if (name === classes[idx].name) return;
+    commit(updateQosClass(classes, idx, { name }));
+  }
+
+  function blurOnEnter(e: KeyboardEvent) {
+    if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
+  }
+
+  function handleOutboundChange(idx: number, outbound: string) {
+    if (outbound === classes[idx].outbound) return;
+    commit(updateQosClass(classes, idx, { outbound }));
+  }
+
+  function handleToggle(idx: number, enabled: boolean) {
+    commit(updateQosClass(classes, idx, { enabled }));
+  }
+
+  function handleRemove(idx: number) {
+    commit(removeQosClass(classes, idx));
+  }
+</script>
+
+<section class="sec">
+  <div class="sec-cap">QoS-маршрутизация (DSCP)</div>
+
+  <p class="hint">
+    Трафик с меткой DSCP направляется в выбранный туннель. Метку на трафик программ
+    ставит клиентское устройство (например, политика QoS в Windows).
+  </p>
+
+  {#if locked}
+    <p class="hint locked-hint">Доступно только в режиме TProxy.</p>
+  {:else}
+    {#if xtDscpMissing}
+      <IssueRow tone="warning" text="Модуль ядра xt_dscp недоступен — правила DSCP не будут применены" />
+    {/if}
+
+    {#if classes.length > 0}
+      <div class="qos-list">
+        <div class="qos-grid qos-head">
+          <span>DSCP</span>
+          <span>Название</span>
+          <span class="col-center">Вкл</span>
+          <span></span>
+        </div>
+        {#each classes as cls, idx (cls.dscp)}
+          {@const outboundView = resolveOutboundOptions(outboundDropdownOptions, cls.outbound)}
+          <div class="qos-row" class:row-off={!cls.enabled}>
+            <div class="qos-grid">
+              <input
+                class="inp dscp-inp"
+                type="number"
+                min={QOS_DSCP_MIN}
+                max={QOS_DSCP_MAX}
+                step="1"
+                value={cls.dscp}
+                aria-label="DSCP класса {idx + 1}"
+                onblur={(e) => handleDscpCommit(e, idx)}
+                onkeydown={blurOnEnter}
+              />
+              <input
+                class="inp"
+                type="text"
+                maxlength={QOS_NAME_MAX}
+                placeholder="Название"
+                value={cls.name}
+                aria-label="Название класса {idx + 1}"
+                onblur={(e) => handleNameCommit(e, idx)}
+                onkeydown={blurOnEnter}
+              />
+              <span class="col-center">
+                <Toggle
+                  size="sm"
+                  checked={cls.enabled}
+                  ariaLabel="Включить класс DSCP {cls.dscp}"
+                  onchange={(v) => handleToggle(idx, v)}
+                />
+              </span>
+              <IconButton
+                variant="danger"
+                size="sm"
+                ariaLabel="Удалить класс {cls.name || cls.dscp}"
+                title="Удалить класс"
+                onclick={() => handleRemove(idx)}
+              >
+                <Trash2 size={14} />
+              </IconButton>
+            </div>
+            <Dropdown
+              value={cls.outbound}
+              options={outboundView.options}
+              placeholder="— outbound —"
+              fullWidth
+              onchange={(v) => handleOutboundChange(idx, String(v))}
+            />
+            {#if outboundView.missing}
+              <p class="qos-warn">
+                <TriangleAlert size={12} aria-hidden="true" />
+                outbound не найден — выберите другой
+              </p>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <p class="hint">
+        Классы не настроены. Добавьте класс, чтобы направлять помеченный трафик
+        в отдельный туннель.
+      </p>
+    {/if}
+
+    <Button variant="ghost" size="sm" fullWidth disabled={atCap} onclick={handleAdd}>
+      {#snippet iconBefore()}
+        <Plus size={14} aria-hidden="true" />
+      {/snippet}
+      Добавить класс
+    </Button>
+    {#if atCap}
+      <p class="hint">Достигнут максимум — {QOS_MAX_CLASSES} классов.</p>
+    {/if}
+
+    <p class="hint">
+      DSCP: 0–63. Типичные метки: 46 (EF — голос/игры), 32 (CS4 — видео),
+      8 (CS1 — фоновая закачка).
+    </p>
+
+    <button type="button" class="link-btn" onclick={() => (helpOpen = true)}>
+      Как пометить трафик на ПК →
+    </button>
+  {/if}
+</section>
+
+<QosHelpModal open={helpOpen} {classes} onclose={() => (helpOpen = false)} />
+
+<style>
+  /* Стили секции повторяют .sec/.sec-cap/.hint дровера (scoped-стили
+     родителя не проникают в дочерний компонент — как в TrafficSourceSettings). */
+  .sec {
+    padding: 14px var(--sp-4);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .sec:last-of-type { border-bottom: 0; }
+  .sec-cap {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+  .hint { margin: 0; font-size: 11.5px; color: var(--text-muted); line-height: 1.4; }
+  .locked-hint { color: var(--text-secondary); }
+
+  .qos-list { display: flex; flex-direction: column; gap: 8px; }
+  .qos-grid {
+    display: grid;
+    grid-template-columns: 56px minmax(0, 1fr) auto auto;
+    gap: 6px;
+    align-items: center;
+  }
+  .qos-head {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    padding: 0 2px;
+  }
+  .col-center { display: inline-flex; justify-content: center; }
+  .qos-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+  }
+  .qos-row.row-off { opacity: 0.65; }
+  .inp {
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    font-size: 12.5px;
+    font-family: inherit;
+  }
+  .dscp-inp { font-family: var(--font-mono); font-size: 12px; }
+
+  .qos-warn {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--warning);
+    line-height: 1.4;
+  }
+
+  .link-btn {
+    align-self: flex-start;
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--accent);
+  }
+  .link-btn:hover { text-decoration: underline; }
+</style>

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -19,6 +19,7 @@
   import SubnetChipsInput from './SubnetChipsInput.svelte';
   import TrafficSourceSettings from './TrafficSourceSettings.svelte';
   import SelectiveIpsetSnapshot from './SelectiveIpsetSnapshot.svelte';
+  import QosSettingsCard from './QosSettingsCard.svelte';
   import { deriveDeps, deriveIssues } from './drawerData';
   import { mergeAndSaveSettings, BYPASS_PRESETS } from './settingsActions';
   import { resolveWanAuto, planToggleAutoDetect, planSelectWanInterface, type WanAutoOverride } from './wanMode';
@@ -30,6 +31,7 @@
 
   const status = singboxRouterStore.status;
   const storeSettings = singboxRouterStore.settings;
+  const storeOptions = singboxRouterStore.options;
 
   let open = $derived($drawerOpen);
   let s = $derived($status);
@@ -432,6 +434,15 @@
           </p>
         {/if}
       </section>
+
+      <!-- QoS-маршрутизация (DSCP): onPatch возвращает Promise — карточка
+           сериализует свои PUT-ы и ресинкается со стором после дренажа очереди. -->
+      <QosSettingsCard
+        {cfg}
+        status={s}
+        outboundOptions={$storeOptions}
+        onPatch={(patch) => applyPatch(patch)}
+      />
 
       <!-- Исключения портов -->
       <section class="sec">

--- a/frontend/src/lib/components/sb-router/qosClasses.test.ts
+++ b/frontend/src/lib/components/sb-router/qosClasses.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SingboxQosClass } from '$lib/types';
+import {
+  QOS_MAX_CLASSES,
+  clampDscp,
+  normalizeQosClasses,
+  nextFreeDscp,
+  addQosClass,
+  isDscpTaken,
+  updateQosClass,
+  removeQosClass,
+  resolveOutboundOptions,
+  createSaveQueue,
+} from './qosClasses';
+
+function cls(dscp: number, over: Partial<SingboxQosClass> = {}): SingboxQosClass {
+  return { dscp, name: `c${dscp}`, outbound: 'direct', enabled: true, ...over };
+}
+
+describe('clampDscp', () => {
+  it('clamps to 0–63 and truncates fractions', () => {
+    expect(clampDscp(-5)).toBe(0);
+    expect(clampDscp(64)).toBe(63);
+    expect(clampDscp(46.9)).toBe(46);
+    expect(clampDscp(NaN)).toBe(0);
+    expect(clampDscp(Infinity)).toBe(0);
+  });
+});
+
+describe('normalizeQosClasses', () => {
+  it('treats undefined/null (mock payloads without the field) as empty list', () => {
+    expect(normalizeQosClasses(undefined)).toEqual([]);
+    expect(normalizeQosClasses(null)).toEqual([]);
+  });
+
+  it('dedupes duplicate dscp values, first occurrence wins', () => {
+    const out = normalizeQosClasses([cls(46, { name: 'first' }), cls(46, { name: 'second' }), cls(8)]);
+    expect(out.map((c) => c.dscp)).toEqual([46, 8]);
+    expect(out[0].name).toBe('first');
+  });
+
+  it('caps the list at 8 classes', () => {
+    const input = Array.from({ length: 12 }, (_, i) => cls(i));
+    const out = normalizeQosClasses(input);
+    expect(out).toHaveLength(QOS_MAX_CLASSES);
+    expect(out.map((c) => c.dscp)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('clamps dscp and truncates name to 32 chars', () => {
+    const out = normalizeQosClasses([cls(200, { name: 'x'.repeat(40) })]);
+    expect(out[0].dscp).toBe(63);
+    expect(out[0].name).toHaveLength(32);
+  });
+
+  it('dedupe applies after clamping (100 and 63 collide)', () => {
+    const out = normalizeQosClasses([cls(100), cls(63)]);
+    expect(out).toHaveLength(1);
+    expect(out[0].dscp).toBe(63);
+  });
+
+  it('defaults enabled to true unless explicitly false', () => {
+    const out = normalizeQosClasses([
+      { dscp: 1, name: 'a', outbound: 'direct', enabled: undefined as unknown as boolean },
+      cls(2, { enabled: false }),
+    ]);
+    expect(out[0].enabled).toBe(true);
+    expect(out[1].enabled).toBe(false);
+  });
+});
+
+describe('nextFreeDscp / addQosClass', () => {
+  it('prefers presets 46 → 32 → 8, then lowest free value', () => {
+    expect(nextFreeDscp([])).toBe(46);
+    expect(nextFreeDscp([cls(46)])).toBe(32);
+    expect(nextFreeDscp([cls(46), cls(32)])).toBe(8);
+    expect(nextFreeDscp([cls(46), cls(32), cls(8), cls(0)])).toBe(1);
+  });
+
+  it('addQosClass appends an enabled class with a free dscp', () => {
+    const out = addQosClass([cls(46)], 'awg-vpn0');
+    expect(out).not.toBeNull();
+    expect(out).toHaveLength(2);
+    expect(out![1]).toMatchObject({ dscp: 32, outbound: 'awg-vpn0', enabled: true });
+  });
+
+  it('addQosClass returns null at the 8-class cap', () => {
+    const full = Array.from({ length: QOS_MAX_CLASSES }, (_, i) => cls(i));
+    expect(addQosClass(full, 'direct')).toBeNull();
+  });
+});
+
+describe('isDscpTaken', () => {
+  it('detects duplicates excluding the edited row itself', () => {
+    const list = [cls(46), cls(8)];
+    expect(isDscpTaken(list, 0, 46)).toBe(false); // own value
+    expect(isDscpTaken(list, 0, 8)).toBe(true); // other row's value
+    expect(isDscpTaken(list, 1, 32)).toBe(false);
+  });
+});
+
+describe('updateQosClass / removeQosClass', () => {
+  it('patches one entry immutably with clamping and name truncation', () => {
+    const list = [cls(46), cls(8)];
+    const out = updateQosClass(list, 1, { dscp: 99, name: 'y'.repeat(50) });
+    expect(out[1].dscp).toBe(63);
+    expect(out[1].name).toHaveLength(32);
+    expect(out[0]).toBe(list[0]); // untouched entry keeps identity
+    expect(list[1].dscp).toBe(8); // source not mutated
+  });
+
+  it('removes by index', () => {
+    const out = removeQosClass([cls(46), cls(8)], 0);
+    expect(out.map((c) => c.dscp)).toEqual([8]);
+  });
+});
+
+describe('resolveOutboundOptions', () => {
+  const opts = [
+    { value: 'direct', label: 'Direct' },
+    { value: 'awg-vpn0', label: 'VPN 0' },
+  ];
+
+  it('returns options as-is when the tag is present', () => {
+    const out = resolveOutboundOptions(opts, 'awg-vpn0');
+    expect(out.options).toBe(opts);
+    expect(out.missing).toBe(false);
+  });
+
+  it('returns options as-is for an empty tag (placeholder is legit)', () => {
+    const out = resolveOutboundOptions(opts, '');
+    expect(out.options).toBe(opts);
+    expect(out.missing).toBe(false);
+  });
+
+  it('cold-load (no options yet): shows the raw tag, no missing warning', () => {
+    const out = resolveOutboundOptions([], 'awg-gone');
+    expect(out.options).toEqual([{ value: 'awg-gone', label: 'awg-gone', disabled: true }]);
+    expect(out.missing).toBe(false);
+  });
+
+  it('missing tag among real options: appends disabled «(недоступен)» entry and flags missing', () => {
+    const out = resolveOutboundOptions(opts, 'awg-gone');
+    expect(out.missing).toBe(true);
+    expect(out.options).toHaveLength(3);
+    expect(out.options[2]).toEqual({
+      value: 'awg-gone',
+      label: '(недоступен) awg-gone',
+      disabled: true,
+    });
+  });
+});
+
+describe('createSaveQueue', () => {
+  function deferred() {
+    let resolve!: () => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+  const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  it('serializes saves: second commit waits for the first PUT to finish', async () => {
+    const gates = [deferred(), deferred()];
+    let calls = 0;
+    const save = vi.fn((_: number) => gates[calls++].promise);
+    const onDrained = vi.fn();
+    const enqueue = createSaveQueue<number>(save, onDrained);
+
+    enqueue(1);
+    await tick();
+    enqueue(2);
+    await tick();
+    expect(save).toHaveBeenCalledTimes(1); // 2 queued, not sent yet
+
+    gates[0].resolve();
+    await tick();
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenLastCalledWith(2);
+    expect(onDrained).not.toHaveBeenCalled();
+
+    gates[1].resolve();
+    await tick();
+    expect(onDrained).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces commits made while a save is in flight (latest snapshot wins)', async () => {
+    const gate = deferred();
+    const seen: number[] = [];
+    const save = vi.fn((v: number) => {
+      seen.push(v);
+      return seen.length === 1 ? gate.promise : Promise.resolve();
+    });
+    const enqueue = createSaveQueue<number>(save, () => {});
+
+    enqueue(1);
+    enqueue(2);
+    enqueue(3);
+    gate.resolve();
+    await tick();
+    expect(seen).toEqual([1, 3]); // 2 superseded by 3 while 1 was in flight
+  });
+
+  it('keeps draining after a failed save and still calls onDrained', async () => {
+    let calls = 0;
+    const save = vi.fn((_: number) =>
+      calls++ === 0 ? Promise.reject(new Error('boom')) : Promise.resolve(),
+    );
+    const onDrained = vi.fn();
+    const enqueue = createSaveQueue<number>(save, onDrained);
+
+    enqueue(1);
+    await tick();
+    expect(onDrained).toHaveBeenCalledTimes(1);
+
+    enqueue(2);
+    await tick();
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(onDrained).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/components/sb-router/qosClasses.ts
+++ b/frontend/src/lib/components/sb-router/qosClasses.ts
@@ -1,0 +1,188 @@
+// Pure edit-helpers for the QoS/DSCP class list (issue #371).
+// Kept out of the Svelte component so normalization rules (dedupe dscp,
+// cap 8, clamp 0–63, name ≤ 32) are unit-testable — see qosClasses.test.ts.
+
+import type { SingboxQosClass } from '$lib/types';
+
+export const QOS_MAX_CLASSES = 8;
+export const QOS_DSCP_MIN = 0;
+export const QOS_DSCP_MAX = 63;
+export const QOS_NAME_MAX = 32;
+
+/**
+ * Preferred DSCP values for new classes, in pick order. Common presets:
+ * 46 = EF (голос/игры), 32 = CS4 (видео), 8 = CS1 (фоновый трафик).
+ */
+export const QOS_DSCP_PRESETS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 46, label: '46 (EF — голос/игры)' },
+  { value: 32, label: '32 (CS4 — видео)' },
+  { value: 8, label: '8 (CS1 — фоновая закачка)' },
+];
+
+/** Clamp an arbitrary number to a valid integer DSCP mark (0–63). */
+export function clampDscp(value: number): number {
+  if (!Number.isFinite(value)) return QOS_DSCP_MIN;
+  return Math.min(QOS_DSCP_MAX, Math.max(QOS_DSCP_MIN, Math.trunc(value)));
+}
+
+/**
+ * Normalize a raw settings payload into a valid class list:
+ * undefined/null (legacy/mock payloads without the field) → [];
+ * dscp clamped to 0–63; name truncated to 32 chars; duplicate dscp values
+ * deduped (first occurrence wins); list capped at 8 entries.
+ */
+export function normalizeQosClasses(
+  list: SingboxQosClass[] | undefined | null,
+): SingboxQosClass[] {
+  if (!Array.isArray(list)) return [];
+  const seen = new Set<number>();
+  const out: SingboxQosClass[] = [];
+  for (const raw of list) {
+    if (!raw || typeof raw !== 'object') continue;
+    const dscp = clampDscp(Number(raw.dscp));
+    if (seen.has(dscp)) continue;
+    seen.add(dscp);
+    out.push({
+      dscp,
+      name: String(raw.name ?? '').slice(0, QOS_NAME_MAX),
+      outbound: String(raw.outbound ?? ''),
+      enabled: raw.enabled !== false,
+    });
+    if (out.length >= QOS_MAX_CLASSES) break;
+  }
+  return out;
+}
+
+/** First unused DSCP: presets (46, 32, 8) first, then lowest free 0–63. */
+export function nextFreeDscp(list: SingboxQosClass[]): number | null {
+  const used = new Set(list.map((c) => c.dscp));
+  for (const p of QOS_DSCP_PRESETS) {
+    if (!used.has(p.value)) return p.value;
+  }
+  for (let d = QOS_DSCP_MIN; d <= QOS_DSCP_MAX; d++) {
+    if (!used.has(d)) return d;
+  }
+  return null;
+}
+
+/**
+ * Append a new class with the first free DSCP. Returns null when the list
+ * is at the 8-class cap (or, theoretically, when all 64 marks are taken).
+ */
+export function addQosClass(
+  list: SingboxQosClass[],
+  defaultOutbound: string,
+): SingboxQosClass[] | null {
+  if (list.length >= QOS_MAX_CLASSES) return null;
+  const dscp = nextFreeDscp(list);
+  if (dscp === null) return null;
+  return [
+    ...list,
+    {
+      dscp,
+      name: `Класс ${list.length + 1}`,
+      outbound: defaultOutbound,
+      enabled: true,
+    },
+  ];
+}
+
+/** True when `dscp` is already used by a class other than list[index]. */
+export function isDscpTaken(list: SingboxQosClass[], index: number, dscp: number): boolean {
+  return list.some((c, i) => i !== index && c.dscp === dscp);
+}
+
+/** Immutable single-entry patch; dscp is clamped, name truncated. */
+export function updateQosClass(
+  list: SingboxQosClass[],
+  index: number,
+  patch: Partial<SingboxQosClass>,
+): SingboxQosClass[] {
+  return list.map((c, i) => {
+    if (i !== index) return c;
+    const next = { ...c, ...patch };
+    next.dscp = clampDscp(next.dscp);
+    next.name = next.name.slice(0, QOS_NAME_MAX);
+    return next;
+  });
+}
+
+export function removeQosClass(list: SingboxQosClass[], index: number): SingboxQosClass[] {
+  return list.filter((_, i) => i !== index);
+}
+
+/** Synthetic entry appended when a stored outbound tag has no matching option. */
+export interface StaleOutboundOption {
+  value: string;
+  label: string;
+  disabled: true;
+}
+
+/**
+ * Options for a row's outbound dropdown, handling a stored tag that is
+ * absent from the current option list:
+ * - tag present (or empty) → options as-is;
+ * - options still cold-loading (empty stores) → single synthetic entry with
+ *   the raw tag, no warning — «нет опций» ещё не значит «тег пропал»;
+ * - tag missing among real options → append a disabled «(недоступен) tag»
+ *   entry (so the trigger shows it instead of the placeholder) and flag
+ *   `missing` for the row warning.
+ */
+export function resolveOutboundOptions<O extends { value: string }>(
+  options: O[],
+  tag: string,
+): { options: Array<O | StaleOutboundOption>; missing: boolean } {
+  if (!tag || options.some((o) => o.value === tag)) {
+    return { options, missing: false };
+  }
+  if (options.length === 0) {
+    return { options: [{ value: tag, label: tag, disabled: true }], missing: false };
+  }
+  return {
+    options: [...options, { value: tag, label: `(недоступен) ${tag}`, disabled: true }],
+    missing: true,
+  };
+}
+
+/**
+ * Serialized save queue for the QoS card: at most one save() in flight;
+ * commits made meanwhile are coalesced — only the latest snapshot is sent
+ * next (each snapshot is the full class list built on top of the previous
+ * one, so nothing is lost). Prevents concurrent PUTs racing through
+ * mergeAndSaveSettings with stale store state and out-of-order responses.
+ *
+ * `onDrained` fires once the queue empties (after success OR failure) —
+ * the card uses it to drop its optimistic draft and resync to the store,
+ * reverting rejected values. save() errors are swallowed here: the drawer's
+ * applyPatch already surfaces them (toast).
+ */
+export function createSaveQueue<T>(
+  save: (snapshot: T) => void | Promise<void>,
+  onDrained: () => void,
+): (snapshot: T) => void {
+  let inFlight = false;
+  let pending: { value: T } | null = null;
+
+  async function pump(): Promise<void> {
+    inFlight = true;
+    try {
+      while (pending) {
+        const next = pending.value;
+        pending = null;
+        try {
+          await save(next);
+        } catch {
+          // errors are surfaced by the caller's save() itself; keep draining
+        }
+      }
+    } finally {
+      inFlight = false;
+      onDrained();
+    }
+  }
+
+  return (snapshot: T) => {
+    pending = { value: snapshot };
+    if (!inFlight) void pump();
+  };
+}

--- a/frontend/src/lib/components/ui/Toggle.svelte
+++ b/frontend/src/lib/components/ui/Toggle.svelte
@@ -12,6 +12,8 @@
         disabled?: boolean;
         label?: string;
         hint?: string;
+        /** Accessible name for the checkbox input — for toggles without a visible label. */
+        ariaLabel?: string;
         size?: 'sm' | 'md';
         variant?: 'slider' | 'flip';
         /** Flip ON-state colour override (AWG recovering / starting / unreachable). */
@@ -34,6 +36,7 @@
         disabled = false,
         label = '',
         hint = '',
+        ariaLabel = '',
         size = 'md',
         variant = 'slider',
         tint,
@@ -71,7 +74,7 @@
             class:tint-starting={tint === 'starting'}
             class:tint-unreachable={tint === 'unreachable'}
         >
-            <input type="checkbox" checked={checked} {disabled} oninput={handleInput} />
+            <input type="checkbox" checked={checked} {disabled} aria-label={ariaLabel || undefined} oninput={handleInput} />
             {#if variant === 'flip'}
                 <span class="flip-track">
                     <span class="flip-lever">
@@ -111,7 +114,7 @@
         class:tint-starting={tint === 'starting'}
         class:tint-unreachable={tint === 'unreachable'}
     >
-        <input type="checkbox" checked={checked} {disabled} oninput={handleInput} />
+        <input type="checkbox" checked={checked} {disabled} aria-label={ariaLabel || undefined} oninput={handleInput} />
         {#if variant === 'flip'}
             <span class="flip-track">
                 <span class="flip-lever">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1323,6 +1323,25 @@ export interface SingboxRouterSettings {
 	 * Requires ipset binary and xt_set kernel module on the router.
 	 */
 	selectiveBypass?: boolean;
+	/**
+	 * QoS/DSCP routing classes (issue #371). Traffic marked with class DSCP is
+	 * routed to the class outbound, trumping other route rules. Works only in
+	 * routingMode 'tproxy' (not fakeip-tun). Max 8 classes; dscp 0–63 unique;
+	 * name ≤ 32 chars; outbound = any valid outbound tag. Omitempty on the
+	 * wire → absent on legacy/mock payloads (treat undefined as []).
+	 */
+	qosClasses?: SingboxQosClass[];
+}
+
+/** One QoS/DSCP routing class (SingboxRouterSettings.qosClasses entry). */
+export interface SingboxQosClass {
+	/** DSCP mark 0–63, unique within the list. */
+	dscp: number;
+	/** Display name, ≤ 32 chars. */
+	name: string;
+	/** Outbound tag the marked traffic is routed to. */
+	outbound: string;
+	enabled: boolean;
 }
 
 // WAN interface for the sing-box router WAN-binding picker. `name` is
@@ -1382,6 +1401,12 @@ export interface SingboxRouterStatus {
 	issues?: SingboxRouterIssue[];
 	/** Последняя fatal-причина sing-box; непусто только при «СБОЙ» (enabled && !active). */
 	lastError?: string;
+	/**
+	 * xt_dscp kernel module is available for DSCP matching (issue #371 QoS).
+	 * Strict `false` → QoS classes cannot be applied (UI shows a warning).
+	 * Optional: absent on legacy/mock payloads → treated as unknown, no warning.
+	 */
+	xtDscpAvailable?: boolean;
 }
 
 export interface SingboxRouterTransitionStep {

--- a/internal/api/accesspolicy.go
+++ b/internal/api/accesspolicy.go
@@ -146,6 +146,7 @@ func NewAccessPolicyHandler(svc accesspolicy.Service) *AccessPolicyHandler {
 //	@Success		200		{object}	AccessPoliciesListResponse
 //	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/access-policies [get]
+//	@Router			/routing/access-policies [get]
 func (h *AccessPolicyHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -480,6 +481,7 @@ func (h *AccessPolicyHandler) ListDevices(w http.ResponseWriter, r *http.Request
 //	@Success		200	{object}	PolicyInterfacesListResponse
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/access-policies/interfaces [get]
+//	@Router			/routing/policy-interfaces [get]
 func (h *AccessPolicyHandler) ListGlobalInterfaces(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/bootstatus.go
+++ b/internal/api/bootstatus.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ── Response DTOs ────────────────────────────────────────────────
+
+// BootStatusResponse is the raw (non-enveloped) payload for GET /boot-status.
+type BootStatusResponse struct {
+	Initializing     bool   `json:"initializing" example:"false"`
+	RemainingSeconds int    `json:"remainingSeconds" example:"0"`
+	Phase            string `json:"phase" example:"ready"`
+	InstanceId       string `json:"instanceId" example:"a1b2c3d4e5f6"`
+}
+
+// BootStatusHandler serves GET /api/boot-status (public).
+type BootStatusHandler struct {
+	InstanceID string
+}
+
+// NewBootStatusHandler returns a handler that reports boot phase and instance id.
+func NewBootStatusHandler(instanceID string) *BootStatusHandler {
+	return &BootStatusHandler{InstanceID: instanceID}
+}
+
+// Get responds with boot readiness and instance id for frontend restart detection.
+//
+//	@Summary		Boot status
+//	@Description	Public snapshot: initializing flag, phase, instance id.
+//	@Tags			system
+//	@Produce		json
+//	@Success		200	{object}	BootStatusResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/boot-status [get]
+func (h *BootStatusHandler) Get(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(BootStatusResponse{
+		Initializing:     false,
+		RemainingSeconds: 0,
+		Phase:            "ready",
+		InstanceId:       h.InstanceID,
+	})
+}

--- a/internal/api/singbox.go
+++ b/internal/api/singbox.go
@@ -381,6 +381,18 @@ func (h *SingboxHandler) Control(w http.ResponseWriter, r *http.Request) {
 
 // ListTunnels handles GET /api/singbox/tunnels.
 // Returns all tunnels enriched with per-tunnel connectivity from the Clash API.
+// (server.go routes GET with ?tag= to GetTunnel — same path/method, so the
+// single-tunnel variant is documented here via the optional tag parameter.)
+//
+//	@Summary		List or get sing-box tunnel(s)
+//	@Tags			singbox
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			tag	query		string	false	"When set, returns single tunnel"
+//	@Success		200	{object}	SingboxTunnelsResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		500	{object}	APIErrorEnvelope
+//	@Router			/singbox/tunnels [get]
 func (h *SingboxHandler) ListTunnels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -30,12 +30,16 @@ type SingboxRouterIssueDTO struct {
 
 // SingboxRouterStatusData mirrors router.Status.
 type SingboxRouterStatusData struct {
-	Enabled                bool                    `json:"enabled" example:"true"`
-	Installed              bool                    `json:"installed" example:"true"`
-	Active                 bool                    `json:"active" example:"true"`
-	NetfilterAvailable     bool                    `json:"netfilterAvailable" example:"true"`
-	NetfilterComponentName string                  `json:"netfilterComponentName,omitempty" example:"iptables-mod-tproxy"`
-	TProxyTargetAvailable  bool                    `json:"tproxyTargetAvailable" example:"true"`
+	Enabled                bool   `json:"enabled" example:"true"`
+	Installed              bool   `json:"installed" example:"true"`
+	Active                 bool   `json:"active" example:"true"`
+	NetfilterAvailable     bool   `json:"netfilterAvailable" example:"true"`
+	NetfilterComponentName string `json:"netfilterComponentName,omitempty" example:"iptables-mod-tproxy"`
+	TProxyTargetAvailable  bool   `json:"tproxyTargetAvailable" example:"true"`
+	// XtDscpAvailable reports whether iptables DSCP matching is usable
+	// (xt_dscp kernel module present AND iptables `-m dscp` extension works).
+	// The QoS-DSCP settings UI keys its "supported" badge on this field.
+	XtDscpAvailable        bool                    `json:"xtDscpAvailable" example:"true"`
 	PolicyName             string                  `json:"policyName" example:"awgm-router"`
 	PolicyMark             string                  `json:"policyMark,omitempty" example:"0xffffaaa"`
 	PolicyExists           bool                    `json:"policyExists" example:"true"`
@@ -103,6 +107,27 @@ type SingboxRouterSettingsData struct {
 	// Increase to prevent long-quiet UDP applications (games, etc.) from
 	// having their sessions silently dropped mid-game.
 	UDPTimeout string `json:"udpTimeout,omitempty" example:"10m0s"`
+	// QoSClasses lists DSCP-based QoS traffic classes routed to dedicated
+	// outbounds. At most 8 classes; DSCP must be 0-63 and unique across
+	// classes; outbound is required; name is limited to 32 characters.
+	// Only effective when routingMode is "tproxy" and xt_dscp is available
+	// (see status.xtDscpAvailable). Empty = feature off.
+	QoSClasses []SingboxRouterQoSClassDTO `json:"qosClasses,omitempty"`
+}
+
+// SingboxRouterQoSClassDTO mirrors storage.SingboxQoSClass — one DSCP-based
+// QoS traffic class.
+type SingboxRouterQoSClassDTO struct {
+	DSCP     int    `json:"dscp" example:"46" minimum:"0" maximum:"63"`
+	Name     string `json:"name,omitempty" example:"VoIP" maxLength:"32"`
+	Outbound string `json:"outbound" example:"my-selector"`
+	Enabled  bool   `json:"enabled" example:"true"`
+	// Slot is the backend-assigned stable listen-port slot (0-7). Read-only:
+	// clients send classes without it and the backend re-associates each
+	// class with its persisted slot by DSCP, so a class keeps its ports when
+	// other classes are edited, disabled or removed. Any value sent by a
+	// client is ignored.
+	Slot int `json:"slot" example:"0" minimum:"0" maximum:"7" readonly:"true"`
 }
 
 // SingboxRouterSettingsResponse is the envelope for GET /singbox/router/settings.
@@ -119,8 +144,12 @@ type SingboxRouterRuleDTO struct {
 	Port         []int    `json:"port,omitempty" example:"443"`
 	RuleSet      []string `json:"rule_set,omitempty" example:"geosite-cn"`
 	Protocol     string   `json:"protocol,omitempty" example:"tcp"`
-	Action       string   `json:"action" example:"route"`
-	Outbound     string   `json:"outbound,omitempty" example:"selector"`
+	// Inbound matches sing-box listener tags the connection entered through.
+	// Managed QoS-DSCP rules use the reserved tproxy-qos-N / redirect-qos-N
+	// tag pair (N = DSCP codepoint).
+	Inbound  []string `json:"inbound,omitempty" example:"tproxy-qos-46"`
+	Action   string   `json:"action" example:"route"`
+	Outbound string   `json:"outbound,omitempty" example:"selector"`
 }
 
 // SingboxRouterRulesListResponse is the envelope for GET /singbox/router/rules/list.
@@ -1554,6 +1583,14 @@ func (h *SingboxRouterHandler) handleErr(w http.ResponseWriter, action string, e
 	case errors.Is(err, router.ErrInvalidMatchers),
 		errors.Is(err, router.ErrDNSInvalidServer):
 		response.Error(w, err.Error(), "INVALID_MATCHERS")
+	case errors.Is(err, router.ErrQoSClassesInvalid):
+		// 400 with the detailed Russian message (DSCP range/duplicate/limit/
+		// outbound) intact so the settings UI can surface it verbatim.
+		response.Error(w, err.Error(), "QOS_CLASSES_INVALID")
+	case errors.Is(err, router.ErrReservedInboundTag):
+		// 400: user rules must not claim the reserved qos-* inbound namespace
+		// (they'd be inert shadow rules — the managed slot merges first).
+		response.Error(w, err.Error(), "RESERVED_INBOUND_TAG")
 	default:
 		response.InternalError(w, err.Error())
 	}

--- a/internal/api/singbox_router_test.go
+++ b/internal/api/singbox_router_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,17 +31,32 @@ type mockRouterSvc struct {
 	applyRes      orchestrator.ValidationResult
 	discardErr    error
 	datFileErr    error
-	switchTarget  string
-	switchErr     error
-	settings      storage.SingboxRouterSettings
+	// switchTarget is written from the handler's async goroutine (SwitchMode
+	// responds 202-style before the service call) and polled by the test —
+	// guard it or `go test -race` trips.
+	switchMu     sync.Mutex
+	switchTarget string
+	switchErr    error
+	settings     storage.SingboxRouterSettings
+	// updateSettingsErr, when set, is returned by UpdateSettings so handler
+	// error-mapping (e.g. QOS_CLASSES_INVALID → 400) can be asserted.
+	updateSettingsErr error
 }
 
 func (m *mockRouterSvc) Enable(ctx context.Context) error    { return m.enableErr }
 func (m *mockRouterSvc) Disable(ctx context.Context) error   { return nil }
 func (m *mockRouterSvc) Reconcile(ctx context.Context) error { return nil }
 func (m *mockRouterSvc) SwitchRoutingMode(ctx context.Context, target string) error {
+	m.switchMu.Lock()
 	m.switchTarget = target
+	m.switchMu.Unlock()
 	return m.switchErr
+}
+
+func (m *mockRouterSvc) switchedTarget() string {
+	m.switchMu.Lock()
+	defer m.switchMu.Unlock()
+	return m.switchTarget
 }
 func (m *mockRouterSvc) GetStatus(ctx context.Context) (router.Status, error) {
 	return router.Status{}, nil
@@ -48,6 +65,9 @@ func (m *mockRouterSvc) GetSettings(ctx context.Context) (storage.SingboxRouterS
 	return m.settings, nil
 }
 func (m *mockRouterSvc) UpdateSettings(ctx context.Context, s storage.SingboxRouterSettings) error {
+	if m.updateSettingsErr != nil {
+		return m.updateSettingsErr
+	}
 	m.settings = s
 	return nil
 }
@@ -130,7 +150,7 @@ func (m *mockRouterSvc) UpdateDNSServer(ctx context.Context, tag string, s route
 func (m *mockRouterSvc) DeleteDNSServer(ctx context.Context, tag string, force bool) error {
 	return nil
 }
-func (m *mockRouterSvc) MoveDNSServer(ctx context.Context, from, to int) error { return nil }
+func (m *mockRouterSvc) MoveDNSServer(ctx context.Context, from, to int) error      { return nil }
 func (m *mockRouterSvc) ListDNSRules(ctx context.Context) ([]router.DNSRule, error) { return nil, nil }
 func (m *mockRouterSvc) AddDNSRule(ctx context.Context, r router.DNSRule) error     { return nil }
 func (m *mockRouterSvc) UpdateDNSRule(ctx context.Context, index int, r router.DNSRule) error {
@@ -223,6 +243,43 @@ func TestRouterEnable_PolicyMissing_Returns400(t *testing.T) {
 	}
 }
 
+func TestRouterPutSettings_QoSClassesInvalid_Returns400(t *testing.T) {
+	svc := &mockRouterSvc{updateSettingsErr: fmt.Errorf("%w: qosClasses[0]: DSCP должен быть 0-63 (получено 99)", router.ErrQoSClassesInvalid)}
+	h := newMockRouterHandler(svc)
+	req := httptest.NewRequest(http.MethodPut, "/api/singbox/router/settings",
+		strings.NewReader(`{"qosClasses":[{"dscp":99,"outbound":"vpn","enabled":true}]}`))
+	rr := httptest.NewRecorder()
+	h.PutSettings(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "QOS_CLASSES_INVALID") {
+		t.Errorf("want code QOS_CLASSES_INVALID in body: %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "DSCP") {
+		t.Errorf("want detailed DSCP message in body: %s", rr.Body.String())
+	}
+}
+
+func TestRouterPutSettings_RoundTripsQoSClasses(t *testing.T) {
+	svc := &mockRouterSvc{}
+	h := newMockRouterHandler(svc)
+	req := httptest.NewRequest(http.MethodPost, "/api/singbox/router/settings",
+		strings.NewReader(`{"enabled":true,"wanAutoDetect":true,"qosClasses":[{"dscp":46,"name":"VoIP","outbound":"vpn-a","enabled":true}]}`))
+	rr := httptest.NewRecorder()
+	h.PutSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if len(svc.settings.QoSClasses) != 1 {
+		t.Fatalf("qosClasses not decoded: %+v", svc.settings)
+	}
+	got := svc.settings.QoSClasses[0]
+	if got.DSCP != 46 || got.Name != "VoIP" || got.Outbound != "vpn-a" || !got.Enabled {
+		t.Errorf("qos class round-trip mismatch: %+v", got)
+	}
+}
+
 func TestRouterSwitchMode_CallsService(t *testing.T) {
 	svc := &mockRouterSvc{}
 	h := newMockRouterHandler(svc)
@@ -235,13 +292,13 @@ func TestRouterSwitchMode_CallsService(t *testing.T) {
 	}
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if svc.switchTarget == "fakeip-tun" {
+		if svc.switchedTarget() == "fakeip-tun" {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if svc.switchTarget != "fakeip-tun" {
-		t.Errorf("svc.SwitchRoutingMode target = %q want fakeip-tun", svc.switchTarget)
+	if got := svc.switchedTarget(); got != "fakeip-tun" {
+		t.Errorf("svc.SwitchRoutingMode target = %q want fakeip-tun", got)
 	}
 }
 
@@ -255,8 +312,8 @@ func TestRouterSwitchMode_BadMode_Returns400(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("want 400, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
-	if svc.switchTarget != "" {
-		t.Errorf("service should not be called for bad mode, got target=%q", svc.switchTarget)
+	if got := svc.switchedTarget(); got != "" {
+		t.Errorf("service should not be called for bad mode, got target=%q", got)
 	}
 }
 

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1518,7 +1518,7 @@ definitions:
         - error
         - fatal
         - panic
-        example: trace
+        example: info
         type: string
       singboxMaxEntries:
         example: 5000
@@ -2606,6 +2606,12 @@ definitions:
           LastRebuild is the RFC3339 timestamp of the last successful rebuild, or
           empty string if no rebuild has run yet.
         type: string
+      rebuilding:
+        description: |-
+          Rebuilding is true while an ipset rebuild is in flight (POST /rebuild
+          responds 202 and runs the rebuild in the background; completion is
+          delivered via the singbox-router:selective-status SSE event).
+        type: boolean
       snapshot:
         allOf:
         - $ref: '#/definitions/api.SelectiveRebuildSnapshotDTO'
@@ -3563,6 +3569,36 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.SingboxRouterQoSClassDTO:
+    properties:
+      dscp:
+        example: 46
+        maximum: 63
+        minimum: 0
+        type: integer
+      enabled:
+        example: true
+        type: boolean
+      name:
+        example: VoIP
+        maxLength: 32
+        type: string
+      outbound:
+        example: my-selector
+        type: string
+      slot:
+        description: |-
+          Slot is the backend-assigned stable listen-port slot (0-7). Read-only:
+          clients send classes without it and the backend re-associates each
+          class with its persisted slot by DSCP, so a class keeps its ports when
+          other classes are edited, disabled or removed. Any value sent by a
+          client is ignored.
+        example: 0
+        maximum: 7
+        minimum: 0
+        readOnly: true
+        type: integer
+    type: object
   api.SingboxRouterRouteFinalRequest:
     properties:
       final:
@@ -3577,6 +3613,16 @@ definitions:
       domain_suffix:
         example:
         - .example.com
+        items:
+          type: string
+        type: array
+      inbound:
+        description: |-
+          Inbound matches sing-box listener tags the connection entered through.
+          Managed QoS-DSCP rules use the reserved tproxy-qos-N / redirect-qos-N
+          tag pair (N = DSCP codepoint).
+        example:
+        - tproxy-qos-46
         items:
           type: string
         type: array
@@ -3770,6 +3816,16 @@ definitions:
       policyName:
         example: awgm-router
         type: string
+      qosClasses:
+        description: |-
+          QoSClasses lists DSCP-based QoS traffic classes routed to dedicated
+          outbounds. At most 8 classes; DSCP must be 0-63 and unique across
+          classes; outbound is required; name is limited to 32 characters.
+          Only effective when routingMode is "tproxy" and xt_dscp is available
+          (see status.xtDscpAvailable). Empty = feature off.
+        items:
+          $ref: '#/definitions/api.SingboxRouterQoSClassDTO'
+        type: array
       routingMode:
         enum:
         - tproxy
@@ -3880,6 +3936,13 @@ definitions:
         example: true
         type: boolean
       tproxyTargetAvailable:
+        example: true
+        type: boolean
+      xtDscpAvailable:
+        description: |-
+          XtDscpAvailable reports whether iptables DSCP matching is usable
+          (xt_dscp kernel module present AND iptables `-m dscp` extension works).
+          The QoS-DSCP settings UI keys its "supported" badge on this field.
         example: true
         type: boolean
     type: object
@@ -8726,7 +8789,12 @@ paths:
       - device-proxy
   /routing/access-policies:
     get:
-      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
+      description: KeeneticOS 5 only when route is registered.
+      parameters:
+      - description: Pass 'true' to bypass NDMS cache
+        in: query
+        name: refresh
+        type: string
       produces:
       - application/json
       responses:
@@ -8734,19 +8802,15 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.AccessPoliciesListResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: OS4 access policies stub
+      summary: List access policies
       tags:
-      - routing
+      - access-policy
   /routing/client-routes:
     get:
       produces:
@@ -8816,7 +8880,6 @@ paths:
       - access-policy
   /routing/policy-interfaces:
     get:
-      description: Always {"data":[]}. Real data on KeeneticOS 5 only.
       produces:
       - application/json
       responses:
@@ -8824,19 +8887,15 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.PolicyInterfacesListResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: OS4 policy interfaces stub
+      summary: List global policy interfaces
       tags:
-      - routing
+      - access-policy
   /routing/refresh:
     post:
       produces:
@@ -12232,13 +12291,22 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: rebuild started (or already running); rebuilding reflects live
+            state
           schema:
             $ref: '#/definitions/api.SelectiveStatusData'
+        "409":
+          description: sing-box config apply in progress
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "503":
+          description: builder not configured
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
       security:
       - CookieAuth: []
-      summary: Force ipset rebuild
+      summary: Force ipset rebuild (asynchronous)
       tags:
       - singbox-router
   /singbox/router/selective/snapshot/matchers:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1000,16 +999,11 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	ndmsHandler := api.NewNDMSHandler(s.ndmsSaveCoord)
 	mux.HandleFunc("/api/ndms/save-status", guarded(ndmsHandler.GetSaveStatus))
 
-	// Boot status (public - frontend uses instanceId for restart detection)
-	mux.HandleFunc("/api/boot-status", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"initializing":     false,
-			"remainingSeconds": 0,
-			"phase":            "ready",
-			"instanceId":       s.instanceID,
-		})
-	})
+	// Boot status (public - frontend uses instanceId for restart detection).
+	// Dedicated api.BootStatusHandler so the endpoint keeps its swagger
+	// annotations (@Router /boot-status) — an inline closure here is
+	// invisible to `swag init` and silently drops the path from the spec.
+	mux.HandleFunc("/api/boot-status", api.NewBootStatusHandler(s.instanceID).Get)
 
 	// Wire event bus to CRUD handlers for SSE publishing
 	tunnelsHandler.SetEventBus(s.bus)

--- a/internal/singbox/orchestrator/types.go
+++ b/internal/singbox/orchestrator/types.go
@@ -16,16 +16,17 @@ import "time"
 type Slot string
 
 const (
-	SlotBase          Slot = "base"          // 00-base.json — always on
-	SlotTunnels       Slot = "tunnels"       // 10-tunnels.json
-	SlotAwg           Slot = "awg"           // 15-awg.json
-	SlotDNSRewrites   Slot = "dns-rewrites"  // 17-dns-rewrites.json
+	SlotBase            Slot = "base"             // 00-base.json — always on
+	SlotTunnels         Slot = "tunnels"          // 10-tunnels.json
+	SlotAwg             Slot = "awg"              // 15-awg.json
+	SlotDNSRewrites     Slot = "dns-rewrites"     // 17-dns-rewrites.json
+	SlotQoSRoutes       Slot = "qos-routes"       // 18-qos-routes.json
 	SlotSelectiveRoutes Slot = "selective-routes" // 19-selective-routes.json
-	SlotRouter        Slot = "router"        // 20-router.json
-	SlotFakeIP        Slot = "fakeip"        // 21-fakeip.json
-	SlotDeviceProxy   Slot = "deviceproxy"   // 30-deviceproxy.json
-	SlotDownloadProxy Slot = "downloadproxy" // 35-download-proxy.json
-	SlotSubscriptions Slot = "subscriptions" // 40-subscriptions.json
+	SlotRouter          Slot = "router"           // 20-router.json
+	SlotFakeIP          Slot = "fakeip"           // 21-fakeip.json
+	SlotDeviceProxy     Slot = "deviceproxy"      // 30-deviceproxy.json
+	SlotDownloadProxy   Slot = "downloadproxy"    // 35-download-proxy.json
+	SlotSubscriptions   Slot = "subscriptions"    // 40-subscriptions.json
 )
 
 // SlotMeta describes a producer's contract with the orchestrator.
@@ -68,6 +69,10 @@ func KnownSlots() []SlotMeta {
 		{Slot: SlotTunnels, Filename: "10-tunnels.json", AlwaysOn: true},
 		{Slot: SlotAwg, Filename: "15-awg.json", AlwaysOn: true},
 		{Slot: SlotDNSRewrites, Filename: "17-dns-rewrites.json"},
+		// 18 merges BEFORE 19/20 on purpose: sing-box evaluates route rules
+		// in merged-file order, so managed QoS rules (an explicit per-packet
+		// DSCP policy) win over selective /32 overlays and user rules.
+		{Slot: SlotQoSRoutes, Filename: "18-qos-routes.json"},
 		{Slot: SlotSelectiveRoutes, Filename: "19-selective-routes.json"},
 		{Slot: SlotRouter, Filename: "20-router.json"},
 		{Slot: SlotFakeIP, Filename: "21-fakeip.json"},

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -841,7 +841,7 @@ func isProxyIface(name string) bool {
 func (r Rule) hasAnyMatcher() bool {
 	return len(r.DomainSuffix) > 0 || len(r.IPCIDR) > 0 || len(r.SourceIPCIDR) > 0 ||
 		len(r.Port) > 0 || len(r.RuleSet) > 0 || r.Protocol != "" || len(r.Rules) > 0 ||
-		r.IPIsPrivate != nil
+		r.IPIsPrivate != nil || len(r.Inbound) > 0
 }
 
 // validateCIDROrAddr accepts a value that is either a CIDR prefix or a bare IP
@@ -872,6 +872,21 @@ func validateRule(r Rule) error {
 	for _, p := range r.Port {
 		if p < 1 || p > 65535 {
 			return fmt.Errorf("port %d out of range [1,65535]", p)
+		}
+	}
+	for _, tag := range r.Inbound {
+		if strings.TrimSpace(tag) == "" {
+			return fmt.Errorf("inbound tag must be a non-empty string")
+		}
+		if isQoSInboundTag(strings.TrimSpace(tag)) {
+			return fmt.Errorf("%w (получен %q)", ErrReservedInboundTag, tag)
+		}
+	}
+	// Nested logical sub-rules carry matchers too — a reserved tag must not
+	// slip in through `rules: [...]`.
+	for _, nested := range r.Rules {
+		if err := validateRule(nested); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/singbox/router/errors.go
+++ b/internal/singbox/router/errors.go
@@ -35,4 +35,18 @@ var (
 	// an engine-locked field (the fakeip/real DNS servers, dns.final,
 	// default_domain_resolver, or the hijack-dns rule). Surfaced as 4xx.
 	ErrFakeIPLockedField = errors.New("fakeip-tun config field is engine-locked")
+
+	// ErrQoSClassesInvalid wraps every QoS-class validation failure from
+	// NormalizeSingboxRouterSettings (DSCP out of 0-63, duplicate DSCP,
+	// class limit exceeded, empty outbound, name too long) and the
+	// UpdateSettings outbound-existence check so the API can map them to
+	// 400 with the detailed Russian message intact.
+	ErrQoSClassesInvalid = errors.New("некорректные классы QoS")
+
+	// ErrReservedInboundTag rejects user route rules whose inbound matcher
+	// references the reserved tproxy-qos-*/redirect-qos-* namespace. The
+	// managed QoS rules live in 18-qos-routes.json and merge BEFORE the user
+	// slot, so such a user rule could never match — it would only sit in the
+	// UI as an inert, confusing shadow rule. Mapped to 400 by the API.
+	ErrReservedInboundTag = errors.New("теги qos-* зарезервированы для QoS-классов")
 )

--- a/internal/singbox/router/fakeip_cidr_routes.go
+++ b/internal/singbox/router/fakeip_cidr_routes.go
@@ -32,6 +32,7 @@ func loopSafeProxyRule(r Rule) bool {
 		r.Type == "" && r.Mode == "" && len(r.Rules) == 0 &&
 		len(r.DomainSuffix) == 0 && len(r.Domain) == 0 && len(r.SourceIPCIDR) == 0 &&
 		len(r.Port) == 0 && r.Protocol == "" && r.IPIsPrivate == nil &&
+		len(r.Inbound) == 0 &&
 		r.AwgmManaged == ""
 }
 

--- a/internal/singbox/router/inspector.go
+++ b/internal/singbox/router/inspector.go
@@ -252,6 +252,14 @@ func evaluateRule(input InspectInput, parsedIP net.IP, rule Rule, env *inspectEn
 		out.Conditions = append(out.Conditions, fmt.Sprintf("source_ip_cidr: %s (пропущено — нет источника)", strings.Join(rule.SourceIPCIDR, ", ")))
 	}
 
+	// Inbound (listener tag) is likewise unknowable for a manual probe —
+	// record it but never count it as a hit, so managed QoS-DSCP rules
+	// (inbound-only matchers) don't sweep every inspected query into their
+	// class outbound.
+	if len(rule.Inbound) > 0 {
+		out.Conditions = append(out.Conditions, fmt.Sprintf("inbound: %s (пропущено — вход недоступен для ручной проверки)", strings.Join(rule.Inbound, ", ")))
+	}
+
 	// Track each matcher's outcome. AND across present matchers.
 	type partial struct{ present, hit bool }
 	var (

--- a/internal/singbox/router/iptables.go
+++ b/internal/singbox/router/iptables.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -200,6 +201,104 @@ func IsTProxyTargetAvailable(ctx context.Context) bool {
 	return ok
 }
 
+// EnsureXtDscpModule best-effort loads xt_dscp so the QoS `-m dscp` dispatch
+// rules can be accepted at iptables-restore COMMIT time. Same soft-fail
+// contract as EnsureCommentModule: an absent .ko (possibly built-in kernel
+// support) returns nil and lets iptables-restore surface the real verdict.
+func EnsureXtDscpModule(ctx context.Context) error {
+	err := ensureKernelModuleFn(ctx, "xt_dscp")
+	if errors.Is(err, ErrNetfilterComponentMissing) {
+		return nil
+	}
+	return err
+}
+
+var (
+	xtDscpMu        sync.Mutex
+	xtDscpModuleOK  bool
+	xtDscpMatchOK   bool
+	xtDscpCheckedAt time.Time
+	// xtDscpAvailabilityFn is the indirection point tests use to count/stub
+	// raw probes; production always runs the real XtDscpAvailability.
+	xtDscpAvailabilityFn = XtDscpAvailability
+)
+
+// xtDscpNegativeTTL bounds how long a NEGATIVE xt_dscp probe result is
+// served from cache. The probe execs `iptables -m dscp -h` — running it on
+// every reconcile tick forever while the module stays missing is pure waste,
+// but installing the missing piece must still be picked up without a daemon
+// restart, hence the re-probe after the TTL. Positive results are cached
+// forever (availability never degrades within one daemon lifetime).
+const xtDscpNegativeTTL = 10 * time.Minute
+
+// XtDscpAvailability probes the two independent halves of `-m dscp` support
+// separately so status/diagnostics can tell the failure causes apart:
+//
+//   - moduleOK: the xt_dscp KERNEL module is loaded (/proc/modules) or its
+//     .ko exists at the standard /lib/modules/<uname -r>/xt_dscp.ko path —
+//     the exact pattern ensureKernelModule targets. Keenetic ships the .ko
+//     there even on 4.9-ndm kernels. (Some third-party setups also carry
+//     modules under /opt/lib/modules or /opt/lib/system-modules/<uname -r>
+//     — XKeen issue #94 — but AWGM's whole module stack, xt_TPROXY
+//     included, keys on the single standard path; keep parity here.)
+//   - matchOK: the iptables USERSPACE extension parses `-m dscp` (runtime
+//     `iptables -m dscp -h` probe, mirroring IsTProxyTargetAvailable). This
+//     is the realistic gap on some Entware arches — the kernel module can be
+//     present while the iptables build lacks the extension.
+func XtDscpAvailability(ctx context.Context) (moduleOK, matchOK bool) {
+	moduleOK = isModuleLoaded("xt_dscp")
+	if !moduleOK {
+		if kernel := osdetect.KernelRelease(); kernel != "" {
+			_, err := os.Stat(filepath.Join("/lib/modules", kernel, "xt_dscp.ko"))
+			moduleOK = err == nil
+		}
+	}
+	res, err := sysexec.Run(ctx, sysiptables.Binary, "-m", "dscp", "-h")
+	matchOK = err == nil && res != nil &&
+		strings.Contains(strings.ToLower(res.Stdout+res.Stderr), "dscp")
+	return moduleOK, matchOK
+}
+
+// cachedXtDscpAvailability returns the (moduleOK, matchOK) pair through the
+// probe cache: a fully-positive result is cached forever, anything else for
+// xtDscpNegativeTTL (see the const above). All availability consumers
+// (IsXtDscpAvailable, GetStatus diagnostics) go through this so a missing
+// module costs at most one `iptables -m dscp -h` exec per TTL window instead
+// of one per reconcile tick / status poll.
+func cachedXtDscpAvailability(ctx context.Context) (moduleOK, matchOK bool) {
+	xtDscpMu.Lock()
+	if xtDscpModuleOK && xtDscpMatchOK {
+		xtDscpMu.Unlock()
+		return true, true
+	}
+	if !xtDscpCheckedAt.IsZero() && time.Since(xtDscpCheckedAt) < xtDscpNegativeTTL {
+		m, x := xtDscpModuleOK, xtDscpMatchOK
+		xtDscpMu.Unlock()
+		return m, x
+	}
+	probe := xtDscpAvailabilityFn
+	xtDscpMu.Unlock()
+
+	m, x := probe(ctx)
+	xtDscpMu.Lock()
+	xtDscpModuleOK, xtDscpMatchOK = m, x
+	xtDscpCheckedAt = time.Now()
+	xtDscpMu.Unlock()
+	return m, x
+}
+
+// IsXtDscpAvailable reports whether DSCP matching is usable end-to-end: BOTH
+// the kernel module (loaded or .ko on disk) AND the iptables extension must
+// pass. Positive results are cached forever (availability never degrades
+// within one daemon lifetime); negative results are cached for
+// xtDscpNegativeTTL and then re-probed so installing the missing piece is
+// picked up without a restart. Surfaced to the UI as the status field
+// `xtDscpAvailable`.
+func IsXtDscpAvailable(ctx context.Context) bool {
+	moduleOK, matchOK := cachedXtDscpAvailability(ctx)
+	return moduleOK && matchOK
+}
+
 type RestoreInputSpec struct {
 	// PolicyMark is the NDMS-assigned mark (hex, e.g. "0xffffaaa") that
 	// NDMS sets on connections from devices bound to the chosen access
@@ -261,6 +360,25 @@ type RestoreInputSpec struct {
 	// REDIRECT rule, so explicit bypass rules still take precedence.
 	// Only meaningful when the xt_set kernel module is loaded.
 	SelectiveIPSet bool
+
+	// QoSClasses lists the active DSCP QoS classes (issue #371). Each entry
+	// yields one `-m dscp --dscp N` dispatch rule per chain (mangle UDP
+	// TPROXY --on-port TProxyPort, nat TCP REDIRECT --to-ports RedirectPort)
+	// inserted immediately before the catch-all — see the emission sites in
+	// buildRestoreInput for the full ordering rationale. Empty = feature off.
+	// Requires the xt_dscp kernel module (preloaded by the netfilter.d hook
+	// and EnsureRouterNetfilterModules).
+	QoSClasses []QoSClassSpec
+}
+
+// QoSClassSpec is the iptables projection of one active QoS class: the DSCP
+// codepoint to match and the per-class sing-box listen ports to dispatch to.
+// Ports come from QoSClassPorts so iptables and inbound generation share one
+// source of truth. Comparable — reconcile change-detection uses slices.Equal.
+type QoSClassSpec struct {
+	DSCP         int
+	TProxyPort   int
+	RedirectPort int
 }
 
 var bypassCIDRs = []string{
@@ -370,6 +488,26 @@ func buildRestoreInput(spec RestoreInputSpec) string {
 	// the same destinations as discrete CIDR rules (semantically equal).
 	emitBypassReturns(&b, ChainName, spec.WANIPs)
 
+	// QoS-by-DSCP dispatch (issue #371): per-class TPROXY onto the class
+	// port, immediately BEFORE the catch-all. Ordering rationale:
+	//   - AFTER the DNS intercept: UDP/53 must keep landing on the MAIN
+	//     tproxy port regardless of DSCP marks — hijack-dns lives there, so
+	//     DNS handling never depends on the managed QoS route rules (the nat
+	//     chain mirrors this with its own TCP/53 carve-out before the class
+	//     rules).
+	//   - AFTER user/builtin bypass RETURNs and WAN-IP exclusions: an
+	//     explicit bypass always wins; DSCP marks must not re-capture
+	//     traffic the user excluded (or loop router-WAN-IP traffic back in).
+	//   - AFTER the selective guard: in selective mode only ipset-listed
+	//     destinations enter sing-box at all; QoS classifies within that
+	//     scope, it does not widen it.
+	//   - BEFORE the catch-all: otherwise the unconditional TPROXY eats the
+	//     packet first and the class rule is dead.
+	for _, q := range spec.QoSClasses {
+		fmt.Fprintf(&b, "-A %s -p udp -m dscp --dscp %d -j TPROXY --on-port %d --on-ip 127.0.0.1 --tproxy-mark 0x%x\n",
+			ChainName, q.DSCP, q.TProxyPort, Fwmark)
+	}
+
 	// add_tproxy_rules: catch-all TPROXY for UDP.
 	fmt.Fprintf(&b, "-A %s -p udp -j TPROXY --on-port %d --on-ip 127.0.0.1 --tproxy-mark 0x%x\n",
 		ChainName, TPROXYPort, Fwmark)
@@ -402,7 +540,10 @@ func buildRestoreInput(spec RestoreInputSpec) string {
 	// catch-all is no longer unconditional, so TCP/53 gets its own
 	// intercept before the guard (see below) — otherwise a truncated-UDP
 	// retry or DNS-over-TCP to a resolver outside the set escapes
-	// hijack-dns and leaks real IPs of proxied domains.
+	// hijack-dns and leaks real IPs of proxied domains. The QoS DSCP
+	// dispatch needs the same carve-out (a class REDIRECT would otherwise
+	// swallow marked TCP/53 onto a class port), emitted with the class
+	// rules below when the selective intercept isn't already present.
 	b.WriteString("*nat\n")
 	fmt.Fprintf(&b, ":%s - [0:0]\n", RedirectChain)
 
@@ -427,6 +568,27 @@ func buildRestoreInput(spec RestoreInputSpec) string {
 			RedirectChain, RedirectPort)
 		fmt.Fprintf(&b, "-A %s -m set ! --match-set %s dst -j RETURN\n",
 			RedirectChain, selectiveSetName)
+	}
+
+	// QoS-by-DSCP dispatch for TCP — mirrors the mangle block above (same
+	// ordering rationale: after bypasses and the selective guard, before the
+	// catch-all). DNS carve-out first: without it, DSCP-marked DNS-over-TCP
+	// (or a truncated-UDP retry) would land on a CLASS redirect inbound and
+	// only get hijacked if the managed route rules happened to order right —
+	// intercepting TCP/53 onto the MAIN redirect port here kills that whole
+	// leak class at the netfilter level, exactly like the mangle chain's
+	// unconditional UDP/53 intercept above the UDP class rules. Skipped when
+	// the selective guard already emitted the identical intercept earlier in
+	// this chain.
+	if len(spec.QoSClasses) > 0 {
+		if !spec.SelectiveIPSet {
+			fmt.Fprintf(&b, "-A %s -p tcp --dport 53 -j REDIRECT --to-ports %d\n",
+				RedirectChain, RedirectPort)
+		}
+		for _, q := range spec.QoSClasses {
+			fmt.Fprintf(&b, "-A %s -p tcp -m dscp --dscp %d -j REDIRECT --to-ports %d\n",
+				RedirectChain, q.DSCP, q.RedirectPort)
+		}
 	}
 
 	// add_redirect_rules: catch-all REDIRECT for TCP.
@@ -594,7 +756,7 @@ pidof sing-box >/dev/null 2>&1 || exit 0
 # Best-effort kernel module preload. Absent .ko or built-in modules are
 # silently skipped — iptables-restore will surface the final verdict anyway.
 KREL="$(uname -r)"
-for mod in xt_TPROXY xt_comment xt_mark xt_connmark xt_conntrack xt_pkttype; do
+for mod in xt_TPROXY xt_comment xt_mark xt_connmark xt_conntrack xt_pkttype xt_dscp; do
   grep -q "^${mod} " /proc/modules 2>/dev/null && continue
   [ -f "/lib/modules/${KREL}/${mod}.ko" ] && insmod "/lib/modules/${KREL}/${mod}.ko" 2>/dev/null || true
 done
@@ -750,7 +912,7 @@ func (it *IPTables) removeSourceHooksFromTable(ctx context.Context, table, chain
 
 // EnsureRouterNetfilterModules best-effort preloads the remaining xt_*
 // modules that our iptables rules reference but that TPROXY preflight
-// does not cover: comment, mark, connmark, conntrack, pkttype.
+// does not cover: comment, mark, connmark, conntrack, pkttype, dscp.
 // ErrNetfilterComponentMissing (module absent or built-in) is silently
 // skipped. All other insmod errors are collected and returned without
 // blocking — a hard failure here would prevent a working install on
@@ -764,6 +926,7 @@ func EnsureRouterNetfilterModules(ctx context.Context) []error {
 		"xt_connmark",
 		"xt_conntrack",
 		"xt_pkttype",
+		"xt_dscp",
 	} {
 		err := ensureKernelModuleFn(ctx, name)
 		if err == nil || errors.Is(err, ErrNetfilterComponentMissing) {

--- a/internal/singbox/router/iptables_test.go
+++ b/internal/singbox/router/iptables_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fakeExec struct {
@@ -1391,12 +1392,309 @@ func TestBuildRestoreInput_SelectiveIPSet_NatTCPDNSBeforeGuard(t *testing.T) {
 }
 
 func TestBuildRestoreInput_NoSelective_NoNatTCPDNSRule(t *testing.T) {
-	// Without the selective guard the catch-all REDIRECT covers TCP/53 —
-	// the chain must stay a literal port of SKeen's add_redirect_rules.
+	// Without the selective guard AND without QoS classes the catch-all
+	// REDIRECT covers TCP/53 — the chain must stay a literal port of SKeen's
+	// add_redirect_rules.
 	spec := RestoreInputSpec{PolicyMark: "0xffffaaa"}
 	out := buildRestoreInput(spec)
 
 	if strings.Contains(out, fmt.Sprintf("-A %s -p tcp --dport 53 -j REDIRECT", RedirectChain)) {
-		t.Errorf("unexpected TCP/53 rule without SelectiveIPSet\ngot:\n%s", out)
+		t.Errorf("unexpected TCP/53 rule without SelectiveIPSet/QoS\ngot:\n%s", out)
+	}
+}
+
+// ── QoS-by-DSCP dispatch (issue #371) ────────────────────────────────────────
+
+func qosTestSpec() RestoreInputSpec {
+	return RestoreInputSpec{
+		PolicyMark: "0xffffaaa",
+		QoSClasses: []QoSClassSpec{
+			{DSCP: 46, TProxyPort: 51281, RedirectPort: 51301},
+			{DSCP: 26, TProxyPort: 51282, RedirectPort: 51302},
+		},
+	}
+}
+
+func TestBuildRestoreInput_QoSClasses_RulesPresentInBothChains(t *testing.T) {
+	out := buildRestoreInput(qosTestSpec())
+
+	expected := []string{
+		// mangle: UDP TPROXY per class, numeric --dscp, main fwmark reused.
+		"-A AWGM-TPROXY -p udp -m dscp --dscp 46 -j TPROXY --on-port 51281 --on-ip 127.0.0.1 --tproxy-mark 0x1",
+		"-A AWGM-TPROXY -p udp -m dscp --dscp 26 -j TPROXY --on-port 51282 --on-ip 127.0.0.1 --tproxy-mark 0x1",
+		// nat: TCP REDIRECT per class.
+		"-A AWGM-REDIRECT -p tcp -m dscp --dscp 46 -j REDIRECT --to-ports 51301",
+		"-A AWGM-REDIRECT -p tcp -m dscp --dscp 26 -j REDIRECT --to-ports 51302",
+	}
+	for _, line := range expected {
+		if !strings.Contains(out, line) {
+			t.Errorf("missing QoS rule: %q\nin:\n%s", line, out)
+		}
+	}
+}
+
+func TestBuildRestoreInput_QoSClasses_OrderingWithinMangle(t *testing.T) {
+	// Anti-recapture invariant (XKeen PR #81 class of bug): the per-class
+	// TPROXY must be in the SAME chain and STRICTLY BEFORE the catch-all —
+	// both are terminating targets, so class traffic never also traverses
+	// the general path. And it must come AFTER the DNS intercept and AFTER
+	// bypass RETURNs so DNS stays on the main port and bypasses still win.
+	spec := qosTestSpec()
+	spec.BypassCIDRs = []string{"203.0.113.0/24"}
+	spec.BypassUDPPorts = []PortRange{{500, 500}}
+	spec.WANIPs = []string{"198.51.100.7/32"}
+	out := buildRestoreInput(spec)
+
+	qosIdx := strings.Index(out, "-A AWGM-TPROXY -p udp -m dscp --dscp 46")
+	dnsIdx := strings.Index(out, "-A AWGM-TPROXY -p udp --dport 53 -j TPROXY")
+	catchIdx := strings.Index(out, fmt.Sprintf("-A AWGM-TPROXY -p udp -j TPROXY --on-port %d", TPROXYPort))
+	userBypassIdx := strings.Index(out, "-A AWGM-TPROXY -d 203.0.113.0/24 -j RETURN")
+	portBypassIdx := strings.Index(out, "-A AWGM-TPROXY -p udp --dport 500 -j RETURN")
+	wanIdx := strings.Index(out, "-A AWGM-TPROXY -d 198.51.100.7/32 -j RETURN")
+	builtinBypassIdx := strings.Index(out, "-A AWGM-TPROXY -d 192.168.0.0/16 -j RETURN")
+
+	for name, idx := range map[string]int{
+		"qos": qosIdx, "dns": dnsIdx, "catch-all": catchIdx,
+		"user-bypass": userBypassIdx, "port-bypass": portBypassIdx,
+		"wan": wanIdx, "builtin-bypass": builtinBypassIdx,
+	} {
+		if idx == -1 {
+			t.Fatalf("%s rule not found in:\n%s", name, out)
+		}
+	}
+	if qosIdx < dnsIdx {
+		t.Errorf("QoS rule (%d) must come AFTER DNS intercept (%d) — DSCP must not hijack UDP/53", qosIdx, dnsIdx)
+	}
+	for name, idx := range map[string]int{
+		"user CIDR bypass": userBypassIdx,
+		"port bypass":      portBypassIdx,
+		"WAN-IP exclusion": wanIdx,
+		"builtin bypass":   builtinBypassIdx,
+	} {
+		if qosIdx < idx {
+			t.Errorf("QoS rule (%d) must come AFTER %s (%d)", qosIdx, name, idx)
+		}
+	}
+	if qosIdx > catchIdx {
+		t.Errorf("QoS rule (%d) must come BEFORE catch-all TPROXY (%d)", qosIdx, catchIdx)
+	}
+}
+
+func TestBuildRestoreInput_QoSClasses_OrderingWithinNat(t *testing.T) {
+	spec := qosTestSpec()
+	spec.BypassTCPPorts = []PortRange{{445, 445}}
+	spec.WANIPs = []string{"198.51.100.7/32"}
+	out := buildRestoreInput(spec)
+
+	qosIdx := strings.Index(out, "-A AWGM-REDIRECT -p tcp -m dscp --dscp 46")
+	catchIdx := strings.Index(out, fmt.Sprintf("-A AWGM-REDIRECT -p tcp -j REDIRECT --to-ports %d", RedirectPort))
+	portBypassIdx := strings.Index(out, "-A AWGM-REDIRECT -p tcp --dport 445 -j RETURN")
+	adminIdx := strings.Index(out, "-A AWGM-REDIRECT -p tcp --dport 79 -j RETURN")
+	wanIdx := strings.Index(out, "-A AWGM-REDIRECT -d 198.51.100.7/32 -j RETURN")
+
+	for name, idx := range map[string]int{
+		"qos": qosIdx, "catch-all": catchIdx, "port-bypass": portBypassIdx,
+		"admin-bypass": adminIdx, "wan": wanIdx,
+	} {
+		if idx == -1 {
+			t.Fatalf("%s rule not found in:\n%s", name, out)
+		}
+	}
+	for name, idx := range map[string]int{
+		"TCP port bypass":  portBypassIdx,
+		"admin-79 bypass":  adminIdx,
+		"WAN-IP exclusion": wanIdx,
+	} {
+		if qosIdx < idx {
+			t.Errorf("QoS rule (%d) must come AFTER %s (%d)", qosIdx, name, idx)
+		}
+	}
+	if qosIdx > catchIdx {
+		t.Errorf("QoS rule (%d) must come BEFORE catch-all REDIRECT (%d)", qosIdx, catchIdx)
+	}
+}
+
+func TestBuildRestoreInput_QoSClasses_AfterSelectiveGuard(t *testing.T) {
+	// Selective mode narrows what enters sing-box; QoS classifies WITHIN that
+	// scope. Both chains: guard first, then the DSCP dispatch.
+	spec := qosTestSpec()
+	spec.SelectiveIPSet = true
+	out := buildRestoreInput(spec)
+
+	mangleGuardIdx := strings.Index(out, fmt.Sprintf("-A %s -m set ! --match-set %s dst -j RETURN", ChainName, selectiveSetName))
+	mangleQoSIdx := strings.Index(out, "-A AWGM-TPROXY -p udp -m dscp --dscp 46")
+	natGuardIdx := strings.Index(out, fmt.Sprintf("-A %s -m set ! --match-set %s dst -j RETURN", RedirectChain, selectiveSetName))
+	natQoSIdx := strings.Index(out, "-A AWGM-REDIRECT -p tcp -m dscp --dscp 46")
+
+	if mangleGuardIdx == -1 || mangleQoSIdx == -1 || natGuardIdx == -1 || natQoSIdx == -1 {
+		t.Fatalf("missing rule(s): mGuard=%d mQoS=%d nGuard=%d nQoS=%d\n%s",
+			mangleGuardIdx, mangleQoSIdx, natGuardIdx, natQoSIdx, out)
+	}
+	if mangleQoSIdx < mangleGuardIdx {
+		t.Errorf("mangle QoS rule (%d) must come AFTER selective guard (%d)", mangleQoSIdx, mangleGuardIdx)
+	}
+	if natQoSIdx < natGuardIdx {
+		t.Errorf("nat QoS rule (%d) must come AFTER selective guard (%d)", natQoSIdx, natGuardIdx)
+	}
+}
+
+func TestBuildRestoreInput_NoQoSClasses_NoDscpRules(t *testing.T) {
+	out := buildRestoreInput(RestoreInputSpec{PolicyMark: "0xffffaaa"})
+	if strings.Contains(out, "-m dscp") {
+		t.Errorf("dscp rules must be absent when QoSClasses is empty:\n%s", out)
+	}
+}
+
+func TestWriteNetfilterHookPreloadsXtDscp(t *testing.T) {
+	body := netfilterHookScript()
+	if !strings.Contains(body, "xt_dscp") {
+		t.Errorf("hook preload loop missing xt_dscp:\n%s", body)
+	}
+}
+
+func TestEnsureXtDscpModule_MissingKoIsNotFatal(t *testing.T) {
+	orig := ensureKernelModuleFn
+	ensureKernelModuleFn = func(_ context.Context, name string) error {
+		if name != "xt_dscp" {
+			t.Errorf("expected module xt_dscp, got %q", name)
+		}
+		return ErrNetfilterComponentMissing
+	}
+	t.Cleanup(func() { ensureKernelModuleFn = orig })
+
+	if err := EnsureXtDscpModule(context.Background()); err != nil {
+		t.Errorf("expected nil when .ko absent (built-in fallback), got %v", err)
+	}
+}
+
+// TestBuildRestoreInput_QoS_NatTCPDNSCarveOutBeforeClassRules guards the
+// DNS carve-out: with QoS classes present, TCP/53 must be REDIRECTed to the
+// MAIN redirect port strictly BEFORE the per-class DSCP rules, so DSCP-marked
+// DNS (UDP is intercepted by the mangle chain, TCP here) always lands on the
+// main inbounds where hijack-dns applies — independent of the managed route
+// rules' ordering.
+func TestBuildRestoreInput_QoS_NatTCPDNSCarveOutBeforeClassRules(t *testing.T) {
+	out := buildRestoreInput(qosTestSpec())
+
+	dnsRule := fmt.Sprintf("-A %s -p tcp --dport 53 -j REDIRECT --to-ports %d", RedirectChain, RedirectPort)
+	dnsIdx := strings.Index(out, dnsRule)
+	qosIdx := strings.Index(out, fmt.Sprintf("-A %s -p tcp -m dscp --dscp 46", RedirectChain))
+	if dnsIdx == -1 {
+		t.Fatalf("TCP/53 carve-out missing with QoS classes present:\n%s", out)
+	}
+	if qosIdx == -1 {
+		t.Fatalf("QoS nat rule missing:\n%s", out)
+	}
+	if dnsIdx > qosIdx {
+		t.Errorf("TCP/53 carve-out (%d) must come BEFORE the per-class DSCP rules (%d)", dnsIdx, qosIdx)
+	}
+	if strings.Count(out, dnsRule) != 1 {
+		t.Errorf("expected exactly one TCP/53 intercept, got %d:\n%s", strings.Count(out, dnsRule), out)
+	}
+
+	// Mangle side: the UDP/53 intercept to the MAIN tproxy port already
+	// precedes the class rules (verified ordering, part of the same DNS
+	// invariant).
+	udpDNSIdx := strings.Index(out, fmt.Sprintf("-A %s -p udp --dport 53 -j TPROXY --on-port %d", ChainName, TPROXYPort))
+	udpQoSIdx := strings.Index(out, fmt.Sprintf("-A %s -p udp -m dscp --dscp 46", ChainName))
+	if udpDNSIdx == -1 || udpQoSIdx == -1 || udpDNSIdx > udpQoSIdx {
+		t.Errorf("mangle UDP/53 intercept (%d) must precede the class rules (%d)", udpDNSIdx, udpQoSIdx)
+	}
+}
+
+// TestBuildRestoreInput_QoSWithSelective_SingleTCPDNSIntercept: the selective
+// guard already emits the identical TCP/53 intercept ahead of the guard; the
+// QoS block must not duplicate it.
+func TestBuildRestoreInput_QoSWithSelective_SingleTCPDNSIntercept(t *testing.T) {
+	spec := qosTestSpec()
+	spec.SelectiveIPSet = true
+	out := buildRestoreInput(spec)
+
+	dnsRule := fmt.Sprintf("-A %s -p tcp --dport 53 -j REDIRECT --to-ports %d", RedirectChain, RedirectPort)
+	if n := strings.Count(out, dnsRule); n != 1 {
+		t.Fatalf("expected exactly one TCP/53 intercept with selective+QoS, got %d:\n%s", n, out)
+	}
+	dnsIdx := strings.Index(out, dnsRule)
+	qosIdx := strings.Index(out, fmt.Sprintf("-A %s -p tcp -m dscp --dscp 46", RedirectChain))
+	if dnsIdx > qosIdx {
+		t.Errorf("TCP/53 intercept (%d) must precede the class rules (%d)", dnsIdx, qosIdx)
+	}
+}
+
+// ── xt_dscp probe cache (FIX-7) ──────────────────────────────────────────────
+
+// resetXtDscpProbeCache clears the package-level probe cache and installs a
+// counting stub; returns the counter.
+func stubXtDscpProbe(t *testing.T, moduleOK, matchOK bool) *int {
+	t.Helper()
+	calls := 0
+	xtDscpMu.Lock()
+	origModule, origMatch, origAt := xtDscpModuleOK, xtDscpMatchOK, xtDscpCheckedAt
+	origFn := xtDscpAvailabilityFn
+	xtDscpModuleOK, xtDscpMatchOK = false, false
+	xtDscpCheckedAt = time.Time{}
+	xtDscpAvailabilityFn = func(_ context.Context) (bool, bool) {
+		calls++
+		return moduleOK, matchOK
+	}
+	xtDscpMu.Unlock()
+	t.Cleanup(func() {
+		xtDscpMu.Lock()
+		xtDscpModuleOK, xtDscpMatchOK, xtDscpCheckedAt = origModule, origMatch, origAt
+		xtDscpAvailabilityFn = origFn
+		xtDscpMu.Unlock()
+	})
+	return &calls
+}
+
+func TestIsXtDscpAvailable_NegativeResultCachedWithTTL(t *testing.T) {
+	calls := stubXtDscpProbe(t, false, false)
+	ctx := context.Background()
+
+	// Many availability checks within the TTL window → exactly ONE raw probe
+	// (previously: one `iptables -m dscp -h` exec per reconcile tick forever).
+	for i := 0; i < 10; i++ {
+		if IsXtDscpAvailable(ctx) {
+			t.Fatal("expected unavailable")
+		}
+	}
+	if *calls != 1 {
+		t.Fatalf("expected 1 raw probe within TTL, got %d", *calls)
+	}
+	// The detailed diagnostics path shares the same cache.
+	if m, x := cachedXtDscpAvailability(ctx); m || x {
+		t.Fatal("expected cached negative detail")
+	}
+	if *calls != 1 {
+		t.Fatalf("detail check must not re-probe within TTL, got %d probes", *calls)
+	}
+
+	// TTL expiry → exactly one re-probe.
+	xtDscpMu.Lock()
+	xtDscpCheckedAt = time.Now().Add(-xtDscpNegativeTTL - time.Minute)
+	xtDscpMu.Unlock()
+	_ = IsXtDscpAvailable(ctx)
+	if *calls != 2 {
+		t.Fatalf("expected re-probe after TTL, got %d probes", *calls)
+	}
+}
+
+func TestIsXtDscpAvailable_PositiveResultCachedForever(t *testing.T) {
+	calls := stubXtDscpProbe(t, true, true)
+	ctx := context.Background()
+	if !IsXtDscpAvailable(ctx) {
+		t.Fatal("expected available")
+	}
+	// Even past the TTL, a positive result never re-probes.
+	xtDscpMu.Lock()
+	xtDscpCheckedAt = time.Now().Add(-2 * xtDscpNegativeTTL)
+	xtDscpMu.Unlock()
+	for i := 0; i < 5; i++ {
+		if !IsXtDscpAvailable(ctx) {
+			t.Fatal("expected available")
+		}
+	}
+	if *calls != 1 {
+		t.Fatalf("positive result must be cached forever, got %d probes", *calls)
 	}
 }

--- a/internal/singbox/router/qos.go
+++ b/internal/singbox/router/qos.go
@@ -1,0 +1,301 @@
+package router
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// QoS-by-DSCP (issue #371): traffic classes marked with a DSCP codepoint are
+// dispatched by iptables `-m dscp` into per-class TPROXY/REDIRECT ports, each
+// backed by a dedicated pair of sing-box inbounds; managed route rules
+// (`{"inbound":[...],"outbound":X}`) send each class to its outbound. The
+// rules live in their own orchestrator slot (18-qos-routes.json, see
+// qos_routes.go) — never in the user-visible 20-router.json. sing-box ≤1.14
+// has no native dscp route matcher, so the classification has to happen at
+// the netfilter layer.
+
+const (
+	// MaxQoSClasses caps the number of QoS classes. Bounds both the settings
+	// validator and the reserved listen-port ranges below.
+	MaxQoSClasses = 8
+
+	// QoSTPROXYPortBase / QoSRedirectPortBase are the first ports of the two
+	// reserved contiguous ranges for per-class inbounds (base+index, index <
+	// MaxQoSClasses): UDP TPROXY 51281-51288, TCP REDIRECT 51301-51308.
+	// Chosen to not collide with TPROXYPort (51271), RedirectPort (51272) or
+	// any other AWGM listener (device-proxy 1080+, clash API 9099); the two
+	// ranges do not overlap each other (51281+8 = 51289 < 51301).
+	QoSTPROXYPortBase   = 51281
+	QoSRedirectPortBase = 51301
+)
+
+// QoSClassPorts returns the deterministic (tproxy, redirect) listen-port pair
+// for the QoS class occupying persisted slot (storage.SingboxQoSClass.Slot,
+// 0..MaxQoSClasses-1). Single source of truth shared by iptables rendering
+// and inbound generation so the two can never drift. Keyed on the STABLE
+// slot, not the class's position among active classes: positional ports
+// would shift when another class is disabled/removed, RSTing untouched flows.
+func QoSClassPorts(slot int) (tproxyPort, redirectPort int) {
+	return QoSTPROXYPortBase + slot, QoSRedirectPortBase + slot
+}
+
+// qosTProxyTagPrefix / qosRedirectTagPrefix form the RESERVED inbound-tag
+// namespace for QoS classes. validateRule rejects user rules that reference
+// these prefixes so managed QoS routing (18-qos-routes.json) can never be
+// shadowed or confused by hand-written lookalike rules. No persisted
+// `awgm_managed` marker anywhere: both 18-qos-routes.json and 20-router.json
+// are parsed by sing-box itself (config.d merge), and sing-box rejects
+// unknown rule fields — the selective-ip feature already learned that the
+// hard way (selectiveRoutesSlotNeedsHeal).
+const (
+	qosTProxyTagPrefix   = "tproxy-qos-"
+	qosRedirectTagPrefix = "redirect-qos-"
+)
+
+func qosTProxyTag(dscp int) string   { return fmt.Sprintf("%s%d", qosTProxyTagPrefix, dscp) }
+func qosRedirectTag(dscp int) string { return fmt.Sprintf("%s%d", qosRedirectTagPrefix, dscp) }
+
+// isQoSInboundTag reports whether tag belongs to the reserved QoS inbound
+// namespace (either protocol prefix).
+func isQoSInboundTag(tag string) bool {
+	return strings.HasPrefix(tag, qosTProxyTagPrefix) || strings.HasPrefix(tag, qosRedirectTagPrefix)
+}
+
+// qosClass is the resolved projection of one ACTIVE (enabled + valid) QoS
+// class: settings data plus the deterministic port pair for its slot.
+type qosClass struct {
+	DSCP         int
+	Outbound     string
+	TProxyPort   int
+	RedirectPort int
+}
+
+// activeQoSClasses filters settings classes down to the enabled, valid ones
+// and derives their deterministic ports from the persisted Slot. Defensive by
+// design: entries with an out-of-range DSCP, an empty outbound, a duplicate
+// DSCP, an out-of-range slot or a duplicate slot are silently dropped (first
+// occurrence wins) even though NormalizeSingboxRouterSettings repairs/rejects
+// them at the API — a hand-edited settings.json must degrade to "class
+// skipped", not to a broken iptables restore. Output order follows the
+// persisted slice order (deterministic — syncQoSRoutesSlot byte-compares the
+// marshalled slot); ports follow the STABLE per-class slot, so disabling or
+// removing one class never shifts another class's ports. Slot range implies
+// the MaxQoSClasses cap.
+func activeQoSClasses(classes []storage.SingboxQoSClass) []qosClass {
+	out := make([]qosClass, 0, len(classes))
+	seenDSCP := make(map[int]bool, len(classes))
+	seenSlot := make(map[int]bool, len(classes))
+	for _, c := range classes {
+		if !c.Enabled {
+			continue
+		}
+		outbound := strings.TrimSpace(c.Outbound)
+		if c.DSCP < 0 || c.DSCP > 63 || outbound == "" || seenDSCP[c.DSCP] {
+			continue
+		}
+		if c.Slot < 0 || c.Slot >= MaxQoSClasses || seenSlot[c.Slot] {
+			continue
+		}
+		seenDSCP[c.DSCP] = true
+		seenSlot[c.Slot] = true
+		tp, rp := QoSClassPorts(c.Slot)
+		out = append(out, qosClass{
+			DSCP:         c.DSCP,
+			Outbound:     outbound,
+			TProxyPort:   tp,
+			RedirectPort: rp,
+		})
+	}
+	return out
+}
+
+// qosIPTablesSpecs projects active classes into the RestoreInputSpec DTO
+// (iptables cares about DSCP + ports only; the outbound lives in sing-box).
+func qosIPTablesSpecs(classes []qosClass) []QoSClassSpec {
+	if len(classes) == 0 {
+		return nil
+	}
+	out := make([]QoSClassSpec, 0, len(classes))
+	for _, c := range classes {
+		out = append(out, QoSClassSpec{
+			DSCP:         c.DSCP,
+			TProxyPort:   c.TProxyPort,
+			RedirectPort: c.RedirectPort,
+		})
+	}
+	return out
+}
+
+// ensureQoSInbounds convergent-syncs the per-class inbound pairs: every
+// active class gets a canonical tproxy (UDP) + redirect (TCP) inbound and
+// every stale qos-* inbound (class removed/disabled, port drifted) is
+// dropped. Mirrors ensureTProxyInbound's canonical shapes: 0.0.0.0 listen
+// (REDIRECT rewrites the packet destination to the LAN-bridge IP, a loopback
+// listener would RST), UDP-only tproxy with udp_fragment + the same effective
+// UDP timeout as tproxy-in, TCP redirect with tcp_fast_open. Rebuild instead
+// of patch-in-place: the whole spec is derived, so "drop all qos inbounds,
+// append the canonical list" is the simplest convergent form. Returns the
+// new slice and whether anything changed (callers on the reconcile path skip
+// the persist+reload when false).
+func ensureQoSInbounds(in []Inbound, classes []qosClass, udpTimeout string) ([]Inbound, bool) {
+	if len(in) == 0 && len(classes) == 0 {
+		return in, false // nil-vs-empty guard: no phantom "changed" on a bare config
+	}
+	effective := resolveUDPTimeout(udpTimeout)
+	kept := make([]Inbound, 0, len(in)+2*len(classes))
+	for _, i := range in {
+		if isQoSInboundTag(i.Tag) {
+			continue
+		}
+		kept = append(kept, i)
+	}
+	for _, c := range classes {
+		kept = append(kept, Inbound{
+			Type:        "tproxy",
+			Tag:         qosTProxyTag(c.DSCP),
+			Listen:      inboundListen,
+			ListenPort:  c.TProxyPort,
+			Network:     "udp",
+			UDPFragment: true,
+			UDPTimeout:  effective,
+		}, Inbound{
+			Type:        "redirect",
+			Tag:         qosRedirectTag(c.DSCP),
+			Listen:      inboundListen,
+			ListenPort:  c.RedirectPort,
+			TCPFastOpen: true,
+		})
+	}
+	return kept, !reflect.DeepEqual(in, kept)
+}
+
+// validateQoSClasses enforces the QoS settings contract at the API boundary
+// (PUT /singbox/router/settings): at most MaxQoSClasses entries, DSCP within
+// 0-63 and unique across ALL entries (enabled or not — a disabled duplicate
+// would silently shadow on re-enable), Name at most 32 runes, Outbound
+// non-empty. Errors wrap ErrQoSClassesInvalid so the API maps them to 400.
+func validateQoSClasses(classes []storage.SingboxQoSClass) error {
+	if len(classes) > MaxQoSClasses {
+		return fmt.Errorf("%w: превышен лимит классов (%d)", ErrQoSClassesInvalid, MaxQoSClasses)
+	}
+	seen := make(map[int]bool, len(classes))
+	for i, c := range classes {
+		if c.DSCP < 0 || c.DSCP > 63 {
+			return fmt.Errorf("%w: qosClasses[%d]: DSCP должен быть 0-63 (получено %d)", ErrQoSClassesInvalid, i, c.DSCP)
+		}
+		if seen[c.DSCP] {
+			return fmt.Errorf("%w: qosClasses[%d]: дублирующийся DSCP %d", ErrQoSClassesInvalid, i, c.DSCP)
+		}
+		seen[c.DSCP] = true
+		if len([]rune(c.Name)) > 32 {
+			return fmt.Errorf("%w: qosClasses[%d]: имя не должно превышать 32 символа", ErrQoSClassesInvalid, i)
+		}
+		if strings.TrimSpace(c.Outbound) == "" {
+			return fmt.Errorf("%w: qosClasses[%d]: outbound обязателен", ErrQoSClassesInvalid, i)
+		}
+	}
+	return nil
+}
+
+// normalizeQoSClasses canonicalises the stored form: trimmed name/outbound
+// plus a defensively repaired slot assignment — in-range unique slots are
+// PRESERVED (they encode the stable per-class ports), while slotless,
+// out-of-range or duplicate slots get the first free slot in slice order.
+// Idempotent, so re-normalizing persisted settings is a fixed point and a
+// class keeps its ports across reloads. Called after validateQoSClasses
+// passed, so it never drops entries — the defensive dropping lives in
+// activeQoSClasses on the apply path.
+//
+// NOTE: this only repairs a single slice in isolation. Re-associating a PUT
+// payload (which carries no slots) with the previously persisted slots is
+// reassociateQoSSlots' job — see UpdateSettings.
+func normalizeQoSClasses(classes []storage.SingboxQoSClass) []storage.SingboxQoSClass {
+	if len(classes) == 0 {
+		return classes
+	}
+	out := make([]storage.SingboxQoSClass, len(classes))
+	used := make(map[int]bool, len(classes))
+	for i, c := range classes {
+		c.Name = strings.TrimSpace(c.Name)
+		c.Outbound = strings.TrimSpace(c.Outbound)
+		if c.Slot < 0 || c.Slot >= MaxQoSClasses || used[c.Slot] {
+			c.Slot = -1 // needs (re)assignment below
+		} else {
+			used[c.Slot] = true
+		}
+		out[i] = c
+	}
+	for i := range out {
+		if out[i].Slot >= 0 {
+			continue
+		}
+		out[i].Slot = firstFreeQoSSlot(used)
+		if out[i].Slot >= 0 {
+			used[out[i].Slot] = true
+		}
+	}
+	return out
+}
+
+// firstFreeQoSSlot returns the lowest slot in [0, MaxQoSClasses) not marked
+// used, or -1 when all are taken (only possible for a hand-edited settings
+// file with more than MaxQoSClasses entries — validateQoSClasses rejects
+// that at the API; activeQoSClasses skips slot -1 defensively).
+func firstFreeQoSSlot(used map[int]bool) int {
+	for s := 0; s < MaxQoSClasses; s++ {
+		if !used[s] {
+			return s
+		}
+	}
+	return -1
+}
+
+// reassociateQoSSlots carries persisted port slots over to an incoming PUT
+// payload. The UI contract has no slot field — clients send classes as
+// {dscp,name,outbound,enabled} — so incoming slots are IGNORED entirely and
+// each class is re-associated with its stored slot by DSCP (the unique key).
+// Classes with a brand-new DSCP get the first slot not carried over (a freed
+// slot is reused). This is what keeps class C's ports stable when class B is
+// disabled, edited or removed: without it, positional assignment would shift
+// C onto B's ports and RST/blackhole its flows.
+func reassociateQoSSlots(incoming, stored []storage.SingboxQoSClass) []storage.SingboxQoSClass {
+	if len(incoming) == 0 {
+		return incoming
+	}
+	slotByDSCP := make(map[int]int, len(stored))
+	storedUsed := make(map[int]bool, len(stored))
+	for _, c := range stored {
+		if c.Slot < 0 || c.Slot >= MaxQoSClasses || storedUsed[c.Slot] {
+			continue // defensively skip corrupt persisted slots
+		}
+		if _, dup := slotByDSCP[c.DSCP]; dup {
+			continue
+		}
+		slotByDSCP[c.DSCP] = c.Slot
+		storedUsed[c.Slot] = true
+	}
+	out := make([]storage.SingboxQoSClass, len(incoming))
+	used := make(map[int]bool, len(incoming))
+	for i, c := range incoming {
+		if slot, ok := slotByDSCP[c.DSCP]; ok && !used[slot] {
+			c.Slot = slot
+			used[slot] = true
+		} else {
+			c.Slot = -1 // new DSCP → assigned below from the free pool
+		}
+		out[i] = c
+	}
+	for i := range out {
+		if out[i].Slot >= 0 {
+			continue
+		}
+		out[i].Slot = firstFreeQoSSlot(used)
+		if out[i].Slot >= 0 {
+			used[out[i].Slot] = true
+		}
+	}
+	return out
+}

--- a/internal/singbox/router/qos_routes.go
+++ b/internal/singbox/router/qos_routes.go
@@ -1,0 +1,309 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// qosReloadWait bounds the reconcile-path wait for sing-box to rebind its
+// inbounds after a QoS config heal, before Install moves the iptables
+// dispatch onto the new per-class ports (see reconcileInstalled). Shorter
+// than Enable's full boot window on purpose: reconcile is a periodic heal
+// and must not block the scheduler for a minute behind a dead engine —
+// the wait is soft (proceed on timeout).
+const qosReloadWait = 15 * time.Second
+
+// Managed QoS route rules live in their own orchestrator slot,
+// 18-qos-routes.json, mirroring the selective-routes slot (19). Why not
+// 20-router.json:
+//   - 20 is the user-visible rules file: managed rules leaked into the rules
+//     UI as anonymous matcher-less rows, users deleted them, the reconcile
+//     heal re-added them — a churn loop;
+//   - the user slot goes through the staging pipeline: a heal that loads the
+//     EFFECTIVE config (pending draft preferred) and direct-writes to active
+//     silently applied staged drafts, bypassing the «Применить» gate;
+//   - sing-box evaluates merged route rules in file order, so rules parked at
+//     a fixed position inside 20 could end up AFTER the selective /32 overlay
+//     rules from 19 and never match under selective bypass. Slot 18 merges
+//     before 19 and 20, so a DSCP mark (an explicit per-packet policy signal)
+//     always wins over selective overlays and user rules.
+//
+// DNS never depends on these rules: buildRestoreInput intercepts UDP/53 to
+// the main TPROXY port and (with QoS classes present) TCP/53 to the main
+// REDIRECT port BEFORE the per-class DSCP dispatch, so DSCP-marked DNS lands
+// on the main inbounds where the system hijack-dns rule (slot 20) applies.
+// LAN/RFC1918 destinations likewise never reach the class inbounds — the
+// builtin bypass RETURNs precede the DSCP dispatch in both chains.
+
+// qosRoutesSlot is the JSON shape for 18-qos-routes.json. Only route.rules —
+// never inbounds/outbounds; null slices in a merged slot corrupt sing-box's
+// outbounds array (same lesson as selectiveRoutesSlot).
+type qosRoutesSlot struct {
+	Route struct {
+		Rules []Rule `json:"rules"`
+	} `json:"route"`
+}
+
+func marshalQoSRoutesSlot(rules []Rule) ([]byte, error) {
+	slot := qosRoutesSlot{}
+	slot.Route.Rules = rules
+	return json.MarshalIndent(slot, "", "  ")
+}
+
+// buildQoSRouteRules renders one managed route rule per class: the class's
+// inbound tag pair routed to its outbound. Output is canonical/deterministic
+// for a given class slice (activeQoSClasses preserves the persisted settings
+// order), so syncQoSRoutesSlot can byte-compare the marshalled slot to skip
+// the sing-box reload. No AwgmManaged marker — the slot is merged by
+// sing-box, which rejects unknown rule fields.
+func buildQoSRouteRules(classes []qosClass) []Rule {
+	if len(classes) == 0 {
+		return nil
+	}
+	out := make([]Rule, 0, len(classes))
+	for _, q := range classes {
+		out = append(out, Rule{
+			Inbound:  []string{qosTProxyTag(q.DSCP), qosRedirectTag(q.DSCP)},
+			Action:   "route",
+			Outbound: q.Outbound,
+		})
+	}
+	return out
+}
+
+// filterQoSClassesWithKnownOutbounds partitions classes into those whose
+// outbound resolves against the known catalogs (cfg composites + subscription
+// composites + AWG tags + sing-box tunnel tags + built-ins) and those that
+// don't. Defense in depth for the emit path (FIX for the engine-down failure
+// mode): a merged rule routing to a nonexistent outbound is rejected by
+// sing-box at load time and takes the WHOLE engine down, so unknown-outbound
+// classes are skipped at emit time and surfaced as a qos-outbound-missing
+// status Issue instead.
+func (s *ServiceImpl) filterQoSClassesWithKnownOutbounds(ctx context.Context, classes []qosClass, cfg *RouterConfig) (known, missing []qosClass) {
+	if len(classes) == 0 {
+		return nil, nil
+	}
+	if cfg == nil {
+		cfg = NewEmptyConfig()
+	}
+	known = make([]qosClass, 0, len(classes))
+	for _, c := range classes {
+		if s.isKnownOutboundTag(ctx, c.Outbound, cfg) {
+			known = append(known, c)
+			continue
+		}
+		missing = append(missing, c)
+	}
+	return known, missing
+}
+
+// syncQoSRoutesSlot writes the managed QoS route rules into
+// 18-qos-routes.json (merged by sing-box, invisible in the rules UI). Uses
+// SaveSilent/SetEnabledSilent so no staging draft or debounced reload is
+// triggered — callers decide when to apply (Enable's orchestratorApplyNow,
+// the reconcile heal's applyQoSRoutesSlot).
+//
+// File semantics mirror syncSelectiveRoutesSlot: at least one emitted rule ⇒
+// slot enabled with the canonical content; no classes (feature off, all
+// disabled, or every outbound unknown) ⇒ the slot is cleared (canonical empty
+// content written, file parked under disabled/). Returns changed=false when
+// the merged config is already in the target shape (byte-equal active file
+// when enabling, absent active file when disabling) so the caller can skip
+// the sing-box reload.
+//
+// Classes whose outbound is unknown at emit time are skipped (see
+// filterQoSClassesWithKnownOutbounds); GetStatus independently reports them
+// as qos-outbound-missing issues.
+func (s *ServiceImpl) syncQoSRoutesSlot(ctx context.Context, classes []qosClass) (bool, error) {
+	if s.deps.Orch == nil {
+		return false, nil
+	}
+	emit := classes
+	if len(classes) > 0 {
+		// Resolve outbounds against the APPLIED router config — the emit
+		// decision must reflect what sing-box actually merges, never a
+		// pending draft.
+		cfg, err := s.loadAppliedRouterConfig()
+		if err != nil {
+			return false, err
+		}
+		var skipped []qosClass
+		emit, skipped = s.filterQoSClassesWithKnownOutbounds(ctx, classes, cfg)
+		for _, c := range skipped {
+			s.appLog.Warn("qos-routes", c.Outbound,
+				fmt.Sprintf("класс QoS (DSCP %d) ссылается на несуществующий outbound %q — правило не эмитится", c.DSCP, c.Outbound))
+		}
+	}
+	rules := buildQoSRouteRules(emit)
+	enable := len(rules) > 0
+	data, err := marshalQoSRoutesSlot(rules)
+	if err != nil {
+		return false, err
+	}
+	// The merged config only sees the ACTIVE file: enabled ⇒ byte-equal
+	// active file is a no-op; disabled ⇒ absent active file is a no-op
+	// regardless of any parked disabled/ copy.
+	activePath := filepath.Join(s.deps.Orch.ConfigDir(), "18-qos-routes.json")
+	existing, readErr := os.ReadFile(activePath)
+	if enable {
+		if readErr == nil && bytes.Equal(existing, data) {
+			return false, nil // already the exact active content — steady state
+		}
+	} else if os.IsNotExist(readErr) {
+		return false, nil // already absent from the merge — steady state
+	}
+	if err := s.deps.Orch.SaveSilent(orchestrator.SlotQoSRoutes, data); err != nil {
+		return false, err
+	}
+	if err := s.deps.Orch.SetEnabledSilent(orchestrator.SlotQoSRoutes, enable); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// disableQoSRoutesSlot parks 18-qos-routes.json under disabled/ when the
+// router itself is disabled: the managed rules reference qos-* inbound tags
+// that only exist while 20-router.json is active, so the overlay must never
+// outlive the router slot.
+func (s *ServiceImpl) disableQoSRoutesSlot() error {
+	if s.deps.Orch == nil {
+		return nil
+	}
+	return s.deps.Orch.SetEnabledSilent(orchestrator.SlotQoSRoutes, false)
+}
+
+// applyQoSRoutesSlot reloads sing-box when the QoS config changed OR the
+// previous apply failed — disk state ≠ running sing-box after a failed
+// apply, so the next heal must re-apply even when everything on disk is
+// byte-identical, or the retry heal becomes a no-op forever and loses its
+// self-heal role. Mirrors selectiveBuilderAdapter.applyRoutesSlot.
+func (s *ServiceImpl) applyQoSRoutesSlot(changed bool) {
+	if !changed && !s.qosApplyFailed.Load() {
+		return
+	}
+	if err := s.orchestratorApplyNow(); err != nil {
+		s.qosApplyFailed.Store(true)
+		s.appLog.Warn("qos-routes", "", err.Error())
+		return
+	}
+	s.qosApplyFailed.Store(false)
+}
+
+// qosClassesReferencing returns human-readable locations of persisted QoS
+// classes (enabled or not) that route to tag. Used by the outbound-delete
+// guard so a non-force delete refuses instead of silently orphaning a class.
+func (s *ServiceImpl) qosClassesReferencing(tag string) []string {
+	if s.deps.Settings == nil || strings.TrimSpace(tag) == "" {
+		return nil
+	}
+	settings, err := s.deps.Settings.Load()
+	if err != nil || settings == nil {
+		return nil
+	}
+	var refs []string
+	for i, c := range settings.SingboxRouter.QoSClasses {
+		if strings.TrimSpace(c.Outbound) == tag {
+			refs = append(refs, fmt.Sprintf("qosClasses[%d] (DSCP %d)", i, c.DSCP))
+		}
+	}
+	return refs
+}
+
+// renameQoSClassOutbound rewrites persisted QoS classes routing to oldTag so
+// an outbound rename never leaves classes pointing at a tag that no longer
+// exists. Companion of renameOutboundReferences for the settings side.
+func (s *ServiceImpl) renameQoSClassOutbound(oldTag, newTag string) error {
+	oldTag = strings.TrimSpace(oldTag)
+	newTag = strings.TrimSpace(newTag)
+	if s.deps.Settings == nil || oldTag == "" || newTag == "" || oldTag == newTag {
+		return nil
+	}
+	settings, err := s.deps.Settings.Load()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for i := range settings.SingboxRouter.QoSClasses {
+		if strings.TrimSpace(settings.SingboxRouter.QoSClasses[i].Outbound) == oldTag {
+			settings.SingboxRouter.QoSClasses[i].Outbound = newTag
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return s.deps.Settings.Save(settings)
+}
+
+// disableQoSClassesForOutbound flips Enabled off on persisted QoS classes
+// routing to tag. Companion of removeOutboundReferences (force-delete) for
+// the settings side: the class is deliberately DISABLED, not deleted, so the
+// UI still shows it (marked off) and the user can re-point it — silently
+// dropping user configuration on a force-delete would be data loss. The next
+// reconcile tick converges the sing-box/iptables side.
+func (s *ServiceImpl) disableQoSClassesForOutbound(tag string) error {
+	tag = strings.TrimSpace(tag)
+	if s.deps.Settings == nil || tag == "" {
+		return nil
+	}
+	settings, err := s.deps.Settings.Load()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for i := range settings.SingboxRouter.QoSClasses {
+		c := &settings.SingboxRouter.QoSClasses[i]
+		if strings.TrimSpace(c.Outbound) == tag && c.Enabled {
+			c.Enabled = false
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return s.deps.Settings.Save(settings)
+}
+
+// healQoSConfig is the reconcile-path self-heal for the QoS sing-box side:
+// per-class inbound pairs in 20-router.json plus the managed route rules in
+// 18-qos-routes.json. It re-derives the canonical state from settings and
+// writes only what actually drifted; applyQoSRoutesSlot then reloads
+// sing-box only on change (sticky-failure aware). Returns whether anything
+// was (re)written so reconcileInstalled can wait for the reload to land
+// before installing new iptables dispatch ports.
+//
+// Load-source discipline: the inbound heal reads the APPLIED router config
+// (active/, then disabled/), never LoadEffective — a heal that starts from
+// the pending draft and direct-writes to active would silently apply staged
+// edits, bypassing the «Применить» gate. persistConfigDirect's byte-equal
+// short-circuit keeps the steady state write-free.
+func (s *ServiceImpl) healQoSConfig(ctx context.Context, sr storage.SingboxRouterSettings) (bool, error) {
+	classes := activeQoSClasses(sr.QoSClasses)
+	cfg, err := s.loadAppliedRouterConfig()
+	if err != nil {
+		return false, err
+	}
+	inbounds, inChanged := ensureQoSInbounds(cfg.Inbounds, classes, sr.UDPTimeout)
+	if inChanged {
+		cfg.Inbounds = inbounds
+		if err := s.persistConfigDirect(ctx, cfg); err != nil {
+			return false, err
+		}
+	}
+	slotChanged, err := s.syncQoSRoutesSlot(ctx, classes)
+	if err != nil {
+		return inChanged, err
+	}
+	changed := inChanged || slotChanged
+	s.applyQoSRoutesSlot(changed)
+	return changed, nil
+}

--- a/internal/singbox/router/qos_test.go
+++ b/internal/singbox/router/qos_test.go
@@ -1,0 +1,1355 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// ── Port allocation ───────────────────────────────────────────────
+
+func TestQoSClassPorts_NoCollisions(t *testing.T) {
+	reserved := map[int]string{
+		TPROXYPort:   "TPROXYPort",
+		RedirectPort: "RedirectPort",
+	}
+	seen := map[int]int{}
+	for i := 0; i < MaxQoSClasses; i++ {
+		tp, rp := QoSClassPorts(i)
+		if owner, clash := reserved[tp]; clash {
+			t.Errorf("QoSClassPorts(%d) tproxy=%d collides with %s", i, tp, owner)
+		}
+		if owner, clash := reserved[rp]; clash {
+			t.Errorf("QoSClassPorts(%d) redirect=%d collides with %s", i, rp, owner)
+		}
+		if tp == rp {
+			t.Errorf("QoSClassPorts(%d): tproxy and redirect port equal (%d)", i, tp)
+		}
+		if prev, dup := seen[tp]; dup {
+			t.Errorf("tproxy port %d reused by classes %d and %d", tp, prev, i)
+		}
+		if prev, dup := seen[rp]; dup {
+			t.Errorf("redirect port %d reused by classes %d and %d", rp, prev, i)
+		}
+		seen[tp] = i
+		seen[rp] = i
+	}
+	// Deterministic bases documented for the frontend/iptables contract.
+	if tp, rp := QoSClassPorts(0); tp != 51281 || rp != 51301 {
+		t.Errorf("QoSClassPorts(0) = (%d, %d), want (51281, 51301)", tp, rp)
+	}
+}
+
+func TestQoSTags(t *testing.T) {
+	if qosTProxyTag(46) != "tproxy-qos-46" {
+		t.Errorf("qosTProxyTag(46) = %q", qosTProxyTag(46))
+	}
+	if qosRedirectTag(46) != "redirect-qos-46" {
+		t.Errorf("qosRedirectTag(46) = %q", qosRedirectTag(46))
+	}
+	for _, tag := range []string{"tproxy-qos-0", "redirect-qos-63"} {
+		if !isQoSInboundTag(tag) {
+			t.Errorf("isQoSInboundTag(%q) = false", tag)
+		}
+	}
+	for _, tag := range []string{"tproxy-in", "redirect-in", "qos-46", ""} {
+		if isQoSInboundTag(tag) {
+			t.Errorf("isQoSInboundTag(%q) = true", tag)
+		}
+	}
+}
+
+// ── activeQoSClasses (defensive filtering + slot-derived ports) ──
+
+func TestActiveQoSClasses_FiltersAndUsesSlotPorts(t *testing.T) {
+	classes := []storage.SingboxQoSClass{
+		{DSCP: 46, Name: "voip", Outbound: "vpn-a", Enabled: true, Slot: 3},
+		{DSCP: 10, Outbound: "vpn-b", Enabled: false, Slot: 1},            // disabled → dropped
+		{DSCP: 99, Outbound: "vpn-c", Enabled: true, Slot: 2},             // DSCP out of range → dropped
+		{DSCP: 8, Outbound: "   ", Enabled: true, Slot: 4},                // empty outbound → dropped
+		{DSCP: 46, Outbound: "vpn-dup", Enabled: true, Slot: 5},           // duplicate DSCP → dropped (first wins)
+		{DSCP: 26, Outbound: "  vpn-d  ", Enabled: true, Slot: 0},         // trimmed; ports from ITS slot, not position
+		{DSCP: -1, Outbound: "vpn-e", Enabled: true, Slot: 6},             // negative DSCP → dropped
+		{DSCP: 20, Outbound: "vpn-f", Enabled: true, Slot: 3},             // duplicate slot → dropped (first wins)
+		{DSCP: 21, Outbound: "vpn-g", Enabled: true, Slot: MaxQoSClasses}, // slot out of range → dropped
+		{DSCP: 22, Outbound: "vpn-h", Enabled: true, Slot: -1},            // negative slot → dropped
+	}
+	got := activeQoSClasses(classes)
+	want := []qosClass{
+		{DSCP: 46, Outbound: "vpn-a", TProxyPort: 51284, RedirectPort: 51304},
+		{DSCP: 26, Outbound: "vpn-d", TProxyPort: 51281, RedirectPort: 51301},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("activeQoSClasses = %+v, want %+v", got, want)
+	}
+}
+
+// TestActiveQoSClasses_PortsStableAcrossDisable is the FIX-3 invariant: a
+// class keeps its slot ports when a preceding class is disabled or removed —
+// positional assignment would shift them and RST/blackhole untouched flows.
+func TestActiveQoSClasses_PortsStableAcrossDisable(t *testing.T) {
+	all := []storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: true, Slot: 0},
+		{DSCP: 20, Outbound: "b", Enabled: true, Slot: 1},
+		{DSCP: 30, Outbound: "c", Enabled: true, Slot: 2},
+	}
+	before := activeQoSClasses(all)
+
+	disabledB := append([]storage.SingboxQoSClass(nil), all...)
+	disabledB[1].Enabled = false
+	after := activeQoSClasses(disabledB)
+	if len(after) != 2 {
+		t.Fatalf("expected 2 active classes, got %+v", after)
+	}
+	if after[1].DSCP != 30 || after[1].TProxyPort != before[2].TProxyPort || after[1].RedirectPort != before[2].RedirectPort {
+		t.Errorf("class C ports shifted after disabling B: before=%+v after=%+v", before[2], after[1])
+	}
+
+	removedB := []storage.SingboxQoSClass{all[0], all[2]}
+	afterRemove := activeQoSClasses(removedB)
+	if afterRemove[1].TProxyPort != before[2].TProxyPort {
+		t.Errorf("class C ports shifted after removing B: %+v", afterRemove[1])
+	}
+}
+
+func TestQoSIPTablesSpecs(t *testing.T) {
+	if qosIPTablesSpecs(nil) != nil {
+		t.Error("empty classes must project to nil specs")
+	}
+	specs := qosIPTablesSpecs([]qosClass{{DSCP: 46, Outbound: "vpn", TProxyPort: 51281, RedirectPort: 51301}})
+	want := []QoSClassSpec{{DSCP: 46, TProxyPort: 51281, RedirectPort: 51301}}
+	if !slices.Equal(specs, want) {
+		t.Fatalf("specs = %+v, want %+v", specs, want)
+	}
+}
+
+// ── Inbound reconcile ─────────────────────────────────────────────
+
+func TestEnsureQoSInbounds_AddsCanonicalPairs(t *testing.T) {
+	base := []Inbound{
+		{Type: "redirect", Tag: "redirect-in", Listen: "0.0.0.0", ListenPort: RedirectPort, TCPFastOpen: true},
+		{Type: "tproxy", Tag: "tproxy-in", Listen: "0.0.0.0", ListenPort: TPROXYPort, Network: "udp"},
+	}
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn", Enabled: true},
+	})
+	got, changed := ensureQoSInbounds(base, classes, "10m0s")
+	if !changed {
+		t.Fatal("expected changed=true when adding class inbounds")
+	}
+	// Main inbounds untouched, in order.
+	if got[0].Tag != "redirect-in" || got[1].Tag != "tproxy-in" {
+		t.Fatalf("main inbounds disturbed: %+v", got)
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected 4 inbounds, got %d: %+v", len(got), got)
+	}
+	tp := got[2]
+	if tp.Type != "tproxy" || tp.Tag != "tproxy-qos-46" || tp.ListenPort != 51281 ||
+		tp.Network != "udp" || !tp.UDPFragment || tp.UDPTimeout != "10m0s" || tp.Listen != "0.0.0.0" {
+		t.Errorf("qos tproxy inbound not canonical: %+v", tp)
+	}
+	rd := got[3]
+	if rd.Type != "redirect" || rd.Tag != "redirect-qos-46" || rd.ListenPort != 51301 ||
+		!rd.TCPFastOpen || rd.Listen != "0.0.0.0" {
+		t.Errorf("qos redirect inbound not canonical: %+v", rd)
+	}
+}
+
+func TestEnsureQoSInbounds_RemovesStaleAndConverges(t *testing.T) {
+	// Stale artifacts: old class 10 removed, class 46 drifted port/timeout.
+	in := []Inbound{
+		{Type: "tproxy", Tag: "tproxy-in", ListenPort: TPROXYPort},
+		{Type: "tproxy", Tag: "tproxy-qos-10", ListenPort: 51282},
+		{Type: "redirect", Tag: "redirect-qos-10", ListenPort: 51302},
+		{Type: "tproxy", Tag: "tproxy-qos-46", ListenPort: 59999, UDPTimeout: "1m0s"},
+	}
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn", Enabled: true},
+	})
+	got, changed := ensureQoSInbounds(in, classes, "")
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	tags := make([]string, 0, len(got))
+	for _, i := range got {
+		tags = append(tags, i.Tag)
+	}
+	want := []string{"tproxy-in", "tproxy-qos-46", "redirect-qos-46"}
+	if !slices.Equal(tags, want) {
+		t.Fatalf("tags = %v, want %v", tags, want)
+	}
+	if got[1].ListenPort != 51281 || got[1].UDPTimeout != DefaultUDPTimeout {
+		t.Errorf("drifted qos inbound not healed: %+v", got[1])
+	}
+
+	// Second pass over the converged result: no change.
+	again, changed2 := ensureQoSInbounds(got, classes, "")
+	if changed2 {
+		t.Errorf("expected idempotent second pass, got change: %+v", again)
+	}
+}
+
+func TestEnsureQoSInbounds_NoClasses_RemovesAll(t *testing.T) {
+	in := []Inbound{
+		{Type: "tproxy", Tag: "tproxy-in"},
+		{Type: "tproxy", Tag: "tproxy-qos-46"},
+		{Type: "redirect", Tag: "redirect-qos-46"},
+	}
+	got, changed := ensureQoSInbounds(in, nil, "")
+	if !changed {
+		t.Fatal("expected changed=true when removing stale qos inbounds")
+	}
+	if len(got) != 1 || got[0].Tag != "tproxy-in" {
+		t.Fatalf("got %+v", got)
+	}
+
+	// Empty in, no classes → no phantom change.
+	if _, changed := ensureQoSInbounds(nil, nil, ""); changed {
+		t.Error("nil inbounds + no classes must not report change")
+	}
+	if _, changed := ensureQoSInbounds([]Inbound{}, nil, ""); changed {
+		t.Error("empty inbounds + no classes must not report change")
+	}
+}
+
+// ── Slot assignment (normalize + PUT re-association) ─────────────
+
+func TestNormalizeQoSClasses_PreservesAndRepairsSlots(t *testing.T) {
+	got := normalizeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Slot: 2},             // valid → preserved
+		{DSCP: 20, Outbound: "b", Slot: 2},             // duplicate → first free (0)
+		{DSCP: 30, Outbound: "c", Slot: MaxQoSClasses}, // out of range → first free (1)
+		{DSCP: 40, Outbound: "d", Slot: -3},            // negative → first free (3)
+	})
+	wantSlots := []int{2, 0, 1, 3}
+	for i, w := range wantSlots {
+		if got[i].Slot != w {
+			t.Errorf("class %d slot = %d, want %d (%+v)", i, got[i].Slot, w, got)
+		}
+	}
+	// Idempotent: re-normalizing the repaired slice is a fixed point.
+	again := normalizeQoSClasses(got)
+	if !reflect.DeepEqual(got, again) {
+		t.Errorf("normalize not idempotent: %+v vs %+v", got, again)
+	}
+}
+
+func TestReassociateQoSSlots_CarriesSlotsByDSCP(t *testing.T) {
+	stored := []storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: true, Slot: 0},
+		{DSCP: 20, Outbound: "b", Enabled: true, Slot: 1},
+		{DSCP: 30, Outbound: "c", Enabled: true, Slot: 2},
+	}
+	// Frontend PUTs the whole array WITHOUT slots (all zero), reordered and
+	// with class 20 removed + a new class 40 added.
+	incoming := []storage.SingboxQoSClass{
+		{DSCP: 30, Outbound: "c", Enabled: true},
+		{DSCP: 40, Outbound: "d", Enabled: true},
+		{DSCP: 10, Outbound: "a", Enabled: false}, // disabled but keeps its slot
+	}
+	got := reassociateQoSSlots(incoming, stored)
+	if got[0].Slot != 2 {
+		t.Errorf("class 30 must keep slot 2, got %d", got[0].Slot)
+	}
+	if got[2].Slot != 0 {
+		t.Errorf("class 10 must keep slot 0 even while disabled, got %d", got[2].Slot)
+	}
+	// New DSCP gets the FREED slot (1, vacated by removed class 20).
+	if got[1].Slot != 1 {
+		t.Errorf("new class 40 must get freed slot 1, got %d", got[1].Slot)
+	}
+}
+
+func TestReassociateQoSSlots_DisableReEnableKeepsPorts(t *testing.T) {
+	stored := []storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: true, Slot: 0},
+		{DSCP: 20, Outbound: "b", Enabled: true, Slot: 1},
+	}
+	// PUT 1: disable class 10 (no slots on the wire).
+	put1 := reassociateQoSSlots([]storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: false},
+		{DSCP: 20, Outbound: "b", Enabled: true},
+	}, stored)
+	// PUT 2: re-enable it.
+	put2 := reassociateQoSSlots([]storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: true},
+		{DSCP: 20, Outbound: "b", Enabled: true},
+	}, put1)
+	if put2[0].Slot != 0 || put2[1].Slot != 1 {
+		t.Errorf("slots drifted across disable/re-enable: %+v", put2)
+	}
+	tp, _ := QoSClassPorts(put2[1].Slot)
+	if tp != 51282 {
+		t.Errorf("class 20 tproxy port = %d, want 51282", tp)
+	}
+}
+
+func TestReassociateQoSSlots_IgnoresIncomingSlots(t *testing.T) {
+	stored := []storage.SingboxQoSClass{{DSCP: 10, Outbound: "a", Enabled: true, Slot: 3}}
+	// A client echoing GET data back sends slot values — they must be
+	// ignored in favour of the stored association.
+	got := reassociateQoSSlots([]storage.SingboxQoSClass{
+		{DSCP: 10, Outbound: "a", Enabled: true, Slot: 7},
+		{DSCP: 20, Outbound: "b", Enabled: true, Slot: 3},
+	}, stored)
+	if got[0].Slot != 3 {
+		t.Errorf("class 10 must keep stored slot 3, got %d", got[0].Slot)
+	}
+	if got[1].Slot == 3 || got[1].Slot < 0 || got[1].Slot >= MaxQoSClasses {
+		t.Errorf("new class must get a free valid slot, got %d", got[1].Slot)
+	}
+}
+
+// ── QoS routes slot (18-qos-routes.json) ──────────────────────────
+
+func TestBuildQoSRouteRules_CanonicalAndDeterministic(t *testing.T) {
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn-a", Enabled: true, Slot: 0},
+		{DSCP: 26, Outbound: "vpn-b", Enabled: true, Slot: 1},
+	})
+	rules := buildQoSRouteRules(classes)
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %+v", rules)
+	}
+	q0 := rules[0]
+	if !slices.Equal(q0.Inbound, []string{"tproxy-qos-46", "redirect-qos-46"}) ||
+		q0.Action != "route" || q0.Outbound != "vpn-a" {
+		t.Errorf("qos rule 0 wrong: %+v", q0)
+	}
+	if q0.AwgmManaged != "" {
+		t.Errorf("qos rule must not carry awgm_managed (sing-box rejects unknown rule fields), got %q", q0.AwgmManaged)
+	}
+	if buildQoSRouteRules(nil) != nil {
+		t.Error("no classes must yield nil rules")
+	}
+	// Deterministic marshalling — syncQoSRoutesSlot byte-compares the slot.
+	first, err := marshalQoSRoutesSlot(rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		again, err := marshalQoSRoutesSlot(buildQoSRouteRules(classes))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Equal(first, again) {
+			t.Fatalf("marshal %d differs:\n%s\nvs\n%s", i, first, again)
+		}
+	}
+}
+
+func TestMarshalQoSRoutesSlot_RouteOnly(t *testing.T) {
+	data, err := marshalQoSRoutesSlot(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"outbounds", "inbounds", "dns"} {
+		if _, ok := m[forbidden]; ok {
+			t.Fatalf("slot JSON must not contain %q: %s", forbidden, data)
+		}
+	}
+	if !strings.Contains(string(data), `"rules"`) {
+		t.Fatalf("slot JSON must carry route.rules: %s", data)
+	}
+}
+
+// newQoSSlotTestService wires a ServiceImpl with a real orchestrator in a
+// temp dir, both router + qos-routes slots registered, and a 20-router.json
+// active config carrying the given outbounds (so isKnownOutboundTag can
+// resolve them at emit time).
+func newQoSSlotTestService(t *testing.T, outbounds ...string) (*ServiceImpl, string) {
+	t.Helper()
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	if err := orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotRouter, Filename: "20-router.json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotQoSRoutes, Filename: "18-qos-routes.json"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := NewEmptyConfig()
+	for _, ob := range outbounds {
+		cfg.Outbounds = append(cfg.Outbounds, Outbound{Type: "selector", Tag: ob, Outbounds: []string{"direct"}})
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.SetEnabledSilent(orchestrator.SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.SaveSilent(orchestrator.SlotRouter, data); err != nil {
+		t.Fatal(err)
+	}
+	return &ServiceImpl{deps: Deps{Orch: orch, Singbox: &fakeSingbox{dir: dir}}}, dir
+}
+
+func TestSyncQoSRoutesSlot_EnableDisableLifecycle(t *testing.T) {
+	svc, dir := newQoSSlotTestService(t, "vpn-a")
+	ctx := context.Background()
+	activePath := filepath.Join(dir, "18-qos-routes.json")
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn-a", Enabled: true, Slot: 0},
+	})
+
+	// First sync: slot written + enabled, changed=true.
+	changed, err := svc.syncQoSRoutesSlot(ctx, classes)
+	if err != nil || !changed {
+		t.Fatalf("first sync: changed=%v err=%v", changed, err)
+	}
+	raw, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("active slot file missing: %v", err)
+	}
+	if !strings.Contains(string(raw), "tproxy-qos-46") || !strings.Contains(string(raw), `"vpn-a"`) {
+		t.Errorf("slot content wrong:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "awgm_managed") {
+		t.Errorf("slot must stay sing-box-parseable (no awgm_managed):\n%s", raw)
+	}
+
+	// Identical classes → byte-equal slot → changed=false (no reload).
+	changed, err = svc.syncQoSRoutesSlot(ctx, classes)
+	if err != nil || changed {
+		t.Fatalf("no-op sync must report changed=false, got changed=%v err=%v", changed, err)
+	}
+
+	// Different class set → changed again.
+	changedClasses := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 26, Outbound: "vpn-a", Enabled: true, Slot: 0},
+	})
+	changed, err = svc.syncQoSRoutesSlot(ctx, changedClasses)
+	if err != nil || !changed {
+		t.Fatalf("diff sync: changed=%v err=%v", changed, err)
+	}
+
+	// No classes → slot cleared (active file parked under disabled/), changed=true.
+	changed, err = svc.syncQoSRoutesSlot(ctx, nil)
+	if err != nil || !changed {
+		t.Fatalf("disable sync: changed=%v err=%v", changed, err)
+	}
+	if _, err := os.Stat(activePath); !os.IsNotExist(err) {
+		t.Errorf("active slot file must be gone after disable, stat err=%v", err)
+	}
+
+	// Still disabled + still no classes → no-op.
+	changed, err = svc.syncQoSRoutesSlot(ctx, nil)
+	if err != nil || changed {
+		t.Fatalf("steady disabled sync must be changed=false, got %v err=%v", changed, err)
+	}
+}
+
+func TestSyncQoSRoutesSlot_SkipsUnknownOutbounds(t *testing.T) {
+	svc, dir := newQoSSlotTestService(t, "vpn-known")
+	ctx := context.Background()
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn-known", Enabled: true, Slot: 0},
+		{DSCP: 26, Outbound: "vpn-ghost", Enabled: true, Slot: 1},
+	})
+	if _, err := svc.syncQoSRoutesSlot(ctx, classes); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "18-qos-routes.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "tproxy-qos-46") {
+		t.Errorf("known-outbound class missing from slot:\n%s", raw)
+	}
+	// A rule routing to a nonexistent outbound would take the whole merged
+	// config down at sing-box load — it must never be emitted.
+	if strings.Contains(string(raw), "vpn-ghost") || strings.Contains(string(raw), "tproxy-qos-26") {
+		t.Errorf("unknown-outbound class must be skipped at emit time:\n%s", raw)
+	}
+
+	// ALL outbounds unknown → slot cleared entirely.
+	ghostOnly := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 26, Outbound: "vpn-ghost", Enabled: true, Slot: 1},
+	})
+	if _, err := svc.syncQoSRoutesSlot(ctx, ghostOnly); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "18-qos-routes.json")); !os.IsNotExist(err) {
+		t.Errorf("slot must be cleared when every class outbound is unknown, stat err=%v", err)
+	}
+}
+
+func TestSyncQoSRoutesSlot_ResolvesOutboundsAgainstAppliedNotDraft(t *testing.T) {
+	// The emit decision must reflect what sing-box actually merges: an
+	// outbound that only exists in the PENDING draft must not unlock the
+	// class (the user may still discard the draft).
+	svc, dir := newQoSSlotTestService(t) // no outbounds in the APPLIED config
+	draft := NewEmptyConfig()
+	draft.Outbounds = append(draft.Outbounds, Outbound{Type: "selector", Tag: "vpn-staged", Outbounds: []string{"direct"}})
+	data, _ := json.MarshalIndent(draft, "", "  ")
+	if err := svc.deps.Orch.SaveDraft(orchestrator.SlotRouter, data); err != nil {
+		t.Fatal(err)
+	}
+	classes := activeQoSClasses([]storage.SingboxQoSClass{
+		{DSCP: 46, Outbound: "vpn-staged", Enabled: true, Slot: 0},
+	})
+	if _, err := svc.syncQoSRoutesSlot(context.Background(), classes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "18-qos-routes.json")); !os.IsNotExist(err) {
+		t.Errorf("draft-only outbound must not be emitted (staging gate), stat err=%v", err)
+	}
+}
+
+// ── Rule model: Inbound matcher + validation ──────────────────────
+
+func TestRuleInbound_HasAnyMatcherAndValidation(t *testing.T) {
+	cfg := NewEmptyConfig()
+	// Inbound-only rule counts as having a matcher (non-reserved tag).
+	if err := cfg.AddRule(Rule{Inbound: []string{"tproxy-in"}, Action: "route", Outbound: "v"}); err != nil {
+		t.Fatalf("inbound-only rule rejected: %v", err)
+	}
+	// Empty inbound tag is invalid.
+	if err := cfg.AddRule(Rule{Inbound: []string{"  "}, Action: "route", Outbound: "v"}); err == nil {
+		t.Fatal("expected error for blank inbound tag")
+	}
+	// Round-trips through JSON as sing-box's native `inbound` field.
+	data, err := json.Marshal(Rule{Inbound: []string{"a", "b"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"inbound":["a","b"]`) {
+		t.Errorf("inbound field serialization: %s", data)
+	}
+}
+
+// TestRuleInbound_ReservedQoSNamespaceRejected guards FIX «reserved
+// namespace»: with the managed rules living in 18-qos-routes.json (merged
+// BEFORE the user slot), a user rule on a qos-* inbound tag could never
+// match — it would only sit in the UI as an inert shadow rule, so
+// AddRule/UpdateRule must reject it with the dedicated 400-mapped error.
+func TestRuleInbound_ReservedQoSNamespaceRejected(t *testing.T) {
+	cfg := NewEmptyConfig()
+	for _, tag := range []string{"tproxy-qos-46", "redirect-qos-0"} {
+		err := cfg.AddRule(Rule{Inbound: []string{tag}, Action: "route", Outbound: "v"})
+		if !errors.Is(err, ErrReservedInboundTag) {
+			t.Errorf("AddRule(%q) err = %v, want ErrReservedInboundTag", tag, err)
+		}
+	}
+	// UpdateRule takes the same path.
+	if err := cfg.AddRule(Rule{DomainSuffix: []string{".x.com"}, Action: "route", Outbound: "v"}); err != nil {
+		t.Fatal(err)
+	}
+	err := cfg.UpdateRule(len(cfg.Route.Rules)-1, Rule{Inbound: []string{"tproxy-qos-1"}, Action: "route", Outbound: "v"})
+	if !errors.Is(err, ErrReservedInboundTag) {
+		t.Errorf("UpdateRule err = %v, want ErrReservedInboundTag", err)
+	}
+	// Reserved tags hidden inside a nested logical rule are caught too.
+	err = cfg.AddRule(Rule{
+		Type: "logical", Mode: "or", Action: "route", Outbound: "v",
+		Rules: []Rule{{Inbound: []string{"redirect-qos-46"}}},
+	})
+	if !errors.Is(err, ErrReservedInboundTag) {
+		t.Errorf("nested reserved tag err = %v, want ErrReservedInboundTag", err)
+	}
+}
+
+// ── Settings validation / normalize ───────────────────────────────
+
+func TestValidateQoSClasses_Table(t *testing.T) {
+	mk := func(classes ...storage.SingboxQoSClass) storage.SingboxRouterSettings {
+		return storage.SingboxRouterSettings{
+			PolicyName:    "Policy0",
+			WANAutoDetect: true,
+			QoSClasses:    classes,
+		}
+	}
+	cases := []struct {
+		name    string
+		sr      storage.SingboxRouterSettings
+		wantErr string // substring; "" = valid
+	}{
+		{"empty ok", mk(), ""},
+		{"valid class", mk(storage.SingboxQoSClass{DSCP: 46, Name: "VoIP", Outbound: "vpn", Enabled: true}), ""},
+		{"disabled class still validated ok", mk(storage.SingboxQoSClass{DSCP: 0, Outbound: "vpn"}), ""},
+		{"dscp too big", mk(storage.SingboxQoSClass{DSCP: 64, Outbound: "vpn"}), "DSCP должен быть 0-63"},
+		{"dscp negative", mk(storage.SingboxQoSClass{DSCP: -1, Outbound: "vpn"}), "DSCP должен быть 0-63"},
+		{"duplicate dscp", mk(
+			storage.SingboxQoSClass{DSCP: 46, Outbound: "a"},
+			storage.SingboxQoSClass{DSCP: 46, Outbound: "b"},
+		), "дублирующийся DSCP"},
+		{"duplicate across disabled", mk(
+			storage.SingboxQoSClass{DSCP: 46, Outbound: "a", Enabled: false},
+			storage.SingboxQoSClass{DSCP: 46, Outbound: "b", Enabled: true},
+		), "дублирующийся DSCP"},
+		{"empty outbound", mk(storage.SingboxQoSClass{DSCP: 46, Outbound: "  "}), "outbound обязателен"},
+		{"name too long", mk(storage.SingboxQoSClass{DSCP: 46, Name: strings.Repeat("я", 33), Outbound: "vpn"}), "32"},
+		{"name exactly 32 ok", mk(storage.SingboxQoSClass{DSCP: 46, Name: strings.Repeat("я", 32), Outbound: "vpn"}), ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NormalizeSingboxRouterSettings(c.sr)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+			if !errors.Is(err, ErrQoSClassesInvalid) {
+				t.Errorf("error %v must wrap ErrQoSClassesInvalid for the 400 mapping", err)
+			}
+		})
+	}
+}
+
+func TestValidateQoSClasses_LimitExceeded(t *testing.T) {
+	classes := make([]storage.SingboxQoSClass, 0, MaxQoSClasses+1)
+	for d := 0; d <= MaxQoSClasses; d++ {
+		classes = append(classes, storage.SingboxQoSClass{DSCP: d, Outbound: "vpn"})
+	}
+	err := validateQoSClasses(classes)
+	if err == nil || !strings.Contains(err.Error(), "превышен лимит классов (8)") {
+		t.Fatalf("expected class-limit error, got %v", err)
+	}
+}
+
+func TestNormalizeSingboxRouterSettings_TrimsQoSFields(t *testing.T) {
+	sr := storage.SingboxRouterSettings{
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Name: "  VoIP  ", Outbound: "  vpn  ", Enabled: true},
+		},
+	}
+	got, err := NormalizeSingboxRouterSettings(sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.QoSClasses[0].Name != "VoIP" || got.QoSClasses[0].Outbound != "vpn" {
+		t.Fatalf("fields not trimmed: %+v", got.QoSClasses[0])
+	}
+}
+
+// ── Reconcile wiring ──────────────────────────────────────────────
+
+func TestReconcile_QoSClassesChanged_Reinstalls(t *testing.T) {
+	stubListeningProbe(t, func() bool { return true })
+	restoreCalls := 0
+	var lastRestore string
+	ipt := newStubIPTables(func(_ context.Context, input string) error {
+		restoreCalls++
+		lastRestore = input
+		return nil
+	})
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc := &ServiceImpl{
+		deps: Deps{
+			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
+			IPTables:           ipt,
+			WANIPCollector:     &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}},
+			Singbox:            singbox,
+			NetfilterPreflight: func(context.Context) error { return nil },
+			XtDscpProbe:        func(context.Context) bool { return true },
+		},
+		currentMark:         "0xffffaaa",
+		currentWANIPs:       []string{"203.0.113.207/32"},
+		currentQoSClasses:   nil, // was off, now one class
+		netfilterStateKnown: true,
+	}
+	if err := svc.reconcileInstalled(context.Background(), storage.SingboxRouterSettings{
+		Enabled:       true,
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn", Enabled: true},
+		},
+	}); err != nil {
+		t.Fatalf("reconcileInstalled err: %v", err)
+	}
+	if restoreCalls != 1 {
+		t.Fatalf("expected 1 Install due to QoS class change, got %d", restoreCalls)
+	}
+	if !strings.Contains(lastRestore, "-m dscp --dscp 46") {
+		t.Errorf("restore input missing dscp rule:\n%s", lastRestore)
+	}
+	want := []QoSClassSpec{{DSCP: 46, TProxyPort: 51281, RedirectPort: 51301}}
+	if !slices.Equal(svc.currentQoSClasses, want) {
+		t.Errorf("currentQoSClasses not updated: %+v", svc.currentQoSClasses)
+	}
+}
+
+// TestReconcile_QoSPortChange_HealsConfigBeforeInstall guards the FIX-5
+// ordering: when the QoS port set changes, the sing-box config heal (which
+// makes the new per-class inbounds listen) plus its reload must complete
+// BEFORE the iptables Install starts dispatching to the new ports —
+// otherwise marked traffic blackholes onto ports nothing listens on. This
+// is the same config→wait→install order Enable uses.
+func TestReconcile_QoSPortChange_HealsConfigBeforeInstall(t *testing.T) {
+	stubListeningProbe(t, func() bool { return true })
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	var sequence []string
+	// The recorder snapshots the persisted config AT INSTALL TIME: the heal
+	// must already have provisioned the class inbounds by then.
+	installedWithInbounds := false
+	ipt := newStubIPTables(func(_ context.Context, _ string) error {
+		sequence = append(sequence, "install")
+		if cfg, err := LoadConfig(filepath.Join(singbox.dir, "20-router.json")); err == nil {
+			for _, in := range cfg.Inbounds {
+				if in.Tag == "tproxy-qos-46" {
+					installedWithInbounds = true
+				}
+			}
+		}
+		return nil
+	})
+	svc := &ServiceImpl{
+		deps: Deps{
+			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
+			IPTables:           ipt,
+			WANIPCollector:     &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}},
+			Singbox:            singbox,
+			NetfilterPreflight: func(context.Context) error { return nil },
+			XtDscpProbe:        func(context.Context) bool { return true },
+		},
+		currentMark:         "0xffffaaa",
+		currentWANIPs:       []string{"203.0.113.207/32"},
+		currentQoSClasses:   nil, // port set is about to change
+		netfilterStateKnown: true,
+	}
+	if err := svc.reconcileInstalled(context.Background(), storage.SingboxRouterSettings{
+		Enabled:       true,
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn", Enabled: true},
+		},
+	}); err != nil {
+		t.Fatalf("reconcileInstalled err: %v", err)
+	}
+	if len(sequence) != 1 || sequence[0] != "install" {
+		t.Fatalf("expected exactly one install, got %v", sequence)
+	}
+	if !installedWithInbounds {
+		t.Error("Install ran BEFORE the config heal provisioned the class inbounds — blackhole window (FIX-5 regression)")
+	}
+}
+
+func TestReconcile_QoSClassesSame_NoReinstall(t *testing.T) {
+	restoreCalls := 0
+	ipt := newStubIPTables(func(_ context.Context, _ string) error {
+		restoreCalls++
+		return nil
+	})
+	svc := &ServiceImpl{
+		deps: Deps{
+			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
+			IPTables:           ipt,
+			WANIPCollector:     &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}},
+			Singbox:            newTestSingbox(t),
+			NetfilterPreflight: func(context.Context) error { return nil },
+			XtDscpProbe:        func(context.Context) bool { return true },
+		},
+		currentMark:         "0xffffaaa",
+		currentWANIPs:       []string{"203.0.113.207/32"},
+		currentQoSClasses:   []QoSClassSpec{{DSCP: 46, TProxyPort: 51281, RedirectPort: 51301}},
+		netfilterStateKnown: true,
+	}
+	if err := svc.reconcileInstalled(context.Background(), storage.SingboxRouterSettings{
+		Enabled:       true,
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn", Enabled: true},
+		},
+	}); err != nil {
+		t.Fatalf("reconcileInstalled err: %v", err)
+	}
+	if restoreCalls != 0 {
+		t.Errorf("expected no Install when QoS classes unchanged, got %d", restoreCalls)
+	}
+}
+
+func TestReconcile_QoSXtDscpUnavailable_DegradesWithoutFailing(t *testing.T) {
+	// xt_dscp missing: reconcile must neither fail nor churn — the desired
+	// dispatch set degrades to empty, which equals the installed state.
+	restoreCalls := 0
+	ipt := newStubIPTables(func(_ context.Context, _ string) error {
+		restoreCalls++
+		return nil
+	})
+	origEnsure := ensureKernelModuleFn
+	ensureKernelModuleFn = func(_ context.Context, _ string) error { return ErrNetfilterComponentMissing }
+	t.Cleanup(func() { ensureKernelModuleFn = origEnsure })
+
+	svc := &ServiceImpl{
+		deps: Deps{
+			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
+			IPTables:           ipt,
+			WANIPCollector:     &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}},
+			Singbox:            newTestSingbox(t),
+			NetfilterPreflight: func(context.Context) error { return nil },
+			XtDscpProbe:        func(context.Context) bool { return false },
+		},
+		currentMark:         "0xffffaaa",
+		currentWANIPs:       []string{"203.0.113.207/32"},
+		currentQoSClasses:   nil,
+		netfilterStateKnown: true,
+	}
+	if err := svc.reconcileInstalled(context.Background(), storage.SingboxRouterSettings{
+		Enabled:       true,
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn", Enabled: true},
+		},
+	}); err != nil {
+		t.Fatalf("reconcileInstalled must not fail on missing xt_dscp: %v", err)
+	}
+	if restoreCalls != 0 {
+		t.Errorf("expected no Install churn while xt_dscp unavailable, got %d", restoreCalls)
+	}
+	if svc.currentQoSClasses != nil {
+		t.Errorf("currentQoSClasses must stay empty, got %+v", svc.currentQoSClasses)
+	}
+}
+
+// ── Enable wiring (tproxy path) ───────────────────────────────────
+
+func TestEnable_Tproxy_QoSClasses_WiresConfigAndIPTables(t *testing.T) {
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		RoutingMode:   "tproxy",
+		DeviceMode:    "all",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Name: "VoIP", Outbound: "vpn-a", Enabled: true},
+			{DSCP: 10, Name: "off", Outbound: "vpn-b", Enabled: false},
+		},
+	})
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	stubListeningProbe(t, func() bool { return true })
+
+	var restoreInput string
+	svc := newTestService(t, Deps{
+		Settings:           settingsStore,
+		Policies:           &fakeAccessPolicyProvider{},
+		IPTables:           newStubIPTables(func(_ context.Context, input string) error { restoreInput = input; return nil }),
+		Singbox:            singbox,
+		WANIPCollector:     &fakeWANIPCollector{},
+		NetfilterPreflight: func(context.Context) error { return nil },
+		XtDscpProbe:        func(context.Context) bool { return true },
+	})
+
+	if err := svc.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable (tproxy, qos): %v", err)
+	}
+
+	// iptables side: dispatch rules for the ENABLED class only.
+	if !strings.Contains(restoreInput, "-m dscp --dscp 46 -j TPROXY --on-port 51281") {
+		t.Errorf("restore input missing UDP dscp dispatch:\n%s", restoreInput)
+	}
+	if !strings.Contains(restoreInput, "-m dscp --dscp 46 -j REDIRECT --to-ports 51301") {
+		t.Errorf("restore input missing TCP dscp dispatch:\n%s", restoreInput)
+	}
+	if strings.Contains(restoreInput, "--dscp 10") {
+		t.Errorf("disabled class must not be dispatched:\n%s", restoreInput)
+	}
+	want := []QoSClassSpec{{DSCP: 46, TProxyPort: 51281, RedirectPort: 51301}}
+	if !slices.Equal(svc.currentQoSClasses, want) {
+		t.Errorf("currentQoSClasses = %+v, want %+v", svc.currentQoSClasses, want)
+	}
+
+	// sing-box side: persisted config carries the class inbound pair. The
+	// managed route rule does NOT live here anymore — it goes to the
+	// 18-qos-routes.json slot (invisible in the rules UI); with no
+	// orchestrator wired in this legacy-mode test the slot sync is a no-op.
+	cfg, err := LoadConfig(svc.routerConfigPath())
+	if err != nil {
+		t.Fatalf("load persisted config: %v", err)
+	}
+	var tags []string
+	for _, in := range cfg.Inbounds {
+		tags = append(tags, in.Tag)
+	}
+	for _, wantTag := range []string{"tproxy-in", "redirect-in", "tproxy-qos-46", "redirect-qos-46"} {
+		if !slices.Contains(tags, wantTag) {
+			t.Errorf("persisted inbounds missing %q: %v", wantTag, tags)
+		}
+	}
+	if slices.Contains(tags, "tproxy-qos-10") {
+		t.Errorf("disabled class inbound persisted: %v", tags)
+	}
+	// No managed rules may leak into the user-visible rules file — that was
+	// the ListRules churn loop (users saw anonymous rows, deleted them, the
+	// heal re-added them).
+	for _, r := range cfg.Route.Rules {
+		for _, tag := range r.Inbound {
+			if isQoSInboundTag(tag) {
+				t.Errorf("managed qos rule leaked into 20-router.json: %+v", r)
+			}
+		}
+	}
+	// The persisted JSON must stay sing-box-parseable: no awgm_managed key.
+	raw, _ := os.ReadFile(svc.routerConfigPath())
+	if strings.Contains(string(raw), "awgm_managed") {
+		t.Errorf("persisted config contains awgm_managed (sing-box rejects unknown rule fields):\n%s", raw)
+	}
+}
+
+// TestEnable_Tproxy_QoS_WritesRoutesSlot is the orchestrator-backed variant:
+// Enable must materialize the managed rules into 18-qos-routes.json and keep
+// 20-router.json free of them.
+func TestEnable_Tproxy_QoS_WritesRoutesSlot(t *testing.T) {
+	svc, dir := newQoSSlotTestService(t, "vpn-a")
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		RoutingMode:   "tproxy",
+		DeviceMode:    "all",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Name: "VoIP", Outbound: "vpn-a", Enabled: true, Slot: 0},
+		},
+	})
+	singbox := &fakeSingbox{dir: dir, isRunningFn: func() (bool, int) { return true, 1234 }}
+	stubListeningProbe(t, func() bool { return true })
+	svc.deps.Settings = settingsStore
+	svc.deps.Singbox = singbox
+	svc.deps.Policies = &fakeAccessPolicyProvider{}
+	svc.deps.IPTables = newStubIPTables(func(_ context.Context, _ string) error { return nil })
+	svc.deps.WANIPCollector = &fakeWANIPCollector{}
+	svc.deps.NetfilterPreflight = func(context.Context) error { return nil }
+	svc.deps.XtDscpProbe = func(context.Context) bool { return true }
+
+	if err := svc.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	slotRaw, err := os.ReadFile(filepath.Join(dir, "18-qos-routes.json"))
+	if err != nil {
+		t.Fatalf("qos routes slot not written: %v", err)
+	}
+	if !strings.Contains(string(slotRaw), "tproxy-qos-46") || !strings.Contains(string(slotRaw), `"vpn-a"`) {
+		t.Errorf("slot content wrong:\n%s", slotRaw)
+	}
+	routerRaw, err := os.ReadFile(filepath.Join(dir, "20-router.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(routerRaw), "\"inbound\": [\n        \"tproxy-qos-46\"") {
+		t.Errorf("managed rule leaked into 20-router.json:\n%s", routerRaw)
+	}
+	// ListRules (user-visible) must not surface the managed rules.
+	rules, err := svc.ListRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rules {
+		for _, tag := range r.Inbound {
+			if isQoSInboundTag(tag) {
+				t.Errorf("ListRules leaked a managed qos rule: %+v", r)
+			}
+		}
+	}
+
+	// Disable parks the slot with the router.
+	if err := svc.Disable(context.Background()); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "18-qos-routes.json")); !os.IsNotExist(err) {
+		t.Errorf("qos routes slot must be parked on Disable, stat err=%v", err)
+	}
+}
+
+func TestEnable_Tproxy_QoSXtDscpMissing_DegradesWithoutFailing(t *testing.T) {
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		RoutingMode:   "tproxy",
+		DeviceMode:    "all",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-a", Enabled: true},
+		},
+	})
+	singbox := newTestSingbox(t)
+	singbox.isRunningFn = func() (bool, int) { return true, 1234 }
+	stubListeningProbe(t, func() bool { return true })
+	origEnsure := ensureKernelModuleFn
+	ensureKernelModuleFn = func(_ context.Context, _ string) error { return ErrNetfilterComponentMissing }
+	t.Cleanup(func() { ensureKernelModuleFn = origEnsure })
+
+	var restoreInput string
+	svc := newTestService(t, Deps{
+		Settings:           settingsStore,
+		Policies:           &fakeAccessPolicyProvider{},
+		IPTables:           newStubIPTables(func(_ context.Context, input string) error { restoreInput = input; return nil }),
+		Singbox:            singbox,
+		WANIPCollector:     &fakeWANIPCollector{},
+		NetfilterPreflight: func(context.Context) error { return nil },
+		XtDscpProbe:        func(context.Context) bool { return false },
+	})
+
+	if err := svc.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable must not fail when xt_dscp is unavailable: %v", err)
+	}
+	if strings.Contains(restoreInput, "-m dscp") {
+		t.Errorf("dscp rules must be skipped when xt_dscp unavailable:\n%s", restoreInput)
+	}
+	if svc.currentQoSClasses != nil {
+		t.Errorf("currentQoSClasses must stay empty when degraded, got %+v", svc.currentQoSClasses)
+	}
+}
+
+// ── healQoSConfig (reconcile self-heal) ───────────────────────────
+
+func TestHealQoSConfig_ConvergesAndNoopsWhenClean(t *testing.T) {
+	svc, dir := newQoSSlotTestService(t, "fresh-outbound")
+
+	// Seed the active config with a stale class-10 inbound pair on top of the
+	// catalog config newQoSSlotTestService wrote.
+	seed, err := svc.loadAppliedRouterConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed.Inbounds = []Inbound{
+		{Type: "tproxy", Tag: "tproxy-in", Listen: "0.0.0.0", ListenPort: TPROXYPort, Network: "udp", UDPFragment: true, UDPTimeout: DefaultUDPTimeout},
+		{Type: "tproxy", Tag: "tproxy-qos-10", ListenPort: 51281},
+	}
+	if err := svc.persistConfigDirect(context.Background(), seed); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a stale slot file for a class that no longer exists.
+	staleRules := buildQoSRouteRules([]qosClass{{DSCP: 10, Outbound: "old", TProxyPort: 51281, RedirectPort: 51301}})
+	staleData, _ := marshalQoSRoutesSlot(staleRules)
+	if err := svc.deps.Orch.SaveSilent(orchestrator.SlotQoSRoutes, staleData); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.deps.Orch.SetEnabledSilent(orchestrator.SlotQoSRoutes, true); err != nil {
+		t.Fatal(err)
+	}
+
+	sr := storage.SingboxRouterSettings{
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "fresh-outbound", Enabled: true, Slot: 0},
+		},
+	}
+	changed, err := svc.healQoSConfig(context.Background(), sr)
+	if err != nil {
+		t.Fatalf("healQoSConfig: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on a drifted config")
+	}
+	cfg, err := svc.loadAppliedRouterConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tags []string
+	for _, in := range cfg.Inbounds {
+		tags = append(tags, in.Tag)
+	}
+	wantTags := []string{"tproxy-in", "tproxy-qos-46", "redirect-qos-46"}
+	if !slices.Equal(tags, wantTags) {
+		t.Fatalf("healed inbound tags = %v, want %v", tags, wantTags)
+	}
+	slotRaw, err := os.ReadFile(filepath.Join(dir, "18-qos-routes.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(slotRaw), "tproxy-qos-46") || strings.Contains(string(slotRaw), "tproxy-qos-10") {
+		t.Fatalf("healed slot content wrong:\n%s", slotRaw)
+	}
+
+	// Steady state: second heal must not rewrite either file and must report
+	// changed=false (no sing-box reload).
+	beforeCfg, _ := os.Stat(filepath.Join(dir, "20-router.json"))
+	beforeSlot, _ := os.Stat(filepath.Join(dir, "18-qos-routes.json"))
+	changed, err = svc.healQoSConfig(context.Background(), sr)
+	if err != nil {
+		t.Fatalf("second healQoSConfig: %v", err)
+	}
+	if changed {
+		t.Error("steady-state heal must report changed=false")
+	}
+	afterCfg, _ := os.Stat(filepath.Join(dir, "20-router.json"))
+	afterSlot, _ := os.Stat(filepath.Join(dir, "18-qos-routes.json"))
+	if !afterCfg.ModTime().Equal(beforeCfg.ModTime()) {
+		t.Error("steady-state heal must not rewrite 20-router.json")
+	}
+	if !afterSlot.ModTime().Equal(beforeSlot.ModTime()) {
+		t.Error("steady-state heal must not rewrite 18-qos-routes.json")
+	}
+}
+
+// TestHealQoSConfig_DoesNotApplyPendingDraft guards the staging gate: the
+// heal derives from the APPLIED config (LoadApplied), never the pending
+// draft — the old LoadEffective-based heal silently applied staged edits to
+// active on every reconcile tick.
+func TestHealQoSConfig_DoesNotApplyPendingDraft(t *testing.T) {
+	svc, dir := newQoSSlotTestService(t, "vpn-a")
+
+	// Stage a draft with a user rule the user has NOT applied yet.
+	draft, err := svc.loadAppliedRouterConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft.Route.Rules = append(draft.Route.Rules, Rule{DomainSuffix: []string{".staged.example"}, Action: "route", Outbound: "vpn-a"})
+	draftData, _ := json.MarshalIndent(draft, "", "  ")
+	if err := svc.deps.Orch.SaveDraft(orchestrator.SlotRouter, draftData); err != nil {
+		t.Fatal(err)
+	}
+
+	sr := storage.SingboxRouterSettings{
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-a", Enabled: true, Slot: 0},
+		},
+	}
+	if _, err := svc.healQoSConfig(context.Background(), sr); err != nil {
+		t.Fatalf("healQoSConfig: %v", err)
+	}
+	activeRaw, err := os.ReadFile(filepath.Join(dir, "20-router.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(activeRaw), ".staged.example") {
+		t.Errorf("heal leaked the pending draft into the active config (staging gate bypassed):\n%s", activeRaw)
+	}
+	// And the draft itself must still be pending.
+	if !svc.deps.Orch.HasDraft(orchestrator.SlotRouter) {
+		t.Error("pending draft vanished during heal")
+	}
+}
+
+// ── Outbound lifecycle (FIX-4) ────────────────────────────────────
+
+// noopNotInstalledIPTables reports "nothing installed" so Reconcile at the
+// end of UpdateSettings is a clean no-op for a disabled router.
+func noopNotInstalledIPTables() *IPTables {
+	return &IPTables{
+		restoreNoflush: func(_ context.Context, _ string) error { return nil },
+		runIPTables:    func(_ context.Context, _ ...string) error { return errors.New("chain missing") },
+		runIPTablesOut: func(_ context.Context, _ ...string) (string, error) { return "", nil },
+		runIP:          func(_ context.Context, _ ...string) error { return nil },
+		persistRules:   func(_ string) error { return nil },
+		persistHook:    func() error { return nil },
+		cleanupHook:    func() {},
+	}
+}
+
+func newQoSLifecycleService(t *testing.T, sr storage.SingboxRouterSettings, outbounds ...string) *ServiceImpl {
+	t.Helper()
+	settingsStore := newTestSettingsStore(t, sr)
+	singbox := newTestSingbox(t)
+	svc := newTestService(t, Deps{
+		Settings: settingsStore,
+		Singbox:  singbox,
+		IPTables: noopNotInstalledIPTables(),
+		Policies: &fakeAccessPolicyProvider{},
+	})
+	cfg := NewEmptyConfig()
+	for _, ob := range outbounds {
+		cfg.Outbounds = append(cfg.Outbounds, Outbound{Type: "selector", Tag: ob, Outbounds: []string{"member-x"}})
+	}
+	if err := SaveConfig(svc.routerConfigPath(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func TestUpdateSettings_ReassociatesQoSSlotsByDSCP(t *testing.T) {
+	svc := newQoSLifecycleService(t, storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 10, Outbound: "vpn-a", Enabled: true, Slot: 0},
+			{DSCP: 20, Outbound: "vpn-b", Enabled: true, Slot: 1},
+			{DSCP: 30, Outbound: "vpn-c", Enabled: true, Slot: 2},
+		},
+	}, "vpn-a", "vpn-b", "vpn-c", "vpn-d")
+
+	// Frontend PUT: no slots on the wire, class 20 removed, class 40 added,
+	// class 30 disabled.
+	err := svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 30, Outbound: "vpn-c", Enabled: false},
+			{DSCP: 10, Outbound: "vpn-a", Enabled: true},
+			{DSCP: 40, Outbound: "vpn-d", Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+	all, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := all.SingboxRouter.QoSClasses
+	bySlot := map[int]int{}
+	for _, c := range got {
+		bySlot[c.DSCP] = c.Slot
+	}
+	if bySlot[30] != 2 || bySlot[10] != 0 {
+		t.Errorf("existing classes must keep their slots: %+v", got)
+	}
+	if bySlot[40] != 1 {
+		t.Errorf("new class must reuse the freed slot 1, got %d (%+v)", bySlot[40], got)
+	}
+}
+
+func TestUpdateSettings_RejectsUnknownQoSOutbound(t *testing.T) {
+	svc := newQoSLifecycleService(t, storage.SingboxRouterSettings{WANAutoDetect: true}, "vpn-a")
+
+	err := svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-ghost", Enabled: true},
+		},
+	})
+	if !errors.Is(err, ErrQoSClassesInvalid) {
+		t.Fatalf("expected ErrQoSClassesInvalid for unknown enabled outbound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "vpn-ghost") {
+		t.Errorf("error must name the offending outbound: %v", err)
+	}
+
+	// A DISABLED class may keep an unknown outbound (force-delete leaves the
+	// class around disabled; a verbatim re-PUT must not 400).
+	err = svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-ghost", Enabled: false},
+			{DSCP: 26, Outbound: "vpn-a", Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("disabled class with unknown outbound must be storable: %v", err)
+	}
+}
+
+func TestUpdateCompositeOutbound_RenameFollowsQoSClasses(t *testing.T) {
+	svc := newQoSLifecycleService(t, storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-a", Enabled: true, Slot: 0},
+		},
+	}, "vpn-a")
+
+	err := svc.UpdateCompositeOutbound(context.Background(), "vpn-a",
+		Outbound{Type: "selector", Tag: "vpn-renamed", Outbounds: []string{"member-x"}})
+	if err != nil {
+		t.Fatalf("UpdateCompositeOutbound: %v", err)
+	}
+	all, _ := svc.deps.Settings.Load()
+	if got := all.SingboxRouter.QoSClasses[0].Outbound; got != "vpn-renamed" {
+		t.Errorf("QoS class outbound = %q, want vpn-renamed", got)
+	}
+}
+
+func TestRenameExternalOutboundTag_FollowsQoSClasses(t *testing.T) {
+	svc := newQoSLifecycleService(t, storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "tunnel-old", Enabled: true, Slot: 0},
+		},
+	})
+
+	if err := svc.RenameExternalOutboundTag(context.Background(), "tunnel-old", "tunnel-new"); err != nil {
+		t.Fatalf("RenameExternalOutboundTag: %v", err)
+	}
+	all, _ := svc.deps.Settings.Load()
+	if got := all.SingboxRouter.QoSClasses[0].Outbound; got != "tunnel-new" {
+		t.Errorf("QoS class outbound = %q, want tunnel-new", got)
+	}
+}
+
+func TestDeleteCompositeOutbound_QoSClassGuardAndForceDisable(t *testing.T) {
+	svc := newQoSLifecycleService(t, storage.SingboxRouterSettings{
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Name: "VoIP", Outbound: "vpn-a", Enabled: true, Slot: 0},
+		},
+	}, "vpn-a")
+
+	// Non-force: refused while a QoS class references the outbound.
+	err := svc.DeleteCompositeOutbound(context.Background(), "vpn-a", false)
+	if !errors.Is(err, ErrOutboundReferenced) {
+		t.Fatalf("expected ErrOutboundReferenced, got %v", err)
+	}
+
+	// Force: outbound removed, class kept but DISABLED (never silently
+	// deleted — the UI must show it off).
+	if err := svc.DeleteCompositeOutbound(context.Background(), "vpn-a", true); err != nil {
+		t.Fatalf("force delete: %v", err)
+	}
+	all, _ := svc.deps.Settings.Load()
+	classes := all.SingboxRouter.QoSClasses
+	if len(classes) != 1 {
+		t.Fatalf("class must survive force-delete: %+v", classes)
+	}
+	if classes[0].Enabled {
+		t.Error("class must be disabled after force-deleting its outbound")
+	}
+	if classes[0].Outbound != "vpn-a" || classes[0].Name != "VoIP" || classes[0].Slot != 0 {
+		t.Errorf("class data must be preserved: %+v", classes[0])
+	}
+}
+
+// ── GetStatus: qos-outbound-missing issue (FIX-4c) ────────────────
+
+func TestGetStatus_ReportsQoSOutboundMissing(t *testing.T) {
+	stubListeningProbe(t, func() bool { return false })
+	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{
+		Enabled:       true,
+		PolicyName:    "Policy0",
+		WANAutoDetect: true,
+		QoSClasses: []storage.SingboxQoSClass{
+			{DSCP: 46, Outbound: "vpn-known", Enabled: true, Slot: 0},
+			{DSCP: 26, Outbound: "vpn-ghost", Enabled: true, Slot: 1},
+			{DSCP: 30, Outbound: "vpn-off-ghost", Enabled: false, Slot: 2}, // disabled → no issue
+		},
+	})
+	fe := &fakeExec{}
+	singbox := newTestSingbox(t)
+	svc := newTestService(t, Deps{
+		Settings:    settingsStore,
+		Policies:    &fakeAccessPolicyProvider{mark: "0xffffaaa"},
+		IPTables:    newTestIPTables(fe),
+		Singbox:     singbox,
+		XtDscpProbe: func(context.Context) bool { return true },
+	})
+	cfg := NewEmptyConfig()
+	cfg.Outbounds = append(cfg.Outbounds, Outbound{Type: "selector", Tag: "vpn-known", Outbounds: []string{"member-x"}})
+	if err := SaveConfig(svc.routerConfigPath(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := svc.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	var hits []Issue
+	for _, is := range st.Issues {
+		if is.Kind == "qos-outbound-missing" {
+			hits = append(hits, is)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 qos-outbound-missing issue, got %+v", st.Issues)
+	}
+	if hits[0].Tag != "vpn-ghost" || !strings.Contains(hits[0].Message, "vpn-ghost") {
+		t.Errorf("issue must name the missing outbound: %+v", hits[0])
+	}
+}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
@@ -292,7 +293,13 @@ type Deps struct {
 	// xt_connmark, xt_conntrack, xt_pkttype via
 	// EnsureRouterNetfilterModules). Tests set this to avoid real syscalls.
 	NetfilterPreflight func(context.Context) error
-	GeoData            GeoTagExpander
+	// XtDscpProbe is an optional override for the xt_dscp availability
+	// check (kernel module + iptables `-m dscp` extension) that gates the
+	// QoS-DSCP dispatch rules and the status field xtDscpAvailable. When
+	// nil, the real IsXtDscpAvailable probe runs. Tests set this to avoid
+	// exec'ing iptables.
+	XtDscpProbe func(context.Context) bool
+	GeoData     GeoTagExpander
 	// OpkgTun provisions the fakeip-tun kernel interface via NDMS.
 	// Optional — nil in tests; wired in cmd/awg-manager to
 	// *ndmscommand.InterfaceCommands. Consumed by Slice 1D Enable.
@@ -372,6 +379,22 @@ type ServiceImpl struct {
 
 	// selective tracking
 	currentSelectiveBypass bool // last-applied value of SelectiveBypass
+
+	// currentQoSClasses is the last-installed QoS-DSCP dispatch set (DSCP +
+	// ports only — the class outbound lives in sing-box config, not in
+	// iptables). Reconcile re-Installs when it drifts from settings.
+	currentQoSClasses []QoSClassSpec
+
+	// qosApplyFailed remembers a failed sing-box apply of the QoS routes
+	// slot so the next heal re-applies even when disk state is byte-equal.
+	// See applyQoSRoutesSlot (mirrors selectiveBuilderAdapter.lastApplyFailed).
+	qosApplyFailed atomic.Bool
+
+	// xtDscpState tracks the last observed xt_dscp availability for
+	// transition-only logging (0 = unknown, 1 = available, 2 = unavailable):
+	// the reconcile loop must not Warn every tick while the module stays
+	// missing — only when availability actually flips.
+	xtDscpState atomic.Int32
 
 	// inspectCache backs the route-inspector's rule_set match path. Lazy
 	// constructed on first Inspect call so dev-machine builds (no
@@ -576,6 +599,34 @@ func (s *ServiceImpl) orchestratorApplyNow() error {
 		return nil
 	}
 	return s.deps.Orch.ReloadNow()
+}
+
+// xtDscpUsable reports whether iptables `-m dscp` matching is usable,
+// honouring the test seam (Deps.XtDscpProbe) when set. Availability changes
+// are logged on TRANSITIONS only (available↔unavailable), never per call —
+// the reconcile loop hits this every tick and a missing optional module must
+// not spam two Warn lines per tick forever (negative probe results are
+// additionally TTL-cached inside IsXtDscpAvailable).
+func (s *ServiceImpl) xtDscpUsable(ctx context.Context) bool {
+	ok := false
+	if s.deps.XtDscpProbe != nil {
+		ok = s.deps.XtDscpProbe(ctx)
+	} else {
+		ok = IsXtDscpAvailable(ctx)
+	}
+	state := int32(2)
+	if ok {
+		state = 1
+	}
+	if prev := s.xtDscpState.Swap(state); prev != state {
+		switch {
+		case !ok:
+			s.appLog.Warn("qos-dscp", "", "xt_dscp недоступен — классы QoS пропущены (см. статус xtDscpAvailable)")
+		case prev == 2:
+			s.appLog.Info("qos-dscp", "", "xt_dscp снова доступен — классы QoS будут применены")
+		}
+	}
+	return ok
 }
 
 // prepareNetfilter runs the common netfilter preflight: xt_TPROXY module
@@ -1034,6 +1085,13 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	cfg.Inbounds = ensureTProxyInbound(cfg.Inbounds, sr.UDPTimeout)
 	cfg.Outbounds = stripAutoManagedDirect(cfg.Outbounds)
 	cfg.EnsureSystemRules(sr.SnifferEnabled)
+	// QoS-by-DSCP (issue #371): per-class inbound pairs, derived from the
+	// same settings snapshot the iptables spec below uses so ports/classes
+	// cannot drift between the two. The managed route rules live in their
+	// own slot (18-qos-routes.json) and are synced after the config write
+	// below — see qos_routes.go for why they must not live in 20-router.json.
+	qosClasses := activeQoSClasses(sr.QoSClasses)
+	cfg.Inbounds, _ = ensureQoSInbounds(cfg.Inbounds, qosClasses, sr.UDPTimeout)
 	// Settings was already loaded above; revalidate here in case the
 	// store is corrupted or hand-edited around a schema migration. We
 	// fail Enable rather than apply a half-broken config — the user
@@ -1065,6 +1123,12 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	// "Несохранённые правки" banner that used to follow every reboot.
 	if err := s.persistConfigDirect(ctx, cfg); err != nil {
 		return err
+	}
+	// Managed QoS route rules → 18-qos-routes.json. Runs AFTER the router
+	// slot write so outbound resolution sees the applied config; the
+	// orchestratorApplyNow below covers both slots in one reload.
+	if _, err := s.syncQoSRoutesSlot(ctx, qosClasses); err != nil {
+		return fmt.Errorf("sync qos routes slot: %w", err)
 	}
 	if err := s.orchestratorApplyNow(); err != nil {
 		return fmt.Errorf("orchestrator reload after enable: %w", err)
@@ -1132,6 +1196,23 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 		}
 	}
 
+	// QoS iptables dispatch — graceful degradation: when xt_dscp support is
+	// missing the DSCP rules are skipped (feature-off) with a warning, NEVER
+	// failing Enable — otherwise a missing optional module would take down
+	// the whole interception path at iptables-restore COMMIT (XKeen shipped
+	// the same policy). EnsureXtDscpModule first: prepareNetfilter already
+	// tried, this is the belt-and-suspenders retry closest to Install.
+	qosSpecs := qosIPTablesSpecs(qosClasses)
+	if len(qosSpecs) > 0 {
+		if err := EnsureXtDscpModule(ctx); err != nil {
+			s.appLog.Warn("ensure-xt-dscp", "", err.Error())
+		}
+		if !s.xtDscpUsable(ctx) {
+			s.appLog.Warn("qos-dscp", "", "xt_dscp недоступен — классы QoS пропущены (см. статус xtDscpAvailable)")
+			qosSpecs = nil
+		}
+	}
+
 	if err := s.deps.IPTables.Install(ctx, RestoreInputSpec{
 		PolicyMark:        mark,
 		MatchAll:          !policyMode,
@@ -1142,6 +1223,7 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 		BypassCIDRs:       bypassSubnets,
 		IngressInterfaces: ingress,
 		SelectiveIPSet:    sr.SelectiveBypass,
+		QoSClasses:        qosSpecs,
 	}); err != nil {
 		// Stop sing-box from listening on the now-orphan TPROXY port,
 		// but DO NOT corrupt the persisted user config. With orchestrator
@@ -1151,6 +1233,9 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 		// (legacy fallback) the only recourse is to strip the inbound.
 		if s.deps.Orch != nil {
 			_ = s.deps.Orch.SetEnabled(orchestrator.SlotRouter, false)
+			// The QoS overlay references qos-* inbounds that just got
+			// parked with the router slot — park it too.
+			_ = s.disableQoSRoutesSlot()
 		} else {
 			cfg.Inbounds = filterTProxyInbound(cfg.Inbounds)
 			_ = s.persistConfigDirect(ctx, cfg)
@@ -1165,6 +1250,7 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	s.currentBypassExtraSubnets = sr.BypassExtraSubnets
 	s.currentIngress = ingress
 	s.currentSelectiveBypass = sr.SelectiveBypass
+	s.currentQoSClasses = qosSpecs
 	s.netfilterStateKnown = true
 
 	settings.SingboxRouter = sr
@@ -1401,6 +1487,43 @@ func (s *ServiceImpl) GetStatus(ctx context.Context) (Status, error) {
 		lastError = s.deps.Singbox.LastError()
 	}
 	issues := s.computeIssues(cfg)
+	// QoS-DSCP support: xtDscpAvailable is always reported (the UI keys the
+	// feature's "supported" state on it). When classes are actually
+	// configured but the support probe fails, additionally surface an issue
+	// that distinguishes the two causes (kernel module vs iptables
+	// extension) so diagnostics can tell them apart. The detailed check on
+	// the failure path is served from the same TTL-bounded probe cache as
+	// the availability flag, so status polling never execs iptables per poll.
+	qosActive := activeQoSClasses(sr.QoSClasses)
+	// A class whose outbound no longer resolves is skipped at emit time
+	// (syncQoSRoutesSlot) — surface WHY the class is inert so the user can
+	// re-point or disable it.
+	if sr.RoutingMode != "fakeip-tun" {
+		for _, c := range qosActive {
+			if !s.isKnownOutboundTag(ctx, c.Outbound, cfg) {
+				issues = append(issues, Issue{
+					Severity: "warning",
+					Kind:     "qos-outbound-missing",
+					Tag:      c.Outbound,
+					Message:  fmt.Sprintf("класс QoS (DSCP %d) ссылается на несуществующий outbound %q — класс не применяется", c.DSCP, c.Outbound),
+				})
+			}
+		}
+	}
+	xtDscpAvailable := s.xtDscpUsable(ctx)
+	if !xtDscpAvailable && sr.RoutingMode != "fakeip-tun" && len(qosActive) > 0 {
+		moduleOK, matchOK := cachedXtDscpAvailability(ctx)
+		var msg string
+		switch {
+		case !moduleOK && !matchOK:
+			msg = "QoS DSCP: модуль ядра xt_dscp не найден и расширение iptables «dscp» недоступно — классы QoS не будут применены"
+		case !moduleOK:
+			msg = "QoS DSCP: модуль ядра xt_dscp не найден (/lib/modules) — классы QoS не будут применены"
+		default:
+			msg = "QoS DSCP: расширение iptables «dscp» недоступно — классы QoS не будут применены"
+		}
+		issues = append(issues, Issue{Severity: "warning", Kind: "qos-xt-dscp", Message: msg})
+	}
 	// fakeip-tun active iface: surface the provisioned kernel iface name
 	// ("opkgtun<idx>") so the UI can show it in the engine-settings panel. Only
 	// when in fakeip-tun mode AND actually provisioned (persisted FakeIPState);
@@ -1425,6 +1548,7 @@ func (s *ServiceImpl) GetStatus(ctx context.Context) (Status, error) {
 		NetfilterAvailable:     IsNetfilterAvailable(),
 		NetfilterComponentName: "Модули ядра подсистемы сетевой фильтрации",
 		TProxyTargetAvailable:  IsTProxyTargetAvailable(ctx),
+		XtDscpAvailable:        xtDscpAvailable,
 		PolicyName:             sr.PolicyName,
 		PolicyMark:             policyMark,
 		PolicyExists:           policyExists,
@@ -1479,6 +1603,7 @@ func (s *ServiceImpl) Disable(ctx context.Context) error {
 	// made tproxy→off→tproxy re-enables skip the rebuild (selectiveChanged
 	// stayed false) and run with a permanently empty set.
 	s.currentSelectiveBypass = false
+	s.currentQoSClasses = nil
 	s.netfilterStateKnown = false
 
 	if s.deps.Orch != nil {
@@ -1488,6 +1613,11 @@ func (s *ServiceImpl) Disable(ctx context.Context) error {
 		// all disappear from the merged config in one atomic rename.
 		if err := s.deps.Orch.SetEnabled(orchestrator.SlotRouter, false); err != nil {
 			s.appLog.Warn("orch-disable", "", err.Error())
+		}
+		// Park the QoS routes overlay with it: its rules reference qos-*
+		// inbound tags that only exist while 20-router.json is active.
+		if err := s.disableQoSRoutesSlot(); err != nil {
+			s.appLog.Warn("orch-disable", "qos-routes", err.Error())
 		}
 	} else {
 		// Legacy fallback: strip the tproxy inbound in place so
@@ -1623,6 +1753,59 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// Selective-bypass change detection.
 	selectiveChanged := s.currentSelectiveBypass != sr.SelectiveBypass
 
+	// QoS-DSCP change detection: only the iptables-relevant projection
+	// (DSCP + ports). An outbound-only change does not need an iptables
+	// re-Install — the healQoSConfig call below converges the sing-box side.
+	// Graceful degradation happens HERE, before change detection: when
+	// xt_dscp support is missing the desired dispatch set degrades to empty
+	// (feature-off; xtDscpUsable logs availability transitions) — gating
+	// later would leave desired≠installed forever and re-Install on every
+	// tick. When the module/extension shows up, the (TTL-bounded) probe
+	// flips and qosChanged triggers one re-Install with rules.
+	qosClasses := activeQoSClasses(sr.QoSClasses)
+	qosSpecs := qosIPTablesSpecs(qosClasses)
+	if len(qosSpecs) > 0 {
+		if err := EnsureXtDscpModule(ctx); err != nil {
+			s.appLog.Warn("ensure-xt-dscp", "", err.Error())
+		}
+		if !s.xtDscpUsable(ctx) {
+			qosSpecs = nil
+		}
+	}
+	qosChanged := !slices.Equal(s.currentQoSClasses, qosSpecs)
+
+	// Self-heal the sing-box side BEFORE any iptables change — same safe
+	// order as Enable (config → wait → Install). Installing new per-class
+	// dispatch ports first would blackhole class traffic onto ports nothing
+	// listens on until the debounced reload lands.
+	//
+	// healTProxyInbound: a previous Install rollback or upgrade hop may have
+	// left 20-router.json without the tproxy-in inbound — re-add it
+	// idempotently so sing-box keeps listening on TPROXYPort.
+	if err := s.healTProxyInbound(ctx, sr.UDPTimeout); err != nil {
+		s.appLog.Warn("heal-tproxy", "", err.Error())
+	}
+	// healQoSConfig: per-class inbound pairs (20-router.json) + managed route
+	// rules (18-qos-routes.json). Converges class add/remove/disable and
+	// outbound edits applied through UpdateSettings→Reconcile, and cleans
+	// stale qos-* artifacts. No-op (no write, no reload) when converged.
+	qosHealed := false
+	if healed, err := s.healQoSConfig(ctx, sr); err != nil {
+		s.appLog.Warn("heal-qos", "", err.Error())
+	} else {
+		qosHealed = healed
+	}
+	// The heal rewrote the QoS sing-box config AND the iptables port set is
+	// about to change: wait for sing-box to come back up on its inbounds
+	// before Install redirects traffic to the new per-class ports. Soft
+	// deadline — on timeout we proceed and accept the brief race rather
+	// than blocking the reconcile loop behind a dead engine forever.
+	if qosHealed && qosChanged {
+		if err := s.waitForSingbox(ctx, qosReloadWait); err != nil {
+			s.appLog.Warn("qos-dscp", "", fmt.Sprintf("sing-box not ready after QoS config heal: %v — installing anyway", err))
+		}
+	}
+
 	// After a daemon restart or upgrade the old awg-manager process died
 	// with no chance to run Uninstall, so stale AWGM chains, ip rules
 	// and ip routes may remain from the old process. netfilterStateKnown
@@ -1638,7 +1821,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// during an NDMS reload must not trigger a needless rebuild.
 	_, jumps, probeErr := s.deps.IPTables.Probe(ctx)
 	jumpsMissing := probeErr == nil && !jumps
-	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged || selectiveChanged
+	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged || selectiveChanged || qosChanged
 
 	if needsInstall {
 		if forceInitialSync {
@@ -1679,6 +1862,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 			BypassCIDRs:       bypassSubnets,
 			IngressInterfaces: ingress,
 			SelectiveIPSet:    sr.SelectiveBypass,
+			QoSClasses:        qosSpecs,
 		}); err != nil {
 			s.mu.Unlock()
 			return err
@@ -1691,6 +1875,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 		s.currentBypassExtraSubnets = sr.BypassExtraSubnets
 		s.currentIngress = ingress
 		s.currentSelectiveBypass = sr.SelectiveBypass
+		s.currentQoSClasses = qosSpecs
 		s.netfilterStateKnown = true
 		s.mu.Unlock()
 
@@ -1707,13 +1892,6 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 				s.appLog.Warn("selective", "", fmt.Sprintf("strip legacy selective rules: %v", err))
 			}
 		}
-	}
-
-	// Self-heal: a previous Install rollback or upgrade hop may
-	// have left 20-router.json without the tproxy-in inbound. Re-add
-	// it idempotently so sing-box keeps listening on TPROXYPort.
-	if err := s.healTProxyInbound(ctx, sr.UDPTimeout); err != nil {
-		s.appLog.Warn("heal-tproxy", "", err.Error())
 	}
 
 	// Selective-bypass: rebuild on first Enable, when toggled on, or on daemon
@@ -1800,6 +1978,11 @@ func (s *ServiceImpl) RenameExternalOutboundTag(ctx context.Context, oldTag, new
 	newTag = strings.TrimSpace(newTag)
 	if oldTag == "" || newTag == "" || oldTag == newTag {
 		return nil
+	}
+	// Settings-side references: QoS classes route to outbound tags too and
+	// must follow the rename (config-side rewrites below don't see them).
+	if err := s.renameQoSClassOutbound(oldTag, newTag); err != nil {
+		return err
 	}
 	if s.deps.Orch == nil {
 		return s.withConfig(ctx, "all", func(c *RouterConfig) error {
@@ -2039,11 +2222,38 @@ func (s *ServiceImpl) UpdateCompositeOutbound(ctx context.Context, tag string, o
 			return err
 		}
 	}
-	return s.withConfig(ctx, "outbounds", func(c *RouterConfig) error { return c.UpdateCompositeOutbound(tag, o) })
+	if err := s.withConfig(ctx, "outbounds", func(c *RouterConfig) error { return c.UpdateCompositeOutbound(tag, o) }); err != nil {
+		return err
+	}
+	// A rename rewrites config references (renameOutboundReferences inside
+	// UpdateCompositeOutbound); mirror it for the settings-side QoS classes.
+	if newTag := strings.TrimSpace(o.Tag); newTag != "" && newTag != tag {
+		if err := s.renameQoSClassOutbound(tag, newTag); err != nil {
+			s.appLog.Warn("qos-classes", tag, "rename outbound in QoS classes: "+err.Error())
+		}
+	}
+	return nil
 }
 
 func (s *ServiceImpl) DeleteCompositeOutbound(ctx context.Context, tag string, force bool) error {
-	return s.withConfig(ctx, "outbounds", func(c *RouterConfig) error { return c.DeleteCompositeOutbound(tag, force) })
+	// QoS classes reference outbounds from settings, invisible to the config's
+	// own reference scan — guard them the same way route rules are guarded.
+	if !force {
+		if refs := s.qosClassesReferencing(tag); len(refs) > 0 {
+			return fmt.Errorf("%w: %q referenced by %s", ErrOutboundReferenced, tag, strings.Join(refs, ", "))
+		}
+	}
+	if err := s.withConfig(ctx, "outbounds", func(c *RouterConfig) error { return c.DeleteCompositeOutbound(tag, force) }); err != nil {
+		return err
+	}
+	if force {
+		// Force-delete DISABLES (not deletes) referencing classes so the UI
+		// shows them off instead of silently losing user configuration.
+		if err := s.disableQoSClassesForOutbound(tag); err != nil {
+			s.appLog.Warn("qos-classes", tag, "disable QoS classes after outbound delete: "+err.Error())
+		}
+	}
+	return nil
 }
 
 func (s *ServiceImpl) ListPresets() ([]Preset, error) {
@@ -2076,15 +2286,53 @@ func (s *ServiceImpl) UpdateSettings(ctx context.Context, sr storage.SingboxRout
 	if err := s.validateSelectiveBypassSettings(ctx, normalized); err != nil {
 		return err
 	}
+	// QoS classes must route to outbounds that actually exist — an unknown
+	// tag would either be skipped at emit time (class silently inert) or,
+	// unguarded, take the whole merged config down at sing-box load. Checked
+	// here (not in the pure Normalize) because outbound catalogs are deps.
+	if err := s.validateQoSClassOutbounds(ctx, normalized.QoSClasses); err != nil {
+		return err
+	}
 	settings, err := s.deps.Settings.Load()
 	if err != nil {
 		return err
 	}
+	// Port-slot stability: the UI contract carries no slot field, so incoming
+	// classes are re-associated with their persisted slots by DSCP before the
+	// save — otherwise every PUT would re-deal ports positionally and RST
+	// untouched classes' flows.
+	normalized.QoSClasses = reassociateQoSSlots(normalized.QoSClasses, settings.SingboxRouter.QoSClasses)
 	settings.SingboxRouter = normalized
 	if err := s.deps.Settings.Save(settings); err != nil {
 		return err
 	}
 	return s.Reconcile(ctx)
+}
+
+// validateQoSClassOutbounds rejects ENABLED QoS classes whose Outbound does
+// not resolve against any known catalog (router composites, subscription
+// composites, AWG tags, sing-box tunnel tags, built-ins). Disabled classes
+// are deliberately exempt: outbound force-delete keeps the class around in a
+// disabled state (see disableQoSClassesForOutbound), and a later settings
+// PUT carrying that class verbatim must not 400. Wraps ErrQoSClassesInvalid
+// so the API maps it to 400 QOS_CLASSES_INVALID.
+func (s *ServiceImpl) validateQoSClassOutbounds(ctx context.Context, classes []storage.SingboxQoSClass) error {
+	if len(classes) == 0 {
+		return nil
+	}
+	cfg, err := s.loadRouterConfig()
+	if err != nil {
+		cfg = NewEmptyConfig()
+	}
+	for i, c := range classes {
+		if !c.Enabled {
+			continue
+		}
+		if !s.isKnownOutboundTag(ctx, c.Outbound, cfg) {
+			return fmt.Errorf("%w: qosClasses[%d]: неизвестный outbound %q", ErrQoSClassesInvalid, i, c.Outbound)
+		}
+	}
+	return nil
 }
 
 // ValidateSingboxRouterSettings enforces the WAN-binding discriminator:
@@ -2140,6 +2388,10 @@ func NormalizeSingboxRouterSettings(sr storage.SingboxRouterSettings) (storage.S
 			return sr, fmt.Errorf("udpTimeout: invalid duration %q: %w", sr.UDPTimeout, err)
 		}
 	}
+	if err := validateQoSClasses(sr.QoSClasses); err != nil {
+		return sr, err
+	}
+	sr.QoSClasses = normalizeQoSClasses(sr.QoSClasses)
 	return sr, nil
 }
 

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -18,6 +18,10 @@ type Status struct {
 	NetfilterAvailable     bool   `json:"netfilterAvailable"`
 	NetfilterComponentName string `json:"netfilterComponentName,omitempty"`
 	TProxyTargetAvailable  bool   `json:"tproxyTargetAvailable"`
+	// XtDscpAvailable reports whether iptables `-m dscp` matching is usable
+	// (xt_dscp kernel module loaded/on-disk AND iptables extension present).
+	// The QoS-DSCP settings UI keys its "supported" state on this field.
+	XtDscpAvailable        bool   `json:"xtDscpAvailable"`
 	PolicyName             string `json:"policyName"`
 	PolicyMark             string `json:"policyMark,omitempty"`
 	PolicyExists           bool   `json:"policyExists"`
@@ -72,6 +76,11 @@ type Rule struct {
 	Port         []int    `json:"port,omitempty"`
 	RuleSet      []string `json:"rule_set,omitempty"`
 	Protocol     string   `json:"protocol,omitempty"`
+	// Inbound matches the sing-box listener tag the connection entered
+	// through (native sing-box route-rule field). Managed QoS-DSCP rules use
+	// it to bind a per-class inbound pair (tproxy-qos-N / redirect-qos-N) to
+	// the class outbound; user rules may use it too.
+	Inbound []string `json:"inbound,omitempty"`
 	// IPIsPrivate, when set, matches packets whose destination is an
 	// RFC1918/loopback/link-local/CGNAT/multicast address. Pointer so
 	// the zero value (unset) stays out of JSON — `{"ip_is_private":false}`

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -154,6 +154,36 @@ type SingboxRouterSettings struct {
 	// all active router rules and their rule sets. Only meaningful when
 	// RoutingMode == "tproxy" and ipset + xt_set are available on the router.
 	SelectiveBypass bool `json:"selectiveBypass,omitempty"`
+	// QoSClasses lists DSCP-based QoS traffic classes (issue #371). Each
+	// enabled class gets its own iptables `-m dscp` dispatch (mangle TPROXY +
+	// nat REDIRECT), a dedicated pair of sing-box inbounds and a managed route
+	// rule sending the class to Outbound. Only meaningful when RoutingMode ==
+	// "tproxy". Validated by router.NormalizeSingboxRouterSettings: at most 8
+	// classes, DSCP 0-63 unique across classes, Name ≤ 32 chars, Outbound
+	// non-empty. Empty slice = feature off; no schema migration needed (the
+	// zero value is the correct default, same as BypassPresets).
+	QoSClasses []SingboxQoSClass `json:"qosClasses,omitempty"`
+}
+
+// SingboxQoSClass is one DSCP-based QoS traffic class routed to a dedicated
+// sing-box outbound (issue #371). DSCP is the 6-bit codepoint matched by
+// iptables `-m dscp --dscp N`; Name is a user-facing label; Outbound is the
+// sing-box outbound tag the class routes to; Enabled toggles the class
+// without losing its configuration.
+type SingboxQoSClass struct {
+	DSCP     int    `json:"dscp"`
+	Name     string `json:"name,omitempty"`
+	Outbound string `json:"outbound"`
+	Enabled  bool   `json:"enabled"`
+	// Slot is the persisted 0-based listen-port slot (0..MaxQoSClasses-1)
+	// the class's inbound pair derives from (router.QoSClassPorts). It is
+	// backend-owned: the UI contract stays {dscp,name,outbound,enabled} —
+	// clients PUT classes without slots and router.UpdateSettings
+	// re-associates each incoming class with its stored slot by DSCP (the
+	// unique key), so disabling or removing one class never shifts another
+	// class's ports (a shift would RST/blackhole untouched flows). Brand-new
+	// DSCPs get the first free slot.
+	Slot int `json:"slot"`
 }
 
 // ManagedServer represents the user-created WireGuard server interface.


### PR DESCRIPTION
Closes #371.

## Идея

На ПК метка ставится штатной политикой QoS (Windows Policy-based QoS помечает трафик конкретных exe значением DSCP; Linux — mangle OUTPUT), роутер маршрутизирует помеченные потоки в выбранный outbound sing-box (AWG/системный WG/sing-box туннель/composite/direct).

## Почему так

Сверились с документацией: sing-box ≤1.14 (у нас embedded 1.14.0-alpha.25) **не умеет** DSCP в route-rules (открытые FR SagerNet/sing-box#3732, #4106 без ответа), mihomo умеет только для tproxy-UDP. Рабочая схема — классификация на netfilter с мостом через пер-класс inbound'ы (тот же приём, что в XKeen, чьи полевые уроки — anti-recapture из их PR #81, conntrack-гарды, единый fwmark — закодированы в порядок правил и тесты):

```
iptables -m dscp --dscp N (mangle TPROXY / nat REDIRECT, до catch-all,
  после bypass и DNS-перехватов; TCP/53 отрезается на основной порт,
  чтобы DNS-hijack всегда побеждал)
  → inbound'ы tproxy-qos-N / redirect-qos-N
    (порты 51281+/51301+ по персистентному слоту класса — стабильны
     при отключении/удалении других классов)
  → правила в новом слоте 18-qos-routes.json
    (мержится до селективного 19 и пользовательского 20: QoS приоритетнее,
     не виден в UI правил, не пересекается со staging-пайплайном)
```

`xt_dscp.ko` есть в штатной прошивке (подтверждено на реальном роутере: `/lib/modules/4.9-ndm-5/`); доступность проверяется двойной пробой (kernel-модуль + iptables-расширение), недоступность деградирует в «фича выключена» со статус-issue.

## Что вошло

- **Настройки**: `qosClasses` (до 8 классов: DSCP 0–63 уникальный, имя, outbound, вкл) с валидацией по каталогу известных outbound'ов; переименование outbound'а переписывает классы, force-удаление — отключает; sync слота пропускает неизвестные outbound'ы (движок никогда не получает конфиг, который отверг бы).
- **Порядок применения**: reconcile сначала лечит конфиг/слот, потом ставит iptables — смена портов не роняет помеченный трафик в чёрную дыру. Зарезервированный неймспейс `*-qos-*` отвергается в пользовательских правилах.
- **UI**: карточка «QoS-маршрутизация (DSCP)» в expert-drawer движка (таблица классов с общим селектором outbound'ов, сериализованные сохранения с откатом при ошибке, предупреждение о «повисшем» outbound, баннер при недоступном xt_dscp, hint в fakeip-режиме) + модалка-помощник с готовыми командами для Windows (`New-NetQosPolicy` + reg-ключ `Do not use NLA`), Linux и предупреждением про Wi-Fi/WMM.
- **Попутно**: восстановлены потерянные swagger-аннотации живых эндпоинтов (`/boot-status` — теперь настоящий handler, access-policies, policy-interfaces, `GET /singbox/tunnels`); починен pre-existing data race в `TestRouterSwitchMode_CallsService`.

## Проверки

- `go vet`/`go test` чисто; `-race` на затронутых пакетах чисто; кросс-компиляция mips/mipsle (softfloat) + arm64
- svelte-check 0/0; vitest 1212/1212 (+25 новых)
- Ревью в 3 угла (netfilter/rules-корректность, регрессии/совместимость, UX): 18 находок, все исправлены до пуша — включая переезд managed-правил в собственный слот, стабильные порт-слоты и жизненный цикл outbound'ов

## Ограничения (v1)

- Только режим TProxy (в fakeip-tun DSCP до sing-box не доносится без нативной поддержки) — карточка честно об этом говорит
- IPv4 (паритет с существующими цепями AWGM)
- macOS системно не умеет пер-приложенческий DSCP (задокументировано в помощнике)
- Если DSCP-матчинг когда-нибудь приедет в sing-box (FR #3732) — пер-класс inbound'ы схлопываются в одно поле правила

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_