### PR TITLE
fix(sb-router): UDP-сессии рвались ровно через 5 минут (fakeip udp_timeout + сниф-таймауты)

### DIFF
--- a/frontend/src/lib/components/sb-router/simpleRule.test.ts
+++ b/frontend/src/lib/components/sb-router/simpleRule.test.ts
@@ -3,6 +3,7 @@ import {
   classifyRuleSimplicity,
   COMPLEX_RULE_EDIT_MESSAGE,
   isCustomInlineRuleSetTag,
+  isSystemRule,
   singleRuleSetTagFromTemplateId,
   templateIdForExternalRuleSetTag,
 } from './simpleRule';
@@ -23,6 +24,28 @@ const ruleSets: SingboxRouterRuleSet[] = [
   { tag: 'geosite-discord', type: 'remote', url: 'https://example.com/discord.srs' },
   { tag: 'geoip-ru', type: 'local', path: '/data/geoip-ru.srs' },
 ];
+
+describe('isSystemRule', () => {
+  it('recognizes the system route-options UDP-timeout rule', () => {
+    expect(isSystemRule({ action: 'route-options', network: 'udp', udp_timeout: '1h' })).toBe(true);
+  });
+  it('recognizes sniff / hijack-dns / private-bypass', () => {
+    expect(isSystemRule({ action: 'sniff' })).toBe(true);
+    expect(isSystemRule({ action: 'hijack-dns', protocol: 'dns' })).toBe(true);
+    expect(isSystemRule({ ip_is_private: true, outbound: 'direct' })).toBe(true);
+  });
+  it('does not treat a plain user route-options-less rule as system', () => {
+    expect(isSystemRule({ domain_suffix: ['x.com'], outbound: 'proxy' })).toBe(false);
+    // route-options without the udp network scope is not the system rule
+    expect(isSystemRule({ action: 'route-options', network: 'tcp' })).toBe(false);
+  });
+  // A route-options system rule must fall out of the simple editor (expert-only).
+  it('classifies the system route-options rule as complex', () => {
+    expect(classifyRuleSimplicity({ action: 'route-options', network: 'udp', udp_timeout: '1h' })).toEqual({
+      simple: false,
+    });
+  });
+});
 
 describe('classifyRuleSimplicity — простые', () => {
   it('inline-text: domain_suffix', () => {

--- a/frontend/src/lib/components/sb-router/simpleRule.ts
+++ b/frontend/src/lib/components/sb-router/simpleRule.ts
@@ -4,6 +4,8 @@ import { resolveRuleSetByTag } from '$lib/utils/singboxInlineRules';
 export function isSystemRule(rule: SingboxRouterRule): boolean {
   if (rule.action === 'sniff' || rule.action === 'hijack-dns') return true;
   if (rule.ip_is_private && rule.outbound === 'direct') return true;
+  // System UDP-timeout override (route-options scoped to udp).
+  if (rule.action === 'route-options' && rule.network === 'udp') return true;
   return false;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1530,9 +1530,14 @@ export interface SingboxRouterRule {
 	// Optional — sing-box defaults to `route` when omitted. The system
 	// ip_is_private rule omits action because that's how SKeen's
 	// reference config writes it and the backend's `omitempty` mirrors
-	// the same shape.
-	action?: 'route' | 'reject' | 'sniff' | 'hijack-dns';
+	// the same shape. `route-options` is the system UDP-timeout rule.
+	action?: 'route' | 'reject' | 'sniff' | 'hijack-dns' | 'route-options';
 	outbound?: string;
+	// L4 matcher ("tcp" | "udp"). The system route-options rule scopes its
+	// udp_timeout override to "udp".
+	network?: string;
+	// `udp_timeout` route option carried by the system `route-options` rule.
+	udp_timeout?: string;
 	rules?: SingboxRouterRule[];
 }
 

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -109,9 +109,9 @@ type SingboxRouterSettingsData struct {
 	FakeIPPool6 string `json:"fakeipPool6,omitempty" example:"fc00::/18"`
 	// FakeIPMTU is the tun MTU (default 1500; valid range 576-9000).
 	FakeIPMTU int `json:"fakeipMtu,omitempty" example:"1500"`
-	// UDPTimeout sets the UDP session timeout for the tproxy-in inbound
-	// (Go duration string, e.g. "3m0s", "10m0s"). Empty = use default (3m0s).
-	// Increase to prevent long-quiet UDP applications (games, etc.) from
+	// UDPTimeout sets the UDP session timeout for the tproxy-in / fakeip tun-in
+	// inbound (Go duration string, e.g. "5m0s", "10m0s"). Empty = use default
+	// (5m0s). Increase to prevent long-quiet UDP applications (games, etc.) from
 	// having their sessions silently dropped mid-game.
 	UDPTimeout string `json:"udpTimeout,omitempty" example:"10m0s"`
 	// QoSClasses lists DSCP-based QoS traffic classes routed to dedicated

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -277,26 +277,21 @@ func (c *RouterConfig) EnsureSystemRules(snifferEnabled bool) {
 	// clients.
 	hijackIdx := -1
 	for i, r := range c.Route.Rules {
-		if r.Action == "sniff" && !r.hasAnyMatcher() {
+		if isSystemSniffRule(r) {
 			hasSniff = true
 		}
-		// Detect both the legacy (`protocol:dns`) and current
-		// (`logical(or){protocol:dns, port:53}`) system hijack-dns
-		// forms so re-running EnsureSystemRules doesn't stack
-		// duplicates on configs migrated from older versions.
-		if r.Action == "hijack-dns" {
-			if r.Protocol == "dns" || (r.Type == "logical" && r.Mode == "or") {
-				hasHijack = true
-				if hijackIdx == -1 {
-					hijackIdx = i
-				}
+		// isSystemHijackRule detects both the legacy (`protocol:dns`) and
+		// current (`logical(or){protocol:dns, port:53}`) forms so re-running
+		// EnsureSystemRules doesn't stack duplicates on migrated configs.
+		if isSystemHijackRule(r) {
+			hasHijack = true
+			if hijackIdx == -1 {
+				hijackIdx = i
 			}
 		}
-		// Any user-authored ip_is_private rule wins over the system
-		// one — we just have to not duplicate. Outbound is intentionally
-		// not checked: a user might point private destinations at a
-		// specific direct-LAN outbound and we should respect that.
-		if r.IPIsPrivate != nil && *r.IPIsPrivate {
+		// Any user-authored ip_is_private rule wins over the system one — we
+		// just have to not duplicate (isSystemPrivateRule ignores outbound).
+		if isSystemPrivateRule(r) {
 			hasPrivateBypass = true
 		}
 	}
@@ -304,7 +299,7 @@ func (c *RouterConfig) EnsureSystemRules(snifferEnabled bool) {
 	if !snifferEnabled && hasSniff {
 		filtered := c.Route.Rules[:0]
 		for _, r := range c.Route.Rules {
-			if r.Action == "sniff" && !r.hasAnyMatcher() {
+			if isSystemSniffRule(r) {
 				continue
 			}
 			filtered = append(filtered, r)
@@ -314,11 +309,9 @@ func (c *RouterConfig) EnsureSystemRules(snifferEnabled bool) {
 		if hijackIdx >= 0 {
 			hijackIdx = -1
 			for i, r := range c.Route.Rules {
-				if r.Action == "hijack-dns" {
-					if r.Protocol == "dns" || (r.Type == "logical" && r.Mode == "or") {
-						hijackIdx = i
-						break
-					}
+				if isSystemHijackRule(r) {
+					hijackIdx = i
+					break
 				}
 			}
 		}
@@ -850,19 +843,38 @@ func isSystemUDPTimeoutRule(r Rule) bool {
 	return r.Action == "route-options" && r.Network == "udp"
 }
 
+// The three predicates below are the single definition of what counts as a
+// leading "system rule". EnsureSystemRules (detection) and systemPrefixLen
+// (insertion boundary for the route-options rule) both use them so the two can
+// never drift apart.
+
+func isSystemSniffRule(r Rule) bool {
+	return r.Action == "sniff" && !r.hasAnyMatcher()
+}
+
+// isSystemHijackRule matches both the legacy (`protocol:dns`) and current
+// (`logical(or){protocol:dns, port:53}`) system hijack-dns forms.
+func isSystemHijackRule(r Rule) bool {
+	return r.Action == "hijack-dns" &&
+		(r.Protocol == "dns" || (r.Type == "logical" && r.Mode == "or"))
+}
+
+// isSystemPrivateRule matches any ip_is_private bypass. Outbound is intentionally
+// NOT checked (mirrors EnsureSystemRules): a user may point private destinations
+// at a specific direct-LAN outbound and that rule is still part of the prefix.
+func isSystemPrivateRule(r Rule) bool {
+	return r.IPIsPrivate != nil && *r.IPIsPrivate
+}
+
 // systemPrefixLen counts the leading system rules (sniff / hijack-dns /
-// ip_is_private→direct bypass) that EnsureSystemRules keeps ahead of any
-// user routing rule. It marks the boundary where a non-final system rule
-// (the udp_timeout route-options rule) can be inserted so it still runs
-// before a user's final `route` action stops evaluation.
+// ip_is_private bypass) that EnsureSystemRules keeps ahead of any user routing
+// rule. It marks the boundary where a non-final system rule (the udp_timeout
+// route-options rule) can be inserted so it still runs before a user's final
+// `route` action stops evaluation.
 func (c *RouterConfig) systemPrefixLen() int {
 	n := 0
 	for _, r := range c.Route.Rules {
-		isSniff := r.Action == "sniff" && !r.hasAnyMatcher()
-		isHijack := r.Action == "hijack-dns" &&
-			(r.Protocol == "dns" || (r.Type == "logical" && r.Mode == "or"))
-		isPrivate := r.IPIsPrivate != nil && *r.IPIsPrivate && r.Outbound == "direct"
-		if isSniff || isHijack || isPrivate {
+		if isSystemSniffRule(r) || isSystemHijackRule(r) || isSystemPrivateRule(r) {
 			n++
 			continue
 		}

--- a/internal/singbox/router/config.go
+++ b/internal/singbox/router/config.go
@@ -841,7 +841,62 @@ func isProxyIface(name string) bool {
 func (r Rule) hasAnyMatcher() bool {
 	return len(r.DomainSuffix) > 0 || len(r.IPCIDR) > 0 || len(r.SourceIPCIDR) > 0 ||
 		len(r.Port) > 0 || len(r.RuleSet) > 0 || r.Protocol != "" || len(r.Rules) > 0 ||
-		r.IPIsPrivate != nil || len(r.Inbound) > 0
+		r.IPIsPrivate != nil || len(r.Inbound) > 0 || r.Network != ""
+}
+
+// isSystemUDPTimeoutRule reports whether r is the system route-options rule that
+// raises the UDP idle timeout (Action "route-options" scoped to Network "udp").
+func isSystemUDPTimeoutRule(r Rule) bool {
+	return r.Action == "route-options" && r.Network == "udp"
+}
+
+// systemPrefixLen counts the leading system rules (sniff / hijack-dns /
+// ip_is_private→direct bypass) that EnsureSystemRules keeps ahead of any
+// user routing rule. It marks the boundary where a non-final system rule
+// (the udp_timeout route-options rule) can be inserted so it still runs
+// before a user's final `route` action stops evaluation.
+func (c *RouterConfig) systemPrefixLen() int {
+	n := 0
+	for _, r := range c.Route.Rules {
+		isSniff := r.Action == "sniff" && !r.hasAnyMatcher()
+		isHijack := r.Action == "hijack-dns" &&
+			(r.Protocol == "dns" || (r.Type == "logical" && r.Mode == "or"))
+		isPrivate := r.IPIsPrivate != nil && *r.IPIsPrivate && r.Outbound == "direct"
+		if isSniff || isHijack || isPrivate {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}
+
+// EnsureUDPTimeoutRule keeps exactly one system route-options rule that raises
+// the UDP idle timeout to `effective`, inserted within the system prefix (before
+// any user routing rule). sing-box applies short per-protocol UDP idle timeouts
+// on sniff/port inference — STUN/DNS 10s, QUIC/DTLS 30s — that ignore the inbound
+// udp_timeout, so games/VoIP sessions drop early; a route-options rule raising
+// the timeout to the inbound value neutralizes them. Idempotent: any prior copy
+// is stripped first so a changed timeout takes effect and re-runs never stack.
+func (c *RouterConfig) EnsureUDPTimeoutRule(effective string) {
+	filtered := c.Route.Rules[:0]
+	for _, r := range c.Route.Rules {
+		if isSystemUDPTimeoutRule(r) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	c.Route.Rules = filtered
+	if effective == "" {
+		return
+	}
+	pos := c.systemPrefixLen()
+	rule := Rule{Action: "route-options", Network: "udp", UDPTimeout: effective}
+	newRules := make([]Rule, 0, len(c.Route.Rules)+1)
+	newRules = append(newRules, c.Route.Rules[:pos]...)
+	newRules = append(newRules, rule)
+	newRules = append(newRules, c.Route.Rules[pos:]...)
+	c.Route.Rules = newRules
 }
 
 // validateCIDROrAddr accepts a value that is either a CIDR prefix or a bare IP

--- a/internal/singbox/router/config_fakeip.go
+++ b/internal/singbox/router/config_fakeip.go
@@ -89,6 +89,7 @@ func BuildFakeIPTunConfig(s FakeIPTunSpec) (*RouterConfig, error) {
 	if stack == "" {
 		stack = "gvisor"
 	}
+	udpTimeout := resolveUDPTimeout(s.UDPTimeout)
 	in := Inbound{
 		Type:                   "tun",
 		Tag:                    "tun-in",
@@ -100,7 +101,7 @@ func BuildFakeIPTunConfig(s FakeIPTunSpec) (*RouterConfig, error) {
 		StrictRoute:            boolPtr(false),
 		Stack:                  stack,
 		EndpointIndependentNAT: boolPtr(false),
-		UDPTimeout:             resolveUDPTimeout(s.UDPTimeout),
+		UDPTimeout:             udpTimeout,
 	}
 	if stack == "system" {
 		in.GSO = boolPtr(false)
@@ -151,7 +152,7 @@ func BuildFakeIPTunConfig(s FakeIPTunSpec) (*RouterConfig, error) {
 		{Action: "hijack-dns", Protocol: "dns"},
 		{Action: "route", Outbound: s.ProxyTag},
 	}
-	cfg.EnsureUDPTimeoutRule(resolveUDPTimeout(s.UDPTimeout))
+	cfg.EnsureUDPTimeoutRule(udpTimeout)
 	cfg.Route.Final = s.ProxyTag
 	cfg.Route.DefaultDomainResolver = &DomainResolver{Server: "real"}
 
@@ -191,6 +192,7 @@ func ensureFakeIPOverlay(cfg *RouterConfig, spec FakeIPTunSpec) {
 	if stack == "" {
 		stack = "gvisor"
 	}
+	udpTimeout := resolveUDPTimeout(spec.UDPTimeout)
 	in := Inbound{
 		Type:                   "tun",
 		Tag:                    "tun-in",
@@ -202,7 +204,7 @@ func ensureFakeIPOverlay(cfg *RouterConfig, spec FakeIPTunSpec) {
 		StrictRoute:            boolPtr(false),
 		Stack:                  stack,
 		EndpointIndependentNAT: boolPtr(false),
-		UDPTimeout:             resolveUDPTimeout(spec.UDPTimeout),
+		UDPTimeout:             udpTimeout,
 	}
 	if stack == "system" {
 		in.GSO = boolPtr(false)
@@ -242,7 +244,7 @@ func ensureFakeIPOverlay(cfg *RouterConfig, spec FakeIPTunSpec) {
 	normalizeFakeIPDNSRules(cfg)
 
 	// --- UDP idle-timeout override (route-options), same as tproxy path ---
-	cfg.EnsureUDPTimeoutRule(resolveUDPTimeout(spec.UDPTimeout))
+	cfg.EnsureUDPTimeoutRule(udpTimeout)
 }
 
 // upsertInbound replaces the first Inbound with the same Tag in-place, or

--- a/internal/singbox/router/config_fakeip.go
+++ b/internal/singbox/router/config_fakeip.go
@@ -30,6 +30,11 @@ type FakeIPTunSpec struct {
 	// the only stable system-stack combo on this router's kernel (4.9), where the
 	// system stack with GSO panics sing-tun under load (PoC-proven 2026-06-13).
 	Stack string
+	// UDPTimeout is the UDP-NAT expiration for the tun inbound (Go duration
+	// string). Empty → DefaultUDPTimeout via resolveUDPTimeout. Without it
+	// sing-box falls back to its built-in C.UDPTimeout (5m), so a user who set a
+	// longer timeout still lost UDP sessions at exactly 5 minutes in fakeip mode.
+	UDPTimeout string
 }
 
 // boolPtr returns a pointer to v. The tun inbound's auto_route / auto_redirect /
@@ -95,6 +100,7 @@ func BuildFakeIPTunConfig(s FakeIPTunSpec) (*RouterConfig, error) {
 		StrictRoute:            boolPtr(false),
 		Stack:                  stack,
 		EndpointIndependentNAT: boolPtr(false),
+		UDPTimeout:             resolveUDPTimeout(s.UDPTimeout),
 	}
 	if stack == "system" {
 		in.GSO = boolPtr(false)
@@ -145,6 +151,7 @@ func BuildFakeIPTunConfig(s FakeIPTunSpec) (*RouterConfig, error) {
 		{Action: "hijack-dns", Protocol: "dns"},
 		{Action: "route", Outbound: s.ProxyTag},
 	}
+	cfg.EnsureUDPTimeoutRule(resolveUDPTimeout(s.UDPTimeout))
 	cfg.Route.Final = s.ProxyTag
 	cfg.Route.DefaultDomainResolver = &DomainResolver{Server: "real"}
 
@@ -195,6 +202,7 @@ func ensureFakeIPOverlay(cfg *RouterConfig, spec FakeIPTunSpec) {
 		StrictRoute:            boolPtr(false),
 		Stack:                  stack,
 		EndpointIndependentNAT: boolPtr(false),
+		UDPTimeout:             resolveUDPTimeout(spec.UDPTimeout),
 	}
 	if stack == "system" {
 		in.GSO = boolPtr(false)
@@ -232,6 +240,9 @@ func ensureFakeIPOverlay(cfg *RouterConfig, spec FakeIPTunSpec) {
 
 	// --- fakeip DNS rules: restrict query_type to A/AAAA ---
 	normalizeFakeIPDNSRules(cfg)
+
+	// --- UDP idle-timeout override (route-options), same as tproxy path ---
+	cfg.EnsureUDPTimeoutRule(resolveUDPTimeout(spec.UDPTimeout))
 }
 
 // upsertInbound replaces the first Inbound with the same Tag in-place, or

--- a/internal/singbox/router/config_fakeip_test.go
+++ b/internal/singbox/router/config_fakeip_test.go
@@ -42,7 +42,11 @@ func TestBuildFakeIPTunConfig_Shape(t *testing.T) {
 	if cfg.Route.DefaultDomainResolver == nil || cfg.Route.DefaultDomainResolver.Server != "real" {
 		t.Error("default_domain_resolver")
 	}
-	if cfg.Route.Rules[0].Action != "hijack-dns" || cfg.Route.Rules[1].Outbound != "proxy" {
+	// [hijack-dns, route-options(udp_timeout), route→proxy]
+	if cfg.Route.Rules[0].Action != "hijack-dns" ||
+		cfg.Route.Rules[1].Action != "route-options" || cfg.Route.Rules[1].Network != "udp" ||
+		cfg.Route.Rules[1].UDPTimeout != DefaultUDPTimeout ||
+		cfg.Route.Rules[2].Outbound != "proxy" {
 		t.Errorf("route rules: %#v", cfg.Route.Rules)
 	}
 	if cfg.Experimental == nil || cfg.Experimental.CacheFile == nil || !cfg.Experimental.CacheFile.StoreFakeIP {

--- a/internal/singbox/router/config_test.go
+++ b/internal/singbox/router/config_test.go
@@ -159,12 +159,12 @@ func TestStripAutoManagedDirect(t *testing.T) {
 		// Proxy kernel ifaces (t2sN) are NEVER stripped: the bindable picker
 		// only ever offers KeenOS-native (non-ours) proxies, so any direct→t2s
 		// here is a user choice to keep (#323). No runtime lookup at strip time.
-		{Type: "direct", Tag: "native-socks", BindInterface: "t2s0"},  // proxy — keep
-		{Type: "direct", Tag: "direct"},                              // no bind_interface — keep
-		{Type: "selector", Tag: "comp", Outbounds: []string{"awg-x"}}, // composite — keep
+		{Type: "direct", Tag: "native-socks", BindInterface: "t2s0"},    // proxy — keep
+		{Type: "direct", Tag: "direct"},                                 // no bind_interface — keep
+		{Type: "selector", Tag: "comp", Outbounds: []string{"awg-x"}},   // composite — keep
 		{Type: "direct", Tag: "managed-awg", BindInterface: "opkgtun0"}, // managed AWG — strip
-		{Type: "direct", Tag: "nwg", BindInterface: "nwg0"},           // NativeWG — strip
-		{Type: "direct", Tag: "ipsec-vpn", BindInterface: "ipsec0"},  // user VPN — keep
+		{Type: "direct", Tag: "nwg", BindInterface: "nwg0"},             // NativeWG — strip
+		{Type: "direct", Tag: "ipsec-vpn", BindInterface: "ipsec0"},     // user VPN — keep
 	}
 	got := stripAutoManagedDirect(in)
 	tags := map[string]bool{}
@@ -450,7 +450,7 @@ func TestInbound_TunFieldsMarshal(t *testing.T) {
 	in := Inbound{
 		Type: "tun", Tag: "tun-in", InterfaceName: "opkgtun10",
 		Address: []string{"172.18.0.1/30", "fdfe:dcba:9876::1/126"},
-		MTU: 1500, Stack: "gvisor",
+		MTU:     1500, Stack: "gvisor",
 	}
 	b, _ := json.Marshal(in)
 	s := string(b)

--- a/internal/singbox/router/fakeip_cidr_routes.go
+++ b/internal/singbox/router/fakeip_cidr_routes.go
@@ -32,7 +32,7 @@ func loopSafeProxyRule(r Rule) bool {
 		r.Type == "" && r.Mode == "" && len(r.Rules) == 0 &&
 		len(r.DomainSuffix) == 0 && len(r.Domain) == 0 && len(r.SourceIPCIDR) == 0 &&
 		len(r.Port) == 0 && r.Protocol == "" && r.IPIsPrivate == nil &&
-		len(r.Inbound) == 0 &&
+		len(r.Inbound) == 0 && r.Network == "" && r.UDPTimeout == "" &&
 		r.AwgmManaged == ""
 }
 

--- a/internal/singbox/router/fakeip_config.go
+++ b/internal/singbox/router/fakeip_config.go
@@ -193,6 +193,7 @@ func (s *ServiceImpl) ensureFakeIPOverlayFromState(cfg *RouterConfig) error {
 		CachePath:  p.CachePath,
 		RealServer: p.RealServer,
 		Stack:      settings.SingboxRouter.FakeIPStack,
+		UDPTimeout: settings.SingboxRouter.UDPTimeout,
 	}
 	ensureFakeIPOverlay(cfg, spec)
 	return nil

--- a/internal/singbox/router/fakeip_enable.go
+++ b/internal/singbox/router/fakeip_enable.go
@@ -225,6 +225,7 @@ func (s *ServiceImpl) enableFakeIPTun(ctx context.Context, settings *storage.Set
 		CachePath:  p.CachePath,
 		RealServer: p.RealServer,
 		Stack:      sr.FakeIPStack,
+		UDPTimeout: sr.UDPTimeout,
 	}
 	ensureFakeIPOverlay(fcfg, spec)
 

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1366,11 +1366,13 @@ func (s *ServiceImpl) healTProxyInbound(ctx context.Context, udpTimeout string) 
 // "::" for the same reason.
 const inboundListen = "0.0.0.0"
 
-// DefaultUDPTimeout is the fallback UDP session timeout for tproxy-in when
-// the user has not configured a custom value. 3 minutes matches the original
-// sing-box default, but may cause games and other UDP applications that go
-// quiet for longer than 3 minutes to drop their session unexpectedly.
-const DefaultUDPTimeout = "3m0s"
+// DefaultUDPTimeout is the fallback UDP session timeout when the user has not
+// configured a custom value. It matches sing-box's built-in C.UDPTimeout (5m):
+// fakeip's tun-in previously carried no udp_timeout and thus ran at the engine's
+// 5m, so defaulting to 5m here keeps unconfigured sessions no shorter than
+// before while still letting the user raise it. Shorter values dropped games /
+// VoIP that go quiet mid-session.
+const DefaultUDPTimeout = "5m0s"
 
 // resolveUDPTimeout returns the effective UDP timeout string: the user value
 // when non-empty, otherwise DefaultUDPTimeout.

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1118,6 +1118,12 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	cfg.Inbounds = ensureTProxyInbound(cfg.Inbounds, sr.UDPTimeout)
 	cfg.Outbounds = stripAutoManagedDirect(cfg.Outbounds)
 	cfg.EnsureSystemRules(sr.SnifferEnabled)
+	// Neutralize sing-box's short per-protocol UDP timeouts (QUIC/DTLS 30s,
+	// STUN/DNS 10s) applied on sniff/port inference — they ignore the inbound
+	// udp_timeout and drop games/VoIP early. Raise them to the effective inbound
+	// value via a route-options rule. Placed after the system prefix, before user
+	// rules, so it runs ahead of any final `route` action.
+	cfg.EnsureUDPTimeoutRule(resolveUDPTimeout(sr.UDPTimeout))
 	// QoS-by-DSCP (issue #371): per-class inbound pairs, derived from the
 	// same settings snapshot the iptables spec below uses so ports/classes
 	// cannot drift between the two. The managed route rules live in their

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -101,9 +101,19 @@ type Rule struct {
 	// transparent listener on every router LAN IP; a side-effect packet
 	// that slips into sing-box from there gets routed `direct` instead
 	// of ending up at `final: proxy` and being silently dropped.
-	IPIsPrivate *bool  `json:"ip_is_private,omitempty"`
-	Action      string `json:"action,omitempty"`
-	Outbound    string `json:"outbound,omitempty"`
+	IPIsPrivate *bool `json:"ip_is_private,omitempty"`
+	// Network matches the connection L4 protocol ("tcp" | "udp"). The system
+	// route-options rule uses it to scope the udp_timeout override to UDP.
+	Network  string `json:"network,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Outbound string `json:"outbound,omitempty"`
+	// UDPTimeout carries the `udp_timeout` route option for an
+	// `action:"route-options"` rule. sing-box otherwise applies short
+	// per-protocol idle timeouts to sniffed UDP (STUN/DNS 10s, QUIC/DTLS 30s)
+	// that ignore the inbound udp_timeout; a route-options rule raising it to the
+	// inbound value keeps games/VoIP sessions alive. A route rule action carries
+	// no outbound, so this and Action are the only fields it sets.
+	UDPTimeout string `json:"udp_timeout,omitempty"`
 	// AwgmManaged marks auto-generated route rules owned by AWG Manager.
 	// "selective-ip" rules map resolved domain IPs to proxy outbounds for
 	// selective TPROXY mode; they are replaced on each ipset rebuild.

--- a/internal/singbox/router/udp_timeout_test.go
+++ b/internal/singbox/router/udp_timeout_test.go
@@ -1,0 +1,115 @@
+package router
+
+import "testing"
+
+// fakeip tun-in must carry udp_timeout so a user-configured value overrides
+// sing-box's built-in 5-minute UDP-NAT default (the "exactly 5 minutes" drop).
+func TestFakeIPTunInboundUDPTimeout(t *testing.T) {
+	base := FakeIPTunSpec{
+		Iface: "opkgtun10", TunAddr4: "172.18.0.1/30", MTU: 1500,
+		Inet4Range: "10.128.0.0/10", CachePath: "/c.db", RealServer: "1.1.1.1",
+		Outbounds: []Outbound{{Type: "direct", Tag: "proxy"}}, ProxyTag: "proxy",
+	}
+
+	// Explicit value flows through verbatim.
+	spec := base
+	spec.UDPTimeout = "1h"
+	cfg, err := BuildFakeIPTunConfig(spec)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if got := cfg.Inbounds[0].UDPTimeout; got != "1h" {
+		t.Fatalf("tun-in udp_timeout = %q, want 1h", got)
+	}
+
+	// Empty falls back to DefaultUDPTimeout (not sing-box's 5m).
+	cfg2, err := BuildFakeIPTunConfig(base)
+	if err != nil {
+		t.Fatalf("build default: %v", err)
+	}
+	if got := cfg2.Inbounds[0].UDPTimeout; got != DefaultUDPTimeout {
+		t.Fatalf("tun-in default udp_timeout = %q, want %q", got, DefaultUDPTimeout)
+	}
+
+	// The overlay path (every persist) must re-assert it too.
+	oc := NewEmptyConfig()
+	ensureFakeIPOverlay(oc, spec)
+	if got := findInbound(oc, "tun-in").UDPTimeout; got != "1h" {
+		t.Fatalf("overlay tun-in udp_timeout = %q, want 1h", got)
+	}
+}
+
+func findInbound(cfg *RouterConfig, tag string) Inbound {
+	for _, in := range cfg.Inbounds {
+		if in.Tag == tag {
+			return in
+		}
+	}
+	return Inbound{}
+}
+
+// EnsureUDPTimeoutRule inserts exactly one route-options rule inside the system
+// prefix, before user rules, and is idempotent across re-runs.
+func TestEnsureUDPTimeoutRule(t *testing.T) {
+	cfg := NewEmptyConfig()
+	// A user routing rule that would be a *final* route action.
+	cfg.Route.Rules = []Rule{{DomainSuffix: []string{"example.com"}, Action: "route", Outbound: "proxy"}}
+	cfg.EnsureSystemRules(true) // prepends sniff + hijack-dns + ip_is_private
+
+	cfg.EnsureUDPTimeoutRule("1h")
+
+	// Find the route-options rule and assert it sits within the system prefix,
+	// strictly before the user's domain_suffix rule.
+	optIdx, userIdx := -1, -1
+	for i, r := range cfg.Route.Rules {
+		if isSystemUDPTimeoutRule(r) {
+			if optIdx != -1 {
+				t.Fatalf("duplicate route-options rule at %d and %d", optIdx, i)
+			}
+			optIdx = i
+			if r.UDPTimeout != "1h" {
+				t.Fatalf("route-options udp_timeout = %q, want 1h", r.UDPTimeout)
+			}
+		}
+		if len(r.DomainSuffix) == 1 && r.DomainSuffix[0] == "example.com" {
+			userIdx = i
+		}
+	}
+	if optIdx == -1 {
+		t.Fatal("route-options rule not inserted")
+	}
+	if optIdx >= userIdx {
+		t.Fatalf("route-options at %d must precede user rule at %d", optIdx, userIdx)
+	}
+	// It must sit at the end of the system prefix: every rule before it is a
+	// sniff/hijack-dns/ip_is_private system rule (systemPrefixLen does not count
+	// the route-options rule itself).
+	if optIdx != cfg.systemPrefixLen() {
+		t.Fatalf("route-options at %d, want systemPrefixLen=%d", optIdx, cfg.systemPrefixLen())
+	}
+
+	// Idempotent + picks up a changed value: re-run with a new timeout.
+	before := len(cfg.Route.Rules)
+	cfg.EnsureUDPTimeoutRule("30m")
+	if len(cfg.Route.Rules) != before {
+		t.Fatalf("re-run changed rule count %d → %d", before, len(cfg.Route.Rules))
+	}
+	count, val := 0, ""
+	for _, r := range cfg.Route.Rules {
+		if isSystemUDPTimeoutRule(r) {
+			count++
+			val = r.UDPTimeout
+		}
+	}
+	if count != 1 || val != "30m" {
+		t.Fatalf("after re-run: count=%d val=%q, want 1 / 30m", count, val)
+	}
+
+	// Empty effective strips the rule entirely (defensive).
+	cfg.EnsureUDPTimeoutRule("")
+	for _, r := range cfg.Route.Rules {
+		if isSystemUDPTimeoutRule(r) {
+			t.Fatal("empty effective must remove the route-options rule")
+		}
+	}
+}

--- a/internal/singbox/router/wanips_test.go
+++ b/internal/singbox/router/wanips_test.go
@@ -94,10 +94,10 @@ func TestParseInetAddrs_NoAddrs(t *testing.T) {
 
 // fakeWANRunner records calls and returns canned outputs per arg-prefix.
 type fakeWANRunner struct {
-	routeOut   string
-	addrByDev  map[string]string
-	addrErr    map[string]error
-	routeErr   error
+	routeOut  string
+	addrByDev map[string]string
+	addrErr   map[string]error
+	routeErr  error
 }
 
 func (f *fakeWANRunner) run(_ context.Context, args ...string) (string, error) {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -153,10 +153,10 @@ type SingboxRouterSettings struct {
 	FakeIPPool6 string `json:"fakeipPool6,omitempty"`
 	// FakeIPMTU is the tun MTU (default 1500).
 	FakeIPMTU int `json:"fakeipMtu,omitempty"`
-	// UDPTimeout задаёт таймаут UDP-сессий в tproxy-in inbound (формат Go duration,
-	// например "3m0s", "10m0s"). Пустая строка = использовать значение по умолчанию
-	// (DefaultUDPTimeout). Увеличение помогает при работе игр и других UDP-приложений,
-	// которые могут молчать дольше стандартных 3 минут.
+	// UDPTimeout задаёт таймаут UDP-сессий в tproxy-in / fakeip tun-in inbound
+	// (формат Go duration, например "5m0s", "10m0s"). Пустая строка = значение по
+	// умолчанию (DefaultUDPTimeout, 5m). Увеличение помогает играм и другим
+	// UDP-приложениям, которые могут молчать дольше и терять сессию.
 	UDPTimeout string `json:"udpTimeout,omitempty"`
 	// SelectiveBypass, when true, installs an iptables -m set guard in front
 	// of the TPROXY/REDIRECT catch-all rules so only traffic whose destination


### PR DESCRIPTION
## Симптом

UDP-сессии (игры, VoIP, WireGuard-over-proxy) обрывались **ровно через 5 минут**, даже когда пользователь выставил таймаут движка в 1 час.

> Примечание: это отдельная проблема, не связанная с issue #440 (blackhole). Ветка названа `...-440-...` по историческим причинам — правка UDP-таймаута самостоятельна.

## Причина

sing-box держит собственную константу `C.UDPTimeout = 5m` как fallback UDP-NAT таймаута инбаунда, когда у инбаунда не задан `udp_timeout`. Заглянув в код 1.14.0-alpha.39:

- **tproxy-in** уже получал пользовательский `udpTimeout` — там всё работало.
- **fakeip `tun-in`** собирался **вообще без `udp_timeout`** → движок применял свои 5 минут, и настройка «1 час» на fakeip-режим не влияла. Это и есть «ровно 5 минут».
- Отдельно: sing-box навешивает **короткие протокольные idle-таймауты** по сниффу/порту (STUN/DNS 10s, QUIC/DTLS 30s), которые **игнорируют** inbound `udp_timeout` и бьют по играм/VoIP ещё до 5 минут. Перекрыть их можно только route-action `udp_timeout`.

## Решение (две части)

**1. Проброс `udp_timeout` в fakeip `tun-in`** — `FakeIPTunSpec.UDPTimeout` выставляется на инбаунд во всех точках сборки (`BuildFakeIPTunConfig`, `ensureFakeIPOverlay`, enable/overlay-from-state).

**2. Системное правило `route-options` против сниф-таймаутов** — `{action:"route-options", network:"udp", udp_timeout:effective}` вставляется в системный префикс правил (перед пользовательскими, до финального `route`) в обоих режимах (`EnsureUDPTimeoutRule`). `route-options` — non-final: ставит таймаут и продолжает маршрутизацию. Устанавливая `metadata.UDPTimeout>0`, оно заставляет `route/conn.go` **пропустить** ветку `ProtocolTimeouts` — сниффнутый UDP получает полный inbound-таймаут вместо 10/30 секунд.

`Rule` получил поля `network` и `udp_timeout`; `loopSafeProxyRule` их исключает (не даёт петлевого tun-маршрута — заодно закрыта латентная дыра, когда `network` терялся при unmarshal); фронтенд `isSystemRule`/`simpleRule` прячут правило из пользовательского редактора.

## Дефолт таймаута

`DefaultUDPTimeout` поднят **3m → 5m**: ненастроенный fakeip раньше жил на 5m движка, так что новый дефолт не короче прежнего («никогда не хуже»), а для tproxy это удлинение в сторону запроса. Один общий дефолт, снят fakeip/tproxy-рассинхрон.

## Верификация семантики (ревью Fable 5)

По коду закреплённой версии подтверждено: `route-options` — реальный non-final action; `udp_timeout` → `metadata.UDPTimeout`; `network:"udp"` — валидный matcher; на `tun` inbound `udp_timeout` не deprecated. Ключевое: установка route-options `udp_timeout` == inbound **действительно** гасит 30s/10s (а не no-op) — ветка `ProtocolTimeouts` в `route/conn.go` не выполняется при `metadata.UDPTimeout>0`, а canceler-no-op сохраняет inbound-значение. Без route-options сниффнутый QUIC понижается до 30s даже при inbound 1h — поэтому часть 2 необходима.

## Ревью и фиксы

Три угла (корректность / семантика / качество): **жёстких багов нет**. Применены фиксы: дефолт 5m (регресс fakeip), единый предикат «системного правила» (`isSystemSniffRule/HijackRule/PrivateRule` в `EnsureSystemRules` + `systemPrefixLen` — устранён дрейф `outbound=="direct"`), однократный `resolveUDPTimeout` на функцию.

## Проверки

- `go test ./...` + `go vet`: зелёные; кросс-компиляция mips/mipsle/arm64 (softfloat): OK
- Новые тесты: `udp_timeout` в tun-in (оба пути), размещение/идемпотентность/смена значения `EnsureUDPTimeoutRule`, `isSystemRule`/`classifyRuleSimplicity` для route-options
- `svelte-check` 0/0; `vitest` (sb-router) зелёный

Финальная валидация emitted-конфига — сам `sing-box check` при reload (принимает route-options/network/udp_timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg