### PR TITLE
chore: gofmt всего проекта

### DIFF
--- a/internal/accesspolicy/policyname_test.go
+++ b/internal/accesspolicy/policyname_test.go
@@ -18,12 +18,12 @@ func TestIsStandardPolicyName(t *testing.T) {
 		{"HydraRoute", false},
 		{"HrNeoUS", false},
 		{"", false},
-		{"Policy", false},     // prefix only, no number
-		{"PolicyABC", false},  // suffix is not a number
-		{"Policy-1", false},   // strconv.Atoi accepts "-1"; filter rejects negatives
-		{"Policy+1", false},   // strconv.Atoi accepts "+1"; filter rejects signed prefix
-		{"Policy 1", false},   // space inside
-		{"policy0", false},    // case-sensitive prefix
+		{"Policy", false},    // prefix only, no number
+		{"PolicyABC", false}, // suffix is not a number
+		{"Policy-1", false},  // strconv.Atoi accepts "-1"; filter rejects negatives
+		{"Policy+1", false},  // strconv.Atoi accepts "+1"; filter rejects signed prefix
+		{"Policy 1", false},  // space inside
+		{"policy0", false},   // case-sensitive prefix
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/api/dnsroute_test.go
+++ b/internal/api/dnsroute_test.go
@@ -143,119 +143,225 @@ func sampleDNSList(id, name string) dnsroute.DomainList {
 func TestDNSRouteHandlerContracts(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		h := NewDNSRouteHandler(&fakeDNSRouteService{}, nil)
-		if rr := perform(h.List, http.MethodPost, "/dns-routes/list", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
+		if rr := perform(h.List, http.MethodPost, "/dns-routes/list", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
 		rr := perform(h.List, http.MethodGet, "/dns-routes/list", "")
-		if rr.Code != http.StatusOK { t.Fatalf("code=%d", rr.Code) }
+		if rr.Code != http.StatusOK {
+			t.Fatalf("code=%d", rr.Code)
+		}
 		body := decodeJSONBody(t, rr)
-		if body["success"] != true { t.Fatalf("success=%v", body["success"]) }
+		if body["success"] != true {
+			t.Fatalf("success=%v", body["success"])
+		}
 		hErr := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
 		rr = perform(hErr.List, http.MethodGet, "/dns-routes/list", "")
-		if decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 	})
 
 	t.Run("Get", func(t *testing.T) {
 		fake := &fakeDNSRouteService{}
 		h := NewDNSRouteHandler(fake, nil)
-		if rr := perform(h.Get, http.MethodPost, "/dns-routes/get", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.Get, http.MethodGet, "/dns-routes/get", ""); decodeJSONBody(t, rr)["code"] != "MISSING_ID" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.Get, http.MethodPost, "/dns-routes/get", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.Get, http.MethodGet, "/dns-routes/get", ""); decodeJSONBody(t, rr)["code"] != "MISSING_ID" {
+			t.Fatal(rr.Body.String())
+		}
 		rr := perform(h.Get, http.MethodGet, "/dns-routes/get?id=dns1", "")
-		if rr.Code != http.StatusOK { t.Fatalf("code=%d", rr.Code) }
+		if rr.Code != http.StatusOK {
+			t.Fatalf("code=%d", rr.Code)
+		}
 		hErr := NewDNSRouteHandler(&fakeDNSRouteService{getFn: func(context.Context, string) (*dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hErr.Get, http.MethodGet, "/dns-routes/get?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_GET_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hErr.Get, http.MethodGet, "/dns-routes/get?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_GET_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		_ = fake
 	})
 
 	t.Run("CreateUpdate", func(t *testing.T) {
 		fake := &fakeDNSRouteService{}
 		h := NewDNSRouteHandler(fake, nil)
-		if rr := perform(h.Create, http.MethodGet, "/dns-routes/create", "{}"); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.Create, http.MethodPost, "/dns-routes/create", "{"); decodeJSONBody(t, rr)["code"] != "INVALID_JSON" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.Create, http.MethodGet, "/dns-routes/create", "{}"); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.Create, http.MethodPost, "/dns-routes/create", "{"); decodeJSONBody(t, rr)["code"] != "INVALID_JSON" {
+			t.Fatal(rr.Body.String())
+		}
 		rr := perform(h.Create, http.MethodPost, "/dns-routes/create", `{"name":"Work","manualDomains":["corp.local"],"enabled":true}`)
-		if rr.Code != http.StatusOK || len(fake.created) != 1 || fake.created[0].Name != "Work" { t.Fatalf("bad create: %s", rr.Body.String()) }
-		hCreateErr := NewDNSRouteHandler(&fakeDNSRouteService{createFn: func(context.Context, dnsroute.DomainList) (*dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hCreateErr.Create, http.MethodPost, "/dns-routes/create", `{}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_CREATE_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || len(fake.created) != 1 || fake.created[0].Name != "Work" {
+			t.Fatalf("bad create: %s", rr.Body.String())
+		}
+		hCreateErr := NewDNSRouteHandler(&fakeDNSRouteService{createFn: func(context.Context, dnsroute.DomainList) (*dnsroute.DomainList, error) {
+			return nil, errors.New("boom")
+		}}, nil)
+		if rr := perform(hCreateErr.Create, http.MethodPost, "/dns-routes/create", `{}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_CREATE_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 
-		if rr := perform(h.Update, http.MethodGet, "/dns-routes/update?id=dns1", "{}"); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.Update, http.MethodPost, "/dns-routes/update", `{"name":"New"}`); decodeJSONBody(t, rr)["code"] != "MISSING_ID" { t.Fatal(rr.Body.String()) }
-		if rr := perform(h.Update, http.MethodPost, "/dns-routes/update?id=dns1", "{"); decodeJSONBody(t, rr)["code"] != "INVALID_JSON" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.Update, http.MethodGet, "/dns-routes/update?id=dns1", "{}"); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.Update, http.MethodPost, "/dns-routes/update", `{"name":"New"}`); decodeJSONBody(t, rr)["code"] != "MISSING_ID" {
+			t.Fatal(rr.Body.String())
+		}
+		if rr := perform(h.Update, http.MethodPost, "/dns-routes/update?id=dns1", "{"); decodeJSONBody(t, rr)["code"] != "INVALID_JSON" {
+			t.Fatal(rr.Body.String())
+		}
 		rr = perform(h.Update, http.MethodPost, "/dns-routes/update?id=dns1", `{"name":"New"}`)
-		if rr.Code != http.StatusOK || len(fake.updated) == 0 || fake.updated[0].ID != "dns1" { t.Fatalf("bad update: %s", rr.Body.String()) }
-		hUpdateErr := NewDNSRouteHandler(&fakeDNSRouteService{updateFn: func(context.Context, dnsroute.DomainList) (*dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hUpdateErr.Update, http.MethodPost, "/dns-routes/update?id=dns1", `{}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_UPDATE_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || len(fake.updated) == 0 || fake.updated[0].ID != "dns1" {
+			t.Fatalf("bad update: %s", rr.Body.String())
+		}
+		hUpdateErr := NewDNSRouteHandler(&fakeDNSRouteService{updateFn: func(context.Context, dnsroute.DomainList) (*dnsroute.DomainList, error) {
+			return nil, errors.New("boom")
+		}}, nil)
+		if rr := perform(hUpdateErr.Update, http.MethodPost, "/dns-routes/update?id=dns1", `{}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_UPDATE_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 	})
 
 	t.Run("DeleteDeleteBatchSetEnabled", func(t *testing.T) {
 		fake := &fakeDNSRouteService{}
 		h := NewDNSRouteHandler(fake, nil)
-		if rr := perform(h.Delete, http.MethodGet, "/dns-routes/delete?id=dns1", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.Delete, http.MethodPost, "/dns-routes/delete", ""); decodeJSONBody(t, rr)["code"] != "MISSING_ID" { t.Fatal(rr.Body.String()) }
-		if rr := perform(h.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); rr.Code != http.StatusOK || len(fake.deletedIDs) != 1 { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.Delete, http.MethodGet, "/dns-routes/delete?id=dns1", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.Delete, http.MethodPost, "/dns-routes/delete", ""); decodeJSONBody(t, rr)["code"] != "MISSING_ID" {
+			t.Fatal(rr.Body.String())
+		}
+		if rr := perform(h.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); rr.Code != http.StatusOK || len(fake.deletedIDs) != 1 {
+			t.Fatal(rr.Body.String())
+		}
 		hDelErr := NewDNSRouteHandler(&fakeDNSRouteService{deleteFn: func(context.Context, string) error { return errors.New("boom") }}, nil)
-		if rr := perform(hDelErr.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_DELETE_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hDelErr.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_DELETE_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		hDelListErr := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hDelListErr.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hDelListErr.Delete, http.MethodPost, "/dns-routes/delete?id=dns1", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 
-		if rr := perform(h.DeleteBatch, http.MethodGet, "/dns-routes/delete-batch", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":[]}`); decodeJSONBody(t, rr)["code"] != "MISSING_IDS" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.DeleteBatch, http.MethodGet, "/dns-routes/delete-batch", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":[]}`); decodeJSONBody(t, rr)["code"] != "MISSING_IDS" {
+			t.Fatal(rr.Body.String())
+		}
 		rr := perform(h.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":["a","b"]}`)
-		if rr.Code != http.StatusOK || len(fake.deleteBatchIDs) != 2 { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || len(fake.deleteBatchIDs) != 2 {
+			t.Fatal(rr.Body.String())
+		}
 		hDBErr := NewDNSRouteHandler(&fakeDNSRouteService{deleteBatchFn: func(context.Context, []string) (int, error) { return 0, errors.New("boom") }}, nil)
-		if rr := perform(hDBErr.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":["a"]}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_DELETE_BATCH_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hDBErr.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":["a"]}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_DELETE_BATCH_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		hDBListErr := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hDBListErr.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":["a"]}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hDBListErr.DeleteBatch, http.MethodPost, "/dns-routes/delete-batch", `{"ids":["a"]}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 
-		if rr := perform(h.SetEnabled, http.MethodGet, "/dns-routes/set-enabled?id=dns1", `{"enabled":false}`); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.SetEnabled, http.MethodPost, "/dns-routes/set-enabled", `{"enabled":false}`); decodeJSONBody(t, rr)["code"] != "MISSING_ID" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.SetEnabled, http.MethodGet, "/dns-routes/set-enabled?id=dns1", `{"enabled":false}`); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.SetEnabled, http.MethodPost, "/dns-routes/set-enabled", `{"enabled":false}`); decodeJSONBody(t, rr)["code"] != "MISSING_ID" {
+			t.Fatal(rr.Body.String())
+		}
 		rr = perform(h.SetEnabled, http.MethodPost, "/dns-routes/set-enabled?id=dns1", `{"enabled":false}`)
-		if rr.Code != http.StatusOK || fake.setEnabledID != "dns1" || fake.setEnabledVal != false { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || fake.setEnabledID != "dns1" || fake.setEnabledVal != false {
+			t.Fatal(rr.Body.String())
+		}
 		hSEErr := NewDNSRouteHandler(&fakeDNSRouteService{setEnabledFn: func(context.Context, string, bool) error { return errors.New("boom") }}, nil)
-		if rr := perform(hSEErr.SetEnabled, http.MethodPost, "/dns-routes/set-enabled?id=dns1", `{"enabled":true}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_SET_ENABLED_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hSEErr.SetEnabled, http.MethodPost, "/dns-routes/set-enabled?id=dns1", `{"enabled":true}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_SET_ENABLED_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		hSEListErr := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hSEListErr.SetEnabled, http.MethodPost, "/dns-routes/set-enabled?id=dns1", `{"enabled":true}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hSEListErr.SetEnabled, http.MethodPost, "/dns-routes/set-enabled?id=dns1", `{"enabled":true}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 	})
 
 	t.Run("CreateBatchBulkBackendRefresh", func(t *testing.T) {
 		fake := &fakeDNSRouteService{}
 		h := NewDNSRouteHandler(fake, nil)
-		if rr := perform(h.CreateBatch, http.MethodGet, "/dns-routes/create-batch", "[]"); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.CreateBatch, http.MethodPost, "/dns-routes/create-batch", `[]`); decodeJSONBody(t, rr)["code"] != "MISSING_LISTS" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.CreateBatch, http.MethodGet, "/dns-routes/create-batch", "[]"); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.CreateBatch, http.MethodPost, "/dns-routes/create-batch", `[]`); decodeJSONBody(t, rr)["code"] != "MISSING_LISTS" {
+			t.Fatal(rr.Body.String())
+		}
 		rr := perform(h.CreateBatch, http.MethodPost, "/dns-routes/create-batch", `[ {"name":"A"}, {"name":"B"} ]`)
-		if rr.Code != http.StatusOK || len(fake.created) != 2 { t.Fatal(rr.Body.String()) }
-		hCBE := NewDNSRouteHandler(&fakeDNSRouteService{createBatchFn: func(context.Context, []dnsroute.DomainList) ([]*dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hCBE.CreateBatch, http.MethodPost, "/dns-routes/create-batch", `[{}]`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_CREATE_BATCH_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || len(fake.created) != 2 {
+			t.Fatal(rr.Body.String())
+		}
+		hCBE := NewDNSRouteHandler(&fakeDNSRouteService{createBatchFn: func(context.Context, []dnsroute.DomainList) ([]*dnsroute.DomainList, error) {
+			return nil, errors.New("boom")
+		}}, nil)
+		if rr := perform(hCBE.CreateBatch, http.MethodPost, "/dns-routes/create-batch", `[{}]`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_CREATE_BATCH_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 
-		if rr := perform(h.BulkBackend, http.MethodGet, "/dns-routes/bulk-backend", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
-		if rr := perform(h.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":["a"],"backend":"bad"}`); decodeJSONBody(t, rr)["code"] != "INVALID_BACKEND" { t.Fatal(rr.Body.String()) }
-		if rr := perform(h.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":[],"backend":"ndms"}`); decodeJSONBody(t, rr)["code"] != "EMPTY_LIST" { t.Fatal(rr.Body.String()) }
+		if rr := perform(h.BulkBackend, http.MethodGet, "/dns-routes/bulk-backend", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
+		if rr := perform(h.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":["a"],"backend":"bad"}`); decodeJSONBody(t, rr)["code"] != "INVALID_BACKEND" {
+			t.Fatal(rr.Body.String())
+		}
+		if rr := perform(h.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":[],"backend":"ndms"}`); decodeJSONBody(t, rr)["code"] != "EMPTY_LIST" {
+			t.Fatal(rr.Body.String())
+		}
 		calls := 0
 		hB := NewDNSRouteHandler(&fakeDNSRouteService{
 			getFn: func(_ context.Context, id string) (*dnsroute.DomainList, error) {
-				if id == "bad" { return nil, errors.New("x") }
+				if id == "bad" {
+					return nil, errors.New("x")
+				}
 				l := sampleDNSList(id, id)
 				return &l, nil
 			},
 			updateFn: func(_ context.Context, l dnsroute.DomainList) (*dnsroute.DomainList, error) {
-				if l.ID == "uerr" { return nil, errors.New("uerr") }
-				if l.Backend == "hydraroute" { calls++ }
+				if l.ID == "uerr" {
+					return nil, errors.New("uerr")
+				}
+				if l.Backend == "hydraroute" {
+					calls++
+				}
 				return &l, nil
 			},
 		}, nil)
 		rr = perform(hB.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":["good","bad","uerr"],"backend":"hydraroute"}`)
-		if rr.Code != http.StatusOK || calls == 0 { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || calls == 0 {
+			t.Fatal(rr.Body.String())
+		}
 		hBL := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hBL.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":["a"],"backend":"ndms"}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hBL.BulkBackend, http.MethodPost, "/dns-routes/bulk-backend", `{"listIDs":["a"],"backend":"ndms"}`); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 
-		if rr := perform(h.Refresh, http.MethodGet, "/dns-routes/refresh", ""); rr.Code != http.StatusMethodNotAllowed { t.Fatalf("code=%d", rr.Code) }
+		if rr := perform(h.Refresh, http.MethodGet, "/dns-routes/refresh", ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("code=%d", rr.Code)
+		}
 		rr = perform(h.Refresh, http.MethodPost, "/dns-routes/refresh?id=dns1", "")
-		if rr.Code != http.StatusOK || fake.refreshID != "dns1" { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || fake.refreshID != "dns1" {
+			t.Fatal(rr.Body.String())
+		}
 		fake.refreshID = ""
 		rr = perform(h.Refresh, http.MethodPost, "/dns-routes/refresh", "")
-		if rr.Code != http.StatusOK || !fake.refreshAll { t.Fatal(rr.Body.String()) }
+		if rr.Code != http.StatusOK || !fake.refreshAll {
+			t.Fatal(rr.Body.String())
+		}
 		hR1 := NewDNSRouteHandler(&fakeDNSRouteService{refreshSubscriptionsFn: func(context.Context, string) error { return errors.New("boom") }}, nil)
-		if rr := perform(hR1.Refresh, http.MethodPost, "/dns-routes/refresh?id=a", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_REFRESH_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hR1.Refresh, http.MethodPost, "/dns-routes/refresh?id=a", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_REFRESH_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		hR2 := NewDNSRouteHandler(&fakeDNSRouteService{refreshAllSubscriptionsFn: func(context.Context) error { return errors.New("boom") }}, nil)
-		if rr := perform(hR2.Refresh, http.MethodPost, "/dns-routes/refresh", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_REFRESH_ALL_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hR2.Refresh, http.MethodPost, "/dns-routes/refresh", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_REFRESH_ALL_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 		hR3 := NewDNSRouteHandler(&fakeDNSRouteService{listFn: func(context.Context) ([]dnsroute.DomainList, error) { return nil, errors.New("boom") }}, nil)
-		if rr := perform(hR3.Refresh, http.MethodPost, "/dns-routes/refresh", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" { t.Fatal(rr.Body.String()) }
+		if rr := perform(hR3.Refresh, http.MethodPost, "/dns-routes/refresh", ""); decodeJSONBody(t, rr)["code"] != "DNS_ROUTE_LIST_ERROR" {
+			t.Fatal(rr.Body.String())
+		}
 	})
 }

--- a/internal/api/external.go
+++ b/internal/api/external.go
@@ -39,11 +39,11 @@ type ExternalTunnelService interface {
 
 // ExternalTunnelsHandler handles external tunnel operations.
 type ExternalTunnelsHandler struct {
-	svc                ExternalTunnelService
-	tunnelSvc          TunnelService
-	store              *storage.AWGTunnelStore
-	log                *logging.ScopedLogger
-	publishTunnelList  func(ctx context.Context)
+	svc               ExternalTunnelService
+	tunnelSvc         TunnelService
+	store             *storage.AWGTunnelStore
+	log               *logging.ScopedLogger
+	publishTunnelList func(ctx context.Context)
 }
 
 // NewExternalTunnelsHandler creates a new external tunnels handler.

--- a/internal/api/hook.go
+++ b/internal/api/hook.go
@@ -100,25 +100,26 @@ func (h *HookHandler) SetTunnelRefresher(fn TunnelHookInvalidator) {
 // forwards to the orchestrator for tunnel-lifecycle decisions.
 //
 // POST /api/hook/ndms
-//   type=iflayerchanged|ifcreated|ifdestroyed|ifipchanged
-//   id=<ndms-interface-id>
-//   system_name=<kernel-name>
-//   layer=<conf|link|ipv4|ipv6|ctrl>      (layerchanged only)
-//   level=<running|disabled|...>          (layerchanged only)
-//   address=<ipv4>                        (ipchanged only)
-//   up=<0|1>
-//   connected=<0|1>
 //
-//	@Summary		NDMS shell hook
-//	@Description	Called from router scripts (public). Form fields: type, id, system_name, layer, etc.
-//	@Tags			hook
-//	@Accept			x-www-form-urlencoded
-//	@Produce		json
-//	@Param			type	formData	string	true	"Event type (iflayerchanged, ifcreated, ...)"
-//	@Success		200	{object}	APIEnvelope
-//	@Failure		400	{object}	APIErrorEnvelope
-//	@Failure		500	{object}	APIErrorEnvelope
-//	@Router			/hook/ndms [post]
+//	  type=iflayerchanged|ifcreated|ifdestroyed|ifipchanged
+//	  id=<ndms-interface-id>
+//	  system_name=<kernel-name>
+//	  layer=<conf|link|ipv4|ipv6|ctrl>      (layerchanged only)
+//	  level=<running|disabled|...>          (layerchanged only)
+//	  address=<ipv4>                        (ipchanged only)
+//	  up=<0|1>
+//	  connected=<0|1>
+//
+//		@Summary		NDMS shell hook
+//		@Description	Called from router scripts (public). Form fields: type, id, system_name, layer, etc.
+//		@Tags			hook
+//		@Accept			x-www-form-urlencoded
+//		@Produce		json
+//		@Param			type	formData	string	true	"Event type (iflayerchanged, ifcreated, ...)"
+//		@Success		200	{object}	APIEnvelope
+//		@Failure		400	{object}	APIErrorEnvelope
+//		@Failure		500	{object}	APIErrorEnvelope
+//		@Router			/hook/ndms [post]
 func (h *HookHandler) HandleNDMS(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		response.MethodNotAllowed(w)

--- a/internal/api/monitoring.go
+++ b/internal/api/monitoring.go
@@ -28,18 +28,18 @@ type MonitoringTunnelDTO struct {
 
 // MonitoringCellDTO mirrors frontend MonitoringCell.
 type MonitoringCellDTO struct {
-	TargetID        string  `json:"targetId" example:"target_google"`
-	TunnelID        string  `json:"tunnelId" example:"tun_abc123"`
-	LatencyMs       *int    `json:"latencyMs" swaggertype:"integer" example:"42"`
-	OK              bool    `json:"ok" example:"true"`
+	TargetID         string `json:"targetId" example:"target_google"`
+	TunnelID         string `json:"tunnelId" example:"tun_abc123"`
+	LatencyMs        *int   `json:"latencyMs" swaggertype:"integer" example:"42"`
+	OK               bool   `json:"ok" example:"true"`
 	ActiveForRestart bool   `json:"activeForRestart" example:"false"`
-	IsSelf          bool    `json:"isSelf" example:"false"`
-	Ts              string  `json:"ts" example:"2024-01-15T10:30:00Z"`
+	IsSelf           bool   `json:"isSelf" example:"false"`
+	Ts               string `json:"ts" example:"2024-01-15T10:30:00Z"`
 }
 
 // MonitoringSnapshotResponse is the envelope for GET /monitoring/matrix.
 type MonitoringSnapshotResponse struct {
-	Success bool                  `json:"success" example:"true"`
+	Success bool                   `json:"success" example:"true"`
 	Data    MonitoringSnapshotData `json:"data"`
 }
 

--- a/internal/api/pingcheck.go
+++ b/internal/api/pingcheck.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/ndms"
 	"github.com/hoaxisr/awg-manager/internal/orchestrator"
 	"github.com/hoaxisr/awg-manager/internal/pingcheck"
 	"github.com/hoaxisr/awg-manager/internal/response"
-	"github.com/hoaxisr/awg-manager/internal/ndms"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/tunnel/nwg"
 )

--- a/internal/api/pingcheck_test.go
+++ b/internal/api/pingcheck_test.go
@@ -86,7 +86,7 @@ func TestPingCheckHandler_GetStatus(t *testing.T) {
 
 	var resp struct {
 		Data struct {
-			Enabled bool               `json:"enabled"`
+			Enabled bool                     `json:"enabled"`
 			Tunnels []pingcheck.TunnelStatus `json:"tunnels"`
 		} `json:"data"`
 	}

--- a/internal/api/singbox_inspector.go
+++ b/internal/api/singbox_inspector.go
@@ -96,10 +96,10 @@ type SingboxRouterInspectProgressDTO struct {
 
 // SingboxRouterInspectStreamEventDTO mirrors router.InspectStreamEvent.
 type SingboxRouterInspectStreamEventDTO struct {
-	Type     string                            `json:"type" example:"progress"`
-	Progress *SingboxRouterInspectProgressDTO  `json:"progress,omitempty"`
-	Result   *SingboxRouterInspectData         `json:"result,omitempty"`
-	Error    string                            `json:"error,omitempty" example:"load router config: ..."`
+	Type     string                           `json:"type" example:"progress"`
+	Progress *SingboxRouterInspectProgressDTO `json:"progress,omitempty"`
+	Result   *SingboxRouterInspectData        `json:"result,omitempty"`
+	Error    string                           `json:"error,omitempty" example:"load router config: ..."`
 }
 
 // Inspect simulates which router rule would match the given domain/IP.

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -177,8 +177,8 @@ func (h *TerminalHandler) WebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Accept client WebSocket. Disable compression for transparent binary passthrough.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify:  true, // same-origin, auth already checked by middleware
-		CompressionMode:     websocket.CompressionDisabled,
+		InsecureSkipVerify: true, // same-origin, auth already checked by middleware
+		CompressionMode:    websocket.CompressionDisabled,
 	})
 	if err != nil {
 		return // Accept already wrote HTTP error

--- a/internal/api/wan.go
+++ b/internal/api/wan.go
@@ -13,7 +13,7 @@ import (
 // WANStatusEnvelope is the swagger-friendly envelope for GET /wan/status.
 // (The actual handler uses the local WANStatusResponse which embeds wanpkg types.)
 type WANStatusEnvelope struct {
-	Success bool   `json:"success" example:"true"`
+	Success bool `json:"success" example:"true"`
 	Data    struct {
 		AnyWANUp bool `json:"anyWANUp" example:"true"`
 	} `json:"data"`

--- a/internal/clientroute/impl_test.go
+++ b/internal/clientroute/impl_test.go
@@ -31,25 +31,43 @@ func (m *mockCatalog) GetKernelIface(_ context.Context, tunnelID string) (string
 // --- Mock Operator ---
 
 type mockOperator struct {
-	setupCalls   []struct{ iface string; table int }
-	addCalls     []struct{ ip string; table int }
-	removeCalls  []struct{ ip string; table int }
+	setupCalls []struct {
+		iface string
+		table int
+	}
+	addCalls []struct {
+		ip    string
+		table int
+	}
+	removeCalls []struct {
+		ip    string
+		table int
+	}
 	cleanupCalls []int
 	usedTables   []int
 }
 
 func (m *mockOperator) SetupClientRouteTable(_ context.Context, kernelIface string, tableNum int) error {
-	m.setupCalls = append(m.setupCalls, struct{ iface string; table int }{kernelIface, tableNum})
+	m.setupCalls = append(m.setupCalls, struct {
+		iface string
+		table int
+	}{kernelIface, tableNum})
 	return nil
 }
 
 func (m *mockOperator) AddClientRule(_ context.Context, clientIP string, tableNum int) error {
-	m.addCalls = append(m.addCalls, struct{ ip string; table int }{clientIP, tableNum})
+	m.addCalls = append(m.addCalls, struct {
+		ip    string
+		table int
+	}{clientIP, tableNum})
 	return nil
 }
 
 func (m *mockOperator) RemoveClientRule(_ context.Context, clientIP string, tableNum int) error {
-	m.removeCalls = append(m.removeCalls, struct{ ip string; table int }{clientIP, tableNum})
+	m.removeCalls = append(m.removeCalls, struct {
+		ip    string
+		table int
+	}{clientIP, tableNum})
 	return nil
 }
 
@@ -489,7 +507,7 @@ func TestOnTunnelDelete_CleansEverything(t *testing.T) {
 	store.routes = []ClientRoute{
 		{ID: "cr-td1", ClientIP: "192.168.1.10", TunnelID: "tun1", Fallback: "drop", Enabled: true},
 		{ID: "cr-td2", ClientIP: "192.168.1.11", TunnelID: "tun1", Fallback: "bypass", Enabled: true},
-		{ID: "cr-td3", ClientIP: "192.168.1.12", TunnelID: "tun1", Fallback: "drop", Enabled: false}, // disabled, no rule to remove
+		{ID: "cr-td3", ClientIP: "192.168.1.12", TunnelID: "tun1", Fallback: "drop", Enabled: false},  // disabled, no rule to remove
 		{ID: "cr-other", ClientIP: "192.168.1.99", TunnelID: "tun2", Fallback: "drop", Enabled: true}, // different tunnel
 	}
 	store.tables["tun1"] = 400

--- a/internal/clientroute/service.go
+++ b/internal/clientroute/service.go
@@ -56,4 +56,3 @@ type Store interface {
 	GetAllTables() map[string]int
 	DeleteFile() error
 }
-

--- a/internal/connections/types.go
+++ b/internal/connections/types.go
@@ -2,19 +2,19 @@ package connections
 
 // Connection represents a single conntrack entry with resolved tunnel and client info.
 type Connection struct {
-	Protocol   string `json:"protocol"`
-	Src        string `json:"src"`
-	Dst        string `json:"dst"`
-	SrcPort    int    `json:"srcPort"`
-	DstPort    int    `json:"dstPort"`
-	State      string `json:"state"`
-	Packets    int64  `json:"packets"`
-	Bytes      int64  `json:"bytes"`
-	Interface  string `json:"interface"`
-	TunnelID   string `json:"tunnelId"`
-	TunnelName string `json:"tunnelName"`
-	ClientMAC  string `json:"clientMac"`
-	ClientName string `json:"clientName"`
+	Protocol   string    `json:"protocol"`
+	Src        string    `json:"src"`
+	Dst        string    `json:"dst"`
+	SrcPort    int       `json:"srcPort"`
+	DstPort    int       `json:"dstPort"`
+	State      string    `json:"state"`
+	Packets    int64     `json:"packets"`
+	Bytes      int64     `json:"bytes"`
+	Interface  string    `json:"interface"`
+	TunnelID   string    `json:"tunnelId"`
+	TunnelName string    `json:"tunnelName"`
+	ClientMAC  string    `json:"clientMac"`
+	ClientName string    `json:"clientName"`
 	Rules      []RuleHit `json:"rules,omitempty"`
 }
 

--- a/internal/dnsroute/createbatch_hr_test.go
+++ b/internal/dnsroute/createbatch_hr_test.go
@@ -57,11 +57,11 @@ func TestCreateBatch_HydraRouteSubscriptions(t *testing.T) {
 		// manual + subscription → создаётся из ручных, подписка игнорируется.
 		{Name: "hr-mixed", Backend: "hydraroute", ManualDomains: []string{"x.com"},
 			Subscriptions: []Subscription{{URL: "http://example/list", Name: "sub"}},
-			Routes: []RouteTarget{{TunnelID: "t1"}}},
+			Routes:        []RouteTarget{{TunnelID: "t1"}}},
 		// subscription-only (нет ручных) → пропускается, batch не падает.
 		{Name: "hr-subonly", Backend: "hydraroute",
 			Subscriptions: []Subscription{{URL: "http://example/list2", Name: "sub2"}},
-			Routes: []RouteTarget{{TunnelID: "t1"}}},
+			Routes:        []RouteTarget{{TunnelID: "t1"}}},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/dnsroute/failover.go
+++ b/internal/dnsroute/failover.go
@@ -28,16 +28,16 @@ type AffectedListsLookup func(tunnelID string, action string) []AffectedList
 // FailoverManager tracks which tunnels have failed and need DNS route failover.
 // In-memory only — state resets on restart (reconcile rebuilds from primary targets).
 type FailoverManager struct {
-	mu             sync.RWMutex
-	failedSet      map[string]struct{}
-	reconcileFn    func() error // returns error so we can rollback / retry
+	mu          sync.RWMutex
+	failedSet   map[string]struct{}
+	reconcileFn func() error // returns error so we can rollback / retry
 	// dirty is a global "best-effort retry" flag, not a per-tunnel retry queue.
 	// Set when any reconcile fails; cleared on the next successful reconcile.
 	// While dirty, the next event force-retries even on duplicate (alreadyFailed)
 	// tunnels. A success for tunnel B clears the flag and won't retry tunnel A —
 	// but A's next pingcheck event will see alreadyFailed=false (after rollback)
 	// and proceed normally, so self-healing works via the periodic event stream.
-	dirty bool
+	dirty          bool
 	stopCh         chan struct{}
 	stopped        chan struct{}
 	bus            *events.Bus

--- a/internal/dnsroute/scheduler_test.go
+++ b/internal/dnsroute/scheduler_test.go
@@ -24,7 +24,7 @@ func (m *mockRefreshService) List(ctx context.Context) ([]DomainList, error) { r
 func (m *mockRefreshService) Update(ctx context.Context, list DomainList) (*DomainList, error) {
 	return nil, nil
 }
-func (m *mockRefreshService) Delete(ctx context.Context, id string) error            { return nil }
+func (m *mockRefreshService) Delete(ctx context.Context, id string) error { return nil }
 func (m *mockRefreshService) DeleteBatch(ctx context.Context, ids []string) (int, error) {
 	return 0, nil
 }

--- a/internal/dnsroute/types.go
+++ b/internal/dnsroute/types.go
@@ -17,9 +17,9 @@ type DomainList struct {
 	// dedup layer only. NDMS object-group network has no exclude semantics,
 	// so these CIDRs are NEVER rendered to NDMS. They exist purely to allow
 	// another list to claim a child subnet without being marked as a dup.
-	ExcludeSubnets   []string       `json:"excludeSubnets,omitempty"`
-	Subnets          []string       `json:"subnets,omitempty"`
-	ManualDomains    []string       `json:"manualDomains"`
+	ExcludeSubnets []string `json:"excludeSubnets,omitempty"`
+	Subnets        []string `json:"subnets,omitempty"`
+	ManualDomains  []string `json:"manualDomains"`
 	// ManualText preserves the raw manual editor text, including comments and blank lines.
 	// Active ManualDomains are derived from it when the field is present in a request.
 	ManualText       *string        `json:"manualText,omitempty"`

--- a/internal/downloader/adapters_test.go
+++ b/internal/downloader/adapters_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestAWGTunnelIDFromTag(t *testing.T) {
 	tests := []struct {
-		tag       string
-		wantID    string
-		wantSys   bool
+		tag     string
+		wantID  string
+		wantSys bool
 	}{
 		{"awg-awg11", "awg11", false},
 		{"awg-sys-Wireguard0", "Wireguard0", true},

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -143,21 +143,21 @@ type ResourceInvalidatedEvent struct {
 // selective-bypass feature. Phase drives the step indicator in the
 // frontend rebuild modal. Delivered on "singbox-router:selective-progress".
 type SelectiveProgressEvent struct {
-	Phase      string `json:"phase"`   // "collecting"|"resolving"|"populating"|"done"|"error"
-	Message    string `json:"message"` // human-readable description of current step
-	Current    int    `json:"current"` // number of items processed so far
-	Total      int    `json:"total"`   // total items in this phase (0 = unknown)
-	Matcher    string `json:"matcher,omitempty"`
-	QueryHost  string `json:"queryHost,omitempty"`
+	Phase     string `json:"phase"`   // "collecting"|"resolving"|"populating"|"done"|"error"
+	Message   string `json:"message"` // human-readable description of current step
+	Current   int    `json:"current"` // number of items processed so far
+	Total     int    `json:"total"`   // total items in this phase (0 = unknown)
+	Matcher   string `json:"matcher,omitempty"`
+	QueryHost string `json:"queryHost,omitempty"`
 }
 
 // SelectiveRebuildSnapshotEvent is the persisted ipset rebuild outcome in SSE.
 type SelectiveRebuildSnapshotEvent struct {
-	RebuiltAt          string `json:"rebuiltAt"`
-	EntryCount         int    `json:"entryCount"`
-	StaticCIDRCount    int    `json:"staticCidrCount,omitempty"`
-	DomainMatcherCount int    `json:"domainMatcherCount,omitempty"`
-	LastCDNRefresh     string `json:"lastCDNRefresh,omitempty"`
+	RebuiltAt          string   `json:"rebuiltAt"`
+	EntryCount         int      `json:"entryCount"`
+	StaticCIDRCount    int      `json:"staticCidrCount,omitempty"`
+	DomainMatcherCount int      `json:"domainMatcherCount,omitempty"`
+	LastCDNRefresh     string   `json:"lastCDNRefresh,omitempty"`
 	StaticCIDRs        []string `json:"staticCidrs,omitempty"`
 }
 
@@ -165,11 +165,11 @@ type SelectiveRebuildSnapshotEvent struct {
 // entry count changes (e.g. after a successful rebuild or after ipset is
 // installed). Delivered on "singbox-router:selective-status".
 type SelectiveStatusEvent struct {
-	Available          bool   `json:"available"`             // ipset binary present
-	XtSetAvailable     bool   `json:"xtSetAvailable"`        // xt_set kernel module present
-	ConntrackAvailable bool   `json:"conntrackAvailable"`    // conntrack binary present
-	Enabled            bool   `json:"enabled"`               // setting enabled in storage
-	EntryCount         int    `json:"entryCount"`            // current ipset entry count
+	Available          bool                           `json:"available"`             // ipset binary present
+	XtSetAvailable     bool                           `json:"xtSetAvailable"`        // xt_set kernel module present
+	ConntrackAvailable bool                           `json:"conntrackAvailable"`    // conntrack binary present
+	Enabled            bool                           `json:"enabled"`               // setting enabled in storage
+	EntryCount         int                            `json:"entryCount"`            // current ipset entry count
 	LastRebuild        string                         `json:"lastRebuild,omitempty"` // RFC3339 timestamp
 	LastError          string                         `json:"lastError,omitempty"`
 	Snapshot           *SelectiveRebuildSnapshotEvent `json:"snapshot,omitempty"`

--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -117,4 +117,3 @@ func splitHostPortOptionalIPv6(s string) (host, port string) {
 	}
 	return s, ""
 }
-

--- a/internal/logging/service_test.go
+++ b/internal/logging/service_test.go
@@ -7,11 +7,11 @@ import (
 
 // mockSettings implements SettingsGetter for testing.
 type mockSettings struct {
-	enabled        bool
-	maxAge         int
-	logLevel       string
-	appMaxEntries  int
-	sbMaxEntries   int
+	enabled       bool
+	maxAge        int
+	logLevel      string
+	appMaxEntries int
+	sbMaxEntries  int
 }
 
 func (m *mockSettings) IsLoggingEnabled() bool {

--- a/internal/managed/types.go
+++ b/internal/managed/types.go
@@ -71,7 +71,7 @@ type TogglePeerRequest struct {
 
 // ManagedServerStats holds runtime statistics for the managed server.
 type ManagedServerStats struct {
-	Status string            `json:"status"` // "up" or "down"
+	Status string             `json:"status"` // "up" or "down"
 	Peers  []ManagedPeerStats `json:"peers"`
 }
 

--- a/internal/ndms/command/interfaces_payload_test.go
+++ b/internal/ndms/command/interfaces_payload_test.go
@@ -108,4 +108,3 @@ func TestInterfaceCommandsPayloads_DNS(t *testing.T) {
 		t.Fatalf("ClearDNS: %v", err)
 	}
 }
-

--- a/internal/ndms/command/policies_test.go
+++ b/internal/ndms/command/policies_test.go
@@ -104,4 +104,3 @@ func TestPolicyCommands_UnassignDevice(t *testing.T) {
 		t.Errorf("unassign: %#v", pol)
 	}
 }
-

--- a/internal/ndms/command/save.go
+++ b/internal/ndms/command/save.go
@@ -28,7 +28,9 @@ type PostSaveInvalidator interface {
 
 // savePayload is the NDMS command for "persist running-config to flash".
 // Matches the exact shape Keenetic's own web UI uses:
-//   {"system":{"configuration":{"save":{}}}}
+//
+//	{"system":{"configuration":{"save":{}}}}
+//
 // (This is `system configuration save` in ndmc CLI form.)
 // The previous shorthand {"save": true} was not a valid RCI path and
 // silently no-oped on OS5 — changes survived the session but certain
@@ -76,14 +78,18 @@ const (
 // debounce    — delay before firing Save after the last Request().
 // maxWait     — hard ceiling from first Request() in the current batch.
 // settleDelay — pause after a successful save before invalidating the
-//               RunningConfig cache. NDMS publishes running-config
-//               asynchronously after writing flash, so reads issued
-//               immediately after save would still see the old view.
-//               Pass 0 to disable settle entirely (skip both sleep and
-//               invalidate).
+//
+//	RunningConfig cache. NDMS publishes running-config
+//	asynchronously after writing flash, so reads issued
+//	immediately after save would still see the old view.
+//	Pass 0 to disable settle entirely (skip both sleep and
+//	invalidate).
+//
 // invalidator — cache surface invalidated after settle. Pass nil to
-//               disable settle (sleep is still skipped). Typically
-//               wired to query.Queries.RunningConfig.
+//
+//	disable settle (sleep is still skipped). Typically
+//	wired to query.Queries.RunningConfig.
+//
 // Retries: 3 attempts 5 seconds apart after a failed fire.
 func NewSaveCoordinator(
 	poster Poster,

--- a/internal/ndms/command/save_flush_test.go
+++ b/internal/ndms/command/save_flush_test.go
@@ -128,4 +128,3 @@ func TestSaveCoordinatorFlushDoesNotInvalidateOnFailure(t *testing.T) {
 		t.Fatalf("invalidator count = %d, want 0", invalidator.count)
 	}
 }
-

--- a/internal/ndms/metrics/poller.go
+++ b/internal/ndms/metrics/poller.go
@@ -45,8 +45,8 @@ type Poller struct {
 	interval    time.Duration
 	log         Logger
 
-	mu          sync.Mutex
-	prev        map[string]peerDigest
+	mu   sync.Mutex
+	prev map[string]peerDigest
 	// emptyUntil holds per-interface cooldown timestamps. Once an
 	// interface is observed with zero peers, we skip polling it for
 	// emptyCooldown — no point hitting NDMS every 5s for an empty

--- a/internal/ndms/query/dnsproxyconfig_test.go
+++ b/internal/ndms/query/dnsproxyconfig_test.go
@@ -51,4 +51,3 @@ func TestDNSProxyConfigStoreGetterErrorWrapped(t *testing.T) {
 		t.Fatalf("error = %q, want wrapped fetch dns-proxy config", err)
 	}
 }
-

--- a/internal/ndms/query/dnsproxystatus_test.go
+++ b/internal/ndms/query/dnsproxystatus_test.go
@@ -37,4 +37,3 @@ func TestDNSProxyStatusStoreGetterErrorWrapped(t *testing.T) {
 		t.Fatalf("error = %q, want wrapped fetch dns-proxy status", err)
 	}
 }
-

--- a/internal/ndms/query/getter_test.go
+++ b/internal/ndms/query/getter_test.go
@@ -77,4 +77,3 @@ func TestFakeGetterPostHandler(t *testing.T) {
 		t.Fatalf("Post() = %s", string(got))
 	}
 }
-

--- a/internal/ndms/query/interfaces.go
+++ b/internal/ndms/query/interfaces.go
@@ -1098,4 +1098,3 @@ func allInterfaceLabel(ifaceType, kernelName, description string) string {
 	}
 	return kernelName
 }
-

--- a/internal/ndms/query/interfaces_test.go
+++ b/internal/ndms/query/interfaces_test.go
@@ -433,16 +433,16 @@ func TestLooksLikeKernelIfname(t *testing.T) {
 		}
 	}
 	bad := []string{
-		"",               // empty
-		"ISP",            // upper-case
-		"Wireguard0",     // NDMS id
-		"PPPoE0",         // NDMS id
-		"GigabitEthernet1", // 16 chars AND upper-case
-		"AccessPoint",    // upper-case
-		"0eth",           // starts with digit
-		".eth",           // starts with punctuation
-		"eth/0",          // forbidden char
-		"a b",            // space
+		"",                   // empty
+		"ISP",                // upper-case
+		"Wireguard0",         // NDMS id
+		"PPPoE0",             // NDMS id
+		"GigabitEthernet1",   // 16 chars AND upper-case
+		"AccessPoint",        // upper-case
+		"0eth",               // starts with digit
+		".eth",               // starts with punctuation
+		"eth/0",              // forbidden char
+		"a b",                // space
 		"thisifnametoolong1", // 18 chars > IFNAMSIZ-1
 	}
 	for _, s := range bad {

--- a/internal/ndms/query/static_nat.go
+++ b/internal/ndms/query/static_nat.go
@@ -11,8 +11,8 @@ import (
 
 // StaticNATEntry is one row from /show/rc/ip/static.
 type StaticNATEntry struct {
-	Interface    string `json:"interface"`
-	ToInterface  string `json:"to-interface"`
+	Interface   string `json:"interface"`
+	ToInterface string `json:"to-interface"`
 }
 
 const staticNATTTL = 30 * time.Second

--- a/internal/ndms/transport/batcher_test.go
+++ b/internal/ndms/transport/batcher_test.go
@@ -473,7 +473,7 @@ func TestBatcher_Close_FinalFlushOfPending(t *testing.T) {
 		}(i)
 	}
 	time.Sleep(20 * time.Millisecond) // enqueued
-	b.Close()                          // should trigger final flush
+	b.Close()                         // should trigger final flush
 
 	for i := 0; i < 3; i++ {
 		select {

--- a/internal/ndms/transport/transport.go
+++ b/internal/ndms/transport/transport.go
@@ -16,4 +16,3 @@ var sharedTransport = &http.Transport{
 	IdleConnTimeout:     90 * time.Second,
 	DisableKeepAlives:   false,
 }
-

--- a/internal/ndms/types.go
+++ b/internal/ndms/types.go
@@ -6,14 +6,14 @@ import "time"
 // /show/interface/{name} or extracted from /show/interface/.
 type Interface struct {
 	ID            string `json:"id"`
-	SystemName    string `json:"systemName"`  // kernel name, e.g. nwg3
-	Type          string `json:"type"`         // "proxy", "wireguard", "ethernet", ...
+	SystemName    string `json:"systemName"` // kernel name, e.g. nwg3
+	Type          string `json:"type"`       // "proxy", "wireguard", "ethernet", ...
 	Description   string `json:"description"`
-	State         string `json:"state"`        // "up" | "down"
-	Link          string `json:"link"`         // "up" | "down"
-	Connected     string `json:"connected"`    // "yes" | "no" | ""
+	State         string `json:"state"`     // "up" | "down"
+	Link          string `json:"link"`      // "up" | "down"
+	Connected     string `json:"connected"` // "yes" | "no" | ""
 	SecurityLevel string `json:"securityLevel"`
-	IPv4          string `json:"ipv4,omitempty"`    // summary.layer.ipv4 — "running" | ""
+	IPv4          string `json:"ipv4,omitempty"` // summary.layer.ipv4 — "running" | ""
 	Address       string `json:"address,omitempty"`
 	Mask          string `json:"mask,omitempty"`
 	MTU           int    `json:"mtu,omitempty"`
@@ -46,19 +46,19 @@ type ProxyInfo struct {
 // Peer is one peer entry under an NDMS wireguard interface —
 // populated from the .wireguard.peer field of /show/interface/{name}.
 type Peer struct {
-	PublicKey              string    `json:"publicKey"`
-	Description            string    `json:"description,omitempty"`
-	LocalPort              int       `json:"localPort,omitempty"`
-	RemotePort             int       `json:"remotePort,omitempty"`
-	Via                    string    `json:"via,omitempty"`
-	LocalEndpointAddress   string    `json:"localEndpointAddress,omitempty"`
-	RemoteEndpointAddress  string    `json:"remoteEndpointAddress,omitempty"`
-	RxBytes                int64     `json:"rxBytes"`
-	TxBytes                int64     `json:"txBytes"`
-	LastHandshakeSecondsAgo int64    `json:"lastHandshakeSecondsAgo"`
-	Online                 bool      `json:"online"`
-	Enabled                bool      `json:"enabled"`
-	Fwmark                 int64     `json:"fwmark,omitempty"`
+	PublicKey               string `json:"publicKey"`
+	Description             string `json:"description,omitempty"`
+	LocalPort               int    `json:"localPort,omitempty"`
+	RemotePort              int    `json:"remotePort,omitempty"`
+	Via                     string `json:"via,omitempty"`
+	LocalEndpointAddress    string `json:"localEndpointAddress,omitempty"`
+	RemoteEndpointAddress   string `json:"remoteEndpointAddress,omitempty"`
+	RxBytes                 int64  `json:"rxBytes"`
+	TxBytes                 int64  `json:"txBytes"`
+	LastHandshakeSecondsAgo int64  `json:"lastHandshakeSecondsAgo"`
+	Online                  bool   `json:"online"`
+	Enabled                 bool   `json:"enabled"`
+	Fwmark                  int64  `json:"fwmark,omitempty"`
 }
 
 // Policy — NDMS ip policy (from /show/rc/ip/policy).
@@ -165,7 +165,7 @@ type WireguardServer struct {
 type WireguardServerPeer struct {
 	PublicKey     string   `json:"publicKey"`
 	Description   string   `json:"description"`
-	Endpoint      string   `json:"endpoint"`              // "ip:port"
+	Endpoint      string   `json:"endpoint"`             // "ip:port"
 	AllowedIPs    []string `json:"allowedIPs,omitempty"` // enriched from /show/rc/interface
 	RxBytes       int64    `json:"rxBytes"`
 	TxBytes       int64    `json:"txBytes"`
@@ -211,7 +211,7 @@ type SystemWireguardTunnel struct {
 // WireguardPeerInfo is the minimal tunnel-peer view (first peer only, for system-tunnel UI).
 type WireguardPeerInfo struct {
 	PublicKey     string `json:"publicKey"`
-	Endpoint      string `json:"endpoint"` // "ip:port"
+	Endpoint      string `json:"endpoint"`      // "ip:port"
 	Via           string `json:"via,omitempty"` // ISP/connection interface (e.g. "PPPoE0")
 	RxBytes       int64  `json:"rxBytes"`
 	TxBytes       int64  `json:"txBytes"`
@@ -255,18 +255,18 @@ func (d InterfaceDetails) LinkUp() bool { return d.Link == "up" }
 
 // Version — NDMS system version from /show/version. Cached write-once at boot.
 type Version struct {
-	Release      string    `json:"release"`      // e.g. "4.2.5"
-	Title        string    `json:"title"`        // product name
-	HardwareID   string    `json:"hardwareId"`
-	Description  string    `json:"description"`
-	Manufacturer string    `json:"manufacturer,omitempty"`
-	Vendor       string    `json:"vendor,omitempty"`
-	Series       string    `json:"series,omitempty"`
-	Model        string    `json:"model,omitempty"`
-	Device       string    `json:"device,omitempty"`
-	Region       string    `json:"region,omitempty"`
-	Components   []string  `json:"components,omitempty"`
-	Uptime       int64     `json:"uptime,omitempty"` // seconds
+	Release      string   `json:"release"` // e.g. "4.2.5"
+	Title        string   `json:"title"`   // product name
+	HardwareID   string   `json:"hardwareId"`
+	Description  string   `json:"description"`
+	Manufacturer string   `json:"manufacturer,omitempty"`
+	Vendor       string   `json:"vendor,omitempty"`
+	Series       string   `json:"series,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	Device       string   `json:"device,omitempty"`
+	Region       string   `json:"region,omitempty"`
+	Components   []string `json:"components,omitempty"`
+	Uptime       int64    `json:"uptime,omitempty"` // seconds
 	// LastFetched is set by SystemInfoStore.Init (not from NDMS).
 	LastFetched time.Time `json:"lastFetched"`
 }

--- a/internal/pingcheck/facade.go
+++ b/internal/pingcheck/facade.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/events"
-	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/ndms"
+	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/sys/ndmsinfo"
 	"github.com/hoaxisr/awg-manager/internal/tunnel/nwg"
 )

--- a/internal/pingcheck/facade_test.go
+++ b/internal/pingcheck/facade_test.go
@@ -237,11 +237,11 @@ func TestFacade_MinInterval(t *testing.T) {
 // (fail or success counter > 0) the warming label gives way to the real state.
 func TestNwgCardStatus_WarmupVsRealStates(t *testing.T) {
 	cases := []struct {
-		name                       string
-		status                     string
-		failCount, successCount    int
-		bound, restartDetected     bool
-		want                       string
+		name                    string
+		status                  string
+		failCount, successCount int
+		bound, restartDetected  bool
+		want                    string
 	}{
 		{"fresh warmup fail/0/0", "fail", 0, 0, true, false, "warming"},
 		{"warmup empty status", "", 0, 0, true, false, "warming"},

--- a/internal/pingcheck/types.go
+++ b/internal/pingcheck/types.go
@@ -28,16 +28,16 @@ type TunnelStatus struct {
 	TunnelID      string     `json:"tunnelId"`
 	TunnelName    string     `json:"tunnelName"`
 	Enabled       bool       `json:"enabled"`
-	Backend       string     `json:"backend"`                // "kernel" or "nativewg"
-	Status        string     `json:"status"`                 // "alive", "recovering", "disabled", "stopped"
-	Method        string     `json:"method"`                 // "http", "icmp", "connect", "tls", "uri"
+	Backend       string     `json:"backend"` // "kernel" or "nativewg"
+	Status        string     `json:"status"`  // "alive", "recovering", "disabled", "stopped"
+	Method        string     `json:"method"`  // "http", "icmp", "connect", "tls", "uri"
 	LastCheck     *time.Time `json:"lastCheck"`
-	LastLatency   int        `json:"lastLatency"`            // ms
+	LastLatency   int        `json:"lastLatency"` // ms
 	FailCount     int        `json:"failCount"`
 	SuccessCount  int        `json:"successCount,omitempty"` // NDMS native only
 	FailThreshold int        `json:"failThreshold"`
 	RestartCount  int        `json:"restartCount"`
-	TunnelRunning bool       `json:"tunnelRunning"`          // whether the tunnel interface is actually up
+	TunnelRunning bool       `json:"tunnelRunning"` // whether the tunnel interface is actually up
 }
 
 // TunnelPingInfo is a lightweight status for embedding in tunnel list responses.

--- a/internal/presets/defaults_test.go
+++ b/internal/presets/defaults_test.go
@@ -103,12 +103,12 @@ func TestDefaultsCatalogCovers(t *testing.T) {
 		}
 	}
 	wantParents := map[string]int{
-		"category-ai":     6,
-		"category-games":  10,
-		"category-media":  12,
-		"meta":            4,
-		"dev-tools":       3,
-		"google":          2,
+		"category-ai":    6,
+		"category-games": 10,
+		"category-media": 12,
+		"meta":           4,
+		"dev-tools":      3,
+		"google":         2,
 	}
 	for id, n := range wantParents {
 		var found *Preset

--- a/internal/presets/types.go
+++ b/internal/presets/types.go
@@ -12,16 +12,16 @@ const (
 // Preset is a reusable service template. It is NOT an applied route — applied
 // routes are separate instances that reference a preset by ID.
 type Preset struct {
-	ID        string  `json:"id"`
-	Name      string  `json:"name"`
-	IconSlug  string  `json:"iconSlug"`
-	Category  string  `json:"category"` // social|media|ai|developer|cloud|gaming|block (free string)
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	IconSlug  string   `json:"iconSlug"`
+	Category  string   `json:"category"` // social|media|ai|developer|cloud|gaming|block (free string)
 	Notice    string   `json:"notice,omitempty"`
 	Covers    []string `json:"covers,omitempty"` // preset ids included in this composite list
 	Featured  bool     `json:"featured,omitempty"`
 	Sensitive bool     `json:"sensitive,omitempty"`
 	Origin    Origin   `json:"origin"`
-	Engines   Engines `json:"engines"`
+	Engines   Engines  `json:"engines"`
 }
 
 // Engines holds per-engine payloads. A nil pointer means the preset does not

--- a/internal/routing/catalog.go
+++ b/internal/routing/catalog.go
@@ -69,9 +69,9 @@ type Catalog interface {
 type TunnelWithStatus struct {
 	ID       string
 	Name     string
-	Backend  string       // "kernel" or "nativewg"
+	Backend  string // "kernel" or "nativewg"
 	State    tunnel.State
-	NWGIndex int          // only for nativewg
+	NWGIndex int // only for nativewg
 }
 
 // TunnelProvider abstracts the tunnel service for Catalog.
@@ -119,8 +119,8 @@ type CatalogImpl struct {
 	snapAccessPolicies   SnapshotFunc
 	snapPolicyDevices    SnapshotFunc
 	snapPolicyInterfaces SnapshotFunc
-	snapClientRoutes         SnapshotFunc
-	snapHydraRouteStatus     SnapshotFunc
+	snapClientRoutes     SnapshotFunc
+	snapHydraRouteStatus SnapshotFunc
 }
 
 // NewCatalog creates a new CatalogImpl.

--- a/internal/signature/capture.go
+++ b/internal/signature/capture.go
@@ -135,7 +135,6 @@ func captureQUIC(domain, ip string, timeout time.Duration) ([][]byte, error) {
 	return packets, nil
 }
 
-
 // buildQUICInitial constructs a properly AEAD-encrypted QUIC v1 Initial packet
 // containing a real TLS 1.3 ClientHello with the given domain as SNI.
 // Encryption follows RFC 9001: Initial keys derived from DCID via HKDF,
@@ -177,7 +176,7 @@ func buildQUICInitial(domain string) ([]byte, error) {
 	// Payload to encrypt = CRYPTO frame + PADDING (to reach 1200 bytes minimum)
 	// We need to calculate header size first to know how much padding we need
 	headerSizeEstimate := 1 + 4 + 1 + len(dcid) + 1 + 1 + 2 + pktNumLen // flags+ver+dcid+scid+token+length+pn
-	minPayloadBytes := 1200 - headerSizeEstimate - 16                     // minus AEAD tag
+	minPayloadBytes := 1200 - headerSizeEstimate - 16                   // minus AEAD tag
 	plaintext := cryptoFrame
 	if len(plaintext) < minPayloadBytes {
 		plaintext = append(plaintext, make([]byte, minPayloadBytes-len(plaintext))...)

--- a/internal/singbox/installer/installer_limit_test.go
+++ b/internal/singbox/installer/installer_limit_test.go
@@ -8,10 +8,10 @@ func TestDownloadByteLimit(t *testing.T) {
 		reserve  = 16 << 20
 	)
 	cases := []struct {
-		name    string
-		free    int64
-		freeOK  bool
-		want    int64
+		name   string
+		free   int64
+		freeOK bool
+		want   int64
 	}{
 		{"free unknown → fallback", 0, false, fallback},
 		{"plenty (external storage, GBs)", 4 << 30, true, (4 << 30) - reserve},

--- a/internal/singbox/operator_manual_stop_test.go
+++ b/internal/singbox/operator_manual_stop_test.go
@@ -173,7 +173,7 @@ func TestOperator_SetManualStop_PersistFailure_RollsBackFlag(t *testing.T) {
 	})
 	// Pre-set flag to false; attempt to set to true; expect rollback.
 	if err := op.setManualStop(true); err == nil {
-			t.Fatalf("setManualStop: want error, got nil")
+		t.Fatalf("setManualStop: want error, got nil")
 	}
 	if op.manuallyStopped.Load() {
 		t.Errorf("in-memory flag must roll back to false on persist failure")

--- a/internal/singbox/subscription/cross_slot_heal_test.go
+++ b/internal/singbox/subscription/cross_slot_heal_test.go
@@ -20,7 +20,7 @@ func TestCleanCrossSlotUnknownRefs(t *testing.T) {
 	}
 	res := orchestrator.ValidationResult{Errors: []orchestrator.ValidationError{
 		{Slot: orchestrator.SlotSubscriptions, Kind: "unknown-outbound", Tag: "gone", InRule: `outbounds[2="g"].outbounds[2]`},
-		{Slot: "router", Kind: "unknown-outbound", Tag: "other"},          // different slot — not ours to clean
+		{Slot: "router", Kind: "unknown-outbound", Tag: "other"},                      // different slot — not ours to clean
 		{Slot: orchestrator.SlotSubscriptions, Kind: "duplicate-outbound", Tag: "s1"}, // wrong kind — ignore
 	}}
 

--- a/internal/singbox/subscription/scheduler_test.go
+++ b/internal/singbox/subscription/scheduler_test.go
@@ -49,7 +49,7 @@ func TestScheduler_SkipsInFlightRefresh(t *testing.T) {
 	}
 
 	sched := NewScheduler(store, doRefresh)
-	now := time.Now().Add(2 * time.Hour) // due
+	now := time.Now().Add(2 * time.Hour)  // due
 	sched.tick(context.Background(), now) // launches refresh #1
 	<-started                             // #1 is now in-flight
 	sched.tick(context.Background(), now) // still due, but #1 in-flight → must skip

--- a/internal/singbox/subscription/types.go
+++ b/internal/singbox/subscription/types.go
@@ -7,9 +7,9 @@ import "time"
 // re-parsing the raw outbound JSON each time.
 type MemberInfo struct {
 	Tag       string `json:"tag"`
-	Label     string `json:"label,omitempty"`     // human-readable name from Clash "name", empty for share-links
-	Protocol  string `json:"protocol"`            // "vless" | "trojan" | "shadowsocks" | "hysteria2" | "naive"
-	Server    string `json:"server"`              // host
+	Label     string `json:"label,omitempty"` // human-readable name from Clash "name", empty for share-links
+	Protocol  string `json:"protocol"`        // "vless" | "trojan" | "shadowsocks" | "hysteria2" | "naive"
+	Server    string `json:"server"`          // host
 	Port      uint16 `json:"port"`
 	SNI       string `json:"sni,omitempty"`
 	Transport string `json:"transport,omitempty"` // "tcp" | "ws" | "grpc" | "http" — empty if N/A
@@ -54,33 +54,33 @@ func DefaultURLTestConfig() URLTestConfig {
 // subscription is either URL-backed (Inline == "") or inline (URL == "");
 // IsInline is the canonical predicate.
 type Subscription struct {
-	ID           string           `json:"id"`                  // uuid
-	Label        string           `json:"label"`               // user-facing
-	URL          string           `json:"url"`                 // subscription URL ("" when inline)
-	Inline       string           `json:"inline,omitempty"`    // raw paste of share-links / clash YAML / sing-box JSON
-	Headers      []Header         `json:"headers"`             // custom HTTP headers for fetch (URL-backed only)
-	RefreshHours int              `json:"refreshHours"`        // 0 = manual only; ignored for inline
-	LastFetched  time.Time        `json:"lastFetched"`
-	LastError    string           `json:"lastError,omitempty"`
-	SelectorTag  string           `json:"selectorTag"`           // "sub-<id-short>"
-	InboundTag   string           `json:"inboundTag"`            // "sub-<id-short>-in"
-	ListenPort   uint16           `json:"listenPort"`            // localhost port for the mixed inbound
-	ProxyIndex   int              `json:"proxyIndex"`            // NDMS ProxyN index, -1 if not yet allocated
-	MemberTags   []string         `json:"memberTags"`            // every member outbound tag (kept for back-compat)
-	Members      []MemberInfo     `json:"members,omitempty"`     // per-member parsed metadata
-	OrphanTags        []string               `json:"orphanTags"`                  // tags missing on last refresh
-	RejectedMembers   []RejectedMember       `json:"rejectedMembers,omitempty"`   // parsed but not in sing-box / invalid
-	InfoItems         []SubscriptionInfoItem `json:"infoItems,omitempty"`         // provider banners (max 4)
-	DismissedInfoIDs  []string               `json:"dismissedInfoIds,omitempty"`  // hidden on refresh (user removed from UI)
-	ActiveMember      string                 `json:"activeMember,omitempty"`      // currently-active selector member tag
-	ExcludedTags    []string     `json:"excludedTags,omitempty"`    // полные стабильные теги, исключённые пользователем (источник правды)
-	ExcludedMembers []MemberInfo `json:"excludedMembers,omitempty"` // display-метаданные исключённых (обновляются при refresh)
-	FilterInclude   string       `json:"filterInclude,omitempty"`   // regex (Go RE2): оставить только серверы с совпадающим именем; "" = без фильтра
-	FilterExclude   string       `json:"filterExclude,omitempty"`   // regex (Go RE2): скрыть серверы с совпадающим именем; "" = без фильтра
-	FilteredMembers []MemberInfo `json:"filteredMembers,omitempty"` // display-метаданные скрытых фильтром (перестраиваются при refresh)
-	Enabled      bool             `json:"enabled"`
-	Mode         SubscriptionMode `json:"mode,omitempty"`        // "" treated as ModeSelector for back-compat
-	URLTest      *URLTestConfig   `json:"urlTest,omitempty"`     // populated when Mode == ModeURLTest
+	ID               string                 `json:"id"`               // uuid
+	Label            string                 `json:"label"`            // user-facing
+	URL              string                 `json:"url"`              // subscription URL ("" when inline)
+	Inline           string                 `json:"inline,omitempty"` // raw paste of share-links / clash YAML / sing-box JSON
+	Headers          []Header               `json:"headers"`          // custom HTTP headers for fetch (URL-backed only)
+	RefreshHours     int                    `json:"refreshHours"`     // 0 = manual only; ignored for inline
+	LastFetched      time.Time              `json:"lastFetched"`
+	LastError        string                 `json:"lastError,omitempty"`
+	SelectorTag      string                 `json:"selectorTag"`                // "sub-<id-short>"
+	InboundTag       string                 `json:"inboundTag"`                 // "sub-<id-short>-in"
+	ListenPort       uint16                 `json:"listenPort"`                 // localhost port for the mixed inbound
+	ProxyIndex       int                    `json:"proxyIndex"`                 // NDMS ProxyN index, -1 if not yet allocated
+	MemberTags       []string               `json:"memberTags"`                 // every member outbound tag (kept for back-compat)
+	Members          []MemberInfo           `json:"members,omitempty"`          // per-member parsed metadata
+	OrphanTags       []string               `json:"orphanTags"`                 // tags missing on last refresh
+	RejectedMembers  []RejectedMember       `json:"rejectedMembers,omitempty"`  // parsed but not in sing-box / invalid
+	InfoItems        []SubscriptionInfoItem `json:"infoItems,omitempty"`        // provider banners (max 4)
+	DismissedInfoIDs []string               `json:"dismissedInfoIds,omitempty"` // hidden on refresh (user removed from UI)
+	ActiveMember     string                 `json:"activeMember,omitempty"`     // currently-active selector member tag
+	ExcludedTags     []string               `json:"excludedTags,omitempty"`     // полные стабильные теги, исключённые пользователем (источник правды)
+	ExcludedMembers  []MemberInfo           `json:"excludedMembers,omitempty"`  // display-метаданные исключённых (обновляются при refresh)
+	FilterInclude    string                 `json:"filterInclude,omitempty"`    // regex (Go RE2): оставить только серверы с совпадающим именем; "" = без фильтра
+	FilterExclude    string                 `json:"filterExclude,omitempty"`    // regex (Go RE2): скрыть серверы с совпадающим именем; "" = без фильтра
+	FilteredMembers  []MemberInfo           `json:"filteredMembers,omitempty"`  // display-метаданные скрытых фильтром (перестраиваются при refresh)
+	Enabled          bool                   `json:"enabled"`
+	Mode             SubscriptionMode       `json:"mode,omitempty"`    // "" treated as ModeSelector for back-compat
+	URLTest          *URLTestConfig         `json:"urlTest,omitempty"` // populated when Mode == ModeURLTest
 }
 
 // IsInline reports whether the subscription's content is paste-supplied
@@ -131,30 +131,30 @@ type Header struct {
 // CreateInput is the input to Service.Create. Exactly one of URL or
 // Inline must be set; setting both or neither is rejected.
 type CreateInput struct {
-	Label        string
-	URL          string
-	Inline       string
-	Headers      []Header
-	RefreshHours int
-	Enabled      bool
-	Mode         SubscriptionMode // "" = ModeSelector
-	URLTest      *URLTestConfig   // ignored when Mode != ModeURLTest; defaults applied otherwise
-	ExcludedKeys []string         // суффиксы тегов из превью (suffixOf, узкий или расширенный) для исключения на первичном refresh
-	FilterInclude string          // regex-фильтр «включать только» (валидируется в Service.Create)
-	FilterExclude string          // regex-фильтр «исключать» (валидируется в Service.Create)
+	Label         string
+	URL           string
+	Inline        string
+	Headers       []Header
+	RefreshHours  int
+	Enabled       bool
+	Mode          SubscriptionMode // "" = ModeSelector
+	URLTest       *URLTestConfig   // ignored when Mode != ModeURLTest; defaults applied otherwise
+	ExcludedKeys  []string         // суффиксы тегов из превью (suffixOf, узкий или расширенный) для исключения на первичном refresh
+	FilterInclude string           // regex-фильтр «включать только» (валидируется в Service.Create)
+	FilterExclude string           // regex-фильтр «исключать» (валидируется в Service.Create)
 }
 
 // UpdatePatch is partial update; nil pointers mean "leave as-is".
 type UpdatePatch struct {
-	Label        *string
-	URL          *string
-	Headers      *[]Header
-	RefreshHours *int
-	Enabled      *bool
-	Mode         *SubscriptionMode
-	URLTest      *URLTestConfig // overwrites stored URLTest when non-nil
-	FilterInclude *string       // regex-фильтр «включать только»; "" = снять фильтр
-	FilterExclude *string       // regex-фильтр «исключать»; "" = снять фильтр
+	Label         *string
+	URL           *string
+	Headers       *[]Header
+	RefreshHours  *int
+	Enabled       *bool
+	Mode          *SubscriptionMode
+	URLTest       *URLTestConfig // overwrites stored URLTest when non-nil
+	FilterInclude *string        // regex-фильтр «включать только»; "" = снять фильтр
+	FilterExclude *string        // regex-фильтр «исключать»; "" = снять фильтр
 }
 
 // RefreshResult is the outcome of a single refresh cycle.

--- a/internal/singbox/vlink/amnezia.go
+++ b/internal/singbox/vlink/amnezia.go
@@ -83,9 +83,9 @@ func amneziaVlessToOutbound(ob xrayOutbound, tag string) (*ParsedOutbound, error
 	user := v.Users[0]
 
 	var stream struct {
-		Network         string `json:"network"`
-		Security        string `json:"security"`
-		TLSSettings     struct {
+		Network     string `json:"network"`
+		Security    string `json:"security"`
+		TLSSettings struct {
 			ServerName  string   `json:"serverName"`
 			ALPN        []string `json:"alpn"`
 			Fingerprint string   `json:"fingerprint"`

--- a/internal/singbox/vlink/encode_extra_test.go
+++ b/internal/singbox/vlink/encode_extra_test.go
@@ -83,7 +83,7 @@ func TestEncode_LabelRoundTrip(t *testing.T) {
 // emitting a malformed share-link.
 func TestEncodeOutbound_ErrorBranches(t *testing.T) {
 	cases := map[string]string{
-		"unsupported type":   `{"type":"vmess","server":"h","server_port":443,"uuid":"u"}`,
+		"unsupported type":    `{"type":"vmess","server":"h","server_port":443,"uuid":"u"}`,
 		"ss missing password": `{"type":"shadowsocks","server":"h","server_port":8388,"method":"aes-256-gcm"}`,
 		"ss missing method":   `{"type":"shadowsocks","server":"h","server_port":8388,"password":"p"}`,
 		"vless missing uuid":  `{"type":"vless","server":"h","server_port":443}`,

--- a/internal/staticroute/parser_test.go
+++ b/internal/staticroute/parser_test.go
@@ -106,9 +106,9 @@ func TestParseBatTooFewFields(t *testing.T) {
 
 func TestMaskToCIDR(t *testing.T) {
 	tests := []struct {
-		mask    string
-		want    int
-		wantOK  bool
+		mask   string
+		want   int
+		wantOK bool
 	}{
 		{"255.255.255.255", 32, true},
 		{"255.255.255.0", 24, true},

--- a/internal/storage/stringslices_test.go
+++ b/internal/storage/stringslices_test.go
@@ -28,4 +28,3 @@ func TestContains(t *testing.T) {
 		t.Fatal("contains should not find z")
 	}
 }
-

--- a/internal/storage/types_patch_test.go
+++ b/internal/storage/types_patch_test.go
@@ -15,4 +15,3 @@ func TestLoggingSettingsPatchZeroValuesAreOptional(t *testing.T) {
 		t.Fatalf("zero LoggingSettingsPatch should keep optional fields nil: %#v", p)
 	}
 }
-

--- a/internal/sys/kmod/loader.go
+++ b/internal/sys/kmod/loader.go
@@ -342,4 +342,3 @@ func copyFile(src, dst string) error {
 	}
 	return nil
 }
-

--- a/internal/sys/ndmsinfo/info_test.go
+++ b/internal/sys/ndmsinfo/info_test.go
@@ -31,4 +31,3 @@ func TestIsAtLeast501A3(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/terminal/proc_linux.go
+++ b/internal/terminal/proc_linux.go
@@ -14,7 +14,7 @@ import (
 
 func setTerminalSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:   true,
+		Setpgid: true,
 		// PR_SET_PDEATHSIG: kernel sends SIGTERM to ttyd when our process
 		// dies (including SIGKILL/crash). Without this the child outlives
 		// us and keeps holding its TCP port — over multiple awg-manager

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -38,10 +38,10 @@ type IPCheckService struct {
 // SpeedTestResult from test/speed endpoint.
 type SpeedTestResult struct {
 	Server      string  `json:"server"`
-	Direction   string  `json:"direction"`   // "download" or "upload"
-	Bandwidth   float64 `json:"bandwidth"`   // Mbps
+	Direction   string  `json:"direction"` // "download" or "upload"
+	Bandwidth   float64 `json:"bandwidth"` // Mbps
 	Bytes       int64   `json:"bytes"`
-	Duration    float64 `json:"duration"`    // seconds
+	Duration    float64 `json:"duration"` // seconds
 	Retransmits int     `json:"retransmits"`
 }
 

--- a/internal/tunnel/external/external.go
+++ b/internal/tunnel/external/external.go
@@ -183,4 +183,3 @@ func (s *Service) Adopt(ctx context.Context, req AdoptRequest) (*service.TunnelW
 
 	return s.tunnelService.Get(ctx, t.ID)
 }
-

--- a/internal/tunnel/ops/operator_os4_test.go
+++ b/internal/tunnel/ops/operator_os4_test.go
@@ -285,4 +285,3 @@ func TestOperatorOS4_GetTrackedEndpointIP_NoOp(t *testing.T) {
 		t.Errorf("GetTrackedEndpointIP() = %q, want empty (no-op on OS4)", got)
 	}
 }
-

--- a/internal/tunnel/service/active_wan_test.go
+++ b/internal/tunnel/service/active_wan_test.go
@@ -125,7 +125,7 @@ func (m *mockOp) Start(ctx context.Context, cfg tunnel.Config) error {
 	return m.startError
 }
 
-func (m *mockOp) GetSystemName(_ context.Context, ndmsID string) string { return ndmsID }
+func (m *mockOp) GetSystemName(_ context.Context, ndmsID string) string         { return ndmsID }
 func (m *mockOp) SetDefaultRoute(ctx context.Context, ndmsName string) error    { return nil }
 func (m *mockOp) RemoveDefaultRoute(ctx context.Context, ndmsName string) error { return nil }
 func (m *mockOp) Suspend(ctx context.Context, tunnelID string) error            { return nil }

--- a/internal/tunnel/service/address_check.go
+++ b/internal/tunnel/service/address_check.go
@@ -46,4 +46,3 @@ func checkStoredAddressConflicts(store *storage.AWGTunnelStore, address, exclude
 	}
 	return warnings
 }
-

--- a/internal/tunnel/service/impl.go
+++ b/internal/tunnel/service/impl.go
@@ -72,7 +72,7 @@ type AWGSyncer interface {
 func (s *ServiceImpl) SetAWGSyncer(sync AWGSyncer) { s.awgSyncer = sync }
 
 func (s *ServiceImpl) SetDeviceProxyRefChecker(c DeviceProxyRefChecker) { s.deviceProxyRefs = c }
-func (s *ServiceImpl) SetRouterRefChecker(c RouterRefChecker)            { s.routerRefs = c }
+func (s *ServiceImpl) SetRouterRefChecker(c RouterRefChecker)           { s.routerRefs = c }
 
 func (s *ServiceImpl) notifyAWGSyncer(ctx context.Context) {
 	if s.awgSyncer == nil {

--- a/internal/tunnel/service/impl_test.go
+++ b/internal/tunnel/service/impl_test.go
@@ -33,33 +33,39 @@ func (m *MockStateManager) SetState(tunnelID string, state tunnel.StateInfo) {
 
 // MockOperator is a mock operator.
 type MockOperator struct {
-	createError        error
-	startError         error
-	stopError          error
-	deleteError        error
-	recoverError       error
-	applyConfigError   error
-	setMTUError        error
+	createError      error
+	startError       error
+	stopError        error
+	deleteError      error
+	recoverError     error
+	applyConfigError error
+	setMTUError      error
 
 	// SetupEndpointRouteIP is the IP returned by SetupEndpointRoute.
 	SetupEndpointRouteIP string
 	// TrackedEndpointIPs maps tunnelID -> IP for GetTrackedEndpointIP.
 	TrackedEndpointIPs map[string]string
 
-	CreateCalls              []tunnel.Config
-	StartCalls               []tunnel.Config
-	StopCalls                []string
-	DeleteCalls              []string
-	RecoverCalls             []struct{ ID string; State tunnel.StateInfo }
-	ReconcileCalls           []tunnel.Config
-	ApplyConfigCalls         []struct{ ID, Path string }
-	SetupEndpointRouteCalls  []struct{ ID, Endpoint, ISP string }
-	CleanupEndpointRouteCalls []string
+	CreateCalls  []tunnel.Config
+	StartCalls   []tunnel.Config
+	StopCalls    []string
+	DeleteCalls  []string
+	RecoverCalls []struct {
+		ID    string
+		State tunnel.StateInfo
+	}
+	ReconcileCalls               []tunnel.Config
+	ApplyConfigCalls             []struct{ ID, Path string }
+	SetupEndpointRouteCalls      []struct{ ID, Endpoint, ISP string }
+	CleanupEndpointRouteCalls    []string
 	RestoreEndpointTrackingCalls []struct{ ID, Endpoint string }
-	SetMTUCalls              []struct{ ID string; MTU int }
-	UpdateDescriptionCalls   []struct{ ID, Desc string }
-	SyncDNSCalls             [][]string
-	SyncAddressCalls         []struct{ ID, Addr, IPv6 string }
+	SetMTUCalls                  []struct {
+		ID  string
+		MTU int
+	}
+	UpdateDescriptionCalls []struct{ ID, Desc string }
+	SyncDNSCalls           [][]string
+	SyncAddressCalls       []struct{ ID, Addr, IPv6 string }
 }
 
 func (m *MockOperator) Create(ctx context.Context, cfg tunnel.Config) error {
@@ -88,7 +94,10 @@ func (m *MockOperator) Delete(ctx context.Context, stored *storage.AWGTunnel) er
 }
 
 func (m *MockOperator) Recover(ctx context.Context, tunnelID string, state tunnel.StateInfo) error {
-	m.RecoverCalls = append(m.RecoverCalls, struct{ ID string; State tunnel.StateInfo }{tunnelID, state})
+	m.RecoverCalls = append(m.RecoverCalls, struct {
+		ID    string
+		State tunnel.StateInfo
+	}{tunnelID, state})
 	return m.recoverError
 }
 
@@ -125,7 +134,10 @@ func (m *MockOperator) GetTrackedEndpointIP(tunnelID string) string {
 }
 
 func (m *MockOperator) SetMTU(ctx context.Context, tunnelID string, mtu int) error {
-	m.SetMTUCalls = append(m.SetMTUCalls, struct{ ID string; MTU int }{tunnelID, mtu})
+	m.SetMTUCalls = append(m.SetMTUCalls, struct {
+		ID  string
+		MTU int
+	}{tunnelID, mtu})
 	return m.setMTUError
 }
 

--- a/internal/tunnel/state/impl.go
+++ b/internal/tunnel/state/impl.go
@@ -143,8 +143,6 @@ func (m *ManagerImpl) GetState(ctx context.Context, tunnelID string) tunnel.Stat
 	return info
 }
 
-
-
 // sysfsDeviceExists checks if a network device exists (via sysfs).
 func (m *ManagerImpl) sysfsDeviceExists(ifaceName string) bool {
 	_, err := os.Stat(fmt.Sprintf("/sys/class/net/%s", ifaceName))

--- a/internal/tunnel/state/manager.go
+++ b/internal/tunnel/state/manager.go
@@ -21,4 +21,3 @@ type Manager interface {
 	// Use for operations (Start, Stop, WAN events) that need authoritative state.
 	GetState(ctx context.Context, tunnelID string) tunnel.StateInfo
 }
-

--- a/internal/tunnel/state/matrix_v2_test.go
+++ b/internal/tunnel/state/matrix_v2_test.go
@@ -13,9 +13,9 @@ func TestStateMatrixV2_DetermineState(t *testing.T) {
 	m := StateMatrixV2{}
 
 	tests := []struct {
-		name    string
-		input   StateInputs
-		want    tunnel.State
+		name  string
+		input StateInputs
+		want  tunnel.State
 	}{
 		// === NotCreated: no OpkgTun ===
 		{

--- a/internal/tunnel/types_test.go
+++ b/internal/tunnel/types_test.go
@@ -53,12 +53,12 @@ func TestState_IsTerminal(t *testing.T) {
 
 func TestNewNames(t *testing.T) {
 	tests := []struct {
-		tunnelID     string
-		wantNum      string
-		wantNDMS     string
-		wantIface    string
-		wantConf     string
-		wantSocket   string
+		tunnelID   string
+		wantNum    string
+		wantNDMS   string
+		wantIface  string
+		wantConf   string
+		wantSocket string
 	}{
 		{
 			tunnelID:   "awg0",

--- a/internal/tunnel/wan/model.go
+++ b/internal/tunnel/wan/model.go
@@ -217,5 +217,3 @@ func (m *Model) IsPopulated() bool {
 	defer m.mu.RUnlock()
 	return m.populated
 }
-
-

--- a/internal/updater/changelog_slice_test.go
+++ b/internal/updater/changelog_slice_test.go
@@ -134,7 +134,7 @@ func TestMinorLine_DevelopRevisions(t *testing.T) {
 	entries := map[string]Entry{
 		"2.11.2+r93": {Version: "2.11.2+r93"},
 		"2.11.2+r95": {Version: "2.11.2+r95"},
-		"2.10.9+r4":  {Version: "2.10.9+r4"}, // other minor → excluded
+		"2.10.9+r4":  {Version: "2.10.9+r4"},  // other minor → excluded
 		"2.11.2+r99": {Version: "2.11.2+r99"}, // newer than current → excluded
 	}
 	got := MinorLine(entries, "2.11.2+r95")

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -7,18 +7,18 @@ import (
 
 // UpdateInfo holds the result of an update check.
 type UpdateInfo struct {
-	Available      bool      `json:"available"`
-	CurrentVersion string    `json:"currentVersion"`
-	LatestVersion  string    `json:"latestVersion,omitempty"`
-	DownloadURL    string    `json:"downloadUrl,omitempty"`
+	Available      bool   `json:"available"`
+	CurrentVersion string `json:"currentVersion"`
+	LatestVersion  string `json:"latestVersion,omitempty"`
+	DownloadURL    string `json:"downloadUrl,omitempty"`
 	// SHA256 is the expected ipk checksum from the repo Packages index.
 	// The repo is served over plain HTTP, so verifying it before handing the
 	// file to a root opkg install is the only integrity check we get.
 	SHA256    string    `json:"sha256,omitempty"`
 	CheckedAt time.Time `json:"checkedAt"`
-	Checking       bool      `json:"checking"`
-	Error          string    `json:"error,omitempty"`
-	Warning        string    `json:"warning,omitempty"`
+	Checking  bool      `json:"checking"`
+	Error     string    `json:"error,omitempty"`
+	Warning   string    `json:"warning,omitempty"`
 }
 
 var ErrUpgradeInProgress = errors.New("upgrade already in progress")


### PR DESCRIPTION
`gofmt -w` по всем не-vendor `.go` файлам — устранён накопленный долг форматирования.

- 70 файлов приведены к каноническому виду (в основном выравнивание полей структур и табуляция; пример — выравнивание группы полей в `ExternalTunnelsHandler`).
- Чисто механическое переформатирование, **семантика не меняется**.
- `gofmt -l` после: 0 грязных; `go build ./...`: зелёный.

После мержа `gofmt -l` по проекту будет пустым — можно закрепить `gofmt`-гейтом в CI на весь проект (сейчас, судя по всему, проверялись только изменённые файлы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_