### PR TITLE
fix(sb-router): хил iptables по singboxReady, не голому IsRunning (safety-3) [stacked на #472]

### DIFF
--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1835,12 +1835,18 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	// (б) погасит heal PREROUTING-джампов. Движок поднимет watchdog своим тиком;
 	// следующий reconcile-тик при живом движке восстановит перехват и снимет
 	// blackhole. Fail-closed держится blackhole'ом всё время, пока движок мёртв.
-	engineDown := false
+	//
+	// «Готов» = process + оба inbound-сокета ПРИВЯЗАНЫ (singboxReady, hard-gate
+	// #221), а не просто IsRunning. Процесс может быть жив, но inbound не
+	// привязался (порт занят, отклонённый hot-reload) — тогда установка iptables
+	// REDIRECT/TPROXY в непривязанный сокет заблэкхолила бы весь policy-трафик,
+	// включая DNS:53. Поэтому up-but-unbound трактуем как engineDown: ставим
+	// fail-closed blackhole и НЕ ставим реальный перехват, пока сокеты не встанут.
+	engineReady := true
 	if s.deps.Singbox != nil {
-		if running, _ := s.deps.Singbox.IsRunning(); !running {
-			engineDown = true
-		}
+		engineReady = s.singboxReady(ctx, false)
 	}
+	engineDown := !engineReady
 	if sr.SelectiveBypass {
 		if err := s.validateSelectiveBypassAgainstApplied(sr); err != nil {
 			if errors.Is(err, errSelectiveIncompatible) {
@@ -2010,6 +2016,17 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 		jumpsMissing = false
 	}
 	needsInstall := forceInitialSync || jumpsMissing || markChanged || wanIPsChanged || lanBridgesChanged || ingressChanged || bypassPresetsChanged || bypassExtraChanged || bypassSubnetsChanged || selectiveChanged || qosChanged
+
+	// Движок не готов интерсептить (мёртв или inbound-сокеты не привязаны) —
+	// НЕ ставим iptables ни по какому триггеру (#221): REDIRECT/TPROXY в
+	// непривязанный сокет заблэкхолил бы весь policy-трафик, включая DNS:53.
+	// Fail-closed уже держит blackhole (при снесённых джампах) или перехват в
+	// мёртвый порт (при целых). Установку откладываем до готовности — следующий
+	// reconcile-тик поставит iptables, когда сокеты встанут.
+	if needsInstall && engineDown {
+		s.appLog.Warn("reconcile", "", "движок не готов (inbound-сокеты не привязаны) — откладываем установку iptables до готовности")
+		needsInstall = false
+	}
 
 	if needsInstall {
 		if forceInitialSync {

--- a/internal/singbox/router/service_reconcile_restart_test.go
+++ b/internal/singbox/router/service_reconcile_restart_test.go
@@ -16,6 +16,11 @@ import (
 // steady state needs no re-Install.
 func newReconcileInstalledService(t *testing.T, sb *fakeSingbox) *ServiceImpl {
 	t.Helper()
+	// singboxReady (tproxy) gates on the inbound-socket probe; stub it "bound"
+	// by default so an alive engine reads as ready. Dead-engine cases short-
+	// circuit on IsRunning before the probe; the up-but-unbound case overrides
+	// this stub to return false.
+	stubListeningProbe(t, func() bool { return true })
 	ipt := newStubIPTables(func(_ context.Context, _ string) error { return nil })
 	return &ServiceImpl{
 		deps: Deps{
@@ -160,6 +165,39 @@ func TestReconcileInstalled_DeadEngineInstallsBlackhole(t *testing.T) {
 	}
 	if !svc.blackholeActive {
 		t.Error("blackholeActive must be set after installing the fail-closed blackhole")
+	}
+}
+
+// safety-3: движок ЖИВ, но inbound-сокеты НЕ привязаны (up-but-unbound, порт
+// занят / отклонённый hot-reload). reconcile трактует это как «не готов»:
+// НЕ ставит реальный перехват (REDIRECT/TPROXY в непривязанный сокет
+// заблэкхолил бы весь policy-трафик, вкл. DNS:53), а при снесённых джампах
+// включает fail-closed blackhole.
+func TestReconcileInstalled_LiveButUnboundInstallsBlackhole(t *testing.T) {
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 } // процесс жив
+	var restores []string
+	ipt := newStubIPTables(func(_ context.Context, in string) error { restores = append(restores, in); return nil })
+	ipt.runIPTablesOut = func(_ context.Context, _ ...string) (string, error) { return chainsOnlyDump(), nil } // джампы снесены
+	svc := newReconcileInstalledService(t, sb)
+	svc.deps.IPTables = ipt
+	// ПОСЛЕ харнесса (тот стабит probe=true) переопределяем: сокеты не привязаны.
+	stubListeningProbe(t, func() bool { return false })
+
+	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
+		t.Fatalf("reconcileInstalled: %v", err)
+	}
+	if len(restores) != 1 {
+		t.Fatalf("restore calls = %d, want 1 (blackhole only, no real interception into an unbound socket)", len(restores))
+	}
+	if !strings.Contains(restores[0], "-A "+BlackholeChain+" -j DROP") {
+		t.Errorf("restored blob is not the fail-closed blackhole:\n%s", restores[0])
+	}
+	if strings.Contains(restores[0], ChainName) {
+		t.Errorf("must NOT install real interception (%s) while sockets are unbound:\n%s", ChainName, restores[0])
+	}
+	if !svc.blackholeActive {
+		t.Error("blackholeActive must be set for an up-but-unbound engine")
 	}
 }
 

--- a/internal/singbox/router/service_reconcile_restart_test.go
+++ b/internal/singbox/router/service_reconcile_restart_test.go
@@ -201,6 +201,31 @@ func TestReconcileInstalled_LiveButUnboundInstallsBlackhole(t *testing.T) {
 	}
 }
 
+// safety-3 (покрытие): движок up-but-unbound, но PREROUTING-джампы ЦЕЛЫ →
+// установку iptables откладываем (любой триггер, здесь markChanged), blackhole
+// НЕ ставим — перехват в мёртвый порт сам дропает трафик (fail-closed).
+func TestReconcileInstalled_LiveButUnboundJumpsIntactDefers(t *testing.T) {
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 }
+	restores := 0
+	ipt := newStubIPTables(func(_ context.Context, _ string) error { restores++; return nil })
+	// runIPTablesOut по умолчанию = jumpsPresentDump → джампы целы.
+	svc := newReconcileInstalledService(t, sb)
+	svc.deps.IPTables = ipt
+	svc.currentMark = "0xstale" // форсируем markChanged → needsInstall
+	stubListeningProbe(t, func() bool { return false })
+
+	if err := svc.reconcileInstalled(context.Background(), reconcileInstalledSettings); err != nil {
+		t.Fatalf("reconcileInstalled: %v", err)
+	}
+	if restores != 0 {
+		t.Errorf("установка должна быть отложена (unbound, джампы целы): restore calls = %d, want 0", restores)
+	}
+	if svc.blackholeActive {
+		t.Error("blackhole не нужен при целых джампах — перехват в мёртвый порт держит fail-closed")
+	}
+}
+
 // Regression (ревью lifecycle): probe-ОШИБКА при мёртвом движке НЕ должна
 // снимать blackhole. Иначе транзиентная -S ошибка во время NDMS-reload (ровно
 // когда blackhole и нужен) снесла бы DROP при живой утечке. blackhole сохраняем.

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -136,6 +136,19 @@ type fakeSingbox struct {
 	restartSuppressedUntil time.Time
 }
 
+// newReadyTestSingbox returns a fakeSingbox that reads as ALIVE and — via the
+// singboxListeningProbe seam — as bound/ready. That is the state a config-change
+// reinstall requires now that reconcileInstalled gates the iptables install on
+// singboxReady (inbound sockets bound), not bare IsRunning (safety-3). Dead and
+// up-but-unbound cases set their own isRunningFn / probe stub instead.
+func newReadyTestSingbox(t *testing.T) *fakeSingbox {
+	t.Helper()
+	stubListeningProbe(t, func() bool { return true })
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 }
+	return sb
+}
+
 func (f *fakeSingbox) Reload() error { return nil }
 func (f *fakeSingbox) IsRunning() (bool, int) {
 	if f.isRunningFn != nil {
@@ -440,7 +453,7 @@ func TestReconcile_PolicyMarkChanged_Reinstalls(t *testing.T) {
 			Policies:       &fakeAccessPolicyProvider{mark: "0xffffaab"},
 			IPTables:       ipt,
 			WANIPCollector: collector,
-			Singbox:        newTestSingbox(t),
+			Singbox:        newReadyTestSingbox(t),
 			// Tests call prepareNetfilter via reconcileInstalled when
 			// needsInstall is true — override to avoid real syscalls.
 			NetfilterPreflight: func(context.Context) error { return nil },
@@ -581,6 +594,9 @@ func TestReconcileInstalled_SelectiveSelfHealWhenFinalNotDirect(t *testing.T) {
 	svc.deps.WANIPCollector = &fakeWANIPCollector{ips: []string{"203.0.113.207/32"}}
 	svc.deps.NetfilterPreflight = func(context.Context) error { return nil }
 	svc.currentSelectiveBypass = true
+	// Ready engine so reconcile's iptables install (which updates
+	// currentSelectiveBypass) runs — it now gates on singboxReady (safety-3).
+	svc.deps.Singbox = newReadyTestSingbox(t)
 
 	// The incompatible config must be APPLIED (not a pending draft): the
 	// self-heal judges only what is actually running.
@@ -816,7 +832,7 @@ func TestReconcile_WANIPsChanged_Reinstalls(t *testing.T) {
 			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
 			IPTables:           ipt,
 			WANIPCollector:     collector,
-			Singbox:            newTestSingbox(t),
+			Singbox:            newReadyTestSingbox(t),
 			NetfilterPreflight: func(context.Context) error { return nil },
 		},
 		currentMark:   "0xffffaaa",
@@ -1005,7 +1021,7 @@ func TestReconcile_DeviceModeChanged_ReinstallsImmediately(t *testing.T) {
 					Policies:           policies,
 					IPTables:           newStubIPTables(func(_ context.Context, input string) error { restoreInput = input; restoreCalls++; return nil }),
 					WANIPCollector:     &fakeWANIPCollector{},
-					Singbox:            newTestSingbox(t),
+					Singbox:            newReadyTestSingbox(t),
 					NetfilterPreflight: func(context.Context) error { return nil },
 				},
 				currentMark:         tc.currentMark,
@@ -1112,7 +1128,7 @@ func TestReconcile_StateUnknown_ForcesInitialReinstall(t *testing.T) {
 			Policies:       &fakeAccessPolicyProvider{mark: "0xffffaaa"},
 			IPTables:       ipt,
 			WANIPCollector: collector,
-			Singbox:        newTestSingbox(t),
+			Singbox:        newReadyTestSingbox(t),
 			NetfilterPreflight: func(context.Context) error {
 				preflightCalls++
 				return nil
@@ -1919,7 +1935,7 @@ func TestReconcile_BypassPresetsChanged_Reinstalls(t *testing.T) {
 			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
 			IPTables:           ipt,
 			WANIPCollector:     collector,
-			Singbox:            newTestSingbox(t),
+			Singbox:            newReadyTestSingbox(t),
 			NetfilterPreflight: func(context.Context) error { return nil },
 		},
 		currentMark:          "0xffffaaa",
@@ -2061,7 +2077,7 @@ func TestReconcile_IngressChangeTriggersInstall(t *testing.T) {
 			Policies:           &fakeAccessPolicyProvider{mark: "0xffffaaa"},
 			IPTables:           ipt,
 			WANIPCollector:     collector,
-			Singbox:            newTestSingbox(t),
+			Singbox:            newReadyTestSingbox(t),
 			NetfilterPreflight: func(context.Context) error { return nil },
 			IngressResolver:    resolver,
 		},


### PR DESCRIPTION
Safety-серия, пункт 3. **Stacked на #472** (base = ветка safety-2) — мержить после #471, #472.

## Проблема

Ревью safety-2 отметило узкое окно (и это отдельная находка аудита): живой процесс с **непривязанными inbound-сокетами** (порт занят, отклонённый hot-reload) читался как здоровый (`IsRunning`) → reconcile ставил iptables REDIRECT/TPROXY в непривязанный сокет → blackhole всего policy-трафика, включая DNS:53 (то, против чего создавался `singboxReady`, #221). Проба `singboxReady` существовала, но не использовалась как предикат хила.

## Решение

`reconcileInstalled`:
- `engineDown` теперь = `!singboxReady(ctx, false)` — процесс жив **И** оба inbound-сокета привязаны (hard-gate #221 через `singboxListeningProbe`, читающий /proc/net/tcp,udp), а не просто `IsRunning`. up-but-unbound трактуется как engineDown.
- Установка iptables гейтится на готовности: `if needsInstall && engineDown` → откладываем (для **любого** триггера: markChanged/forceInitialSync/wanIPsChanged/...). Fail-closed держит blackhole (снесённые джампы) или перехват в мёртвый порт (целые). Следующий reconcile-тик поставит iptables, когда сокеты встанут.

Триггеры не теряются (`currentMark`/`currentWANIPs`/... обновляются только внутри install-блока), поэтому отложенный markChanged/etc. перевыстрелит на следующем тике — отсрочка ровно на один тик, самокорректируется.

## Ревью (Fable 5)

Вердикт **корректно и безопасно**: нет утечки (Probe ключуется только по реальным цепочкам — blackhole-джамп не маскирует нужду в реинсталле; снятие blackhole строго после реального Install), нет starvation (проба procfs по константным портам; та же, что уже гейтит Enable — если бы не совпадала с реальным bind, Enable был бы сломан), нет паники (fakeIP=false верен — reconcileInstalled только tproxy). Selective-self-heal при отсрочке — лишь churn, сходится. Отмеченный пробел покрытия закрыт тестом.

## Проверки

- `go test ./internal/singbox/...` + новые тесты: `LiveButUnboundInstallsBlackhole` (unbound + снесённые джампы → blackhole, не перехват в непривязанный сокет), `LiveButUnboundJumpsIntactDefers` (unbound + целые джампы → отсрочка без blackhole); `newReadyTestSingbox` для reinstall-тестов
- `go vet`, gofmt: чисто; кросс mips/mipsle/arm64: OK

## На проверку на роутере
- [ ] Движок жив, но inbound не привязался (порт занят) — reconcile НЕ ставит iptables (нет blackhole-всего), а откладывает; DNS:53 policy-устройств жив (через существующие правила / fail-closed)
- [ ] После привязки сокетов перехват встаёт на следующем тике

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_