### PR TITLE
fix(sb-router): корректный показ системного route-options (UDP-timeout) правила

### DIFF
--- a/frontend/src/lib/components/sb-router/OutboundToneIcon.svelte
+++ b/frontend/src/lib/components/sb-router/OutboundToneIcon.svelte
@@ -8,6 +8,7 @@
     Rss,
     OctagonAlert,
     ScanEye,
+    Timer,
     TriangleAlert,
     Waypoints,
   } from 'lucide-svelte';
@@ -58,6 +59,8 @@
 {:else if tone === 'system'}
   {#if kind === 'hijack-dns'}
     <Network {...iconProps} />
+  {:else if kind === 'udp-timeout'}
+    <Timer {...iconProps} />
   {:else}
     <ScanEye {...iconProps} />
   {/if}

--- a/frontend/src/lib/components/sb-router/RoutingTable.svelte
+++ b/frontend/src/lib/components/sb-router/RoutingTable.svelte
@@ -44,7 +44,7 @@
     bare = false,
   }: Props = $props();
 
-  type ActionLabel = 'SNIFF' | 'HIJACK' | 'BYPASS' | 'REJECT' | 'ROUTE';
+  type ActionLabel = 'SNIFF' | 'HIJACK' | 'BYPASS' | 'REJECT' | 'ROUTE' | 'UDP TTL';
   type ActionVariant = 'default' | 'accent' | 'success' | 'error' | 'warning' | 'info' | 'muted';
 
   interface RowData {
@@ -88,6 +88,7 @@
   function actionDisplay(r: SingboxRouterRule): { label: ActionLabel; variant: ActionVariant } {
     if (r.action === 'sniff') return { label: 'SNIFF', variant: 'default' };
     if (r.action === 'hijack-dns') return { label: 'HIJACK', variant: 'default' };
+    if (r.action === 'route-options') return { label: 'UDP TTL', variant: 'info' };
     if (r.ip_is_private && r.action === 'route' && (!r.outbound || r.outbound === 'direct')) {
       return { label: 'BYPASS', variant: 'default' };
     }
@@ -97,7 +98,7 @@
 
   function outboundForRule(r: SingboxRouterRule): OutboundDisplay | null {
     const action = mapRuleAction(r);
-    if (action === 'sniff' || action === 'hijack-dns') return null;
+    if (action === 'sniff' || action === 'hijack-dns' || action === 'udp-timeout') return null;
     if (action === 'route' && !r.outbound) return null;
     return resolveOutboundDisplay(
       r.outbound,

--- a/frontend/src/lib/components/sb-router/adapters.test.ts
+++ b/frontend/src/lib/components/sb-router/adapters.test.ts
@@ -534,6 +534,25 @@ describe('singboxRuleToCard', () => {
     expect(card.tooltip).toMatch(/LAN/);
   });
 
+  it('route-options UDP-timeout system rule — не как route/direct, а UDP TIMEOUT', () => {
+    const card = singboxRuleToCard(
+      { action: 'route-options', network: 'udp', udp_timeout: '1h' },
+      3,
+      [],
+      {},
+    );
+    expect(card.isSystem).toBe(true);
+    expect(card.action).toBe('udp-timeout');
+    expect(card.title).toBe('UDP таймаут');
+    expect(card.subtitle).toBe('udp · timeout=1h');
+    expect(card.outbound.kind).toBe('udp-timeout');
+    expect(card.outbound.label).toBe('UDP TIMEOUT');
+    // НЕ должно выглядеть как обычный route в direct
+    expect(card.outbound.kind).not.toBe('direct');
+    expect(card.tooltip).toMatch(/таймаут/i);
+    expect(card.tooltip).toContain('1h');
+  });
+
   it('custom-N inline uses first domain as title and catalog icon', () => {
     const card = singboxRuleToCard(
       { rule_set: ['custom-1'], outbound: 'warp' },

--- a/frontend/src/lib/components/sb-router/adapters.ts
+++ b/frontend/src/lib/components/sb-router/adapters.ts
@@ -54,6 +54,10 @@ export function systemRuleTooltip(rule: SingboxRouterRule): string | undefined {
   if (rule.ip_is_private && rule.outbound === 'direct') {
     return 'Трафик в локальные и приватные сети (RFC1918, loopback, link-local) идёт напрямую, минуя VPN. Нужен для доступа к роутеру, NAS и устройствам в LAN.';
   }
+  if (rule.action === 'route-options') {
+    const to = rule.udp_timeout ? ` (${rule.udp_timeout})` : '';
+    return `Автоматически поднимает таймаут UDP-сессий${to} до значения таймаута движка. Без него игры, VoIP и QUIC рвутся из-за коротких протокольных таймаутов (10–30 с). Задаётся системой, редактировать нельзя.`;
+  }
   return undefined;
 }
 
@@ -63,6 +67,7 @@ export function mapRuleAction(rule: SingboxRouterRule): RuleAction {
   if (rule.action === 'reject') return 'block';
   if (rule.action === 'sniff') return 'sniff';
   if (rule.action === 'hijack-dns') return 'hijack-dns';
+  if (rule.action === 'route-options') return 'udp-timeout';
   if (rule.outbound === 'direct') return 'direct';
   return 'route';
 }
@@ -126,6 +131,10 @@ export function resolveOutboundDisplay(
   }
   if (action === 'hijack-dns') {
     return { name: name ?? 'hijack-dns', label: 'HIJACK-DNS', kind: 'hijack-dns', tone: 'system' };
+  }
+
+  if (action === 'udp-timeout') {
+    return { name: name ?? 'udp-timeout', label: 'UDP TIMEOUT', kind: 'udp-timeout', tone: 'system' };
   }
 
   if (action === 'block') {
@@ -340,6 +349,7 @@ function fallbackTitle(
   if (rule.ip_is_private) return 'Локальная сеть';
   if (rule.action === 'sniff') return 'Анализ протокола';
   if (rule.action === 'hijack-dns') return 'Перехват DNS';
+  if (rule.action === 'route-options') return 'UDP таймаут';
   if (rule.domain_suffix?.length) return rule.domain_suffix[0];
   if (rule.ip_cidr?.length) return rule.ip_cidr[0];
   if (rule.rule_set?.length) return displayRuleSetTag(rule.rule_set[0]);
@@ -352,6 +362,9 @@ function systemSubtitle(rule: SingboxRouterRule): string | undefined {
   if (rule.action === 'sniff') return 'sniff';
   if (rule.action === 'hijack-dns') return 'protocol=dns OR port=53';
   if (rule.ip_is_private) return 'RFC1918 · loopback · link-local · CGNAT';
+  if (rule.action === 'route-options') {
+    return rule.udp_timeout ? `udp · timeout=${rule.udp_timeout}` : 'udp · timeout';
+  }
   return undefined;
 }
 

--- a/frontend/src/lib/components/sb-router/types.ts
+++ b/frontend/src/lib/components/sb-router/types.ts
@@ -9,7 +9,7 @@
 import type { RuleSetDisplayType } from '$lib/utils/ruleSetType';
 import type { RuleSimplicity } from './simpleRule';
 
-export type RuleAction = 'route' | 'block' | 'direct' | 'sniff' | 'hijack-dns';
+export type RuleAction = 'route' | 'block' | 'direct' | 'sniff' | 'hijack-dns' | 'udp-timeout';
 
 /** Категория matcher chip — соответствует labelMap из дизайна. */
 export type MatcherKind = 'domain' | 'ip' | 'port' | 'ruleset' | 'src' | 'protocol' | 'private';
@@ -38,7 +38,8 @@ export type OutboundKind =
 	| 'via-route'
 	| 'unknown'
 	| 'sniff'
-	| 'hijack-dns';
+	| 'hijack-dns'
+	| 'udp-timeout';
 
 export interface OutboundDisplay {
   /** Имя outbound'а из singbox config (raw key) */


### PR DESCRIPTION
## Проблема

Фикс #469 добавил в `route.rules` системное правило `{action:"route-options", network:"udp", udp_timeout}` (поднимает UDP-таймаут, чтобы игры/VoIP/QUIC не рвались). Бэкенд его пишет автоматически, но фронт не отображал корректно: `mapRuleAction` не знал `action=route-options` → правило проваливалось в обычный `route` и рендерилось как **«route → Прямо»** (в эксперт-таблице — «ROUTE»), без пояснения. `isSystemRule` его уже распознавал (редактирование заблокировано), но карточка вводила в заблуждение.

## Решение — показать как системное, редактирование запрещено

- **`adapters.ts`**: `mapRuleAction` → `'udp-timeout'`; `resolveOutboundDisplay` рендерит системный mono-бейдж **«UDP TIMEOUT»** (kind=udp-timeout, tone=system); `systemRuleTooltip` (пояснение про короткие протокольные таймауты 10–30 с и «задаётся системой, редактировать нельзя»), `systemSubtitle` (`udp · timeout=1h`), `fallbackTitle` (`UDP таймаут`).
- **`types.ts`**: `RuleAction` / `OutboundKind` += `'udp-timeout'`.
- **`OutboundToneIcon.svelte`**: иконка Timer.
- **`RoutingTable.svelte`** (эксперт): бейдж **«UDP TTL»** (info), без outbound-плитки.

Редактирование остаётся заблокированным — `isSystemRule=true` гейтит `requestEdit`, drag/delete исключены, карточка показывает Lock-бейдж и тултип по наведению. Правило задаётся системой автоматически.

## Проверки

- `svelte-check`: 0 errors / 0 warnings
- `vitest`: 1319/1319 (новый тест на карточку route-options: action/title/subtitle/бейдж/tooltip, НЕ direct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_