### PR TITLE
fix(ci): mieru.patch совместимый с закреплённым sing-box v1.14.0-alpha.34

### DIFF
--- a/scripts/patches/mieru.patch
+++ b/scripts/patches/mieru.patch
@@ -1,8 +1,8 @@
 diff --git a/constant/proxy.go b/constant/proxy.go
-index 60bb806..81163fd 100644
+index 868a3bb8..8f39f232 100644
 --- a/constant/proxy.go
 +++ b/constant/proxy.go
-@@ -21,6 +21,7 @@ const (
+@@ -20,6 +20,7 @@ const (
  	TypeSSH                = "ssh"
  	TypeShadowTLS          = "shadowtls"
  	TypeAnyTLS             = "anytls"
@@ -10,7 +10,7 @@ index 60bb806..81163fd 100644
  	TypeShadowsocksR       = "shadowsocksr"
  	TypeVLESS              = "vless"
  	TypeTUIC               = "tuic"
-@@ -98,6 +99,8 @@ func ProxyDisplayName(proxyType string) string {
+@@ -92,6 +93,8 @@ func ProxyDisplayName(proxyType string) string {
  		return "AnyTLS"
  	case TypeTailscale:
  		return "Tailscale"
@@ -20,7 +20,7 @@ index 60bb806..81163fd 100644
  		return "Cloudflared"
  	case TypeSelector:
 diff --git a/docs/configuration/inbound/index.md b/docs/configuration/inbound/index.md
-index 093db65..9823265 100644
+index 274a3780..1ca56f08 100644
 --- a/docs/configuration/inbound/index.md
 +++ b/docs/configuration/inbound/index.md
 @@ -31,6 +31,7 @@
@@ -28,10 +28,10 @@ index 093db65..9823265 100644
  | `vless`       | [VLESS](./vless/)             | TCP              |
  | `anytls`      | [AnyTLS](./anytls/)           | TCP              |
 +| `mieru`       | [Mieru](./mieru/)             | :material-close: |
- | `snell`       | [Snell](./snell/)             | TCP              |
  | `tun`         | [Tun](./tun/)                 | :material-close: |
  | `redirect`    | [Redirect](./redirect/)       | :material-close: |
-@@ -39,4 +40,4 @@
+ | `tproxy`      | [TProxy](./tproxy/)           | :material-close: |
+@@ -38,4 +39,4 @@
  
  #### tag
  
@@ -39,7 +39,7 @@ index 093db65..9823265 100644
 \ No newline at end of file
 +The tag of the inbound.
 diff --git a/docs/configuration/inbound/index.zh.md b/docs/configuration/inbound/index.zh.md
-index 0f73ae9..696cbb7 100644
+index 99f8df3b..7621cbd3 100644
 --- a/docs/configuration/inbound/index.zh.md
 +++ b/docs/configuration/inbound/index.zh.md
 @@ -31,6 +31,7 @@
@@ -47,10 +47,10 @@ index 0f73ae9..696cbb7 100644
  | `vless`       | [VLESS](./vless/)             | TCP              |
  | `anytls`      | [AnyTLS](./anytls/)           | TCP              |
 +| `mieru`       | [Mieru](./mieru/)             | :material-close: |
- | `snell`       | [Snell](./snell/)             | TCP              |
  | `tun`         | [Tun](./tun/)                 | :material-close: |
  | `redirect`    | [Redirect](./redirect/)       | :material-close: |
-@@ -39,4 +40,4 @@
+ | `tproxy`      | [TProxy](./tproxy/)           | :material-close: |
+@@ -38,4 +39,4 @@
  
  #### tag
  
@@ -59,7 +59,7 @@ index 0f73ae9..696cbb7 100644
 +入站的标签。
 diff --git a/docs/configuration/inbound/mieru.md b/docs/configuration/inbound/mieru.md
 new file mode 100644
-index 0000000..5c42200
+index 00000000..5c422005
 --- /dev/null
 +++ b/docs/configuration/inbound/mieru.md
 @@ -0,0 +1,49 @@
@@ -114,7 +114,7 @@ index 0000000..5c42200
 +If proxy client doesn't sent user hint, proxy server will refuse the connection.
 diff --git a/docs/configuration/inbound/mieru.zh.md b/docs/configuration/inbound/mieru.zh.md
 new file mode 100644
-index 0000000..a389db2
+index 00000000..a389db27
 --- /dev/null
 +++ b/docs/configuration/inbound/mieru.zh.md
 @@ -0,0 +1,49 @@
@@ -168,7 +168,7 @@ index 0000000..a389db2
 +
 +客户端若不发送用户提示，代理服务器将拒绝连接。
 diff --git a/docs/configuration/outbound/index.md b/docs/configuration/outbound/index.md
-index 0411ec0..8f6f705 100644
+index 47b8a96a..6257bdc9 100644
 --- a/docs/configuration/outbound/index.md
 +++ b/docs/configuration/outbound/index.md
 @@ -31,6 +31,7 @@
@@ -176,11 +176,11 @@ index 0411ec0..8f6f705 100644
  | `hysteria2`    | [Hysteria2](./hysteria2/)       |
  | `anytls`       | [AnyTLS](./anytls/)             |
 +| `mieru`        | [Mieru](./mieru/)               |
- | `snell`        | [Snell](./snell/)               |
  | `tor`          | [Tor](./tor/)                   |
  | `ssh`          | [SSH](./ssh/)                   |
+ | `dns`          | [DNS](./dns/)                   |
 diff --git a/docs/configuration/outbound/index.zh.md b/docs/configuration/outbound/index.zh.md
-index 5c7b785..9f21d6f 100644
+index a1c4a7ad..345b0228 100644
 --- a/docs/configuration/outbound/index.zh.md
 +++ b/docs/configuration/outbound/index.zh.md
 @@ -31,6 +31,7 @@
@@ -188,12 +188,12 @@ index 5c7b785..9f21d6f 100644
  | `hysteria2`    | [Hysteria2](./hysteria2/)       |
  | `anytls`       | [AnyTLS](./anytls/)             |
 +| `mieru`        | [Mieru](./mieru/)               |
- | `snell`        | [Snell](./snell/)               |
  | `tor`          | [Tor](./tor/)                   |
  | `ssh`          | [SSH](./ssh/)                   |
+ | `dns`          | [DNS](./dns/)                   |
 diff --git a/docs/configuration/outbound/mieru.md b/docs/configuration/outbound/mieru.md
 new file mode 100644
-index 0000000..22851fc
+index 00000000..22851fcb
 --- /dev/null
 +++ b/docs/configuration/outbound/mieru.md
 @@ -0,0 +1,76 @@
@@ -275,7 +275,7 @@ index 0000000..22851fc
 +See [Dial Fields](/configuration/shared/dial/) for details.
 diff --git a/docs/configuration/outbound/mieru.zh.md b/docs/configuration/outbound/mieru.zh.md
 new file mode 100644
-index 0000000..9fdb52f
+index 00000000..9fdb52fa
 --- /dev/null
 +++ b/docs/configuration/outbound/mieru.zh.md
 @@ -0,0 +1,76 @@
@@ -356,10 +356,10 @@ index 0000000..9fdb52f
 +
 +参阅 [拨号字段](/zh/configuration/shared/dial/)。
 diff --git a/go.mod b/go.mod
-index d66b98a..1fd8bf7 100644
+index 5683d57b..9a4d1d64 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -12,6 +12,7 @@ require (
+@@ -11,6 +11,7 @@ require (
  	github.com/creack/pty v1.1.24
  	github.com/cretz/bine v0.2.0
  	github.com/database64128/tfo-go/v2 v2.3.2
@@ -368,10 +368,10 @@ index d66b98a..1fd8bf7 100644
  	github.com/go-chi/render v1.0.3
  	github.com/godbus/dbus/v5 v5.2.2
 diff --git a/go.sum b/go.sum
-index b37b88d..c9ed684 100644
+index 69cc6e57..6699cccd 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -58,6 +58,8 @@ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+@@ -48,6 +48,8 @@ github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
  github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
  github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
  github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
@@ -381,7 +381,7 @@ index b37b88d..c9ed684 100644
  github.com/florianl/go-nfqueue/v2 v2.0.2/go.mod h1:VA09+iPOT43OMoCKNfXHyzujQUty2xmzyCRkBOlmabc=
  github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 diff --git a/include/registry.go b/include/registry.go
-index 6ea32e1..511511a 100644
+index 2d478bfe..f48d0864 100644
 --- a/include/registry.go
 +++ b/include/registry.go
 @@ -24,6 +24,7 @@ import (
@@ -392,7 +392,7 @@ index 6ea32e1..511511a 100644
  	"github.com/sagernet/sing-box/protocol/mixed"
  	"github.com/sagernet/sing-box/protocol/naive"
  	"github.com/sagernet/sing-box/protocol/redirect"
-@@ -68,6 +69,7 @@ func InboundRegistry() *inbound.Registry {
+@@ -65,6 +66,7 @@ func InboundRegistry() *inbound.Registry {
  	shadowtls.RegisterInbound(registry)
  	vless.RegisterInbound(registry)
  	anytls.RegisterInbound(registry)
@@ -400,7 +400,7 @@ index 6ea32e1..511511a 100644
  
  	registerQUICInbounds(registry)
  	registerCloudflaredInbound(registry)
-@@ -98,6 +100,7 @@ func OutboundRegistry() *outbound.Registry {
+@@ -94,6 +96,7 @@ func OutboundRegistry() *outbound.Registry {
  	shadowtls.RegisterOutbound(registry)
  	vless.RegisterOutbound(registry)
  	anytls.RegisterOutbound(registry)
@@ -410,7 +410,7 @@ index 6ea32e1..511511a 100644
  	registerStubForRemovedOutbounds(registry)
 diff --git a/option/mieru.go b/option/mieru.go
 new file mode 100644
-index 0000000..a3d5b7b
+index 00000000..a3d5b7b6
 --- /dev/null
 +++ b/option/mieru.go
 @@ -0,0 +1,27 @@
@@ -443,7 +443,7 @@ index 0000000..a3d5b7b
 +}
 diff --git a/protocol/mieru/inbound.go b/protocol/mieru/inbound.go
 new file mode 100644
-index 0000000..637df5d
+index 00000000..637df5df
 --- /dev/null
 +++ b/protocol/mieru/inbound.go
 @@ -0,0 +1,340 @@
@@ -789,7 +789,7 @@ index 0000000..637df5d
 +}
 diff --git a/protocol/mieru/outbound.go b/protocol/mieru/outbound.go
 new file mode 100644
-index 0000000..d04826f
+index 00000000..d04826fd
 --- /dev/null
 +++ b/protocol/mieru/outbound.go
 @@ -0,0 +1,277 @@


### PR DESCRIPTION
Superseded by #462: вместо отката патча к alpha.34 переходим вперёд на sing-box v1.14.0-alpha.39, где перегенерированный в #459 mieru-патч ложится как есть. Откат больше не нужен.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg