### PR TITLE
feat(sb-router): fail-closed blackhole при мёртвом sing-box (safety-1) [до теста на железе]

### DIFF
--- a/internal/singbox/router/blackhole_test.go
+++ b/internal/singbox/router/blackhole_test.go
@@ -1,0 +1,134 @@
+package router
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The fail-closed blackhole blob must carry the SAME LAN/router/WAN RETURN
+// exclusions as the interception chain, then a terminal DROP, entered from
+// PREROUTING by the identical policy selector — mangle only, never nat.
+func TestBuildBlackholeRestoreInput_PolicyMark(t *testing.T) {
+	got := buildBlackholeRestoreInput(RestoreInputSpec{
+		PolicyMark:  "0xffffaaa",
+		WANIPs:      []string{"203.0.113.5"},
+		BypassCIDRs: []string{"192.168.50.0/24"},
+	})
+
+	must := []string{
+		"*mangle",
+		":" + BlackholeChain + " - [0:0]",
+		"-A " + BlackholeChain + " -d 192.168.50.0/24 -j RETURN", // user bypass
+		"-A " + BlackholeChain + " -d 10.0.0.0/8 -j RETURN",      // LAN
+		"-A " + BlackholeChain + " -d 127.0.0.0/8 -j RETURN",     // loopback
+		"-A " + BlackholeChain + " -d 203.0.113.5 -j RETURN",     // router WAN IP
+		"-A " + BlackholeChain + " -j DROP",                      // terminal fail-closed drop
+		"-A PREROUTING -m connmark --mark 0xffffaaa -m conntrack ! --ctstate INVALID -j " + BlackholeChain,
+		"COMMIT",
+	}
+	for _, s := range must {
+		if !strings.Contains(got, s) {
+			t.Errorf("blackhole blob missing %q\n---\n%s", s, got)
+		}
+	}
+
+	// mangle-only: the blackhole must never touch nat or emit TPROXY/REDIRECT.
+	for _, bad := range []string{"*nat", RedirectChain, "TPROXY", "REDIRECT"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("blackhole blob unexpectedly contains %q\n%s", bad, got)
+		}
+	}
+
+	// DROP must come AFTER every RETURN exclusion — otherwise it would swallow
+	// LAN/router/WAN traffic the RETURNs are meant to spare.
+	if strings.Index(got, "-j DROP") < strings.LastIndex(got, "-j RETURN") {
+		t.Error("terminal DROP must be positioned after all RETURN exclusions")
+	}
+}
+
+// MatchAll (device mode, no policy mark) drops all non-excluded traffic without
+// a connmark filter — mirroring the interception jump.
+func TestBuildBlackholeRestoreInput_MatchAll(t *testing.T) {
+	got := buildBlackholeRestoreInput(RestoreInputSpec{MatchAll: true})
+	if !strings.Contains(got, "-A PREROUTING -m conntrack ! --ctstate INVALID -j "+BlackholeChain) {
+		t.Errorf("MatchAll jump missing:\n%s", got)
+	}
+	if strings.Contains(got, "connmark") {
+		t.Errorf("MatchAll must not carry a connmark filter:\n%s", got)
+	}
+}
+
+// InstallBlackhole restores the blackhole blob and persists it (so the
+// netfilter.d hook can re-assert it after an NDMS reload while the engine is
+// still down).
+func TestInstallBlackhole_RestoresAndPersists(t *testing.T) {
+	fe := newFakeExec()
+	it := newFakeIPTables(fe)
+	var persisted string
+	it.persistBlackhole = func(in string) error { persisted = in; return nil }
+
+	if err := it.InstallBlackhole(context.Background(), RestoreInputSpec{PolicyMark: "0xff"}); err != nil {
+		t.Fatalf("InstallBlackhole: %v", err)
+	}
+
+	var restored string
+	for _, c := range fe.calls {
+		if c.kind == "restore" {
+			restored = c.stdin
+		}
+	}
+	if !strings.Contains(restored, "-A "+BlackholeChain+" -j DROP") {
+		t.Errorf("restore missing DROP:\n%s", restored)
+	}
+	if !strings.Contains(persisted, "-A "+BlackholeChain+" -j DROP") {
+		t.Errorf("persistBlackhole not given the blackhole blob: %q", persisted)
+	}
+}
+
+// RemoveBlackhole deletes the rules file and flushes+deletes the chain.
+func TestRemoveBlackhole_CleansUp(t *testing.T) {
+	fe := newFakeExec()
+	it := newFakeIPTables(fe)
+	cleaned := false
+	it.cleanupBlackhole = func() { cleaned = true }
+
+	it.RemoveBlackhole(context.Background())
+
+	if !cleaned {
+		t.Error("cleanupBlackhole (delete rules file) not called")
+	}
+	var sawFlush, sawDelete bool
+	for _, c := range fe.calls {
+		if c.kind != "iptables" || len(c.args) < 4 || c.args[3] != BlackholeChain {
+			continue
+		}
+		switch c.args[2] {
+		case "-F":
+			sawFlush = true
+		case "-X":
+			sawDelete = true
+		}
+	}
+	if !sawFlush || !sawDelete {
+		t.Errorf("expected -F and -X on %s; calls=%+v", BlackholeChain, fe.calls)
+	}
+}
+
+// The netfilter.d hook must gain a dead-engine branch that re-asserts the
+// blackhole, and an alive-engine scrub that removes any stale blackhole.
+func TestNetfilterHookScript_BlackholeFailClosed(t *testing.T) {
+	s := netfilterHookScript()
+	if !strings.Contains(s, netfilterBlackholePath) {
+		t.Error("hook missing blackhole rules path (dead-engine restore)")
+	}
+	if !strings.Contains(s, "grep -qE -- '-[jg] "+BlackholeChain+"($| )'") {
+		t.Error("hook missing anchored blackhole jump gate")
+	}
+	if !strings.Contains(s, "-F "+BlackholeChain) || !strings.Contains(s, "-X "+BlackholeChain) {
+		t.Error("hook missing blackhole scrub in the alive-engine path")
+	}
+	if !strings.Contains(s, "if pidof sing-box") || !strings.Contains(s, "\nelse\n") {
+		t.Error("hook missing pidof if/else (alive vs dead) structure")
+	}
+}

--- a/internal/singbox/router/blackhole_test.go
+++ b/internal/singbox/router/blackhole_test.go
@@ -47,6 +47,33 @@ func TestBuildBlackholeRestoreInput_PolicyMark(t *testing.T) {
 	}
 }
 
+// Selective mode + bypass ports: the blackhole must mirror the interception
+// chain's RETURN set — the selective-set guard (so only the selective subset is
+// dropped, not the whole of the user's traffic) and the user's bypass UDP/TCP
+// ports (so deliberately-excluded traffic goes direct, not dropped).
+func TestBuildBlackholeRestoreInput_SelectiveAndBypassPorts(t *testing.T) {
+	got := buildBlackholeRestoreInput(RestoreInputSpec{
+		PolicyMark:     "0xff",
+		SelectiveIPSet: true,
+		BypassUDPPorts: []PortRange{{51820, 51820}},
+		BypassTCPPorts: []PortRange{{22, 22}},
+	})
+	must := []string{
+		"-A " + BlackholeChain + " -p udp --dport 51820 -j RETURN",
+		"-A " + BlackholeChain + " -p tcp --dport 22 -j RETURN",
+		"-A " + BlackholeChain + " -m set ! --match-set " + selectiveSetName + " dst -j RETURN",
+	}
+	for _, s := range must {
+		if !strings.Contains(got, s) {
+			t.Errorf("blackhole blob missing %q\n---\n%s", s, got)
+		}
+	}
+	// The selective guard and every port RETURN must still precede the DROP.
+	if strings.Index(got, "-j DROP") < strings.LastIndex(got, "-j RETURN") {
+		t.Error("DROP must be after the selective guard and bypass-port RETURNs")
+	}
+}
+
 // MatchAll (device mode, no policy mark) drops all non-excluded traffic without
 // a connmark filter — mirroring the interception jump.
 func TestBuildBlackholeRestoreInput_MatchAll(t *testing.T) {

--- a/internal/singbox/router/iptables.go
+++ b/internal/singbox/router/iptables.go
@@ -35,6 +35,15 @@ const (
 	RoutingTable  = 100
 	ChainName     = "AWGM-TPROXY"
 	RedirectChain = "AWGM-REDIRECT"
+	// BlackholeChain is the fail-closed DROP chain (mangle). It is engaged
+	// ONLY while sing-box is dead AND the PREROUTING interception jumps were
+	// wiped (e.g. an NDMS firewall reload): without it, policy-marked traffic
+	// would fall through to the normal Keenetic routing table and LEAK to WAN
+	// unencrypted, even though the user expects it to go through proxy/AWG.
+	// The chain carries the SAME LAN/router/WAN RETURN exclusions as the
+	// interception chains, then a terminal DROP, and is removed the moment the
+	// engine recovers. Traffic is dropped, never leaked.
+	BlackholeChain = "AWGM-BLACKHOLE"
 	// DNSRescueTag identifies our short-circuit REDIRECT rules in nat
 	// PREROUTING that bypass NDMS's _NDM_DNS_FLT_REDIR catch-all
 	// (which would unconditionally REDIRECT DNS to :53, where
@@ -74,8 +83,9 @@ const (
 // Mutable in tests via t.Cleanup so they can redirect into a tmp dir.
 // Production code reads these at call time.
 var (
-	netfilterHookPath  = "/opt/etc/ndm/netfilter.d/50-awgm-tproxy.sh"
-	netfilterRulesPath = "/opt/etc/awg-manager/singbox/router-netfilter.rules"
+	netfilterHookPath      = "/opt/etc/ndm/netfilter.d/50-awgm-tproxy.sh"
+	netfilterRulesPath     = "/opt/etc/awg-manager/singbox/router-netfilter.rules"
+	netfilterBlackholePath = "/opt/etc/awg-manager/singbox/router-blackhole.rules"
 )
 
 // selectiveSetName is the ipset name used for selective bypass — aliased
@@ -430,6 +440,32 @@ func emitPreroutingJump(b *strings.Builder, chain string, spec RestoreInputSpec)
 	}
 }
 
+// buildBlackholeRestoreInput renders the mangle-only *AWGM-BLACKHOLE* blob:
+// the SAME LAN/router/WAN RETURN exclusions as the interception chain, then a
+// terminal DROP, entered from PREROUTING by the identical policy selector
+// (emitPreroutingJump). So the set it drops is exactly the set that would have
+// entered AWGM-TPROXY — nothing local is caught, and no policy traffic escapes.
+// mangle (not nat) so every packet of a flow is matched while the tunnel is
+// down, not only the first packet of a new conntrack.
+func buildBlackholeRestoreInput(spec RestoreInputSpec) string {
+	var b strings.Builder
+	b.WriteString("*mangle\n")
+	fmt.Fprintf(&b, ":%s - [0:0]\n", BlackholeChain)
+	// User bypass first — an explicitly excluded subnet must never be dropped.
+	emitUserBypassReturns(&b, BlackholeChain, spec.BypassCIDRs)
+	// LAN/loopback/CGNAT/multicast + router-owned WAN IPs: reused verbatim from
+	// the interception chain so the exclusion set cannot drift and the blackhole
+	// can never over-block router-local, LAN-to-LAN, or management traffic.
+	emitBypassReturns(&b, BlackholeChain, spec.WANIPs)
+	// Everything else that belongs to the policy: drop it (fail-closed).
+	fmt.Fprintf(&b, "-A %s -j DROP\n", BlackholeChain)
+	// Same PREROUTING selector as the real interception jump (connmark policy
+	// filter, or MatchAll), so exactly the policy traffic is diverted here.
+	emitPreroutingJump(&b, BlackholeChain, spec)
+	b.WriteString("COMMIT\n")
+	return b.String()
+}
+
 func buildRestoreInput(spec RestoreInputSpec) string {
 	var b strings.Builder
 
@@ -639,13 +675,15 @@ type runOutFn func(ctx context.Context, args ...string) (string, error)
 type persistFn func(input string) error
 
 type IPTables struct {
-	restoreNoflush restoreNoflushFn
-	runIPTables    runFn
-	runIPTablesOut runOutFn
-	runIP          runFn
-	persistRules   persistFn
-	persistHook    func() error
-	cleanupHook    func()
+	restoreNoflush   restoreNoflushFn
+	runIPTables      runFn
+	runIPTablesOut   runOutFn
+	runIP            runFn
+	persistRules     persistFn
+	persistHook      func() error
+	cleanupHook      func()
+	persistBlackhole persistFn
+	cleanupBlackhole func()
 }
 
 func NewIPTables() *IPTables {
@@ -657,10 +695,44 @@ func NewIPTables() *IPTables {
 			result, err := sysexec.Run(ctx, "ip", args...)
 			return sysexec.FormatError(result, err)
 		},
-		persistRules: writeNetfilterRulesFile,
-		persistHook:  writeNetfilterHook,
-		cleanupHook:  removeNetfilterRulesFile,
+		persistRules:     writeNetfilterRulesFile,
+		persistHook:      writeNetfilterHook,
+		cleanupHook:      removeNetfilterRulesFile,
+		persistBlackhole: writeNetfilterBlackholeRulesFile,
+		cleanupBlackhole: removeNetfilterBlackholeRulesFile,
 	}
+}
+
+// InstallBlackhole engages the fail-closed DROP chain: scrub any stale jump,
+// persist the blackhole rules (so the netfilter.d hook can re-assert it after
+// an NDMS reload while the engine is still dead), then restore it via
+// iptables-restore --noflush. It reuses the same hook it.persistHook already
+// wrote — only the blackhole rules file is blackhole-specific. No fwmark/ip
+// rule: the blackhole only drops, it never delivers to a table. Idempotent.
+func (it *IPTables) InstallBlackhole(ctx context.Context, spec RestoreInputSpec) error {
+	it.removeSourceHooksFromTable(ctx, "mangle", BlackholeChain)
+	input := buildBlackholeRestoreInput(spec)
+	if it.persistBlackhole != nil {
+		if err := it.persistBlackhole(input); err != nil {
+			return fmt.Errorf("write blackhole rules: %w", err)
+		}
+	}
+	if err := it.restoreNoflush(ctx, input); err != nil {
+		return fmt.Errorf("iptables-restore blackhole: %w", err)
+	}
+	return nil
+}
+
+// RemoveBlackhole tears down the fail-closed DROP chain: delete the rules file
+// (so the hook stops re-asserting it), scrub the PREROUTING jump, then flush +
+// delete the chain. Idempotent — safe to call when no blackhole is present.
+func (it *IPTables) RemoveBlackhole(ctx context.Context) {
+	if it.cleanupBlackhole != nil {
+		it.cleanupBlackhole()
+	}
+	it.removeSourceHooksFromTable(ctx, "mangle", BlackholeChain)
+	_ = it.runIPTables(ctx, "-t", "mangle", "-F", BlackholeChain)
+	_ = it.runIPTables(ctx, "-t", "mangle", "-X", BlackholeChain)
 }
 
 // drainFwmarkRules deletes every `ip rule` for our fwmark/table, looping until
@@ -735,6 +807,17 @@ func writeNetfilterRulesFile(input string) error {
 	return storage.AtomicWritePerm(netfilterRulesPath, []byte(input), 0644)
 }
 
+func writeNetfilterBlackholeRulesFile(input string) error {
+	return storage.AtomicWritePerm(netfilterBlackholePath, []byte(input), 0644)
+}
+
+// removeNetfilterBlackholeRulesFile deletes the persisted blackhole rules so
+// the netfilter.d hook stops re-asserting the fail-closed DROP on the next NDMS
+// reload. Called when the engine recovers (blackhole removed). Idempotent.
+func removeNetfilterBlackholeRulesFile() {
+	_ = os.Remove(netfilterBlackholePath)
+}
+
 func writeNetfilterHook() error {
 	return storage.AtomicWritePerm(netfilterHookPath, []byte(netfilterHookScript()), 0755)
 }
@@ -743,69 +826,89 @@ func writeNetfilterHook() error {
 // substituted. Pure (no I/O) so a test can validate the generated shell with
 // `sh -n`.
 //
-// Scrub block before restore: when NDMS reloads only one table (e.g. nat) but
-// leaves mangle intact, restoring --noflush would append a SECOND PREROUTING
-// jump on top of the surviving one. The `-[jg]` regex covers both legacy `-j`
-// and current `-g` syntax so the upgrade path doesn't leave duplicates around.
+// Two mutually-exclusive paths, chosen by whether sing-box is alive:
+//
+//   - ALIVE: real interception governs. Scrub any lingering fail-closed
+//     blackhole, then restore the AWGM chains if NDMS wiped their PREROUTING
+//     jumps. Scrub-before-restore: when NDMS reloads only one table (e.g. nat)
+//     but leaves mangle intact, restoring --noflush would append a SECOND
+//     jump on top of the surviving one. The `-[jg]` regex covers both legacy
+//     `-j` and current `-g` syntax so upgrades don't leave duplicates.
+//   - DEAD: fail-closed. Re-assert the blackhole DROP (if its rules file exists
+//     and the jump was wiped) so policy traffic can NEVER reach WAN while the
+//     engine is down — the old hook simply exited here, leaving a leak window
+//     until the next reconcile tick.
 func netfilterHookScript() string {
 	return fmt.Sprintf(`#!/bin/sh
 [ "$type" = "ip6tables" ] && exit 0
 case "$table" in mangle|nat) ;; *) exit 0 ;; esac
-[ -f %[1]q ] || exit 0
-pidof sing-box >/dev/null 2>&1 || exit 0
-# Best-effort kernel module preload. Absent .ko or built-in modules are
-# silently skipped — iptables-restore will surface the final verdict anyway.
+# Best-effort kernel module preload (both paths need these). Absent .ko or
+# built-in modules are silently skipped — iptables-restore surfaces the verdict.
 KREL="$(uname -r)"
 for mod in xt_TPROXY xt_comment xt_mark xt_connmark xt_conntrack xt_pkttype xt_dscp; do
   grep -q "^${mod} " /proc/modules 2>/dev/null && continue
   [ -f "/lib/modules/${KREL}/${mod}.ko" ] && insmod "/lib/modules/${KREL}/${mod}.ko" 2>/dev/null || true
 done
-# A chain is "ok" only if it EXISTS and PREROUTING actually jumps into it.
-# NDMS rebuilds PREROUTING and wipes our AWGM PREROUTING jumps while leaving
-# the custom chains intact; gating on chain existence alone would skip the
-# restore in exactly that case, leaving interception silently dead.
-mangle_ok=0; nat_ok=0
-/opt/sbin/iptables -w -t mangle -nL %[2]s >/dev/null 2>&1 \
-  && /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null | grep -qE -- '-[jg] %[2]s($| )' \
-  && mangle_ok=1
-/opt/sbin/iptables -w -t nat -nL %[6]s >/dev/null 2>&1 \
-  && /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null | grep -qE -- '-[jg] %[6]s($| )' \
-  && nat_ok=1
-if [ "$mangle_ok" -eq 0 ] || [ "$nat_ok" -eq 0 ]; then
+if pidof sing-box >/dev/null 2>&1; then
+  # sing-box ALIVE — real interception governs. Drop any lingering fail-closed
+  # blackhole first so a stale DROP never sits in front of the interception jump.
   /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
-    | grep -E -- '-[jg] %[2]s($| )' \
+    | grep -E -- '-[jg] %[11]s($| )' \
     | sed 's/-A PREROUTING/-D PREROUTING/' \
     | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
-  /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null \
-    | grep -E -- '-[jg] %[6]s($| )' \
-    | sed 's/-A PREROUTING/-D PREROUTING/' \
-    | while IFS= read -r line; do /opt/sbin/iptables -w -t nat $line 2>/dev/null; done
-  # Scrub DNS-RESCUE direct PREROUTING rules in nat (identified by
-  # comment tag, not by jump target — these are -j REDIRECT rules,
-  # not chain jumps). Same drop-and-restore approach as above, just
-  # matched via the iptables-save comment serialisation.
-  /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null \
-    | grep -E -- '--comment "?%[7]s' \
-    | sed 's/-A PREROUTING/-D PREROUTING/' \
-    | while IFS= read -r line; do /opt/sbin/iptables -w -t nat $line 2>/dev/null; done
-  # Legacy DNS-NOPOLICY MARK rules in mangle (dead code from earlier
-  # AWGM builds). Always scrub so upgrades don't leave dangling rules
-  # accumulating across NDMS reloads.
-  /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
-    | grep -E -- '--comment "?%[8]s' \
-    | sed 's/-A PREROUTING/-D PREROUTING/' \
-    | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
-  # Ingress-scope MARK/CONNMARK rules in mangle (comment-tagged).
-  /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
-    | grep -E -- '--comment "?%[9]s' \
-    | sed 's/-A PREROUTING/-D PREROUTING/' \
-    | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
-  /opt/sbin/iptables-restore --noflush < %[1]q
-  /opt/sbin/ip rule add fwmark 0x%[3]x table %[4]d priority %[5]d 2>/dev/null || true
-  /opt/sbin/ip route add local 0.0.0.0/0 dev lo table %[4]d 2>/dev/null || true
-  logger -t awgm-tproxy "netfilter.d: restored AWGM chains after NDMS reload"
+  /opt/sbin/iptables -w -t mangle -F %[11]s 2>/dev/null
+  /opt/sbin/iptables -w -t mangle -X %[11]s 2>/dev/null
+  [ -f %[1]q ] || exit 0
+  # A chain is "ok" only if it EXISTS and PREROUTING actually jumps into it.
+  # NDMS rebuilds PREROUTING and wipes our AWGM jumps while leaving the custom
+  # chains intact; gating on chain existence alone would skip the restore.
+  mangle_ok=0; nat_ok=0
+  /opt/sbin/iptables -w -t mangle -nL %[2]s >/dev/null 2>&1 \
+    && /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null | grep -qE -- '-[jg] %[2]s($| )' \
+    && mangle_ok=1
+  /opt/sbin/iptables -w -t nat -nL %[6]s >/dev/null 2>&1 \
+    && /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null | grep -qE -- '-[jg] %[6]s($| )' \
+    && nat_ok=1
+  if [ "$mangle_ok" -eq 0 ] || [ "$nat_ok" -eq 0 ]; then
+    /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
+      | grep -E -- '-[jg] %[2]s($| )' \
+      | sed 's/-A PREROUTING/-D PREROUTING/' \
+      | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
+    /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null \
+      | grep -E -- '-[jg] %[6]s($| )' \
+      | sed 's/-A PREROUTING/-D PREROUTING/' \
+      | while IFS= read -r line; do /opt/sbin/iptables -w -t nat $line 2>/dev/null; done
+    # Scrub DNS-RESCUE direct PREROUTING rules in nat (comment-tagged -j REDIRECT).
+    /opt/sbin/iptables -w -t nat -S PREROUTING 2>/dev/null \
+      | grep -E -- '--comment "?%[7]s' \
+      | sed 's/-A PREROUTING/-D PREROUTING/' \
+      | while IFS= read -r line; do /opt/sbin/iptables -w -t nat $line 2>/dev/null; done
+    # Legacy DNS-NOPOLICY MARK rules in mangle (dead code from earlier builds).
+    /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
+      | grep -E -- '--comment "?%[8]s' \
+      | sed 's/-A PREROUTING/-D PREROUTING/' \
+      | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
+    # Ingress-scope MARK/CONNMARK rules in mangle (comment-tagged).
+    /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null \
+      | grep -E -- '--comment "?%[9]s' \
+      | sed 's/-A PREROUTING/-D PREROUTING/' \
+      | while IFS= read -r line; do /opt/sbin/iptables -w -t mangle $line 2>/dev/null; done
+    /opt/sbin/iptables-restore --noflush < %[1]q
+    /opt/sbin/ip rule add fwmark 0x%[3]x table %[4]d priority %[5]d 2>/dev/null || true
+    /opt/sbin/ip route add local 0.0.0.0/0 dev lo table %[4]d 2>/dev/null || true
+    logger -t awgm-tproxy "netfilter.d: restored AWGM chains after NDMS reload"
+  fi
+else
+  # sing-box DEAD — fail-closed. Re-assert the blackhole DROP if its rules file
+  # exists and the PREROUTING jump was wiped, so policy traffic cannot leak to
+  # WAN while the engine is down.
+  [ -f %[10]q ] || exit 0
+  if ! /opt/sbin/iptables -w -t mangle -S PREROUTING 2>/dev/null | grep -qE -- '-[jg] %[11]s($| )'; then
+    /opt/sbin/iptables-restore --noflush < %[10]q
+    logger -t awgm-tproxy "netfilter.d: re-asserted fail-closed blackhole (sing-box down)"
+  fi
 fi
-`, netfilterRulesPath, ChainName, Fwmark, RoutingTable, IPRulePriority, RedirectChain, DNSRescueTag, DNSNoPolicyTag, IngressTag)
+`, netfilterRulesPath, ChainName, Fwmark, RoutingTable, IPRulePriority, RedirectChain, DNSRescueTag, DNSNoPolicyTag, IngressTag, netfilterBlackholePath, BlackholeChain)
 }
 
 // removeNetfilterRulesFile deletes the persisted rules file so the
@@ -830,6 +933,10 @@ func (it *IPTables) Uninstall(ctx context.Context) error {
 	if it.cleanupHook != nil {
 		it.cleanupHook()
 	}
+	// Also tear down the fail-closed blackhole if one lingers (engine died,
+	// blackhole engaged, then the user disabled the router): delete its rules
+	// file, scrub the jump, drop the chain.
+	it.RemoveBlackhole(ctx)
 	it.removeSourceHooks(ctx)
 	_ = it.runIPTables(ctx, "-t", "mangle", "-F", ChainName)
 	_ = it.runIPTables(ctx, "-t", "mangle", "-X", ChainName)

--- a/internal/singbox/router/iptables.go
+++ b/internal/singbox/router/iptables.go
@@ -453,6 +453,26 @@ func buildBlackholeRestoreInput(spec RestoreInputSpec) string {
 	fmt.Fprintf(&b, ":%s - [0:0]\n", BlackholeChain)
 	// User bypass first — an explicitly excluded subnet must never be dropped.
 	emitUserBypassReturns(&b, BlackholeChain, spec.BypassCIDRs)
+	// User bypass ports (BOTH protocols): traffic the user deliberately keeps off
+	// the proxy (STUN/VoIP/WireGuard/games) must go direct, not be dropped. The
+	// blackhole matches every protocol (connmark on the jump, no -p filter), so it
+	// must honour the TCP ports too — even though real TCP interception lives in
+	// the nat chain, the fail-closed DROP here is the one place TCP policy traffic
+	// is dropped while the engine is down.
+	for _, pr := range spec.BypassUDPPorts {
+		fmt.Fprintf(&b, "-A %s -p udp --dport %s -j RETURN\n", BlackholeChain, pr.String())
+	}
+	for _, pr := range spec.BypassTCPPorts {
+		fmt.Fprintf(&b, "-A %s -p tcp --dport %s -j RETURN\n", BlackholeChain, pr.String())
+	}
+	// Selective mode: only destinations in AWGM-SELECTIVE are proxied; everything
+	// else is SUPPOSED to go direct to WAN. Mirror the interception guard so the
+	// blackhole drops ONLY the selective subset — without it a dead engine would
+	// blackhole the user's entire (mostly non-selective) traffic, taking policy
+	// devices fully offline, which is worse than the fail-open it replaces.
+	if spec.SelectiveIPSet {
+		fmt.Fprintf(&b, "-A %s -m set ! --match-set %s dst -j RETURN\n", BlackholeChain, selectiveSetName)
+	}
 	// LAN/loopback/CGNAT/multicast + router-owned WAN IPs: reused verbatim from
 	// the interception chain so the exclusion set cannot drift and the blackhole
 	// can never over-block router-local, LAN-to-LAN, or management traffic.

--- a/internal/singbox/router/iptables_test.go
+++ b/internal/singbox/router/iptables_test.go
@@ -429,8 +429,11 @@ func TestWriteNetfilterHookContainsPidofGuard(t *testing.T) {
 		t.Fatalf("read: %v", err)
 	}
 	body := string(data)
-	if !strings.Contains(body, "pidof sing-box >/dev/null 2>&1 || exit 0") {
-		t.Errorf("hook missing pidof guard:\n%s", body)
+	// The pidof guard now branches (alive → real interception, dead → fail-closed
+	// blackhole) instead of `|| exit 0`, so interception is only restored for a
+	// live engine while a dead engine still re-asserts the blackhole.
+	if !strings.Contains(body, "if pidof sing-box >/dev/null 2>&1; then") {
+		t.Errorf("hook missing pidof branch guard:\n%s", body)
 	}
 	if !strings.Contains(body, "iptables-restore --noflush") {
 		t.Errorf("hook missing restore line:\n%s", body)

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1997,12 +1997,27 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// течь в WAN, пока движок не вернётся. Снимается ниже, когда движок оживёт.
 	wantBlackhole := jumpsMissing && engineDown
 	if wantBlackhole {
+		bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
 		bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+		// Selective guard references the AWGM-SELECTIVE ipset; ensure it exists so
+		// iptables-restore of the blackhole doesn't fail with "Set ... doesn't
+		// exist" (same pre-create the real Install path does below).
+		if sr.SelectiveBypass {
+			if e := ensureSelectiveSetExists(ctx); e != nil {
+				s.appLog.Warn("selective", "", fmt.Sprintf("pre-create ipset for blackhole: %v", e))
+			}
+		}
+		// Mirror the real interception spec's exclusions (bypass ports + selective
+		// guard) so the blackhole drops EXACTLY what would have been proxied — not
+		// the user's non-selective traffic and not their bypass ports.
 		blackholeSpec := RestoreInputSpec{
-			PolicyMark:  mark,
-			MatchAll:    !policyMode,
-			WANIPs:      wanIPs,
-			BypassCIDRs: bypassSubnets,
+			PolicyMark:     mark,
+			MatchAll:       !policyMode,
+			WANIPs:         wanIPs,
+			BypassCIDRs:    bypassSubnets,
+			BypassUDPPorts: bypassUDP,
+			BypassTCPPorts: bypassTCP,
+			SelectiveIPSet: sr.SelectiveBypass,
 		}
 		s.mu.Lock()
 		err := s.deps.IPTables.InstallBlackhole(ctx, blackholeSpec)
@@ -2091,20 +2106,23 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 		}
 	}
 
-	// Движок вернулся (или джампы целы) — реальный перехват снова главный,
-	// снимаем fail-closed blackhole. Делаем это ПОСЛЕ реального Install (выше),
-	// чтобы между снятием blackhole и восстановлением перехвата не было окна
-	// утечки. Идемпотентно: RemoveBlackhole безопасен и без активного blackhole.
-	if !wantBlackhole {
+	// Снимаем fail-closed blackhole ТОЛЬКО когда движок жив И probe успешен —
+	// тогда реальный перехват гарантированно на месте (steady state с целыми
+	// jumps, либо только что переустановлен выше; при ошибке Install был ранний
+	// return). Делаем ПОСЛЕ реального Install, чтобы не было окна утечки между
+	// снятием blackhole и восстановлением перехвата. Критично: на probe-ОШИБКЕ
+	// (jumpsMissing→false из-за !nil err) или мёртвом движке blackhole СОХРАНЯЕМ,
+	// иначе транзиентная -S ошибка во время NDMS-reload снесла бы DROP при живой
+	// утечке и удалила бы rules-файл, обездвижив и netfilter.d-хук. Идемпотентно.
+	if !engineDown && probeErr == nil {
 		s.mu.Lock()
-		active := s.blackholeActive
-		s.mu.Unlock()
-		if active {
+		if s.blackholeActive {
 			s.deps.IPTables.RemoveBlackhole(ctx)
-			s.mu.Lock()
 			s.blackholeActive = false
 			s.mu.Unlock()
 			s.appLog.Info("reconcile", "", "движок восстановлен — fail-closed blackhole снят")
+		} else {
+			s.mu.Unlock()
 		}
 	}
 

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -401,6 +401,12 @@ type ServiceImpl struct {
 	// After Install succeeds the flag is set to true until Disable resets it.
 	netfilterStateKnown bool
 
+	// blackholeActive tracks whether the fail-closed DROP chain is currently
+	// engaged (installed by reconcileInstalled while sing-box is dead and the
+	// PREROUTING interception jumps were wiped). It is removed the moment the
+	// engine recovers. Guarded by s.mu, like the other current* install state.
+	blackholeActive bool
+
 	// selective tracking
 	currentSelectiveBypass bool // last-applied value of SelectiveBypass
 
@@ -1724,6 +1730,9 @@ func (s *ServiceImpl) Disable(ctx context.Context) error {
 	s.currentSelectiveBypass = false
 	s.currentQoSClasses = nil
 	s.netfilterStateKnown = false
+	// Uninstall already tore down the fail-closed blackhole (if any); clear the
+	// tracking flag so a later reconcile doesn't try to remove it again.
+	s.blackholeActive = false
 
 	if s.deps.Orch != nil {
 		// Move 20-router.json under disabled/ — sing-box's non-recursive
@@ -1979,14 +1988,34 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// during an NDMS reload must not trigger a needless rebuild.
 	_, jumps, probeErr := s.deps.IPTables.Probe(ctx)
 	jumpsMissing := probeErr == nil && !jumps
-	if jumpsMissing && engineDown {
-		// Не восстанавливаем перехват в мёртвый порт (FIX-B): движок не
-		// работает (рестарт подавлен или не удался), и вернуть PREROUTING-
-		// джампы значило бы направить трафик политик (включая hijacked
-		// DNS:53) в никуда на всю паузу backoff'а. Существующие правила НЕ
-		// трогаем — fail-closed остаётся, VPN не должен fail-open'иться;
-		// просто не долечиваем отсутствующие jump'ы на этом тике.
-		s.appLog.Warn("reconcile", "", "PREROUTING jumps missing, но движок не работает — пропускаем восстановление перехвата на этот тик")
+	// wantBlackhole: движок мёртв И PREROUTING-джампы снесены (NDMS перестроил
+	// firewall). Раньше здесь перехват просто не восстанавливался в мёртвый порт
+	// (FIX-B), НО при снесённых джампах это означало fail-OPEN: policy-трафик
+	// уходил в обычный роутинг Keenetic → в WAN мимо proxy/AWG. Теперь ставим
+	// явный fail-closed blackhole — DROP policy-трафика (с теми же RETURN-
+	// исключениями LAN/router/WAN, что и у перехвата), чтобы гарантированно НЕ
+	// течь в WAN, пока движок не вернётся. Снимается ниже, когда движок оживёт.
+	wantBlackhole := jumpsMissing && engineDown
+	if wantBlackhole {
+		bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+		blackholeSpec := RestoreInputSpec{
+			PolicyMark:  mark,
+			MatchAll:    !policyMode,
+			WANIPs:      wanIPs,
+			BypassCIDRs: bypassSubnets,
+		}
+		s.mu.Lock()
+		err := s.deps.IPTables.InstallBlackhole(ctx, blackholeSpec)
+		if err == nil {
+			s.blackholeActive = true
+		}
+		s.mu.Unlock()
+		if err != nil {
+			s.appLog.Warn("reconcile", "", "не удалось поставить fail-closed blackhole: "+err.Error())
+		} else {
+			s.appLog.Warn("reconcile", "", "движок не работает, PREROUTING jumps снесены — включён fail-closed blackhole (policy-трафик дропается, не течёт в WAN)")
+		}
+		// Реальный перехват в мёртвый порт всё равно не восстанавливаем.
 		jumpsMissing = false
 	}
 	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged || selectiveChanged || qosChanged
@@ -2059,6 +2088,23 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 			if _, err := s.stripLegacySelectiveRulesFromRouter(ctx); err != nil {
 				s.appLog.Warn("selective", "", fmt.Sprintf("strip legacy selective rules: %v", err))
 			}
+		}
+	}
+
+	// Движок вернулся (или джампы целы) — реальный перехват снова главный,
+	// снимаем fail-closed blackhole. Делаем это ПОСЛЕ реального Install (выше),
+	// чтобы между снятием blackhole и восстановлением перехвата не было окна
+	// утечки. Идемпотентно: RemoveBlackhole безопасен и без активного blackhole.
+	if !wantBlackhole {
+		s.mu.Lock()
+		active := s.blackholeActive
+		s.mu.Unlock()
+		if active {
+			s.deps.IPTables.RemoveBlackhole(ctx)
+			s.mu.Lock()
+			s.blackholeActive = false
+			s.mu.Unlock()
+			s.appLog.Info("reconcile", "", "движок восстановлен — fail-closed blackhole снят")
 		}
 	}
 

--- a/internal/singbox/router/service_reconcile_restart_test.go
+++ b/internal/singbox/router/service_reconcile_restart_test.go
@@ -192,23 +192,53 @@ func chainsOnlyDump() string {
 		"-N " + RedirectChain + "\n"
 }
 
-// FIX-B: движок мёртв и рестарт подавлен (backoff/ручной Stop) → jump-heal
-// НЕ восстанавливает перехват в мёртвый порт: Install не вызывается,
-// существующие правила не трогаются (fail-closed остаётся).
-func TestReconcileInstalled_DeadEngineSkipsJumpHeal(t *testing.T) {
+// Fail-closed: движок мёртв, рестарт подавлен И PREROUTING-джампы снесены
+// (chainsOnlyDump) → НЕ восстанавливаем перехват в мёртвый порт, а ставим
+// blackhole-DROP policy-трафика, чтобы он не утёк в WAN. Ровно один restore —
+// blackhole-блоб, не реальный перехват; флаг blackholeActive выставлен.
+func TestReconcileInstalled_DeadEngineInstallsBlackhole(t *testing.T) {
 	sb := newTestSingbox(t)                                                   // IsRunning=false весь тест
 	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil } // suppressed
 	svc := newReconcileInstalledService(t, sb)
-	installs := 0
-	ipt := newStubIPTables(func(_ context.Context, _ string) error { installs++; return nil })
+	var restores []string
+	ipt := newStubIPTables(func(_ context.Context, in string) error { restores = append(restores, in); return nil })
 	ipt.runIPTablesOut = func(_ context.Context, _ ...string) (string, error) { return chainsOnlyDump(), nil }
 	svc.deps.IPTables = ipt
 
 	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
 		t.Fatalf("reconcileInstalled: %v", err)
 	}
-	if installs != 0 {
-		t.Errorf("Install calls = %d, want 0 (no jump restore into a dead port)", installs)
+	if len(restores) != 1 {
+		t.Fatalf("restore calls = %d, want 1 (blackhole only, no real interception)", len(restores))
+	}
+	if !strings.Contains(restores[0], "-A "+BlackholeChain+" -j DROP") {
+		t.Errorf("restored blob is not the fail-closed blackhole:\n%s", restores[0])
+	}
+	if strings.Contains(restores[0], ChainName) {
+		t.Errorf("must NOT restore real interception (%s) into a dead port:\n%s", ChainName, restores[0])
+	}
+	if !svc.blackholeActive {
+		t.Error("blackholeActive must be set after installing the fail-closed blackhole")
+	}
+}
+
+// Движок вернулся (jumps present, IsRunning=true) → ранее поставленный
+// fail-closed blackhole снимается: cleanupBlackhole вызван, флаг сброшен.
+func TestReconcileInstalled_EngineRecoveryRemovesBlackhole(t *testing.T) {
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 4242 } // alive
+	svc := newReconcileInstalledService(t, sb)
+	svc.blackholeActive = true // как будто прошлый тик поставил blackhole
+	removed := false
+	ipt := newStubIPTables(func(_ context.Context, _ string) error { return nil })
+	ipt.cleanupBlackhole = func() { removed = true }
+	svc.deps.IPTables = ipt
+
+	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
+		t.Fatalf("reconcileInstalled: %v", err)
+	}
+	if !removed || svc.blackholeActive {
+		t.Errorf("engine recovery must drop the blackhole: cleanup=%v active=%v", removed, svc.blackholeActive)
 	}
 }
 

--- a/internal/singbox/router/service_reconcile_restart_test.go
+++ b/internal/singbox/router/service_reconcile_restart_test.go
@@ -222,6 +222,30 @@ func TestReconcileInstalled_DeadEngineInstallsBlackhole(t *testing.T) {
 	}
 }
 
+// Regression (ревью lifecycle): probe-ОШИБКА при мёртвом движке НЕ должна
+// снимать blackhole. Иначе транзиентная -S ошибка во время NDMS-reload (ровно
+// когда blackhole и нужен) снесла бы DROP при живой утечке. blackhole сохраняем.
+func TestReconcileInstalled_ProbeErrorPreservesBlackhole(t *testing.T) {
+	sb := newTestSingbox(t)                                                   // dead
+	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil } // suppressed
+	svc := newReconcileInstalledService(t, sb)
+	svc.blackholeActive = true // прошлый тик поставил blackhole
+	removed := false
+	ipt := newStubIPTables(func(_ context.Context, _ string) error { return nil })
+	ipt.runIPTablesOut = func(_ context.Context, _ ...string) (string, error) {
+		return "", errors.New("iptables -S failed (NDMS reload)")
+	}
+	ipt.cleanupBlackhole = func() { removed = true }
+	svc.deps.IPTables = ipt
+
+	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
+		t.Fatalf("reconcileInstalled: %v", err)
+	}
+	if removed || !svc.blackholeActive {
+		t.Errorf("probe error + dead engine must PRESERVE blackhole: removed=%v active=%v", removed, svc.blackholeActive)
+	}
+}
+
 // Движок вернулся (jumps present, IsRunning=true) → ранее поставленный
 // fail-closed blackhole снимается: cleanupBlackhole вызван, флаг сброшен.
 func TestReconcileInstalled_EngineRecoveryRemovesBlackhole(t *testing.T) {


### PR DESCRIPTION
Safety-серия по итогам аудита supervision sing-box, пункт 1. **PR открыт до проверки на роутере** — поведение iptables-DROP и netfilter.d-хука верифицируется только на железе (как #455).

## Проблема (fail-open утечка)

При мёртвом движке И снесённых PREROUTING-джампах (NDMS перестроил firewall) `reconcileInstalled` раньше просто пропускал восстановление перехвата в мёртвый порт (FIX-B из #456). Но при **снесённых** джампах это означало **fail-OPEN**: policy-трафик проваливался в обычный роутинг Keenetic → в WAN мимо proxy/AWG, хотя пользователь ждёт, что он пойдёт через туннель. Комментарий в коде утверждал «fail-closed остаётся» — но в под-случае со снесёнными джампами это было не так.

## Решение

Явный **fail-closed blackhole**: пока движок не вернётся, policy-трафик дропается, а не утекает.

- **Цепочка mangle `AWGM-BLACKHOLE`**: те же RETURN-исключения, что и у перехвата — пользовательский bypass, bypass UDP/TCP порты, selective-guard (`-m set ! --match-set AWGM-SELECTIVE dst`), LAN/loopback/CGNAT/multicast + router-WAN-IP, — затем терминальный DROP; вход из PREROUTING по идентичному policy-селектору (connmark или MatchAll). Дропает ровно тот трафик, что ушёл бы в `AWGM-TPROXY`, и ничего лишнего (LAN, роутер, управляющий UI, selective-исключения, bypass-порты сохранены). mangle, а не nat — чтобы ловить все пакеты потока, не только первый.
- **`IPTables.InstallBlackhole`/`RemoveBlackhole`** (iptables-restore --noflush), идемпотентны; blackhole-правила персистятся в отдельный файл.
- **Жизненный цикл в `reconcileInstalled`**: ставим на `engineDown && jumpsMissing`; снимаем ПОСЛЕ реального Install **только** при живом движке и успешном probe (`!engineDown && probeErr == nil`) — на probe-ошибке или мёртвом движке сохраняем (иначе транзиентная `-S` ошибка во время NDMS-reload снесла бы DROP при живой утечке). Флаг `s.blackholeActive` под `s.mu`; Disable/Uninstall его снимают.
- **netfilter.d-хук**: alive → реальный перехват (+scrub залежавшегося blackhole); dead → восстановление blackhole (раньше хук просто выходил при мёртвом движке — оставалось окно утечки до следующего reconcile-тика).

## Ревью (Fable 5, 3 угла)

- **Семантика цепочки**: нашла 2 over-block бага — отсутствие selective-guard (HIGH: ронял весь трафик в selective-режиме) и bypass-портов (MEDIUM). **Исправлено.**
- **Жизненный цикл**: нашёл HIGH — probe-ошибка снимала blackhole при мёртвом движке (реоткрытие утечки + удаление rules-файла обездвиживало хук). **Исправлено** (гейт по `!engineDown && probeErr==nil`).
- **Shell-хук**: вердикт корректно, дефектов нет (alive-путь сохранён дословно, портируемо под BusyBox ash, exit-коды 0).

Все фиксы применены и покрыты тестами.

## Проверки

- `go test ./internal/singbox/router/` + новые тесты (builder policy/MatchAll/selective/bypass-порты, Install/Remove, reconcile install+recovery+probe-error-preserve, хук sh -n + контент): зелёные
- `go vet`, gofmt: чисто; кросс-компиляция mips/mipsle/arm64 (softfloat): OK
- обновлён устаревший FIX-B тест под новое поведение

## На проверку на роутере
- [ ] При мёртвом движке + NDMS-reload policy-трафик дропается (не течёт в WAN)
- [ ] LAN/управляющий UI/DNS роутера/LAN-to-LAN живы при активном blackhole
- [ ] selective-режим: не-selective трафик идёт напрямую, selective — дропается
- [ ] bypass-порты (STUN/VoIP/WG) работают при активном blackhole
- [ ] При возврате движка blackhole снимается, перехват восстанавливается без окна утечки
- [ ] netfilter.d-хук переасертит blackhole при мёртвом движке на NDMS-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_