### PR TITLE
refactor(sb-router): единственный рестарт-авторитет — watchdog (safety-2) [stacked на #471]

### DIFF
--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -2700,9 +2700,10 @@ func (o *Operator) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// AutoRestartIfCrashed is the shared entry point for AUTOMATIC recovery
-// of a dead sing-box (router tproxy/fakeip reconcile loops; the watchdog
-// path uses the waitClash variant via Reconcile). It respects the sticky
+// autoRestartIfCrashed is the shared entry point for AUTOMATIC recovery of a
+// dead sing-box. The ONLY production caller is the watchdog via Reconcile
+// (waitClash=true) — the router reconcile loops no longer restart the engine
+// themselves (watchdog is the single restart authority). It respects the sticky
 // manual-stop intent and the crash-loop backoff:
 //
 //	restarted=true  — the process was dead and has been started;
@@ -2712,16 +2713,7 @@ func (o *Operator) Reconcile(ctx context.Context) error {
 //	err != nil      — the start itself failed.
 //
 // Manual Control("start"/"restart") stays ungated and resets the backoff.
-// Satisfies part of router.SingboxController.
-func (o *Operator) AutoRestartIfCrashed(ctx context.Context) (restarted, suppressed bool, err error) {
-	// Router callers do their own mode-aware readiness wait
-	// (waitForSingbox: tun carrier / inbound sockets), so this variant
-	// spawns without gating on the Clash API — same semantics the fakeip
-	// drift-heal had with plain Start().
-	return o.autoRestartIfCrashed(ctx, false)
-}
-
-// autoRestartIfCrashed implements AutoRestartIfCrashed. waitClash=true
+// waitClash=true
 // (Operator.Reconcile / watchdog) preserves the legacy startAndWait
 // behaviour — block until the Clash API answers, stop the half-started
 // process on timeout. waitClash=false spawns via Start (validate +

--- a/internal/singbox/operator_autorestart_test.go
+++ b/internal/singbox/operator_autorestart_test.go
@@ -151,12 +151,12 @@ func TestOperator_AutoRestartIfCrashed_BackoffSuppression(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < restartFreeBudget; i++ {
-		restarted, suppressed, err := op.AutoRestartIfCrashed(ctx)
+		restarted, suppressed, err := op.autoRestartIfCrashed(ctx, false)
 		if err != nil || !restarted || suppressed {
 			t.Fatalf("attempt %d: restarted=%v suppressed=%v err=%v, want restart", i+1, restarted, suppressed, err)
 		}
 	}
-	restarted, suppressed, err := op.AutoRestartIfCrashed(ctx)
+	restarted, suppressed, err := op.autoRestartIfCrashed(ctx, false)
 	if err != nil || restarted || !suppressed {
 		t.Fatalf("over-budget: restarted=%v suppressed=%v err=%v, want suppressed", restarted, suppressed, err)
 	}
@@ -169,7 +169,7 @@ func TestOperator_AutoRestartIfCrashed_BackoffSuppression(t *testing.T) {
 	}
 	// Ручной сброс (как Control("restart")) → снова можно.
 	op.restartBackoff.Reset()
-	restarted, suppressed, err = op.AutoRestartIfCrashed(ctx)
+	restarted, suppressed, err = op.autoRestartIfCrashed(ctx, false)
 	if err != nil || !restarted || suppressed {
 		t.Fatalf("after reset: restarted=%v suppressed=%v err=%v, want restart", restarted, suppressed, err)
 	}
@@ -182,7 +182,7 @@ func TestOperator_AutoRestartIfCrashed_ManualStopNoop(t *testing.T) {
 	_, plainStarts := seedStartSeam(op)
 	op.manuallyStopped.Store(true)
 
-	restarted, suppressed, err := op.AutoRestartIfCrashed(context.Background())
+	restarted, suppressed, err := op.autoRestartIfCrashed(context.Background(), false)
 	if err != nil || restarted || suppressed {
 		t.Fatalf("manual stop: restarted=%v suppressed=%v err=%v, want all-false", restarted, suppressed, err)
 	}
@@ -369,7 +369,7 @@ func TestOperator_AutoRestart_ManualStopDuringStartWins(t *testing.T) {
 		return true, nil
 	}
 
-	restarted, suppressed, err := op.AutoRestartIfCrashed(context.Background())
+	restarted, suppressed, err := op.autoRestartIfCrashed(context.Background(), false)
 	if err != nil || restarted || !suppressed {
 		t.Fatalf("restarted=%v suppressed=%v err=%v, want suppressed (manual stop during start)", restarted, suppressed, err)
 	}
@@ -427,7 +427,7 @@ func TestOperator_AutoRestart_StartFailureRecordsCrash(t *testing.T) {
 		return false, errors.New("sing-box exited during startup: FATAL boom")
 	}
 
-	_, _, err := op.AutoRestartIfCrashed(context.Background())
+	_, _, err := op.autoRestartIfCrashed(context.Background(), false)
 	if err == nil {
 		t.Fatalf("want start error")
 	}
@@ -450,7 +450,7 @@ func TestOperator_AutoRestart_StartFailureNoDoubleCount(t *testing.T) {
 		return true, errors.New("clash API not ready after 60s")
 	}
 
-	_, _, err := op.AutoRestartIfCrashed(context.Background())
+	_, _, err := op.autoRestartIfCrashed(context.Background(), false)
 	if err == nil {
 		t.Fatalf("want start error")
 	}
@@ -474,7 +474,7 @@ func TestOperator_AutoRestart_NoSpawnRefundsBudget(t *testing.T) {
 	ctx := context.Background()
 	// Вдвое больше бюджета «проигранных гонок» — ни одна не должна жечь Allow.
 	for i := 0; i < restartFreeBudget*2; i++ {
-		restarted, suppressed, err := op.AutoRestartIfCrashed(ctx)
+		restarted, suppressed, err := op.autoRestartIfCrashed(ctx, false)
 		if err != nil || restarted || suppressed {
 			t.Fatalf("no-op attempt %d: restarted=%v suppressed=%v err=%v, want all-false", i+1, restarted, suppressed, err)
 		}
@@ -482,12 +482,12 @@ func TestOperator_AutoRestart_NoSpawnRefundsBudget(t *testing.T) {
 	// Бюджет цел: настоящие спавны всё ещё разрешены в полном объёме.
 	spawned = true
 	for i := 0; i < restartFreeBudget; i++ {
-		restarted, suppressed, err := op.AutoRestartIfCrashed(ctx)
+		restarted, suppressed, err := op.autoRestartIfCrashed(ctx, false)
 		if err != nil || !restarted || suppressed {
 			t.Fatalf("real attempt %d: restarted=%v suppressed=%v err=%v, want restart (budget must be intact)", i+1, restarted, suppressed, err)
 		}
 	}
-	if _, suppressed, _ := op.AutoRestartIfCrashed(ctx); !suppressed {
+	if _, suppressed, _ := op.autoRestartIfCrashed(ctx, false); !suppressed {
 		t.Fatalf("over-budget: want suppressed after %d real spawns", restartFreeBudget)
 	}
 	if starts != restartFreeBudget*3 {

--- a/internal/singbox/router/fakeip_reconcile.go
+++ b/internal/singbox/router/fakeip_reconcile.go
@@ -69,14 +69,15 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 	iface := fakeIPIfaceName(st.Index)   // kernel name: /proc route probe, log labels
 	ndmsName := fakeIPNDMSName(st.Index) // NDMS RCI name: static-route Interface
 
-	// Restart a dead sing-box. The idempotency guard skips this; the drift-heal
-	// MUST do it or a crashed process stays down until the next Enable. Bounded
-	// wait: log on timeout, don't hard-fail a reconcile.
+	// Dead sing-box: the single restart authority is the watchdog
+	// (Operator.Reconcile), not this drift-heal — router reconciles no longer
+	// restart the engine themselves (see reconcileInstalled). We only ensure the
+	// fakeip slot is enabled in the merged config so the watchdog's restart
+	// brings it back up. Fail-closed while down is inherent to fakeip: the pool
+	// routes point at OpkgTun, whose reader (sing-box) is gone, so traffic to the
+	// fakeip pool is dropped, not leaked, until the watchdog revives the process.
 	if running, _ := s.deps.Singbox.IsRunning(); !running {
-		// Ensure the slot file is enabled (idempotent). NB: SetEnabled is a
-		// no-op when the slot is already enabled (orchestrator.go), so it can
-		// NOT revive a process that died with the slot on — we must start the
-		// process directly below.
+		// Ensure the slot file is enabled (idempotent no-op when already on).
 		if s.deps.Orch != nil {
 			if e := s.deps.Orch.SetEnabled(orchestrator.SlotFakeIP, true); e != nil {
 				s.appLog.Warn("fakeip-reconcile", iface, "enable slot: "+e.Error())
@@ -85,19 +86,6 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 				// восстановить композитные ссылки (ветка reprovision покрыта
 				// через enableLocked, эта — нет).
 				s.notifyRoutingSlotsChanged()
-			}
-		}
-		// Спавн через общий backoff-гейт (#456) вместо прямого Start():
-		// уважает ручной Stop (раньше drift-heal воскрешал остановленный
-		// пользователем движок) и подавляет crash-loop; сам запуск — тот же
-		// Singbox.Start (без clash-гейта), readiness ждём ниже как раньше.
-		restarted, _, rerr := s.deps.Singbox.AutoRestartIfCrashed(ctx)
-		switch {
-		case rerr != nil:
-			s.appLog.Warn("fakeip-reconcile", iface, "restart sing-box: "+rerr.Error())
-		case restarted:
-			if e := s.waitForSingbox(ctx, bootWaitWithFloor()); e != nil {
-				s.appLog.Warn("fakeip-reconcile", iface, "sing-box not ready after restart: "+e.Error())
 			}
 		}
 	}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -130,12 +130,6 @@ type SingboxController interface {
 	// (stderr FATAL line or exit tail). Empty after a clean start.
 	// Surfaced via Status.LastError so the UI explains «СБОЙ».
 	LastError() string
-	// AutoRestartIfCrashed restarts a dead sing-box through the shared
-	// crash-loop backoff (issue #456). Respects the sticky manual-stop
-	// intent (all-false return). ONLY for automatic reconcile paths —
-	// user actions go through the ungated Control API. Callers still do
-	// their own mode-aware readiness wait after restarted=true.
-	AutoRestartIfCrashed(ctx context.Context) (restarted, suppressed bool, err error)
 	// CrashStats returns crash observability for Status (issue #456):
 	// crashes within the recent window, the reason of the newest one,
 	// and until when auto-restart is suppressed (zero = not suppressed).
@@ -1832,37 +1826,19 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	if err != nil {
 		return err
 	}
-	// Мёртвый sing-box при живых iptables (issue #456): цепочки и
-	// PREROUTING-джампы целы, но процесс упал (OOM и т.п.) — перехваченный
-	// трафик уходит в никуда, а этот reconcile раньше лечил только iptables.
-	// Зеркалим fakeip-ветку (fakeip_reconcile.go): перезапуск через общий
-	// backoff-гейт — ручной Stop и анти-crash-loop пауза уважаются внутри
-	// AutoRestartIfCrashed (подавление логируется там один раз на смену
-	// состояния, не каждый 30s-тик).
-	// engineDown: движок не работает и восстановить его на этом тике не
-	// вышло (рестарт подавлен backoff'ом / ручным Stop, либо сам старт
-	// упал). Ниже это гасит восстановление PREROUTING-джампов (FIX-B):
-	// лечить перехват в мёртвый порт нельзя.
+	// Единственный рестарт-авторитет sing-box — watchdog (Operator.Reconcile,
+	// свой независимый 30s-тик). Router-reconcile больше НЕ рестартит движок
+	// сам: раньше это был второй независимый авторитет (#456), и вся
+	// токен-машинерия backoff'а существовала только чтобы примирить гонку двух
+	// рестартёров. Здесь лишь фиксируем факт смерти движка: engineDown ниже
+	// (а) включит fail-closed blackhole вместо перехвата в мёртвый порт,
+	// (б) погасит heal PREROUTING-джампов. Движок поднимет watchdog своим тиком;
+	// следующий reconcile-тик при живом движке восстановит перехват и снимет
+	// blackhole. Fail-closed держится blackhole'ом всё время, пока движок мёртв.
 	engineDown := false
 	if s.deps.Singbox != nil {
 		if running, _ := s.deps.Singbox.IsRunning(); !running {
-			restarted, _, rerr := s.deps.Singbox.AutoRestartIfCrashed(ctx)
-			switch {
-			case rerr != nil:
-				s.appLog.Warn("reconcile", "", "restart dead sing-box: "+rerr.Error())
-			case restarted:
-				// Дожидаемся inbound-сокетов, чтобы дальнейшие шаги (re-Install
-				// iptables) не направили трафик на порты, которые ещё не слушаются.
-				// Мягкий дедлайн: на таймауте продолжаем, как QoS-heal ниже.
-				if alive, _ := s.deps.Singbox.IsRunning(); alive {
-					if e := s.waitForSingbox(ctx, bootWaitWithFloor()); e != nil {
-						s.appLog.Warn("reconcile", "", "sing-box not ready after restart: "+e.Error())
-					}
-				}
-			}
-			if alive, _ := s.deps.Singbox.IsRunning(); !alive {
-				engineDown = true
-			}
+			engineDown = true
 		}
 	}
 	if sr.SelectiveBypass {

--- a/internal/singbox/router/service_fakeipreconcile_test.go
+++ b/internal/singbox/router/service_fakeipreconcile_test.go
@@ -220,7 +220,12 @@ func TestReconcileFakeIPTun_ReprovisionsWhenGone(t *testing.T) {
 // routes re-added, DNS re-advertised.
 // ---------------------------------------------------------------------------
 
-func TestReconcileFakeIPTun_DriftHealRestartsDeadSingbox(t *testing.T) {
+// Единственный рестарт-авторитет — watchdog. fakeip drift-heal при мёртвом
+// движке НЕ спавнит сам (раньше звал AutoRestartIfCrashed, #456): только
+// гарантирует, что слот включён, и продолжает best-effort heal маршрутов.
+// Fail-closed при этом врождён fakeip: pool-маршруты ведут на OpkgTun, чей
+// читатель (sing-box) мёртв → трафик к пулу дропается, не течёт в WAN.
+func TestReconcileFakeIPTun_DriftHealNoRestartByReconcile(t *testing.T) {
 	h := newFakeIPEnableHarness(t, "")
 
 	// Provision with sing-box running so Enable succeeds.
@@ -230,39 +235,20 @@ func TestReconcileFakeIPTun_DriftHealRestartsDeadSingbox(t *testing.T) {
 	h.svc.deps.OpkgTunIndices = &recIndices{live: map[int]bool{0: true}}
 	h.log.calls = nil
 
-	// Now model a DEAD sing-box that comes back up after the restart: IsRunning
-	// returns false on the first call (the drift-heal liveness check) then true
-	// (waitForSingbox readiness).
 	sb := h.svc.deps.Singbox.(*fakeSingbox)
-	calls := 0
-	sb.isRunningFn = func() (bool, int) {
-		calls++
-		if calls == 1 {
-			return false, 0
-		}
-		return true, 1234
-	}
+	sb.isRunningFn = func() (bool, int) { return false, 0 } // мёртв весь тест
 
-	// Track the orchestrator restart: SetEnabled(SlotFakeIP,true) is the restart.
-	// The real orch records it via the slot's enabled file; assert via behaviour —
-	// after the heal, routes were re-added.
 	all, _ := h.store.Load()
 	sr, _ := NormalizeSingboxRouterSettings(all.SingboxRouter)
 	if err := h.svc.reconcileFakeIPTun(context.Background(), sr); err != nil {
 		t.Fatalf("reconcileFakeIPTun: %v", err)
 	}
 
-	if calls < 1 {
-		t.Fatalf("IsRunning was never probed (restart path not taken)")
+	// Drift-heal must NOT respawn — that is the watchdog's job now.
+	if sb.startCalls != 0 {
+		t.Errorf("drift-heal must NOT restart (watchdog is the sole authority): startCalls = %d, want 0", sb.startCalls)
 	}
-	// The drift-heal MUST directly (re)spawn the dead process: SetEnabled is a
-	// no-op for an already-enabled slot (Orch != nil here), so only an explicit
-	// Singbox.Start() actually revives it. Assert the spawn happened exactly once.
-	if sb.startCalls != 1 {
-		t.Errorf("Singbox.Start calls = %d, want 1 (drift-heal must respawn the dead process)", sb.startCalls)
-	}
-	// Routes re-added because the live route probe is unstubbed here → reads
-	// /proc/net/route → opkgtun0 route absent → drift detected → re-add fires.
+	// Route heal still runs best-effort even with the engine down.
 	if !h.log.has("AddRoute:198.18.0.0:255.254.0.0:OpkgTun0") {
 		t.Errorf("drift-heal must re-add v4 pool route when absent, got %v", h.log.calls)
 	}

--- a/internal/singbox/router/service_reconcile_restart_test.go
+++ b/internal/singbox/router/service_reconcile_restart_test.go
@@ -37,91 +37,33 @@ var reconcileInstalledSettings = storage.SingboxRouterSettings{
 	WANAutoDetect: true,
 }
 
-// Мёртвый sing-box при живых iptables (#456): tproxy-reconcile обязан
-// попытаться перезапустить процесс через AutoRestartIfCrashed.
-func TestReconcileInstalled_DeadSingboxRestarted(t *testing.T) {
+// Единственный рестарт-авторитет — watchdog (Operator.Reconcile). Мёртвый
+// sing-box: tproxy-reconcile НЕ рестартит сам (раньше это был второй авторитет,
+// #456). Fail-closed при этом держит blackhole (при снесённых джампах) или
+// перехват в мёртвый порт (при целых). Движок поднимет watchdog своим тиком.
+func TestReconcileInstalled_DeadSingboxNotRestartedByReconcile(t *testing.T) {
 	sb := newTestSingbox(t) // IsRunning по умолчанию false — «процесс мёртв»
 	svc := newReconcileInstalledService(t, sb)
 
 	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
 		t.Fatalf("reconcileInstalled: %v", err)
 	}
-	if sb.startCalls != 1 {
-		t.Errorf("restart attempts = %d, want 1 (dead process must be respawned)", sb.startCalls)
+	if sb.startCalls != 0 {
+		t.Errorf("reconcile must NOT restart (watchdog is the sole authority): startCalls = %d, want 0", sb.startCalls)
 	}
 }
 
-// Живой sing-box не трогаем: ни одного вызова AutoRestartIfCrashed/Start.
+// Живой sing-box не трогаем: ни рестарта, ни спавна.
 func TestReconcileInstalled_AliveSingboxUntouched(t *testing.T) {
 	sb := newTestSingbox(t)
 	sb.isRunningFn = func() (bool, int) { return true, 1234 }
-	autoCalls := 0
-	sb.autoRestartFn = func() (bool, bool, error) { autoCalls++; return true, false, nil }
-	svc := newReconcileInstalledService(t, sb)
-
-	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
-		t.Fatalf("reconcileInstalled: %v", err)
-	}
-	if autoCalls != 0 || sb.startCalls != 0 {
-		t.Errorf("alive process must be untouched: autoRestart=%d start=%d, want 0/0", autoCalls, sb.startCalls)
-	}
-}
-
-// Подавленный перезапуск (ручной Stop или backoff внутри Operator) не
-// валит reconcile и не спавнит процесс: остальная работа (iptables)
-// продолжается штатно.
-func TestReconcileInstalled_SuppressedRestartRespected(t *testing.T) {
-	sb := newTestSingbox(t)
-	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil } // suppressed
 	svc := newReconcileInstalledService(t, sb)
 
 	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
 		t.Fatalf("reconcileInstalled: %v", err)
 	}
 	if sb.startCalls != 0 {
-		t.Errorf("suppressed restart must not spawn: startCalls = %d, want 0", sb.startCalls)
-	}
-}
-
-// Ошибка перезапуска логируется и не прерывает reconcile (best-effort,
-// как остальные heal-шаги).
-func TestReconcileInstalled_RestartErrorIsSoft(t *testing.T) {
-	sb := newTestSingbox(t)
-	sb.autoRestartFn = func() (bool, bool, error) { return false, false, errors.New("boom") }
-	svc := newReconcileInstalledService(t, sb)
-
-	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
-		t.Fatalf("reconcileInstalled must not fail on restart error: %v", err)
-	}
-}
-
-// fakeip drift-heal: подавленный перезапуск (ручной Stop или backoff —
-// решает Operator внутри AutoRestartIfCrashed) не спавнит процесс и не
-// ждёт readiness. Регресс-защита: до #456 drift-heal звал Start() напрямую
-// и воскрешал остановленный пользователем движок.
-func TestReconcileFakeIPTun_DriftHealRespectsSuppression(t *testing.T) {
-	h := newFakeIPEnableHarness(t, "")
-	if err := h.svc.Enable(context.Background()); err != nil {
-		t.Fatalf("Enable: %v", err)
-	}
-	h.svc.deps.OpkgTunIndices = &recIndices{live: map[int]bool{0: true}}
-	h.log.calls = nil
-
-	sb := h.svc.deps.Singbox.(*fakeSingbox)
-	sb.isRunningFn = func() (bool, int) { return false, 0 } // мёртв весь тест
-	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil }
-
-	all, _ := h.store.Load()
-	sr, _ := NormalizeSingboxRouterSettings(all.SingboxRouter)
-	if err := h.svc.reconcileFakeIPTun(context.Background(), sr); err != nil {
-		t.Fatalf("reconcileFakeIPTun: %v", err)
-	}
-	if sb.startCalls != 0 {
-		t.Errorf("suppressed drift-heal must not spawn: startCalls = %d, want 0", sb.startCalls)
-	}
-	// Остальной heal (маршруты) продолжается best-effort.
-	if !h.log.has("AddRoute:198.18.0.0:255.254.0.0:OpkgTun0") {
-		t.Errorf("route heal must still run, got %v", h.log.calls)
+		t.Errorf("alive process must be untouched: start=%d, want 0", sb.startCalls)
 	}
 }
 
@@ -197,8 +139,7 @@ func chainsOnlyDump() string {
 // blackhole-DROP policy-трафика, чтобы он не утёк в WAN. Ровно один restore —
 // blackhole-блоб, не реальный перехват; флаг blackholeActive выставлен.
 func TestReconcileInstalled_DeadEngineInstallsBlackhole(t *testing.T) {
-	sb := newTestSingbox(t)                                                   // IsRunning=false весь тест
-	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil } // suppressed
+	sb := newTestSingbox(t) // IsRunning=false весь тест
 	svc := newReconcileInstalledService(t, sb)
 	var restores []string
 	ipt := newStubIPTables(func(_ context.Context, in string) error { restores = append(restores, in); return nil })
@@ -226,8 +167,7 @@ func TestReconcileInstalled_DeadEngineInstallsBlackhole(t *testing.T) {
 // снимать blackhole. Иначе транзиентная -S ошибка во время NDMS-reload (ровно
 // когда blackhole и нужен) снесла бы DROP при живой утечке. blackhole сохраняем.
 func TestReconcileInstalled_ProbeErrorPreservesBlackhole(t *testing.T) {
-	sb := newTestSingbox(t)                                                   // dead
-	sb.autoRestartFn = func() (bool, bool, error) { return false, true, nil } // suppressed
+	sb := newTestSingbox(t) // dead
 	svc := newReconcileInstalledService(t, sb)
 	svc.blackholeActive = true // прошлый тик поставил blackhole
 	removed := false


### PR DESCRIPTION
Safety-серия, пункт 2 (вариант B из аудита supervision). **Stacked на #471** (base = ветка safety-1) — мержить после #471; тогда diff схлопнется до собственных изменений.

## Проблема (структурная)

Аудит выявил **три независимых 30-секундных рестарт-авторитета** над одним процессом: watchdog, router `reconcileInstalled` (tproxy), router `reconcileFakeIPTun`. Все через один `restartBackoff`. Вся токен-машинерия backoff'а (`restartToken`, `spawned bool`, FIX-E) существовала только чтобы примирить гонку двух рестартёров. Плюс три определения «жив».

## Решение

**Единственный рестарт-авторитет — watchdog** (`Operator.Reconcile` → `autoRestartIfCrashed`, свой независимый 30s-тик). Router-reconcile'ы больше НЕ рестартят движок сами.

- `reconcileInstalled` (tproxy): убран `AutoRestartIfCrashed` + readiness-wait; `engineDown = !IsRunning`. При мёртвом движке fail-closed держит **blackhole** (safety-1) при снесённых джампах, либо перехват в мёртвый порт при целых.
- `reconcileFakeIPTun`: убран рестарт+wait; оставлен идемпотентный `SetEnabled` слота (чтобы рестарт watchdog поднял fakeip) + best-effort route-heal. Fail-closed врождён: pool-маршруты ведут на OpkgTun, чей читатель (sing-box) мёртв → трафик к пулу дропается.
- `Deps.Singbox`: удалён метод `AutoRestartIfCrashed` — **структурная гарантия**, что reconcile физически не может рестартить.
- Удалён мёртвый экспортированный `Operator.AutoRestartIfCrashed` (waitClash=false); тесты переведены на приватный вариант.

Движок поднимает watchdog своим тиком (та же 30s-каденция; `HasActiveWork` покрывает **оба** режима — не воскрешает #456); следующий reconcile-тик при живом движке восстанавливает перехват и снимает blackhole (≤30s, fail-closed всё это время).

## Ревью (Fable 5)

Вердикт **SAFE**, no-restart-hole нет. Подтверждено: watchdog рестартит в обоих режимах через `HasActiveWork` (не re-открывает #456), уважает manual-stop и backoff. Замечания LOW/theoretical (tproxy не re-asserts SlotRouter как fakeip — но состояние durable; убранный readiness-wait оставляет узкое окно unbound-сокета — **fail-closed дропает, не течёт**, это территория safety-3). INFO про мёртвый экспортированный метод — устранён.

## Проверки
- `go test ./internal/singbox/ ./internal/singbox/router/` + `-race`: зелёные
- `go vet`, gofmt: чисто; кросс mips/mipsle/arm64: OK
- тесты переписаны под B (reconcile НЕ рестартит tproxy и fakeip; watchdog — единственный)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_