### PR TITLE
frontend: runtime-валидация ответов API — valibot-схемы из swagger, строгий режим

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: "CI"
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Check generated API schemas are fresh
+        # schemas.gen.ts генерируется из internal/openapi/swagger.yaml; правка
+        # спеки без перегенерации молча ослабляет runtime-валидацию.
+        working-directory: frontend
+        run: |
+          set -euo pipefail
+          npm run gen:api
+          git diff --exit-code -- src/lib/api/schemas.gen.ts || {
+            echo "::error::src/lib/api/schemas.gen.ts устарел — запустите 'npm run gen:api' и закоммитьте результат"
+            exit 1
+          }
+
+      - name: svelte-check
+        working-directory: frontend
+        run: npm run check -- --threshold warning
+
+      - name: eslint
+        working-directory: frontend
+        run: npm run lint
+
+      - name: vitest
+        working-directory: frontend
+        run: npm test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "@xterm/xterm": "^6.0.0",
         "lucide-svelte": "^1.0.1",
         "pako": "^2.1.0",
-        "qrcode": "^1.5.4"
+        "qrcode": "^1.5.4",
+        "valibot": "^1.4.2"
       },
       "devDependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
@@ -34,6 +35,7 @@
         "autoprefixer": "^10.4.24",
         "eslint": "^9.39.4",
         "eslint-plugin-svelte": "^3.20.0",
+        "js-yaml": "^4.3.0",
         "jsdom": "^29.1.1",
         "postcss": "^8.5.6",
         "simple-icons": "^16.17.0",
@@ -6316,7 +6318,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6416,12 +6418,10 @@
       "license": "MIT"
     },
     "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "dev": true,
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "license": "MIT",
-      "optional": true,
       "peerDependencies": {
         "typescript": ">=5"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite dev",
     "sync:openapi": "cp ../internal/openapi/swagger.yaml ./static/openapi.yaml",
+    "gen:api": "node scripts/gen-api-schemas.mjs",
     "dev:mock": "npm run sync:openapi && VITE_API_STRIP_PREFIX=1 VITE_API_TARGET=http://127.0.0.1:8081 vite dev",
     "dev:mock:proxy": "npm run sync:openapi && node scripts/mock-stack.mjs",
     "mock": "node scripts/mock-api.mjs",
@@ -38,6 +39,7 @@
     "autoprefixer": "^10.4.24",
     "eslint": "^9.39.4",
     "eslint-plugin-svelte": "^3.20.0",
+    "js-yaml": "^4.3.0",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.6",
     "simple-icons": "^16.17.0",
@@ -61,6 +63,7 @@
     "@xterm/xterm": "^6.0.0",
     "lucide-svelte": "^1.0.1",
     "pako": "^2.1.0",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "valibot": "^1.4.2"
   }
 }

--- a/frontend/scripts/gen-api-schemas.mjs
+++ b/frontend/scripts/gen-api-schemas.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Generates valibot runtime schemas for API responses from the backend's
+// swagger spec (internal/openapi/swagger.yaml, produced by swaggo from Go
+// annotations). Output: src/lib/api/schemas.gen.ts.
+//
+//   npm run gen:api
+//
+// Design decisions (keep in sync with src/lib/api/validate.ts):
+//  - Only definitions REACHABLE from 2xx response schemas are emitted, so
+//    request DTOs never reach the bundle.
+//  - Every object property is optional AND nullable: Go's `omitempty` drops
+//    fields, nil slices/maps/pointers marshal to `null`. Strict-mode failures
+//    must mean "present value of the wrong type" (real drift), never
+//    "backend omitted a field".
+//  - Objects are loose (unknown keys allowed): a newer backend adding fields
+//    must not break an older cached frontend.
+//  - Enums are emitted as their base type, not picklist: the backend adding
+//    an enum value must not break an older frontend.
+//  - $refs are emitted as v.lazy(() => X) so declaration order and cycles
+//    never matter.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const specPath = path.resolve(here, '../../internal/openapi/swagger.yaml');
+const outPath = path.resolve(here, '../src/lib/api/schemas.gen.ts');
+
+const spec = yaml.load(fs.readFileSync(specPath, 'utf8'));
+if (!spec || spec.swagger !== '2.0') {
+	console.error(`Ожидался swagger 2.0 в ${specPath}`);
+	process.exit(1);
+}
+
+const definitions = spec.definitions ?? {};
+
+/** 'api.AccessPolicyDTO' -> 'api_AccessPolicyDTO' (valid TS identifier). */
+function ident(defName) {
+	return defName.replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function refName(ref) {
+	const m = /^#\/definitions\/(.+)$/.exec(ref);
+	if (!m) throw new Error(`Неподдерживаемый $ref: ${ref}`);
+	return m[1];
+}
+
+// ── Reachability: collect definitions used by 2xx response schemas ──────────
+
+const reachable = new Set();
+
+function markSchema(schema) {
+	if (!schema || typeof schema !== 'object') return;
+	if (schema.$ref) {
+		const name = refName(schema.$ref);
+		if (!reachable.has(name)) {
+			reachable.add(name);
+			markSchema(definitions[name]);
+		}
+		return;
+	}
+	if (Array.isArray(schema.allOf)) schema.allOf.forEach(markSchema);
+	if (schema.items) markSchema(schema.items);
+	if (schema.properties) Object.values(schema.properties).forEach(markSchema);
+	if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+		markSchema(schema.additionalProperties);
+	}
+}
+
+// ── Schema expression emission ───────────────────────────────────────────────
+
+/** Bare value schema (no optional/nullable wrapper). */
+function emitValue(schema) {
+	if (!schema || typeof schema !== 'object') return 'v.unknown()';
+	if (schema.$ref) {
+		return `v.lazy(() => ${ident(refName(schema.$ref))})`;
+	}
+	if (Array.isArray(schema.allOf)) {
+		// swaggo emits property-level allOf:[$ref] as "ref with description";
+		// multi-member allOf is a real intersection (envelope + typed data).
+		const parts = schema.allOf.map(emitValue);
+		return parts.length === 1 ? parts[0] : `v.intersect([${parts.join(', ')}])`;
+	}
+	switch (schema.type) {
+		case 'string':
+			return 'v.string()'; // enum намеренно не сужаем — см. шапку файла
+		case 'integer':
+		case 'number':
+			return 'v.number()';
+		case 'boolean':
+			return 'v.boolean()';
+		case 'array':
+			return `v.array(${emitValue(schema.items)})`;
+		case 'file':
+			return 'v.unknown()';
+		case 'object': {
+			if (schema.properties) return emitObject(schema);
+			if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+				return `v.record(v.string(), ${emitValue(schema.additionalProperties)})`;
+			}
+			if (schema.additionalProperties === true) {
+				return 'v.record(v.string(), v.unknown())';
+			}
+			return 'v.unknown()'; // нетипизированный object (например, envelope data)
+		}
+		default:
+			return 'v.unknown()';
+	}
+}
+
+function emitObject(schema) {
+	const props = Object.entries(schema.properties ?? {})
+		.map(([key, propSchema]) => {
+			const safeKey = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
+			return `\t${safeKey}: v.optional(v.nullable(${emitValue(propSchema)})),`;
+		})
+		.join('\n');
+	return props ? `v.looseObject({\n${props}\n})` : 'v.looseObject({})';
+}
+
+// ── Walk paths → response schema map ─────────────────────────────────────────
+
+const METHODS = ['get', 'post', 'put', 'delete', 'patch'];
+const responseEntries = []; // {key: 'GET /path', expr}
+
+for (const [rawPath, ops] of Object.entries(spec.paths ?? {})) {
+	for (const method of METHODS) {
+		const op = ops?.[method];
+		if (!op) continue;
+		// SSE/бинарные ответы не проходят через ApiClient.request() и не
+		// являются JSON-конвертами — им нечего валидировать.
+		const produces = op.produces ?? spec.produces;
+		if (Array.isArray(produces) && !produces.includes('application/json')) continue;
+		const okResponse = op.responses?.['200'] ?? op.responses?.['201'] ?? op.responses?.['202'];
+		const schema = okResponse?.schema;
+		if (!schema) continue;
+		if (schema.type === 'file') continue; // бинарные скачивания не проходят через request()
+		markSchema(schema);
+		responseEntries.push({
+			key: `${method.toUpperCase()} ${rawPath}`,
+			expr: emitValue(schema),
+		});
+	}
+}
+
+// ── Emit ─────────────────────────────────────────────────────────────────────
+
+const defLines = [...reachable]
+	.sort()
+	.map((name) => {
+		const schema = definitions[name];
+		if (!schema) {
+			throw new Error(`$ref на несуществующий definition: ${name}`);
+		}
+		return `const ${ident(name)}: v.GenericSchema = ${emitValue(schema)};`;
+	})
+	.join('\n\n');
+
+const mapLines = responseEntries
+	.sort((a, b) => a.key.localeCompare(b.key))
+	.map(({ key, expr }) => `\t${JSON.stringify(key)}: ${expr},`)
+	.join('\n');
+
+const out = `// GENERATED FILE — do not edit by hand.
+// Source: internal/openapi/swagger.yaml (swaggo). Regenerate: npm run gen:api
+// Generator: scripts/gen-api-schemas.mjs (см. там же дизайн-решения).
+/* eslint-disable */
+import * as v from 'valibot';
+
+${defLines}
+
+/**
+ * 2xx response envelope schema per "METHOD /path" (path как в swagger,
+ * без basePath /api; шаблонные сегменты — {param}).
+ */
+export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
+${mapLines}
+};
+`;
+
+fs.writeFileSync(outPath, out);
+console.log(
+	`schemas.gen.ts: ${responseEntries.length} эндпоинтов, ${reachable.size} DTO (из ${Object.keys(definitions).length} в спеке)`,
+);

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -112,6 +112,7 @@ import type {
 } from '$lib/types';
 import { sanitizeDnsServerForApi } from '$lib/utils/dnsServerDetour';
 import { isMockDevMode as envIsMockDevMode } from '$lib/env';
+import { validateApiResponse } from './validate';
 
 export type TrafficPeriod = '5m' | '10m' | '30m' | '1h' | '3h' | '6h' | '12h' | '24h';
 
@@ -255,6 +256,10 @@ class ApiClient {
 			throw err;
 		}
 
+		// Runtime-проверка конверта по схеме из swagger: каст `as T` ниже
+		// подкреплён фактической валидацией, а не доверием.
+		validateApiResponse(options.method ?? 'GET', endpoint, data);
+
 		return data.data as T;
 	}
 
@@ -348,6 +353,11 @@ class ApiClient {
 		}
 		const data = (await res.json()) as ApiResponse<T>;
 		if (data.error) throw new Error(data.message || 'Ошибка удаления');
+		validateApiResponse(
+			options.method ?? 'POST',
+			url.startsWith(this.baseUrl) ? url.slice(this.baseUrl.length) : url,
+			data,
+		);
 		return data.data as T;
 	}
 

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1,0 +1,2511 @@
+// GENERATED FILE — do not edit by hand.
+// Source: internal/openapi/swagger.yaml (swaggo). Regenerate: npm run gen:api
+// Generator: scripts/gen-api-schemas.mjs (см. там же дизайн-решения).
+/* eslint-disable */
+import * as v from 'valibot';
+
+const api_APIEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.unknown())),
+	message: v.optional(v.nullable(v.string())),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ASCParamsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.unknown())),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AWGInterfaceDTO: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	dns: v.optional(v.nullable(v.string())),
+	h1: v.optional(v.nullable(v.string())),
+	h2: v.optional(v.nullable(v.string())),
+	h3: v.optional(v.nullable(v.string())),
+	h4: v.optional(v.nullable(v.string())),
+	jc: v.optional(v.nullable(v.number())),
+	jmax: v.optional(v.nullable(v.number())),
+	jmin: v.optional(v.nullable(v.number())),
+	mtu: v.optional(v.nullable(v.number())),
+	privateKey: v.optional(v.nullable(v.string())),
+	s1: v.optional(v.nullable(v.number())),
+	s2: v.optional(v.nullable(v.number())),
+	s3: v.optional(v.nullable(v.number())),
+	s4: v.optional(v.nullable(v.number())),
+});
+
+const api_AWGOutboundTagDTO: v.GenericSchema = v.looseObject({
+	iface: v.optional(v.nullable(v.string())),
+	kind: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_AWGOutboundTagsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_AWGOutboundTagDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AWGPeerDTO: v.GenericSchema = v.looseObject({
+	allowedIPs: v.optional(v.nullable(v.array(v.string()))),
+	endpoint: v.optional(v.nullable(v.string())),
+	persistentKeepalive: v.optional(v.nullable(v.number())),
+	publicKey: v.optional(v.nullable(v.string())),
+});
+
+const api_AWGTunnelDTO: v.GenericSchema = v.looseObject({
+	backend: v.optional(v.nullable(v.string())),
+	defaultRoute: v.optional(v.nullable(v.boolean())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	id: v.optional(v.nullable(v.string())),
+	interface: v.optional(v.nullable(v.lazy(() => api_AWGInterfaceDTO))),
+	interfaceName: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	peer: v.optional(v.nullable(v.lazy(() => api_AWGPeerDTO))),
+	state: v.optional(v.nullable(v.string())),
+	stateInfo: v.optional(v.nullable(v.lazy(() => api_TunnelStateInfoDTO))),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_AccessPoliciesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_AccessPolicyDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AccessPolicyDTO: v.GenericSchema = v.looseObject({
+	description: v.optional(v.nullable(v.string())),
+	deviceCount: v.optional(v.nullable(v.number())),
+	interfaces: v.optional(v.nullable(v.array(v.lazy(() => api_AccessPolicyInterfaceDTO)))),
+	isStandard: v.optional(v.nullable(v.boolean())),
+	name: v.optional(v.nullable(v.string())),
+	standalone: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AccessPolicyInterfaceDTO: v.GenericSchema = v.looseObject({
+	denied: v.optional(v.nullable(v.boolean())),
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	order: v.optional(v.nullable(v.number())),
+});
+
+const api_AccessPolicyResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_AccessPolicyDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ActiveNowResponse: v.GenericSchema = v.looseObject({
+	now: v.optional(v.nullable(v.string())),
+});
+
+const api_AllInterfacesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_RouterInterfaceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AmneziaPremiumAccountInfoResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.unknown())),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AmneziaPremiumDownloadConfigData: v.GenericSchema = v.looseObject({
+	config: v.optional(v.nullable(v.string())),
+});
+
+const api_AmneziaPremiumDownloadConfigResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_AmneziaPremiumDownloadConfigData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AmneziaPremiumLoginData: v.GenericSchema = v.looseObject({
+	sid: v.optional(v.nullable(v.string())),
+});
+
+const api_AmneziaPremiumLoginResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_AmneziaPremiumLoginData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_AuthStatusResponse: v.GenericSchema = v.looseObject({
+	authDisabled: v.optional(v.nullable(v.boolean())),
+	authenticated: v.optional(v.nullable(v.boolean())),
+	entwareAuthEnabled: v.optional(v.nullable(v.boolean())),
+	expiresIn: v.optional(v.nullable(v.number())),
+	login: v.optional(v.nullable(v.string())),
+});
+
+const api_BackupWarningDTO: v.GenericSchema = v.looseObject({
+	interfaceName: v.optional(v.nullable(v.string())),
+	message: v.optional(v.nullable(v.string())),
+});
+
+const api_BootStatusResponse: v.GenericSchema = v.looseObject({
+	initializing: v.optional(v.nullable(v.boolean())),
+	instanceId: v.optional(v.nullable(v.string())),
+	phase: v.optional(v.nullable(v.string())),
+	remainingSeconds: v.optional(v.nullable(v.number())),
+});
+
+const api_ChangelogData: v.GenericSchema = v.looseObject({
+	entries: v.optional(v.nullable(v.array(v.lazy(() => api_ChangelogEntryDTO)))),
+});
+
+const api_ChangelogEntryDTO: v.GenericSchema = v.looseObject({
+	date: v.optional(v.nullable(v.string())),
+	groups: v.optional(v.nullable(v.array(v.lazy(() => api_ChangelogGroupDTO)))),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_ChangelogGroupDTO: v.GenericSchema = v.looseObject({
+	heading: v.optional(v.nullable(v.string())),
+	items: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_ChangelogResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ChangelogData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ClientRouteDTO: v.GenericSchema = v.looseObject({
+	clientHostname: v.optional(v.nullable(v.string())),
+	clientIp: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	fallback: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+});
+
+const api_ClientRoutesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_ClientRouteDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ConfigSlotContentResponse: v.GenericSchema = v.looseObject({
+	content: v.optional(v.nullable(v.string())),
+	filename: v.optional(v.nullable(v.string())),
+	hasDraft: v.optional(v.nullable(v.boolean())),
+	slot: v.optional(v.nullable(v.string())),
+	state: v.optional(v.nullable(v.string())),
+});
+
+const api_ConfigSlotInfo: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	filename: v.optional(v.nullable(v.string())),
+	hasDraft: v.optional(v.nullable(v.boolean())),
+	mtime: v.optional(v.nullable(v.string())),
+	ownership: v.optional(v.nullable(v.string())),
+	size: v.optional(v.nullable(v.number())),
+	slot: v.optional(v.nullable(v.string())),
+});
+
+const api_ConfigSlotsResponse: v.GenericSchema = v.looseObject({
+	slots: v.optional(v.nullable(v.array(v.lazy(() => api_ConfigSlotInfo)))),
+});
+
+const api_ConnectionProtocolsDTO: v.GenericSchema = v.looseObject({
+	icmp: v.optional(v.nullable(v.number())),
+	tcp: v.optional(v.nullable(v.number())),
+	udp: v.optional(v.nullable(v.number())),
+});
+
+const api_ConnectionStatsDTO: v.GenericSchema = v.looseObject({
+	direct: v.optional(v.nullable(v.number())),
+	protocols: v.optional(v.nullable(v.lazy(() => api_ConnectionProtocolsDTO))),
+	total: v.optional(v.nullable(v.number())),
+	tunneled: v.optional(v.nullable(v.number())),
+});
+
+const api_ConnectionsData: v.GenericSchema = v.looseObject({
+	connections: v.optional(v.nullable(v.array(v.lazy(() => api_ConntrackConnectionDTO)))),
+	fetchedAt: v.optional(v.nullable(v.string())),
+	pagination: v.optional(v.nullable(v.lazy(() => api_ConnectionsPaginationDTO))),
+	stats: v.optional(v.nullable(v.lazy(() => api_ConnectionStatsDTO))),
+	tunnels: v.optional(v.nullable(v.record(v.string(), v.lazy(() => api_TunnelConnectionInfoDTO)))),
+});
+
+const api_ConnectionsPaginationDTO: v.GenericSchema = v.looseObject({
+	limit: v.optional(v.nullable(v.number())),
+	offset: v.optional(v.nullable(v.number())),
+	returned: v.optional(v.nullable(v.number())),
+	total: v.optional(v.nullable(v.number())),
+});
+
+const api_ConnectionsResponseEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ConnectionsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ConnectivityResultData: v.GenericSchema = v.looseObject({
+	connected: v.optional(v.nullable(v.boolean())),
+	latency: v.optional(v.nullable(v.number())),
+	reason: v.optional(v.nullable(v.string())),
+});
+
+const api_ConnectivityResultResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ConnectivityResultData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ConntrackConnectionDTO: v.GenericSchema = v.looseObject({
+	bytes: v.optional(v.nullable(v.number())),
+	clientMac: v.optional(v.nullable(v.string())),
+	clientName: v.optional(v.nullable(v.string())),
+	dst: v.optional(v.nullable(v.string())),
+	dstPort: v.optional(v.nullable(v.number())),
+	interface: v.optional(v.nullable(v.string())),
+	packets: v.optional(v.nullable(v.number())),
+	protocol: v.optional(v.nullable(v.string())),
+	src: v.optional(v.nullable(v.string())),
+	srcPort: v.optional(v.nullable(v.number())),
+	state: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+	tunnelName: v.optional(v.nullable(v.string())),
+});
+
+const api_DNSRouteSettingsDTO: v.GenericSchema = v.looseObject({
+	autoRefreshEnabled: v.optional(v.nullable(v.boolean())),
+	refreshDailyTime: v.optional(v.nullable(v.string())),
+	refreshIntervalHours: v.optional(v.nullable(v.number())),
+	refreshMode: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyAuthDTO: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	password: v.optional(v.nullable(v.string())),
+	username: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyConfigData: v.GenericSchema = v.looseObject({
+	auth: v.optional(v.nullable(v.lazy(() => api_DeviceProxyAuthDTO))),
+	enabled: v.optional(v.nullable(v.boolean())),
+	listenAll: v.optional(v.nullable(v.boolean())),
+	listenInterface: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+	selectedOutbound: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyInstanceData: v.GenericSchema = v.looseObject({
+	auth: v.optional(v.nullable(v.lazy(() => api_DeviceProxyAuthDTO))),
+	enabled: v.optional(v.nullable(v.boolean())),
+	id: v.optional(v.nullable(v.string())),
+	listenAll: v.optional(v.nullable(v.boolean())),
+	listenInterface: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+	selectedOutbound: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyInstanceIPCheckResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DeviceProxyInstanceIPCheckResultDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DeviceProxyInstanceIPCheckResultDTO: v.GenericSchema = v.looseObject({
+	directIp: v.optional(v.nullable(v.string())),
+	ipChanged: v.optional(v.nullable(v.boolean())),
+	proxyIp: v.optional(v.nullable(v.string())),
+	service: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyOutboundDTO: v.GenericSchema = v.looseObject({
+	detail: v.optional(v.nullable(v.string())),
+	kind: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_DeviceProxyRuntimeData: v.GenericSchema = v.looseObject({
+	activeTag: v.optional(v.nullable(v.string())),
+	alive: v.optional(v.nullable(v.boolean())),
+	defaultTag: v.optional(v.nullable(v.string())),
+	degradedOutbound: v.optional(v.nullable(v.string())),
+	fallbackTag: v.optional(v.nullable(v.string())),
+});
+
+const api_DiagnosticsStatusData: v.GenericSchema = v.looseObject({
+	progress: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_DiagnosticsStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DiagnosticsStatusData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DnsCheckResultDTO: v.GenericSchema = v.looseObject({
+	detail: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	message: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+	title: v.optional(v.nullable(v.string())),
+});
+
+const api_DnsCheckStartData: v.GenericSchema = v.looseObject({
+	checks: v.optional(v.nullable(v.array(v.lazy(() => api_DnsCheckResultDTO)))),
+	clientIP: v.optional(v.nullable(v.string())),
+	hostname: v.optional(v.nullable(v.string())),
+});
+
+const api_DnsCheckStartResponseEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DnsCheckStartData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DnsProxyInfoData: v.GenericSchema = v.looseObject({
+	proxies: v.optional(v.nullable(v.array(v.lazy(() => diagnostics_DNSProxy)))),
+});
+
+const api_DnsProxyInfoEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DnsProxyInfoData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DnsRouteDTO: v.GenericSchema = v.looseObject({
+	backend: v.optional(v.nullable(v.string())),
+	createdAt: v.optional(v.nullable(v.string())),
+	domains: v.optional(v.nullable(v.array(v.string()))),
+	enabled: v.optional(v.nullable(v.boolean())),
+	excludeSubnets: v.optional(v.nullable(v.array(v.string()))),
+	excludes: v.optional(v.nullable(v.array(v.string()))),
+	excludesText: v.optional(v.nullable(v.string())),
+	hrPolicyInterfaces: v.optional(v.nullable(v.array(v.string()))),
+	hrPolicyName: v.optional(v.nullable(v.string())),
+	hrRouteMode: v.optional(v.nullable(v.string())),
+	iconUrl: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	manualDomains: v.optional(v.nullable(v.array(v.string()))),
+	manualText: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	routes: v.optional(v.nullable(v.array(v.lazy(() => api_DnsRouteTargetDTO)))),
+	subnets: v.optional(v.nullable(v.array(v.string()))),
+	subscriptions: v.optional(v.nullable(v.array(v.lazy(() => api_DnsRouteSubscriptionDTO)))),
+	updatedAt: v.optional(v.nullable(v.string())),
+});
+
+const api_DnsRouteResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DnsRouteDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DnsRouteSubscriptionDTO: v.GenericSchema = v.looseObject({
+	lastCount: v.optional(v.nullable(v.number())),
+	lastFetched: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_DnsRouteTargetDTO: v.GenericSchema = v.looseObject({
+	fallback: v.optional(v.nullable(v.string())),
+	interface: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+});
+
+const api_DnsRoutesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_DnsRouteDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DownloadOutboundDTO: v.GenericSchema = v.looseObject({
+	available: v.optional(v.nullable(v.boolean())),
+	detail: v.optional(v.nullable(v.string())),
+	kind: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_DownloadOutboundsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_DownloadOutboundDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_DownloadSettingsDTO: v.GenericSchema = v.looseObject({
+	routeKind: v.optional(v.nullable(v.string())),
+	routeTag: v.optional(v.nullable(v.string())),
+});
+
+const api_ExternalTunnelDTO: v.GenericSchema = v.looseObject({
+	endpoint: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	isAWG: v.optional(v.nullable(v.boolean())),
+	publicKey: v.optional(v.nullable(v.string())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	tunnelNumber: v.optional(v.nullable(v.number())),
+	txBytes: v.optional(v.nullable(v.number())),
+});
+
+const api_ExternalTunnelsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_ExternalTunnelDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_GeoExpandData: v.GenericSchema = v.looseObject({
+	count: v.optional(v.nullable(v.number())),
+	lines: v.optional(v.nullable(v.array(v.string()))),
+	path: v.optional(v.nullable(v.string())),
+});
+
+const api_GeoFileEntryDTO: v.GenericSchema = v.looseObject({
+	external: v.optional(v.nullable(v.boolean())),
+	path: v.optional(v.nullable(v.string())),
+	size: v.optional(v.nullable(v.number())),
+	tagCount: v.optional(v.nullable(v.number())),
+	type: v.optional(v.nullable(v.string())),
+	updated: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_GeoFileResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_GeoFileEntryDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_GeoFileSettingsDTO: v.GenericSchema = v.looseObject({
+	autoRefreshEnabled: v.optional(v.nullable(v.boolean())),
+	refreshDailyTime: v.optional(v.nullable(v.string())),
+	refreshIntervalHours: v.optional(v.nullable(v.number())),
+	refreshMode: v.optional(v.nullable(v.string())),
+});
+
+const api_GeoFileUpdatedData: v.GenericSchema = v.looseObject({
+	error: v.optional(v.nullable(v.string())),
+	partial: v.optional(v.nullable(v.boolean())),
+	updated: v.optional(v.nullable(v.number())),
+});
+
+const api_GeoFileUpdatedResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_GeoFileUpdatedData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_GeoFilesRescannedData: v.GenericSchema = v.looseObject({
+	adopted: v.optional(v.nullable(v.number())),
+});
+
+const api_GeoFilesRescannedResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_GeoFilesRescannedData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_GeoFilesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_GeoFileEntryDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_GeoTagDTO: v.GenericSchema = v.looseObject({
+	count: v.optional(v.nullable(v.number())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_GeoTagsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_GeoTagDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_HealthData: v.GenericSchema = v.looseObject({
+	instanceId: v.optional(v.nullable(v.string())),
+	ok: v.optional(v.nullable(v.boolean())),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_HealthResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_HealthData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_HydraRouteConfigData: v.GenericSchema = v.looseObject({
+	autoStart: v.optional(v.nullable(v.boolean())),
+	cidr: v.optional(v.nullable(v.boolean())),
+	clearIPSet: v.optional(v.nullable(v.boolean())),
+	conntrackFlush: v.optional(v.nullable(v.boolean())),
+	directRouteEnabled: v.optional(v.nullable(v.boolean())),
+	geoIPFiles: v.optional(v.nullable(v.array(v.string()))),
+	geoSiteFiles: v.optional(v.nullable(v.array(v.string()))),
+	globalRouting: v.optional(v.nullable(v.boolean())),
+	ipsetEnableTimeout: v.optional(v.nullable(v.boolean())),
+	ipsetMaxElem: v.optional(v.nullable(v.number())),
+	ipsetTimeout: v.optional(v.nullable(v.number())),
+	log: v.optional(v.nullable(v.string())),
+	logFile: v.optional(v.nullable(v.string())),
+	policyOrder: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_HydraRouteConfigResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_HydraRouteConfigData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_HydraRouteStatusData: v.GenericSchema = v.looseObject({
+	installed: v.optional(v.nullable(v.boolean())),
+	lastError: v.optional(v.nullable(v.string())),
+	pid: v.optional(v.nullable(v.number())),
+	processState: v.optional(v.nullable(v.string())),
+	running: v.optional(v.nullable(v.boolean())),
+	stalePid: v.optional(v.nullable(v.number())),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_HydraRouteStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_HydraRouteStatusData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_IPCheckServiceDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_IPResultData: v.GenericSchema = v.looseObject({
+	directIp: v.optional(v.nullable(v.string())),
+	endpointIp: v.optional(v.nullable(v.string())),
+	ipChanged: v.optional(v.nullable(v.boolean())),
+	vpnIp: v.optional(v.nullable(v.string())),
+});
+
+const api_IPResultResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_IPResultData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_IPServicesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_IPCheckServiceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_IpsetUsageData: v.GenericSchema = v.looseObject({
+	maxElem: v.optional(v.nullable(v.number())),
+	usage: v.optional(v.nullable(v.record(v.string(), v.number()))),
+});
+
+const api_IpsetUsageResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_IpsetUsageData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_LANSegmentEntryDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	subnet: v.optional(v.nullable(v.string())),
+});
+
+const api_LANSegmentsListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_LANSegmentEntryDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_LogEntryDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	group: v.optional(v.nullable(v.string())),
+	level: v.optional(v.nullable(v.string())),
+	message: v.optional(v.nullable(v.string())),
+	sanitized: v.optional(v.nullable(v.boolean())),
+	subgroup: v.optional(v.nullable(v.string())),
+	target: v.optional(v.nullable(v.string())),
+	timestamp: v.optional(v.nullable(v.string())),
+});
+
+const api_LoggingSettingsDTO: v.GenericSchema = v.looseObject({
+	appMaxEntries: v.optional(v.nullable(v.number())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	logLevel: v.optional(v.nullable(v.string())),
+	maxAge: v.optional(v.nullable(v.number())),
+	singboxLogLevel: v.optional(v.nullable(v.string())),
+	singboxMaxEntries: v.optional(v.nullable(v.number())),
+});
+
+const api_LoginResponseRaw: v.GenericSchema = v.looseObject({
+	login: v.optional(v.nullable(v.string())),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_LogsData: v.GenericSchema = v.looseObject({
+	bucket: v.optional(v.nullable(v.string())),
+	bufferCapacity: v.optional(v.nullable(v.number())),
+	bufferSize: v.optional(v.nullable(v.number())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	logs: v.optional(v.nullable(v.array(v.lazy(() => api_LogEntryDTO)))),
+	oldestTimestamp: v.optional(v.nullable(v.string())),
+	sanitized: v.optional(v.nullable(v.boolean())),
+	total: v.optional(v.nullable(v.number())),
+});
+
+const api_LogsResponseEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_LogsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedPeerDTO: v.GenericSchema = v.looseObject({
+	description: v.optional(v.nullable(v.string())),
+	dns: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	presharedKey: v.optional(v.nullable(v.string())),
+	privateKey: v.optional(v.nullable(v.string())),
+	publicKey: v.optional(v.nullable(v.string())),
+	tunnelIP: v.optional(v.nullable(v.string())),
+});
+
+const api_ManagedPeerResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedPeerDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedPeerStatsDTO: v.GenericSchema = v.looseObject({
+	endpoint: v.optional(v.nullable(v.string())),
+	lastHandshake: v.optional(v.nullable(v.string())),
+	online: v.optional(v.nullable(v.boolean())),
+	publicKey: v.optional(v.nullable(v.string())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	txBytes: v.optional(v.nullable(v.number())),
+});
+
+const api_ManagedServerBackupDTO: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	asc: v.optional(v.nullable(v.unknown())),
+	description: v.optional(v.nullable(v.string())),
+	dns: v.optional(v.nullable(v.string())),
+	endpoint: v.optional(v.nullable(v.string())),
+	i1: v.optional(v.nullable(v.string())),
+	i2: v.optional(v.nullable(v.string())),
+	i3: v.optional(v.nullable(v.string())),
+	i4: v.optional(v.nullable(v.string())),
+	i5: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	mask: v.optional(v.nullable(v.string())),
+	mtu: v.optional(v.nullable(v.number())),
+	natEnabled: v.optional(v.nullable(v.boolean())),
+	peers: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedPeerDTO)))),
+	policy: v.optional(v.nullable(v.string())),
+	privateKey: v.optional(v.nullable(v.string())),
+});
+
+const api_ManagedServerBackupFile: v.GenericSchema = v.looseObject({
+	exportedAt: v.optional(v.nullable(v.string())),
+	managedServers: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedServerBackupDTO)))),
+	type: v.optional(v.nullable(v.string())),
+	version: v.optional(v.nullable(v.number())),
+	warnings: v.optional(v.nullable(v.array(v.lazy(() => api_BackupWarningDTO)))),
+});
+
+const api_ManagedServerDTO: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	dns: v.optional(v.nullable(v.string())),
+	endpoint: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	lanSegments: v.optional(v.nullable(v.array(v.string()))),
+	listenPort: v.optional(v.nullable(v.number())),
+	mask: v.optional(v.nullable(v.string())),
+	mtu: v.optional(v.nullable(v.number())),
+	natEnabled: v.optional(v.nullable(v.boolean())),
+	natMode: v.optional(v.nullable(v.string())),
+	peers: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedPeerDTO)))),
+	policy: v.optional(v.nullable(v.string())),
+});
+
+const api_ManagedServerDriftEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedServerDriftResponse))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedServerDriftResponse: v.GenericSchema = v.looseObject({
+	drift: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedServerBackupDTO)))),
+});
+
+const api_ManagedServerExportEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedServerBackupFile))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedServerImportEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedServerRestoreResponse))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedServerResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedServerDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedServerRestoreResponse: v.GenericSchema = v.looseObject({
+	outcomes: v.optional(v.nullable(v.array(v.lazy(() => api_RestoreOutcomeDTO)))),
+});
+
+const api_ManagedServerStatsDTO: v.GenericSchema = v.looseObject({
+	peers: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedPeerStatsDTO)))),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_ManagedServerStatsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ManagedServerStatsDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ManagedServersListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_ManagedServerDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_MonitoringCellDTO: v.GenericSchema = v.looseObject({
+	activeForRestart: v.optional(v.nullable(v.boolean())),
+	isSelf: v.optional(v.nullable(v.boolean())),
+	latencyMs: v.optional(v.nullable(v.number())),
+	ok: v.optional(v.nullable(v.boolean())),
+	targetId: v.optional(v.nullable(v.string())),
+	ts: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+});
+
+const api_MonitoringSnapshotData: v.GenericSchema = v.looseObject({
+	cells: v.optional(v.nullable(v.array(v.lazy(() => api_MonitoringCellDTO)))),
+	targets: v.optional(v.nullable(v.array(v.lazy(() => api_MonitoringTargetDTO)))),
+	tunnels: v.optional(v.nullable(v.array(v.lazy(() => api_MonitoringTunnelDTO)))),
+	updatedAt: v.optional(v.nullable(v.string())),
+});
+
+const api_MonitoringSnapshotResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_MonitoringSnapshotData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_MonitoringTargetDTO: v.GenericSchema = v.looseObject({
+	host: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_MonitoringTunnelDTO: v.GenericSchema = v.looseObject({
+	id: v.optional(v.nullable(v.string())),
+	ifaceName: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	pingcheckTarget: v.optional(v.nullable(v.string())),
+	selfMethod: v.optional(v.nullable(v.string())),
+	selfTarget: v.optional(v.nullable(v.string())),
+});
+
+const api_NativePingCheckStatusDTO: v.GenericSchema = v.looseObject({
+	bound: v.optional(v.nullable(v.boolean())),
+	exists: v.optional(v.nullable(v.boolean())),
+	failCount: v.optional(v.nullable(v.number())),
+	host: v.optional(v.nullable(v.string())),
+	interval: v.optional(v.nullable(v.number())),
+	maxFails: v.optional(v.nullable(v.number())),
+	minSuccess: v.optional(v.nullable(v.number())),
+	mode: v.optional(v.nullable(v.string())),
+	restart: v.optional(v.nullable(v.boolean())),
+	status: v.optional(v.nullable(v.string())),
+	successCount: v.optional(v.nullable(v.number())),
+	timeout: v.optional(v.nullable(v.number())),
+});
+
+const api_NativePingCheckStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_NativePingCheckStatusDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_OkData: v.GenericSchema = v.looseObject({
+	ok: v.optional(v.nullable(v.boolean())),
+});
+
+const api_OkResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_OkData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_OversizedTagDTO: v.GenericSchema = v.looseObject({
+	count: v.optional(v.nullable(v.number())),
+	file: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_OversizedTagsData: v.GenericSchema = v.looseObject({
+	installed: v.optional(v.nullable(v.boolean())),
+	maxelem: v.optional(v.nullable(v.number())),
+	tags: v.optional(v.nullable(v.array(v.lazy(() => api_OversizedTagDTO)))),
+});
+
+const api_OversizedTagsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_OversizedTagsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PeerConfData: v.GenericSchema = v.looseObject({
+	conf: v.optional(v.nullable(v.string())),
+});
+
+const api_PeerConfResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_PeerConfData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PingCheckDefaultsDTO: v.GenericSchema = v.looseObject({
+	deadInterval: v.optional(v.nullable(v.number())),
+	failThreshold: v.optional(v.nullable(v.number())),
+	interval: v.optional(v.nullable(v.number())),
+	method: v.optional(v.nullable(v.string())),
+	target: v.optional(v.nullable(v.string())),
+});
+
+const api_PingCheckSettingsDTO: v.GenericSchema = v.looseObject({
+	defaults: v.optional(v.nullable(v.lazy(() => api_PingCheckDefaultsDTO))),
+	enabled: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PingCheckStatusData: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	tunnels: v.optional(v.nullable(v.array(v.lazy(() => api_TunnelPingStatusDTO)))),
+});
+
+const api_PingCheckStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_PingCheckStatusData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PingLogEntryDTO: v.GenericSchema = v.looseObject({
+	error: v.optional(v.nullable(v.string())),
+	failCount: v.optional(v.nullable(v.number())),
+	latency: v.optional(v.nullable(v.number())),
+	stateChange: v.optional(v.nullable(v.string())),
+	success: v.optional(v.nullable(v.boolean())),
+	threshold: v.optional(v.nullable(v.number())),
+	timestamp: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+	tunnelName: v.optional(v.nullable(v.string())),
+});
+
+const api_PingLogsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_PingLogEntryDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PoliciesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_PolicyOptionDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PolicyDeviceDTO: v.GenericSchema = v.looseObject({
+	active: v.optional(v.nullable(v.boolean())),
+	hostname: v.optional(v.nullable(v.string())),
+	ip: v.optional(v.nullable(v.string())),
+	link: v.optional(v.nullable(v.string())),
+	mac: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	policy: v.optional(v.nullable(v.string())),
+});
+
+const api_PolicyDevicesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_PolicyDeviceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PolicyGlobalInterfaceDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	up: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PolicyInterfacesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_PolicyGlobalInterfaceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PolicyOptionDTO: v.GenericSchema = v.looseObject({
+	description: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+});
+
+const api_PolicyOrderData: v.GenericSchema = v.looseObject({
+	order: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_PolicyOrderResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_PolicyOrderData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_PresetsListResponse: v.GenericSchema = v.looseObject({
+	presets: v.optional(v.nullable(v.array(v.lazy(() => presets_Preset)))),
+});
+
+const api_ProxyConfigResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DeviceProxyConfigData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyInstanceResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DeviceProxyInstanceData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyInstancesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_DeviceProxyInstanceData)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyListenChoicesData: v.GenericSchema = v.looseObject({
+	lanIP: v.optional(v.nullable(v.string())),
+	singboxRunning: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyListenChoicesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ProxyListenChoicesData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyOutboundsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_DeviceProxyOutboundDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ProxyRuntimeResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_DeviceProxyRuntimeData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ResolveResponse: v.GenericSchema = v.looseObject({
+	domain: v.optional(v.nullable(v.string())),
+	error: v.optional(v.nullable(v.string())),
+	ips: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_RestoreOutcomeDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	addedPeers: v.optional(v.nullable(v.number())),
+	conflicts: v.optional(v.nullable(v.array(v.string()))),
+	error: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	newName: v.optional(v.nullable(v.string())),
+});
+
+const api_RouterDetails: v.GenericSchema = v.looseObject({
+	architecture: v.optional(v.nullable(v.string())),
+	bootSlot: v.optional(v.nullable(v.string())),
+	cpuModel: v.optional(v.nullable(v.string())),
+	cpuTempC: v.optional(v.nullable(v.number())),
+	featureComponents: v.optional(v.nullable(v.array(v.string()))),
+	firmwareBuildDate: v.optional(v.nullable(v.string())),
+	firmwareRelease: v.optional(v.nullable(v.string())),
+	firmwareSandbox: v.optional(v.nullable(v.string())),
+	firmwareTitle: v.optional(v.nullable(v.string())),
+	hardwareId: v.optional(v.nullable(v.string())),
+	loadAverage: v.optional(v.nullable(v.string())),
+	memoryTotalMB: v.optional(v.nullable(v.number())),
+	memoryUsedMB: v.optional(v.nullable(v.number())),
+	memoryUsedPercent: v.optional(v.nullable(v.number())),
+	meshMembers: v.optional(v.nullable(v.array(v.string()))),
+	model: v.optional(v.nullable(v.string())),
+	modelDisplay: v.optional(v.nullable(v.string())),
+	opkgStorage: v.optional(v.nullable(v.string())),
+	portedBuild: v.optional(v.nullable(v.boolean())),
+	region: v.optional(v.nullable(v.string())),
+	storageComponents: v.optional(v.nullable(v.array(v.string()))),
+	uptimeHuman: v.optional(v.nullable(v.string())),
+	vpnComponents: v.optional(v.nullable(v.array(v.string()))),
+	wifi5TempC: v.optional(v.nullable(v.number())),
+	wifi24TempC: v.optional(v.nullable(v.number())),
+});
+
+const api_RouterInterfaceDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	up: v.optional(v.nullable(v.boolean())),
+});
+
+const api_RouterStagingStatusResponse: v.GenericSchema = v.looseObject({
+	draftedAt: v.optional(v.nullable(v.string())),
+	hasDraft: v.optional(v.nullable(v.boolean())),
+	validation: v.optional(v.nullable(v.lazy(() => api_RouterValidationDTO))),
+});
+
+const api_RouterValidationDTO: v.GenericSchema = v.looseObject({
+	errors: v.optional(v.nullable(v.array(v.lazy(() => api_RouterValidationErrorDTO)))),
+});
+
+const api_RouterValidationErrorDTO: v.GenericSchema = v.looseObject({
+	inRule: v.optional(v.nullable(v.string())),
+	kind: v.optional(v.nullable(v.string())),
+	message: v.optional(v.nullable(v.string())),
+	slot: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_RoutingRefreshData: v.GenericSchema = v.looseObject({
+	missing: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_RoutingRefreshResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_RoutingRefreshData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_RoutingTunnelDTO: v.GenericSchema = v.looseObject({
+	available: v.optional(v.nullable(v.boolean())),
+	iface: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_RoutingTunnelsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_RoutingTunnelDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SaveStatusDTO: v.GenericSchema = v.looseObject({
+	lastError: v.optional(v.nullable(v.string())),
+	lastSaveAt: v.optional(v.nullable(v.string())),
+	pendingCount: v.optional(v.nullable(v.number())),
+	state: v.optional(v.nullable(v.string())),
+});
+
+const api_SelectiveCancelData: v.GenericSchema = v.looseObject({
+	cancelled: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SelectiveDomainMatcherRecordDTO: v.GenericSchema = v.looseObject({
+	cdn: v.optional(v.nullable(v.boolean())),
+	error: v.optional(v.nullable(v.string())),
+	kind: v.optional(v.nullable(v.string())),
+	matcher: v.optional(v.nullable(v.string())),
+	outbound: v.optional(v.nullable(v.string())),
+	queryHosts: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SelectiveRebuildSnapshotDTO: v.GenericSchema = v.looseObject({
+	domainMatcherCount: v.optional(v.nullable(v.number())),
+	domainResults: v.optional(v.nullable(v.array(v.unknown()))),
+	entryCount: v.optional(v.nullable(v.number())),
+	lastCDNRefresh: v.optional(v.nullable(v.string())),
+	rebuiltAt: v.optional(v.nullable(v.string())),
+	staticCidrCount: v.optional(v.nullable(v.number())),
+	staticCidrs: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SelectiveSnapshotMatchersData: v.GenericSchema = v.looseObject({
+	limit: v.optional(v.nullable(v.number())),
+	matchers: v.optional(v.nullable(v.array(v.lazy(() => api_SelectiveDomainMatcherRecordDTO)))),
+	offset: v.optional(v.nullable(v.number())),
+	total: v.optional(v.nullable(v.number())),
+});
+
+const api_SelectiveStatusData: v.GenericSchema = v.looseObject({
+	available: v.optional(v.nullable(v.boolean())),
+	conntrackAvailable: v.optional(v.nullable(v.boolean())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	entryCount: v.optional(v.nullable(v.number())),
+	installing: v.optional(v.nullable(v.boolean())),
+	lastError: v.optional(v.nullable(v.string())),
+	lastRebuild: v.optional(v.nullable(v.string())),
+	rebuilding: v.optional(v.nullable(v.boolean())),
+	snapshot: v.optional(v.nullable(v.lazy(() => api_SelectiveRebuildSnapshotDTO))),
+	xtSetAvailable: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ServerSettingsDTO: v.GenericSchema = v.looseObject({
+	interface: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+});
+
+const api_ServersAllData: v.GenericSchema = v.looseObject({
+	managedStats: v.optional(v.nullable(v.lazy(() => api_ManagedServerStatsDTO))),
+	servers: v.optional(v.nullable(v.array(v.lazy(() => api_WireguardServerDTO)))),
+	wanIP: v.optional(v.nullable(v.string())),
+});
+
+const api_ServersAllResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ServersAllData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SettingsData: v.GenericSchema = v.looseObject({
+	authEnabled: v.optional(v.nullable(v.boolean())),
+	connectivityCheckUrl: v.optional(v.nullable(v.string())),
+	disableMemorySaving: v.optional(v.nullable(v.boolean())),
+	dnsRoute: v.optional(v.nullable(v.lazy(() => api_DNSRouteSettingsDTO))),
+	download: v.optional(v.nullable(v.lazy(() => api_DownloadSettingsDTO))),
+	entwareAuthEnabled: v.optional(v.nullable(v.boolean())),
+	geoFile: v.optional(v.nullable(v.lazy(() => api_GeoFileSettingsDTO))),
+	logging: v.optional(v.nullable(v.lazy(() => api_LoggingSettingsDTO))),
+	monitoringExcludedTunnels: v.optional(v.nullable(v.array(v.string()))),
+	pingCheck: v.optional(v.nullable(v.lazy(() => api_PingCheckSettingsDTO))),
+	schemaVersion: v.optional(v.nullable(v.number())),
+	server: v.optional(v.nullable(v.lazy(() => api_ServerSettingsDTO))),
+	sessionTtlHours: v.optional(v.nullable(v.number())),
+	updates: v.optional(v.nullable(v.lazy(() => api_UpdateSettingsDTO))),
+	usageLevel: v.optional(v.nullable(v.string())),
+});
+
+const api_SettingsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SettingsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SignatureCaptureData: v.GenericSchema = v.looseObject({
+	ok: v.optional(v.nullable(v.boolean())),
+	packets: v.optional(v.nullable(v.lazy(() => api_SignaturePacketsDTO))),
+	source: v.optional(v.nullable(v.string())),
+	warning: v.optional(v.nullable(v.string())),
+});
+
+const api_SignatureCaptureResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SignatureCaptureData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SignatureGenerateData: v.GenericSchema = v.looseObject({
+	byteSize: v.optional(v.nullable(v.number())),
+	ok: v.optional(v.nullable(v.boolean())),
+	packets: v.optional(v.nullable(v.lazy(() => api_SignaturePacketsDTO))),
+	protocol: v.optional(v.nullable(v.string())),
+	source: v.optional(v.nullable(v.string())),
+});
+
+const api_SignatureGenerateResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SignatureGenerateData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SignaturePacketsDTO: v.GenericSchema = v.looseObject({
+	i1: v.optional(v.nullable(v.string())),
+	i2: v.optional(v.nullable(v.string())),
+	i3: v.optional(v.nullable(v.string())),
+	i4: v.optional(v.nullable(v.string())),
+	i5: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxConfigPreviewResponse: v.GenericSchema = v.looseObject({
+	json: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxConnectionsClientsData: v.GenericSchema = v.looseObject({
+	clientsByIP: v.optional(v.nullable(v.record(v.string(), v.string()))),
+});
+
+const api_SingboxConnectionsClientsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxConnectionsClientsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDNSGlobalsData: v.GenericSchema = v.looseObject({
+	final: v.optional(v.nullable(v.string())),
+	strategy: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxDNSGlobalsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxDNSGlobalsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDNSRewriteDTO: v.GenericSchema = v.looseObject({
+	ips: v.optional(v.nullable(v.array(v.string()))),
+	pattern: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxDNSRewritesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxDNSRewriteDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDNSRuleDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	domain: v.optional(v.nullable(v.array(v.string()))),
+	domain_keyword: v.optional(v.nullable(v.array(v.string()))),
+	domain_suffix: v.optional(v.nullable(v.array(v.string()))),
+	query_type: v.optional(v.nullable(v.array(v.string()))),
+	rule_set: v.optional(v.nullable(v.array(v.string()))),
+	server: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxDNSRulesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxDNSRuleDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDNSServerDTO: v.GenericSchema = v.looseObject({
+	detour: v.optional(v.nullable(v.string())),
+	domain_resolver: v.optional(v.nullable(v.lazy(() => api_SingboxDomainResolverDTO))),
+	domain_strategy: v.optional(v.nullable(v.string())),
+	path: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+	server_port: v.optional(v.nullable(v.number())),
+	tag: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxDNSServersListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxDNSServerDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDomainResolverDTO: v.GenericSchema = v.looseObject({
+	server: v.optional(v.nullable(v.string())),
+	strategy: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxInboundEntry: v.GenericSchema = v.looseObject({
+	idle: v.optional(v.nullable(v.boolean())),
+	idleReason: v.optional(v.nullable(v.string())),
+	listen: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	ownerLabel: v.optional(v.nullable(v.string())),
+	slot: v.optional(v.nullable(v.string())),
+	source: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxInboundsResponse: v.GenericSchema = v.looseObject({
+	inbounds: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxInboundEntry)))),
+	warnings: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SingboxProxiesListResponse: v.GenericSchema = v.looseObject({
+	groups: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxProxyGroup)))),
+});
+
+const api_SingboxProxiesTestResponse: v.GenericSchema = v.looseObject({
+	delays: v.optional(v.nullable(v.record(v.string(), v.number()))),
+});
+
+const api_SingboxProxyGroup: v.GenericSchema = v.looseObject({
+	members: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxProxyMember)))),
+	now: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxProxyMember: v.GenericSchema = v.looseObject({
+	lastDelay: v.optional(v.nullable(v.number())),
+	tag: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterDatRuleSetURLData: v.GenericSchema = v.looseObject({
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterDatRuleSetURLResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterDatRuleSetURLData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterInspectDNSData: v.GenericSchema = v.looseObject({
+	classification: v.optional(v.nullable(v.string())),
+	final: v.optional(v.nullable(v.string())),
+	input: v.optional(v.nullable(v.string())),
+	inputType: v.optional(v.nullable(v.string())),
+	matchedRule: v.optional(v.nullable(v.number())),
+	matches: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterInspectDNSMatchDTO)))),
+	note: v.optional(v.nullable(v.string())),
+	pool: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterInspectDNSMatchDTO: v.GenericSchema = v.looseObject({
+	conditions: v.optional(v.nullable(v.array(v.string()))),
+	index: v.optional(v.nullable(v.number())),
+	matched: v.optional(v.nullable(v.boolean())),
+	reason: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterInspectDNSResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterInspectDNSData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterInspectData: v.GenericSchema = v.looseObject({
+	destination: v.optional(v.nullable(v.string())),
+	final: v.optional(v.nullable(v.string())),
+	input: v.optional(v.nullable(v.string())),
+	inputType: v.optional(v.nullable(v.string())),
+	matchedRule: v.optional(v.nullable(v.number())),
+	matches: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterInspectMatchDTO)))),
+	note: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterInspectMatchDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	conditions: v.optional(v.nullable(v.array(v.string()))),
+	index: v.optional(v.nullable(v.number())),
+	matched: v.optional(v.nullable(v.boolean())),
+	outbound: v.optional(v.nullable(v.string())),
+	reason: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterInspectResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterInspectData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterIssueDTO: v.GenericSchema = v.looseObject({
+	kind: v.optional(v.nullable(v.string())),
+	message: v.optional(v.nullable(v.string())),
+	ruleIndex: v.optional(v.nullable(v.number())),
+	severity: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterOutboundDTO: v.GenericSchema = v.looseObject({
+	bind_interface: v.optional(v.nullable(v.string())),
+	default: v.optional(v.nullable(v.string())),
+	interval: v.optional(v.nullable(v.string())),
+	outbounds: v.optional(v.nullable(v.array(v.string()))),
+	source: v.optional(v.nullable(v.string())),
+	strategy: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+	tolerance: v.optional(v.nullable(v.number())),
+	type: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterOutboundsListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterOutboundDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterPoliciesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterPolicyInfoDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterPolicyDeviceDTO: v.GenericSchema = v.looseObject({
+	bound: v.optional(v.nullable(v.boolean())),
+	ip: v.optional(v.nullable(v.string())),
+	mac: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterPolicyDevicesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterPolicyDeviceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterPolicyInfoDTO: v.GenericSchema = v.looseObject({
+	description: v.optional(v.nullable(v.string())),
+	deviceCount: v.optional(v.nullable(v.number())),
+	isOurDefault: v.optional(v.nullable(v.boolean())),
+	mark: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterPolicyResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterPolicyInfoDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterPresetDTO: v.GenericSchema = v.looseObject({
+	category: v.optional(v.nullable(v.string())),
+	covers: v.optional(v.nullable(v.array(v.string()))),
+	featured: v.optional(v.nullable(v.boolean())),
+	iconSlug: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	notice: v.optional(v.nullable(v.string())),
+	ruleSets: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterPresetRuleRefDTO)))),
+	rules: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterPresetRuleLinkDTO)))),
+	sensitive: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterPresetRuleLinkDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	domain_suffix: v.optional(v.nullable(v.array(v.string()))),
+	rule_set: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SingboxRouterPresetRuleRefDTO: v.GenericSchema = v.looseObject({
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterPresetsListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterPresetDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterQoSClassDTO: v.GenericSchema = v.looseObject({
+	dscp: v.optional(v.nullable(v.number())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	name: v.optional(v.nullable(v.string())),
+	outbound: v.optional(v.nullable(v.string())),
+	slot: v.optional(v.nullable(v.number())),
+});
+
+const api_SingboxRouterRuleDTO: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	domain_suffix: v.optional(v.nullable(v.array(v.string()))),
+	inbound: v.optional(v.nullable(v.array(v.string()))),
+	ip_cidr: v.optional(v.nullable(v.array(v.string()))),
+	outbound: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.array(v.number()))),
+	protocol: v.optional(v.nullable(v.string())),
+	rule_set: v.optional(v.nullable(v.array(v.string()))),
+	source_ip_cidr: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SingboxRouterRuleSetDTO: v.GenericSchema = v.looseObject({
+	download_detour: v.optional(v.nullable(v.string())),
+	format: v.optional(v.nullable(v.string())),
+	materialized_srs: v.optional(v.nullable(v.boolean())),
+	path: v.optional(v.nullable(v.string())),
+	rules: v.optional(v.nullable(v.array(v.record(v.string(), v.unknown())))),
+	tag: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+	update_interval: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterRuleSetsListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterRuleSetDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterRulesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterRuleDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterSettingsData: v.GenericSchema = v.looseObject({
+	bypassExtraPorts: v.optional(v.nullable(v.string())),
+	bypassExtraSubnets: v.optional(v.nullable(v.string())),
+	bypassPresets: v.optional(v.nullable(v.array(v.string()))),
+	deviceMode: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	fakeipMtu: v.optional(v.nullable(v.number())),
+	fakeipPool4: v.optional(v.nullable(v.string())),
+	fakeipPool6: v.optional(v.nullable(v.string())),
+	fakeipStack: v.optional(v.nullable(v.string())),
+	ingressInterfaces: v.optional(v.nullable(v.array(v.string()))),
+	policyName: v.optional(v.nullable(v.string())),
+	qosClasses: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterQoSClassDTO)))),
+	routingMode: v.optional(v.nullable(v.string())),
+	snifferEnabled: v.optional(v.nullable(v.boolean())),
+	udpTimeout: v.optional(v.nullable(v.string())),
+	wanAutoDetect: v.optional(v.nullable(v.boolean())),
+	wanInterface: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxRouterSettingsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterSettingsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterStatusData: v.GenericSchema = v.looseObject({
+	active: v.optional(v.nullable(v.boolean())),
+	crashCount: v.optional(v.nullable(v.number())),
+	deviceCount: v.optional(v.nullable(v.number())),
+	deviceMode: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	fakeipDns: v.optional(v.nullable(v.string())),
+	fakeipIface: v.optional(v.nullable(v.string())),
+	fakeipTunAddr: v.optional(v.nullable(v.string())),
+	final: v.optional(v.nullable(v.string())),
+	installed: v.optional(v.nullable(v.boolean())),
+	issues: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterIssueDTO)))),
+	lastCrashReason: v.optional(v.nullable(v.string())),
+	lastError: v.optional(v.nullable(v.string())),
+	netfilterAvailable: v.optional(v.nullable(v.boolean())),
+	netfilterComponentName: v.optional(v.nullable(v.string())),
+	outboundAwgCount: v.optional(v.nullable(v.number())),
+	outboundCompositeCount: v.optional(v.nullable(v.number())),
+	policyExists: v.optional(v.nullable(v.boolean())),
+	policyMark: v.optional(v.nullable(v.string())),
+	policyName: v.optional(v.nullable(v.string())),
+	restartSuppressedUntil: v.optional(v.nullable(v.string())),
+	ruleCount: v.optional(v.nullable(v.number())),
+	ruleSetCount: v.optional(v.nullable(v.number())),
+	snifferEnabled: v.optional(v.nullable(v.boolean())),
+	tproxyTargetAvailable: v.optional(v.nullable(v.boolean())),
+	xtDscpAvailable: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxRouterStatusData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterWANInterfaceDTO: v.GenericSchema = v.looseObject({
+	id: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	priority: v.optional(v.nullable(v.number())),
+	up: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxRouterWANInterfacesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxRouterWANInterfaceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxStatusData: v.GenericSchema = v.looseObject({
+	currentSha256: v.optional(v.nullable(v.string())),
+	currentVersion: v.optional(v.nullable(v.string())),
+	features: v.optional(v.nullable(v.array(v.string()))),
+	freeBytes: v.optional(v.nullable(v.number())),
+	installState: v.optional(v.nullable(v.string())),
+	installed: v.optional(v.nullable(v.boolean())),
+	lastError: v.optional(v.nullable(v.string())),
+	ndmsProxyEnabled: v.optional(v.nullable(v.boolean())),
+	pid: v.optional(v.nullable(v.number())),
+	proxyComponent: v.optional(v.nullable(v.boolean())),
+	requiredBytes: v.optional(v.nullable(v.number())),
+	requiredSha256: v.optional(v.nullable(v.string())),
+	requiredVersion: v.optional(v.nullable(v.string())),
+	running: v.optional(v.nullable(v.boolean())),
+	tunnelCount: v.optional(v.nullable(v.number())),
+	updateAvailable: v.optional(v.nullable(v.boolean())),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxStatusData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxTunnelConnectivity: v.GenericSchema = v.looseObject({
+	connected: v.optional(v.nullable(v.boolean())),
+	latency: v.optional(v.nullable(v.number())),
+});
+
+const api_SingboxTunnelDTO: v.GenericSchema = v.looseObject({
+	connectivity: v.optional(v.nullable(v.lazy(() => api_SingboxTunnelConnectivity))),
+	fingerprint: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	port: v.optional(v.nullable(v.number())),
+	protocol: v.optional(v.nullable(v.string())),
+	proxyInterface: v.optional(v.nullable(v.string())),
+	running: v.optional(v.nullable(v.boolean())),
+	security: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+	sni: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+	transport: v.optional(v.nullable(v.string())),
+});
+
+const api_SingboxTunnelsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxTunnelDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SpeedTestInfoData: v.GenericSchema = v.looseObject({
+	available: v.optional(v.nullable(v.boolean())),
+	servers: v.optional(v.nullable(v.array(v.lazy(() => api_SpeedTestServerDTO)))),
+});
+
+const api_SpeedTestInfoResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SpeedTestInfoData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SpeedTestResultData: v.GenericSchema = v.looseObject({
+	bandwidth: v.optional(v.nullable(v.number())),
+	bytes: v.optional(v.nullable(v.number())),
+	direction: v.optional(v.nullable(v.string())),
+	duration: v.optional(v.nullable(v.number())),
+	retransmits: v.optional(v.nullable(v.number())),
+	server: v.optional(v.nullable(v.string())),
+});
+
+const api_SpeedTestResultResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SpeedTestResultData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SpeedTestServerDTO: v.GenericSchema = v.looseObject({
+	host: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+});
+
+const api_StaticRouteDTO: v.GenericSchema = v.looseObject({
+	createdAt: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	fallback: v.optional(v.nullable(v.string())),
+	iconUrl: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	subnets: v.optional(v.nullable(v.array(v.string()))),
+	tunnelID: v.optional(v.nullable(v.string())),
+	updatedAt: v.optional(v.nullable(v.string())),
+});
+
+const api_StaticRoutesListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_StaticRouteDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubgroupsData: v.GenericSchema = v.looseObject({
+	group: v.optional(v.nullable(v.string())),
+	subgroups: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SubgroupsResponseEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SubgroupsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubscriptionDTO: v.GenericSchema = v.looseObject({
+	activeMember: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	excludedMembers: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionMemberDTO)))),
+	excludedTags: v.optional(v.nullable(v.array(v.string()))),
+	filterExclude: v.optional(v.nullable(v.string())),
+	filterInclude: v.optional(v.nullable(v.string())),
+	filteredMembers: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionMemberDTO)))),
+	headers: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionHeader)))),
+	id: v.optional(v.nullable(v.string())),
+	inboundTag: v.optional(v.nullable(v.string())),
+	infoItems: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionInfoItemDTO)))),
+	isInline: v.optional(v.nullable(v.boolean())),
+	label: v.optional(v.nullable(v.string())),
+	lastError: v.optional(v.nullable(v.string())),
+	lastFetched: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	memberTags: v.optional(v.nullable(v.array(v.string()))),
+	members: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionMemberDTO)))),
+	mode: v.optional(v.nullable(v.string())),
+	orphanTags: v.optional(v.nullable(v.array(v.string()))),
+	proxyIndex: v.optional(v.nullable(v.number())),
+	refreshHours: v.optional(v.nullable(v.number())),
+	rejectedMembers: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionRejectedDTO)))),
+	selectorTag: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+	urlTest: v.optional(v.nullable(v.lazy(() => api_SubscriptionURLTestDTO))),
+});
+
+const api_SubscriptionGroupDTO: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	filterExclude: v.optional(v.nullable(v.string())),
+	filterInclude: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	inboundTag: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	memberCount: v.optional(v.nullable(v.number())),
+	members: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionGroupMemberDTO)))),
+	mode: v.optional(v.nullable(v.string())),
+	proxyIndex: v.optional(v.nullable(v.number())),
+	tag: v.optional(v.nullable(v.string())),
+	urlTest: v.optional(v.nullable(v.lazy(() => api_SubscriptionURLTestDTO))),
+	useSubscriptionIds: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SubscriptionGroupListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionGroupDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubscriptionGroupMemberDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_SubscriptionGroupResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SubscriptionGroupDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubscriptionHeader: v.GenericSchema = v.looseObject({
+	name: v.optional(v.nullable(v.string())),
+	value: v.optional(v.nullable(v.string())),
+});
+
+const api_SubscriptionInfoItemDTO: v.GenericSchema = v.looseObject({
+	id: v.optional(v.nullable(v.string())),
+	label: v.optional(v.nullable(v.string())),
+	source: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_SubscriptionListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SubscriptionDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubscriptionMemberDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+	protocol: v.optional(v.nullable(v.string())),
+	security: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+	sni: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+	transport: v.optional(v.nullable(v.string())),
+});
+
+const api_SubscriptionRejectedDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	port: v.optional(v.nullable(v.number())),
+	protocol: v.optional(v.nullable(v.string())),
+	reason: v.optional(v.nullable(v.string())),
+	server: v.optional(v.nullable(v.string())),
+	tag: v.optional(v.nullable(v.string())),
+});
+
+const api_SubscriptionResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SubscriptionDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SubscriptionURLTestDTO: v.GenericSchema = v.looseObject({
+	intervalSec: v.optional(v.nullable(v.number())),
+	toleranceMs: v.optional(v.nullable(v.number())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const api_SuggestAddressData: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	mask: v.optional(v.nullable(v.string())),
+});
+
+const api_SuggestAddressResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SuggestAddressData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SystemInfoBackendAvailability: v.GenericSchema = v.looseObject({
+	kernel: v.optional(v.nullable(v.boolean())),
+	nativewg: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SystemInfoData: v.GenericSchema = v.looseObject({
+	activeBackend: v.optional(v.nullable(v.string())),
+	backendAvailability: v.optional(v.nullable(v.lazy(() => api_SystemInfoBackendAvailability))),
+	bootInProgress: v.optional(v.nullable(v.boolean())),
+	disableMemorySaving: v.optional(v.nullable(v.boolean())),
+	firmwareVersion: v.optional(v.nullable(v.string())),
+	gcMemLimit: v.optional(v.nullable(v.string())),
+	goArch: v.optional(v.nullable(v.string())),
+	goOS: v.optional(v.nullable(v.string())),
+	goVersion: v.optional(v.nullable(v.string())),
+	gogc: v.optional(v.nullable(v.string())),
+	isAarch64: v.optional(v.nullable(v.boolean())),
+	isLowMemory: v.optional(v.nullable(v.boolean())),
+	isOS5: v.optional(v.nullable(v.boolean())),
+	keeneticOS: v.optional(v.nullable(v.string())),
+	kernelModuleExists: v.optional(v.nullable(v.boolean())),
+	kernelModuleLoaded: v.optional(v.nullable(v.boolean())),
+	kernelModuleModel: v.optional(v.nullable(v.string())),
+	kernelModuleVersion: v.optional(v.nullable(v.string())),
+	routerDetails: v.optional(v.nullable(v.lazy(() => api_RouterDetails))),
+	routerIP: v.optional(v.nullable(v.string())),
+	routerTime: v.optional(v.nullable(v.string())),
+	routerTimezone: v.optional(v.nullable(v.string())),
+	routerTimezoneOffsetMinutes: v.optional(v.nullable(v.number())),
+	singbox: v.optional(v.nullable(v.lazy(() => api_SystemInfoSingbox))),
+	slowRequestThresholdMs: v.optional(v.nullable(v.number())),
+	supportsExtendedASC: v.optional(v.nullable(v.boolean())),
+	supportsHRanges: v.optional(v.nullable(v.boolean())),
+	supportsPingCheck: v.optional(v.nullable(v.boolean())),
+	totalMemoryMB: v.optional(v.nullable(v.number())),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_SystemInfoResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SystemInfoData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SystemInfoSingbox: v.GenericSchema = v.looseObject({
+	installed: v.optional(v.nullable(v.boolean())),
+	version: v.optional(v.nullable(v.string())),
+});
+
+const api_SystemTunnelDTO: v.GenericSchema = v.looseObject({
+	connected: v.optional(v.nullable(v.boolean())),
+	description: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	mtu: v.optional(v.nullable(v.number())),
+	peer: v.optional(v.nullable(v.lazy(() => api_SystemTunnelPeerDTO))),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_SystemTunnelPeerDTO: v.GenericSchema = v.looseObject({
+	endpoint: v.optional(v.nullable(v.string())),
+	lastHandshake: v.optional(v.nullable(v.string())),
+	online: v.optional(v.nullable(v.boolean())),
+	publicKey: v.optional(v.nullable(v.string())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	txBytes: v.optional(v.nullable(v.number())),
+});
+
+const api_SystemTunnelsResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_SystemTunnelDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TerminalStartData: v.GenericSchema = v.looseObject({
+	port: v.optional(v.nullable(v.number())),
+});
+
+const api_TerminalStartResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TerminalStartData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TerminalStatusResponse: v.GenericSchema = v.looseObject({
+	installed: v.optional(v.nullable(v.boolean())),
+	running: v.optional(v.nullable(v.boolean())),
+	sessionActive: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelConnectionInfoDTO: v.GenericSchema = v.looseObject({
+	count: v.optional(v.nullable(v.number())),
+	interface: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+});
+
+const api_TunnelControlData: v.GenericSchema = v.looseObject({
+	id: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_TunnelControlResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TunnelControlData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelDeleteResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TunnelDeleteResultData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelDeleteResultData: v.GenericSchema = v.looseObject({
+	success: v.optional(v.nullable(v.boolean())),
+	tunnelId: v.optional(v.nullable(v.string())),
+	verified: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelDetailResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_AWGTunnelDTO))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelListItemDTO: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	awgVersion: v.optional(v.nullable(v.string())),
+	backend: v.optional(v.nullable(v.string())),
+	defaultRoute: v.optional(v.nullable(v.boolean())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	endpoint: v.optional(v.nullable(v.string())),
+	hasAddressConflict: v.optional(v.nullable(v.boolean())),
+	id: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	ispInterface: v.optional(v.nullable(v.string())),
+	ispInterfaceLabel: v.optional(v.nullable(v.string())),
+	lastHandshake: v.optional(v.nullable(v.string())),
+	mtu: v.optional(v.nullable(v.number())),
+	name: v.optional(v.nullable(v.string())),
+	ndmsName: v.optional(v.nullable(v.string())),
+	pingCheck: v.optional(v.nullable(v.lazy(() => api_TunnelPingCheckStatus))),
+	resolvedIspInterface: v.optional(v.nullable(v.string())),
+	resolvedIspInterfaceLabel: v.optional(v.nullable(v.string())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	startedAt: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+	txBytes: v.optional(v.nullable(v.number())),
+	type: v.optional(v.nullable(v.string())),
+});
+
+const api_TunnelListResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_TunnelListItemDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelPingCheckStatus: v.GenericSchema = v.looseObject({
+	failCount: v.optional(v.nullable(v.number())),
+	failThreshold: v.optional(v.nullable(v.number())),
+	restartCount: v.optional(v.nullable(v.number())),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_TunnelPingStatusDTO: v.GenericSchema = v.looseObject({
+	backend: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	failCount: v.optional(v.nullable(v.number())),
+	failThreshold: v.optional(v.nullable(v.number())),
+	lastLatency: v.optional(v.nullable(v.number())),
+	method: v.optional(v.nullable(v.string())),
+	restartCount: v.optional(v.nullable(v.number())),
+	status: v.optional(v.nullable(v.string())),
+	tunnelId: v.optional(v.nullable(v.string())),
+	tunnelName: v.optional(v.nullable(v.string())),
+});
+
+const api_TunnelStateInfoDTO: v.GenericSchema = v.looseObject({
+	hasHandshake: v.optional(v.nullable(v.boolean())),
+	interfaceUp: v.optional(v.nullable(v.boolean())),
+	lastHandshake: v.optional(v.nullable(v.string())),
+	processRunning: v.optional(v.nullable(v.boolean())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	state: v.optional(v.nullable(v.number())),
+	txBytes: v.optional(v.nullable(v.number())),
+});
+
+const api_TunnelTrafficData: v.GenericSchema = v.looseObject({
+	points: v.optional(v.nullable(v.array(v.lazy(() => api_TunnelTrafficPoint)))),
+	stats: v.optional(v.nullable(v.lazy(() => api_TunnelTrafficStats))),
+});
+
+const api_TunnelTrafficPoint: v.GenericSchema = v.looseObject({
+	rx: v.optional(v.nullable(v.number())),
+	t: v.optional(v.nullable(v.number())),
+	tx: v.optional(v.nullable(v.number())),
+});
+
+const api_TunnelTrafficResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TunnelTrafficData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelTrafficStats: v.GenericSchema = v.looseObject({
+	avgRx: v.optional(v.nullable(v.number())),
+	avgTx: v.optional(v.nullable(v.number())),
+	currentRx: v.optional(v.nullable(v.number())),
+	currentTx: v.optional(v.nullable(v.number())),
+	peakRate: v.optional(v.nullable(v.number())),
+	points: v.optional(v.nullable(v.number())),
+	volumeRx: v.optional(v.nullable(v.number())),
+	volumeTx: v.optional(v.nullable(v.number())),
+});
+
+const api_TunnelsAllResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TunnelsAllSnapshotData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TunnelsAllSnapshotData: v.GenericSchema = v.looseObject({
+	external: v.optional(v.nullable(v.array(v.lazy(() => api_ExternalTunnelDTO)))),
+	system: v.optional(v.nullable(v.array(v.lazy(() => api_SystemTunnelDTO)))),
+	tunnels: v.optional(v.nullable(v.array(v.lazy(() => api_TunnelListItemDTO)))),
+});
+
+const api_UpdateApplyData: v.GenericSchema = v.looseObject({
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_UpdateApplyResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_UpdateApplyData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_UpdateCheckResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_UpdateInfoData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_UpdateInfoData: v.GenericSchema = v.looseObject({
+	available: v.optional(v.nullable(v.boolean())),
+	checkedAt: v.optional(v.nullable(v.string())),
+	checking: v.optional(v.nullable(v.boolean())),
+	currentVersion: v.optional(v.nullable(v.string())),
+	latestVersion: v.optional(v.nullable(v.string())),
+});
+
+const api_UpdateSettingsDTO: v.GenericSchema = v.looseObject({
+	channel: v.optional(v.nullable(v.string())),
+	checkEnabled: v.optional(v.nullable(v.boolean())),
+});
+
+const api_UserConfigApplyResponse: v.GenericSchema = v.looseObject({
+	ok: v.optional(v.nullable(v.boolean())),
+	warnings: v.optional(v.nullable(v.array(v.lazy(() => api_RouterValidationErrorDTO)))),
+});
+
+const api_UserConfigCheckResponse: v.GenericSchema = v.looseObject({
+	errors: v.optional(v.nullable(v.array(v.lazy(() => api_RouterValidationErrorDTO)))),
+	ok: v.optional(v.nullable(v.boolean())),
+	warnings: v.optional(v.nullable(v.array(v.lazy(() => api_RouterValidationErrorDTO)))),
+});
+
+const api_WANIPData: v.GenericSchema = v.looseObject({
+	ip: v.optional(v.nullable(v.string())),
+});
+
+const api_WANIPResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_WANIPData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_WANInterfaceDTO: v.GenericSchema = v.looseObject({
+	label: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	state: v.optional(v.nullable(v.string())),
+});
+
+const api_WANInterfacesResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.array(v.lazy(() => api_WANInterfaceDTO)))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_WANStatusEnvelope: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.looseObject({
+	anyWANUp: v.optional(v.nullable(v.boolean())),
+}))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_WireguardServerDTO: v.GenericSchema = v.looseObject({
+	address: v.optional(v.nullable(v.string())),
+	builtIn: v.optional(v.nullable(v.boolean())),
+	connected: v.optional(v.nullable(v.boolean())),
+	description: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	enabledKnown: v.optional(v.nullable(v.boolean())),
+	endpoint: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	interfaceName: v.optional(v.nullable(v.string())),
+	keenDnsDomain: v.optional(v.nullable(v.string())),
+	listenPort: v.optional(v.nullable(v.number())),
+	mask: v.optional(v.nullable(v.string())),
+	mtu: v.optional(v.nullable(v.number())),
+	natEnabled: v.optional(v.nullable(v.boolean())),
+	natMode: v.optional(v.nullable(v.string())),
+	natModeKnown: v.optional(v.nullable(v.boolean())),
+	peers: v.optional(v.nullable(v.array(v.lazy(() => api_WireguardServerPeerDTO)))),
+	policy: v.optional(v.nullable(v.string())),
+	policyKnown: v.optional(v.nullable(v.boolean())),
+	publicKey: v.optional(v.nullable(v.string())),
+	status: v.optional(v.nullable(v.string())),
+});
+
+const api_WireguardServerPeerDTO: v.GenericSchema = v.looseObject({
+	allowedIPs: v.optional(v.nullable(v.array(v.string()))),
+	confAvailable: v.optional(v.nullable(v.boolean())),
+	description: v.optional(v.nullable(v.string())),
+	enabled: v.optional(v.nullable(v.boolean())),
+	endpoint: v.optional(v.nullable(v.string())),
+	lastHandshake: v.optional(v.nullable(v.string())),
+	online: v.optional(v.nullable(v.boolean())),
+	publicKey: v.optional(v.nullable(v.string())),
+	rxBytes: v.optional(v.nullable(v.number())),
+	txBytes: v.optional(v.nullable(v.number())),
+});
+
+const diagnostics_DNSProxy: v.GenericSchema = v.looseObject({
+	displayName: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	rebind: v.optional(v.nullable(v.lazy(() => diagnostics_DNSRebind))),
+	stat: v.optional(v.nullable(v.lazy(() => diagnostics_DNSProxyStat))),
+	staticRecords: v.optional(v.nullable(v.array(v.lazy(() => diagnostics_DNSStaticRecord)))),
+	tcpPort: v.optional(v.nullable(v.number())),
+	udpPort: v.optional(v.nullable(v.number())),
+	upstreams: v.optional(v.nullable(v.array(v.lazy(() => diagnostics_DNSUpstream)))),
+});
+
+const diagnostics_DNSProxyStat: v.GenericSchema = v.looseObject({
+	cacheHitRatio: v.optional(v.nullable(v.number())),
+	cacheHits: v.optional(v.nullable(v.number())),
+	memory: v.optional(v.nullable(v.string())),
+	proxyRequestsSent: v.optional(v.nullable(v.number())),
+	totalRequests: v.optional(v.nullable(v.number())),
+});
+
+const diagnostics_DNSRebind: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	excludes: v.optional(v.nullable(v.array(v.string()))),
+	nets: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const diagnostics_DNSStaticRecord: v.GenericSchema = v.looseObject({
+	flag: v.optional(v.nullable(v.number())),
+	host: v.optional(v.nullable(v.string())),
+	type: v.optional(v.nullable(v.string())),
+	value: v.optional(v.nullable(v.string())),
+});
+
+const diagnostics_DNSUpstream: v.GenericSchema = v.looseObject({
+	aRcvd: v.optional(v.nullable(v.number())),
+	address: v.optional(v.nullable(v.string())),
+	avgResp: v.optional(v.nullable(v.string())),
+	encryption: v.optional(v.nullable(v.string())),
+	medResp: v.optional(v.nullable(v.string())),
+	nxRcvd: v.optional(v.nullable(v.number())),
+	port: v.optional(v.nullable(v.number())),
+	rSent: v.optional(v.nullable(v.number())),
+	rank: v.optional(v.nullable(v.number())),
+	scope: v.optional(v.nullable(v.string())),
+	sni: v.optional(v.nullable(v.string())),
+});
+
+const presets_DNSEngine: v.GenericSchema = v.looseObject({
+	domains: v.optional(v.nullable(v.array(v.string()))),
+	subnets: v.optional(v.nullable(v.array(v.string()))),
+	subscriptionUrl: v.optional(v.nullable(v.string())),
+});
+
+const presets_Engines: v.GenericSchema = v.looseObject({
+	dns: v.optional(v.nullable(v.lazy(() => presets_DNSEngine))),
+	hydraroute: v.optional(v.nullable(v.lazy(() => presets_HydraRouteEngine))),
+	singbox: v.optional(v.nullable(v.lazy(() => presets_SingboxEngine))),
+});
+
+const presets_HydraRouteEngine: v.GenericSchema = v.looseObject({
+	geoTags: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const presets_Origin: v.GenericSchema = v.string();
+
+const presets_Preset: v.GenericSchema = v.looseObject({
+	category: v.optional(v.nullable(v.string())),
+	covers: v.optional(v.nullable(v.array(v.string()))),
+	engines: v.optional(v.nullable(v.lazy(() => presets_Engines))),
+	featured: v.optional(v.nullable(v.boolean())),
+	iconSlug: v.optional(v.nullable(v.string())),
+	id: v.optional(v.nullable(v.string())),
+	name: v.optional(v.nullable(v.string())),
+	notice: v.optional(v.nullable(v.string())),
+	origin: v.optional(v.nullable(v.lazy(() => presets_Origin))),
+	sensitive: v.optional(v.nullable(v.boolean())),
+});
+
+const presets_RuleRef: v.GenericSchema = v.looseObject({
+	tag: v.optional(v.nullable(v.string())),
+	url: v.optional(v.nullable(v.string())),
+});
+
+const presets_SingboxEngine: v.GenericSchema = v.looseObject({
+	action: v.optional(v.nullable(v.string())),
+	ruleSets: v.optional(v.nullable(v.array(v.lazy(() => presets_RuleRef)))),
+});
+
+/**
+ * 2xx response envelope schema per "METHOD /path" (path как в swagger,
+ * без basePath /api; шаблонные сегменты — {param}).
+ */
+export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
+	"DELETE /access-policies/assign": v.lazy(() => api_OkResponse),
+	"DELETE /access-policies/delete": v.lazy(() => api_OkResponse),
+	"DELETE /access-policies/permit": v.lazy(() => api_OkResponse),
+	"DELETE /hydraroute/geo-files/delete": v.lazy(() => api_OkResponse),
+	"DELETE /managed-servers/{id}": v.lazy(() => api_ServersAllResponse),
+	"DELETE /managed-servers/{id}/peers/{pubkey}": v.lazy(() => api_ServersAllResponse),
+	"DELETE /proxy/instance": v.lazy(() => api_APIEnvelope),
+	"DELETE /servers/{name}/peers/{pubkey}": v.lazy(() => api_ServersAllResponse),
+	"DELETE /servers/mark": v.lazy(() => api_ServersAllResponse),
+	"DELETE /singbox/subscriptions/delete": v.lazy(() => api_APIEnvelope),
+	"DELETE /singbox/tunnels": v.lazy(() => api_APIEnvelope),
+	"GET /access-policies": v.lazy(() => api_AccessPoliciesListResponse),
+	"GET /access-policies/devices": v.lazy(() => api_PolicyDevicesListResponse),
+	"GET /access-policies/interfaces": v.lazy(() => api_PolicyInterfacesListResponse),
+	"GET /auth/status": v.lazy(() => api_AuthStatusResponse),
+	"GET /boot-status": v.lazy(() => api_BootStatusResponse),
+	"GET /client-routes": v.lazy(() => api_ClientRoutesListResponse),
+	"GET /connections": v.lazy(() => api_ConnectionsResponseEnvelope),
+	"GET /diagnostics/dns-proxy": v.lazy(() => api_DnsProxyInfoEnvelope),
+	"GET /diagnostics/status": v.lazy(() => api_DiagnosticsStatusResponse),
+	"GET /dns-check/client": v.lazy(() => api_DnsCheckStartResponseEnvelope),
+	"GET /dns-check/probe": v.lazy(() => api_APIEnvelope),
+	"GET /dns-routes/get": v.lazy(() => api_DnsRouteResponse),
+	"GET /dns-routes/list": v.lazy(() => api_DnsRoutesListResponse),
+	"GET /download/outbounds": v.lazy(() => api_DownloadOutboundsResponse),
+	"GET /external-tunnels": v.lazy(() => api_ExternalTunnelsResponse),
+	"GET /health": v.lazy(() => api_HealthResponse),
+	"GET /hydraroute/config": v.lazy(() => api_HydraRouteConfigResponse),
+	"GET /hydraroute/geo-expand": v.lazy(() => api_GeoExpandData),
+	"GET /hydraroute/geo-files": v.lazy(() => api_GeoFilesResponse),
+	"GET /hydraroute/geo-tags": v.lazy(() => api_GeoTagsResponse),
+	"GET /hydraroute/ipset-usage": v.lazy(() => api_IpsetUsageResponse),
+	"GET /hydraroute/oversized-tags": v.lazy(() => api_OversizedTagsResponse),
+	"GET /logs": v.lazy(() => api_LogsResponseEnvelope),
+	"GET /logs/subgroups": v.lazy(() => api_SubgroupsResponseEnvelope),
+	"GET /managed-servers": v.lazy(() => api_ManagedServersListResponse),
+	"GET /managed-servers/{id}": v.lazy(() => api_ManagedServerResponse),
+	"GET /managed-servers/{id}/asc": v.lazy(() => api_ASCParamsResponse),
+	"GET /managed-servers/{id}/peers/{pubkey}/conf": v.lazy(() => api_PeerConfResponse),
+	"GET /managed-servers/{id}/stats": v.lazy(() => api_ManagedServerStatsResponse),
+	"GET /managed-servers/lan-segments": v.lazy(() => api_LANSegmentsListResponse),
+	"GET /managed-servers/policies": v.lazy(() => api_PoliciesListResponse),
+	"GET /managed-servers/suggest-address": v.lazy(() => api_SuggestAddressResponse),
+	"GET /managed/drift": v.lazy(() => api_ManagedServerDriftEnvelope),
+	"GET /managed/export": v.lazy(() => api_ManagedServerExportEnvelope),
+	"GET /monitoring/matrix": v.lazy(() => api_MonitoringSnapshotResponse),
+	"GET /ndms/save-status": v.lazy(() => api_SaveStatusDTO),
+	"GET /pingcheck/logs": v.lazy(() => api_PingLogsResponse),
+	"GET /pingcheck/status": v.lazy(() => api_PingCheckStatusResponse),
+	"GET /presets": v.lazy(() => api_PresetsListResponse),
+	"GET /proxy/config": v.lazy(() => api_ProxyConfigResponse),
+	"GET /proxy/instance": v.lazy(() => api_ProxyInstanceResponse),
+	"GET /proxy/instance/check-ip": v.lazy(() => api_DeviceProxyInstanceIPCheckResponse),
+	"GET /proxy/instance/runtime": v.lazy(() => api_ProxyRuntimeResponse),
+	"GET /proxy/instances": v.lazy(() => api_ProxyInstancesResponse),
+	"GET /proxy/listen-choices": v.lazy(() => api_ProxyListenChoicesResponse),
+	"GET /proxy/outbounds": v.lazy(() => api_ProxyOutboundsResponse),
+	"GET /proxy/runtime": v.lazy(() => api_ProxyRuntimeResponse),
+	"GET /routing/access-policies": v.lazy(() => api_AccessPoliciesListResponse),
+	"GET /routing/client-routes": v.lazy(() => api_ClientRoutesListResponse),
+	"GET /routing/dns-routes": v.lazy(() => api_DnsRoutesListResponse),
+	"GET /routing/policy-devices": v.lazy(() => api_PolicyDevicesListResponse),
+	"GET /routing/policy-interfaces": v.lazy(() => api_PolicyInterfacesListResponse),
+	"GET /routing/resolve": v.lazy(() => api_ResolveResponse),
+	"GET /routing/static-routes": v.lazy(() => api_StaticRoutesListResponse),
+	"GET /routing/tunnels": v.lazy(() => api_RoutingTunnelsResponse),
+	"GET /servers/{name}/peers/{pubkey}/conf": v.lazy(() => api_PeerConfResponse),
+	"GET /servers/all": v.lazy(() => api_ServersAllResponse),
+	"GET /servers/marked": v.lazy(() => api_APIEnvelope),
+	"GET /servers/wan-ip": v.lazy(() => api_WANIPResponse),
+	"GET /settings/get": v.lazy(() => api_SettingsResponse),
+	"GET /signature/capture": v.lazy(() => api_SignatureCaptureResponse),
+	"GET /singbox/awg-outbounds/tags": v.lazy(() => api_AWGOutboundTagsResponse),
+	"GET /singbox/config-preview": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxConfigPreviewResponse))),
+})]),
+	"GET /singbox/config/slot": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ConfigSlotContentResponse))),
+})]),
+	"GET /singbox/config/slots": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ConfigSlotsResponse))),
+})]),
+	"GET /singbox/connections/clients": v.lazy(() => api_SingboxConnectionsClientsResponse),
+	"GET /singbox/fakeip/config/dns/globals": v.lazy(() => api_SingboxDNSGlobalsResponse),
+	"GET /singbox/fakeip/config/dns/rules/list": v.lazy(() => api_SingboxDNSRulesListResponse),
+	"GET /singbox/fakeip/config/dns/servers/list": v.lazy(() => api_SingboxDNSServersListResponse),
+	"GET /singbox/fakeip/config/outbounds/list": v.lazy(() => api_SingboxRouterOutboundsListResponse),
+	"GET /singbox/fakeip/config/rules/list": v.lazy(() => api_SingboxRouterRulesListResponse),
+	"GET /singbox/fakeip/config/rulesets/list": v.lazy(() => api_SingboxRouterRuleSetsListResponse),
+	"GET /singbox/inbounds": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxInboundsResponse))),
+})]),
+	"GET /singbox/router/bindable-interfaces": v.lazy(() => api_SingboxRouterWANInterfacesListResponse),
+	"GET /singbox/router/dns/globals": v.lazy(() => api_SingboxDNSGlobalsResponse),
+	"GET /singbox/router/dns/rewrites/list": v.lazy(() => api_SingboxDNSRewritesListResponse),
+	"GET /singbox/router/dns/rules/list": v.lazy(() => api_SingboxDNSRulesListResponse),
+	"GET /singbox/router/dns/servers/list": v.lazy(() => api_SingboxDNSServersListResponse),
+	"GET /singbox/router/ingress-eligible-interfaces": v.lazy(() => api_SingboxRouterWANInterfacesListResponse),
+	"GET /singbox/router/outbounds/list": v.lazy(() => api_SingboxRouterOutboundsListResponse),
+	"GET /singbox/router/policies": v.lazy(() => api_SingboxRouterPoliciesListResponse),
+	"GET /singbox/router/policy-devices": v.lazy(() => api_SingboxRouterPolicyDevicesListResponse),
+	"GET /singbox/router/presets/list": v.lazy(() => api_SingboxRouterPresetsListResponse),
+	"GET /singbox/router/proxies/list": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxProxiesListResponse))),
+})]),
+	"GET /singbox/router/rules/list": v.lazy(() => api_SingboxRouterRulesListResponse),
+	"GET /singbox/router/rulesets/dat-url": v.lazy(() => api_SingboxRouterDatRuleSetURLResponse),
+	"GET /singbox/router/rulesets/list": v.lazy(() => api_SingboxRouterRuleSetsListResponse),
+	"GET /singbox/router/selective/snapshot/matchers": v.lazy(() => api_SelectiveSnapshotMatchersData),
+	"GET /singbox/router/selective/status": v.lazy(() => api_SelectiveStatusData),
+	"GET /singbox/router/settings": v.lazy(() => api_SingboxRouterSettingsResponse),
+	"GET /singbox/router/staging": v.lazy(() => api_RouterStagingStatusResponse),
+	"GET /singbox/router/status": v.lazy(() => api_SingboxRouterStatusResponse),
+	"GET /singbox/router/wan-interfaces": v.lazy(() => api_SingboxRouterWANInterfacesListResponse),
+	"GET /singbox/status": v.lazy(() => api_SingboxStatusResponse),
+	"GET /singbox/subscriptions": v.lazy(() => api_SubscriptionListResponse),
+	"GET /singbox/subscriptions/active-now": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ActiveNowResponse))),
+})]),
+	"GET /singbox/subscriptions/get": v.lazy(() => api_SubscriptionResponse),
+	"GET /singbox/subscriptions/groups": v.lazy(() => api_SubscriptionGroupListResponse),
+	"GET /singbox/tunnels": v.lazy(() => api_SingboxTunnelsResponse),
+	"GET /singbox/tunnels/test/connectivity": v.lazy(() => api_APIEnvelope),
+	"GET /singbox/tunnels/test/ip": v.lazy(() => api_APIEnvelope),
+	"GET /static-routes/list": v.lazy(() => api_StaticRoutesListResponse),
+	"GET /system-tunnels": v.lazy(() => api_SystemTunnelsResponse),
+	"GET /system-tunnels/asc": v.lazy(() => api_ASCParamsResponse),
+	"GET /system/all-interfaces": v.lazy(() => api_AllInterfacesResponse),
+	"GET /system/hydraroute-status": v.lazy(() => api_HydraRouteStatusResponse),
+	"GET /system/info": v.lazy(() => api_SystemInfoResponse),
+	"GET /system/update/changelog": v.lazy(() => api_ChangelogResponse),
+	"GET /system/update/check": v.lazy(() => api_UpdateCheckResponse),
+	"GET /system/wan-interfaces": v.lazy(() => api_WANInterfacesResponse),
+	"GET /terminal/status": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TerminalStatusResponse))),
+})]),
+	"GET /test/connectivity": v.lazy(() => api_ConnectivityResultResponse),
+	"GET /test/ip": v.lazy(() => api_IPResultResponse),
+	"GET /test/ip/services": v.lazy(() => api_IPServicesResponse),
+	"GET /test/speed": v.lazy(() => api_SpeedTestResultResponse),
+	"GET /test/speed/servers": v.lazy(() => api_SpeedTestInfoResponse),
+	"GET /tunnels/all": v.lazy(() => api_TunnelsAllResponse),
+	"GET /tunnels/get": v.lazy(() => api_TunnelDetailResponse),
+	"GET /tunnels/list": v.lazy(() => api_TunnelListResponse),
+	"GET /tunnels/pingcheck": v.lazy(() => api_NativePingCheckStatusResponse),
+	"GET /tunnels/traffic": v.lazy(() => api_TunnelTrafficResponse),
+	"GET /wan/status": v.lazy(() => api_WANStatusEnvelope),
+	"POST /access-policies/assign": v.lazy(() => api_OkResponse),
+	"POST /access-policies/create": v.lazy(() => api_AccessPolicyResponse),
+	"POST /access-policies/description": v.lazy(() => api_OkResponse),
+	"POST /access-policies/interface-up": v.lazy(() => api_OkResponse),
+	"POST /access-policies/permit": v.lazy(() => api_OkResponse),
+	"POST /access-policies/standalone": v.lazy(() => api_OkResponse),
+	"POST /amnezia-premium/account-info": v.lazy(() => api_AmneziaPremiumAccountInfoResponse),
+	"POST /amnezia-premium/download-config": v.lazy(() => api_AmneziaPremiumDownloadConfigResponse),
+	"POST /amnezia-premium/login": v.lazy(() => api_AmneziaPremiumLoginResponse),
+	"POST /auth/login": v.lazy(() => api_LoginResponseRaw),
+	"POST /auth/logout": v.lazy(() => api_APIEnvelope),
+	"POST /client-routes/create": v.lazy(() => api_ClientRoutesListResponse),
+	"POST /client-routes/delete": v.lazy(() => api_ClientRoutesListResponse),
+	"POST /client-routes/toggle": v.lazy(() => api_ClientRoutesListResponse),
+	"POST /client-routes/update": v.lazy(() => api_ClientRoutesListResponse),
+	"POST /control/restart": v.lazy(() => api_TunnelControlResponse),
+	"POST /control/restart-all": v.lazy(() => api_APIEnvelope),
+	"POST /control/start": v.lazy(() => api_TunnelControlResponse),
+	"POST /control/stop": v.lazy(() => api_TunnelControlResponse),
+	"POST /control/toggle-default-route": v.lazy(() => api_APIEnvelope),
+	"POST /control/toggle-enabled": v.lazy(() => api_APIEnvelope),
+	"POST /diagnostics/run": v.lazy(() => api_APIEnvelope),
+	"POST /dns-check/start": v.lazy(() => api_DnsCheckStartResponseEnvelope),
+	"POST /dns-routes/bulk-backend": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/create": v.lazy(() => api_DnsRouteResponse),
+	"POST /dns-routes/create-batch": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/delete": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/delete-batch": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/refresh": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/set-enabled": v.lazy(() => api_APIEnvelope),
+	"POST /dns-routes/update": v.lazy(() => api_DnsRouteResponse),
+	"POST /external-tunnels/adopt": v.lazy(() => api_APIEnvelope),
+	"POST /hook/ndms": v.lazy(() => api_APIEnvelope),
+	"POST /hydraroute/geo-files/add": v.lazy(() => api_GeoFileResponse),
+	"POST /hydraroute/geo-files/rescan": v.lazy(() => api_GeoFilesRescannedResponse),
+	"POST /hydraroute/geo-files/take-control": v.lazy(() => api_GeoFileResponse),
+	"POST /hydraroute/geo-files/update": v.lazy(() => api_GeoFileUpdatedResponse),
+	"POST /hydraroute/policy-order": v.lazy(() => api_PolicyOrderResponse),
+	"POST /import/conf": v.lazy(() => api_APIEnvelope),
+	"POST /logs/clear": v.lazy(() => api_APIEnvelope),
+	"POST /managed-servers": v.lazy(() => api_ManagedServerResponse),
+	"POST /managed-servers/{id}/enabled": v.lazy(() => api_ServersAllResponse),
+	"POST /managed-servers/{id}/lan-segments": v.lazy(() => api_ServersAllResponse),
+	"POST /managed-servers/{id}/nat": v.lazy(() => api_ServersAllResponse),
+	"POST /managed-servers/{id}/peers": v.lazy(() => api_ManagedPeerResponse),
+	"POST /managed-servers/{id}/peers/{pubkey}/toggle": v.lazy(() => api_ServersAllResponse),
+	"POST /managed-servers/{id}/policy": v.lazy(() => api_ServersAllResponse),
+	"POST /managed-servers/{id}/restart": v.lazy(() => api_APIEnvelope),
+	"POST /managed/import": v.lazy(() => api_ManagedServerImportEnvelope),
+	"POST /managed/restore-drift": v.lazy(() => api_ManagedServerImportEnvelope),
+	"POST /pingcheck/check-now": v.lazy(() => api_APIEnvelope),
+	"POST /pingcheck/logs/clear": v.lazy(() => api_APIEnvelope),
+	"POST /proxy/apply": v.lazy(() => api_APIEnvelope),
+	"POST /proxy/instance/runtime/select": v.lazy(() => api_ProxyRuntimeResponse),
+	"POST /proxy/instances/apply": v.lazy(() => api_APIEnvelope),
+	"POST /proxy/runtime/select": v.lazy(() => api_ProxyRuntimeResponse),
+	"POST /routing/refresh": v.lazy(() => api_RoutingRefreshResponse),
+	"POST /servers/{name}/endpoint": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/{name}/nat": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/{name}/peers": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/{name}/peers/{pubkey}/toggle": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/{name}/policy": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/enabled": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/mark": v.lazy(() => api_ServersAllResponse),
+	"POST /servers/restart": v.lazy(() => api_APIEnvelope),
+	"POST /settings/regenerate-api-key": v.lazy(() => api_SettingsResponse),
+	"POST /settings/update": v.lazy(() => api_SettingsResponse),
+	"POST /signature/generate": v.lazy(() => api_SignatureGenerateResponse),
+	"POST /singbox/config/user/apply": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_UserConfigApplyResponse))),
+})]),
+	"POST /singbox/config/user/check": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_UserConfigCheckResponse))),
+})]),
+	"POST /singbox/config/user/discard": v.lazy(() => api_OkResponse),
+	"POST /singbox/config/user/enable": v.lazy(() => api_OkResponse),
+	"POST /singbox/control": v.lazy(() => api_SingboxStatusResponse),
+	"POST /singbox/fakeip/config/dns/globals": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/rules/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/rules/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/rules/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/rules/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/servers/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/servers/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/servers/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/dns/servers/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/outbounds/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/outbounds/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/outbounds/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/route/final": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rules/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rules/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rules/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rules/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rulesets/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rulesets/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/fakeip/config/rulesets/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/install": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/ndms-proxy": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/router/disable": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/globals": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rewrites/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rewrites/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rewrites/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rewrites/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rules/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rules/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rules/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/rules/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/servers/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/servers/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/servers/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/dns/servers/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/enable": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/inspect": v.lazy(() => api_SingboxRouterInspectResponse),
+	"POST /singbox/router/inspect-dns": v.lazy(() => api_SingboxRouterInspectDNSResponse),
+	"POST /singbox/router/mode": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/outbounds/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/outbounds/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/outbounds/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/policies": v.lazy(() => api_SingboxRouterPolicyResponse),
+	"POST /singbox/router/policy-devices/bind": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/policy-devices/unbind": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/presets/apply": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/proxies/select": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/proxies/test": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxProxiesTestResponse))),
+})]),
+	"POST /singbox/router/route/final": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rules/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rules/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rules/move": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rules/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rulesets/add": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rulesets/delete": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/rulesets/update": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/selective/install-conntrack": v.lazy(() => api_SelectiveStatusData),
+	"POST /singbox/router/selective/install-deps": v.lazy(() => api_SelectiveStatusData),
+	"POST /singbox/router/selective/rebuild": v.lazy(() => api_SelectiveStatusData),
+	"POST /singbox/router/selective/rebuild/cancel": v.lazy(() => api_SelectiveCancelData),
+	"POST /singbox/router/settings": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/staging/apply": v.lazy(() => api_OkResponse),
+	"POST /singbox/router/staging/discard": v.lazy(() => api_OkResponse),
+	"POST /singbox/subscriptions/active-member": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/create": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/groups/create": v.lazy(() => api_SubscriptionGroupResponse),
+	"POST /singbox/subscriptions/groups/delete": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/subscriptions/members/add": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/members/exclude": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/members/remove": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/subscriptions/members/restore": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/orphans/delete": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/preview": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/subscriptions/refresh": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/tunnels": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/tunnels/delay-check": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/tunnels/share-link": v.lazy(() => api_APIEnvelope),
+	"POST /singbox/update": v.lazy(() => api_SingboxStatusResponse),
+	"POST /static-routes/create": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /static-routes/delete": v.lazy(() => api_APIEnvelope),
+	"POST /static-routes/import": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /static-routes/set-enabled": v.lazy(() => api_APIEnvelope),
+	"POST /static-routes/update": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /system-tunnels/asc": v.lazy(() => api_OkResponse),
+	"POST /system/hydraroute-control": v.lazy(() => api_APIEnvelope),
+	"POST /system/restart": v.lazy(() => api_APIEnvelope),
+	"POST /system/update/apply": v.lazy(() => api_UpdateApplyResponse),
+	"POST /terminal/install": v.lazy(() => api_TerminalStatusResponse),
+	"POST /terminal/start": v.lazy(() => api_TerminalStartResponse),
+	"POST /terminal/stop": v.lazy(() => api_APIEnvelope),
+	"POST /tunnels/create": v.lazy(() => api_APIEnvelope),
+	"POST /tunnels/delete": v.lazy(() => api_TunnelDeleteResponse),
+	"POST /tunnels/pingcheck": v.lazy(() => api_APIEnvelope),
+	"POST /tunnels/pingcheck/remove": v.lazy(() => api_APIEnvelope),
+	"POST /tunnels/replace": v.lazy(() => api_APIEnvelope),
+	"POST /tunnels/update": v.lazy(() => api_APIEnvelope),
+	"PUT /hydraroute/config/update": v.lazy(() => api_HydraRouteConfigResponse),
+	"PUT /managed-servers/{id}": v.lazy(() => api_ServersAllResponse),
+	"PUT /managed-servers/{id}/asc": v.lazy(() => api_ASCParamsResponse),
+	"PUT /managed-servers/{id}/peers/{pubkey}": v.lazy(() => api_ServersAllResponse),
+	"PUT /proxy/config": v.lazy(() => api_ProxyConfigResponse),
+	"PUT /proxy/instance": v.lazy(() => api_ProxyInstanceResponse),
+	"PUT /servers/{name}/peers/{pubkey}": v.lazy(() => api_ServersAllResponse),
+	"PUT /singbox/config/user": v.lazy(() => api_OkResponse),
+	"PUT /singbox/fakeip/config/dns/globals": v.lazy(() => api_OkResponse),
+	"PUT /singbox/router/dns/globals": v.lazy(() => api_OkResponse),
+	"PUT /singbox/router/settings": v.lazy(() => api_OkResponse),
+	"PUT /singbox/subscriptions/groups/update": v.lazy(() => api_SubscriptionGroupResponse),
+	"PUT /singbox/subscriptions/update": v.lazy(() => api_SubscriptionResponse),
+	"PUT /singbox/tunnels": v.lazy(() => api_APIEnvelope),
+};

--- a/frontend/src/lib/api/validate.test.ts
+++ b/frontend/src/lib/api/validate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { findResponseSchema, validateApiResponse, ApiValidationError } from './validate';
+import { RESPONSE_SCHEMAS } from './schemas.gen';
+
+describe('findResponseSchema', () => {
+	it('находит статический эндпоинт и игнорирует query-строку', () => {
+		expect(findResponseSchema('GET', '/tunnels/list')).toBeDefined();
+		expect(findResponseSchema('GET', '/tunnels/get?id=abc')).toBe(
+			findResponseSchema('GET', '/tunnels/get'),
+		);
+	});
+
+	it('различает методы', () => {
+		// /tunnels/update — только POST в спеке
+		expect(findResponseSchema('POST', '/tunnels/update')).toBeDefined();
+		expect(findResponseSchema('GET', '/tunnels/update')).toBeUndefined();
+	});
+
+	it('матчит шаблонные пути по сегментам', () => {
+		expect(findResponseSchema('GET', '/managed-servers/srv-1')).toBeDefined();
+		expect(findResponseSchema('POST', '/managed-servers/srv-1/peers')).toBeDefined();
+		expect(findResponseSchema('GET', '/managed-servers/srv-1/peers/PUBKEY==/conf')).toBeDefined();
+		// лишний сегмент — не совпадение
+		expect(findResponseSchema('GET', '/managed-servers/srv-1/peers/extra/level/deep')).toBeUndefined();
+	});
+
+	it('неизвестный эндпоинт — undefined (без проверки)', () => {
+		expect(findResponseSchema('GET', '/no/such/endpoint')).toBeUndefined();
+		expect(() => validateApiResponse('GET', '/no/such/endpoint', { total: 'garbage' })).not.toThrow();
+	});
+});
+
+describe('validateApiResponse', () => {
+	it('валидный конверт проходит', () => {
+		expect(() =>
+			validateApiResponse('GET', '/tunnels/list', {
+				success: true,
+				data: [{ id: 't1', name: 'Home', enabled: true }],
+			}),
+		).not.toThrow();
+	});
+
+	it('пропущенные и null-поля валидны (Go omitempty / nil-слайсы)', () => {
+		expect(() => validateApiResponse('GET', '/tunnels/list', { success: true })).not.toThrow();
+		expect(() =>
+			validateApiResponse('GET', '/tunnels/list', { success: true, data: null }),
+		).not.toThrow();
+	});
+
+	it('неизвестные поля валидны (эволюция бэка не ломает старый фронт)', () => {
+		expect(() =>
+			validateApiResponse('GET', '/tunnels/list', {
+				success: true,
+				data: [{ id: 't1', brandNewField: { anything: 1 } }],
+			}),
+		).not.toThrow();
+	});
+
+	it('присутствующее значение неверного типа — ApiValidationError с путём', () => {
+		let caught: unknown;
+		try {
+			validateApiResponse('GET', '/tunnels/list', {
+				success: true,
+				data: [{ id: 42 }], // id должен быть string
+			});
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(ApiValidationError);
+		const err = caught as ApiValidationError;
+		expect(err.endpoint).toBe('/tunnels/list');
+		expect(err.issues.join(' ')).toContain('id');
+		expect(err.message).toContain('/tunnels/list');
+	});
+
+	it('data неверной формы (объект вместо массива) — ошибка', () => {
+		expect(() =>
+			validateApiResponse('GET', '/tunnels/list', { success: true, data: { not: 'array' } }),
+		).toThrow(ApiValidationError);
+	});
+});
+
+describe('schemas.gen.ts инварианты', () => {
+	it('покрытие спеки существенное', () => {
+		expect(Object.keys(RESPONSE_SCHEMAS).length).toBeGreaterThan(250);
+	});
+
+	it('каждая схема принимает минимальный валидный конверт', () => {
+		// Все поля optional+nullable by design, поэтому {} и {success:true}
+		// обязаны проходить любую сгенерированную схему. Ловит регрессию
+		// генератора, случайно сделавшего поле обязательным.
+		for (const [key, _schema] of Object.entries(RESPONSE_SCHEMAS)) {
+			const [method, path] = key.split(' ', 2);
+			expect(
+				() => validateApiResponse(method, path.replaceAll(/\{[^}]+\}/g, 'x'), { success: true }),
+				`схема ${key} отвергла минимальный конверт`,
+			).not.toThrow();
+		}
+	});
+});

--- a/frontend/src/lib/api/validate.ts
+++ b/frontend/src/lib/api/validate.ts
@@ -1,0 +1,91 @@
+// Runtime-валидация ответов API против схем, сгенерированных из swagger
+// (schemas.gen.ts). Вызывается из центральной точки ApiClient.request():
+// невалидный ответ (присутствующее значение неверного типа) — это ошибка
+// запроса и в dev, и в prod. Отсутствующие/null-поля валидны by design —
+// см. дизайн-решения в scripts/gen-api-schemas.mjs.
+import * as v from 'valibot';
+import { RESPONSE_SCHEMAS } from './schemas.gen';
+
+export class ApiValidationError extends Error {
+	readonly endpoint: string;
+	readonly issues: string[];
+
+	constructor(endpoint: string, issues: string[]) {
+		super(`Некорректный ответ сервера (${endpoint}): ${issues.join('; ')}`);
+		this.name = 'ApiValidationError';
+		this.endpoint = endpoint;
+		this.issues = issues;
+	}
+}
+
+type TemplatedEntry = {
+	method: string;
+	segments: string[]; // '{...}' — wildcard-сегмент
+	schema: v.GenericSchema;
+};
+
+// Статические ключи матчатся O(1) по строке; шаблонные (/servers/{name}/…)
+// — посегментно. Разбиение считается один раз на старте модуля.
+const templated: TemplatedEntry[] = [];
+const staticSchemas = new Map<string, v.GenericSchema>();
+
+for (const [key, schema] of Object.entries(RESPONSE_SCHEMAS)) {
+	if (key.includes('{')) {
+		const [method, path] = key.split(' ', 2);
+		templated.push({ method, segments: path.split('/'), schema });
+	} else {
+		staticSchemas.set(key, schema);
+	}
+}
+
+/**
+ * Схема 2xx-ответа для метода и endpoint'а клиента (path без /api,
+ * query-строка игнорируется). undefined — эндпоинта нет в спеке.
+ */
+export function findResponseSchema(method: string, endpoint: string): v.GenericSchema | undefined {
+	const path = endpoint.split('?', 1)[0];
+	const direct = staticSchemas.get(`${method} ${path}`);
+	if (direct) return direct;
+
+	const segments = path.split('/');
+	outer: for (const entry of templated) {
+		if (entry.method !== method || entry.segments.length !== segments.length) continue;
+		for (let i = 0; i < segments.length; i++) {
+			const pattern = entry.segments[i];
+			if (pattern.startsWith('{')) {
+				if (!segments[i]) continue outer; // пустой сегмент — не совпадение
+			} else if (pattern !== segments[i]) {
+				continue outer;
+			}
+		}
+		return entry.schema;
+	}
+	return undefined;
+}
+
+function formatIssue(issue: v.BaseIssue<unknown>): string {
+	const path = (issue.path ?? [])
+		.map((p) => String((p as { key?: unknown }).key ?? '?'))
+		.join('.');
+	const got = issue.received;
+	return `${path || '<root>'}: ожидался ${issue.expected}, получен ${got}`;
+}
+
+/**
+ * Проверяет конверт ответа по схеме эндпоинта. Нет схемы — ответ проходит
+ * без проверки (эндпоинт вне спеки). Несовпадение — ApiValidationError со
+ * списком точных путей расхождения (первые 5).
+ */
+export function validateApiResponse(method: string, endpoint: string, body: unknown): void {
+	const schema = findResponseSchema(method.toUpperCase(), endpoint);
+	if (!schema) return;
+
+	const result = v.safeParse(schema, body);
+	if (result.success) return;
+
+	const issues = result.issues.slice(0, 5).map(formatIssue);
+	if (result.issues.length > 5) {
+		issues.push(`… и ещё ${result.issues.length - 5}`);
+	}
+	throw new ApiValidationError(endpoint, issues);
+}

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -545,7 +545,7 @@ func (h *HydraRouteHandler) UpdateGeoFile(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			path	query	string	true	"Geo file path"
-//	@Success		200	{array}	string
+//	@Success		200	{object}	GeoTagsResponse
 //	@Router			/hydraroute/geo-tags [get]
 func (h *HydraRouteHandler) GetGeoTags(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/routing.go
+++ b/internal/api/routing.go
@@ -61,7 +61,7 @@ func (h *RoutingHandler) SetEventBus(bus *events.Bus) { h.bus = bus }
 //	@Tags			routing
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{array}	object
+//	@Success		200	{object}	RoutingTunnelsResponse
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/tunnels [get]

--- a/internal/api/server_peers.go
+++ b/internal/api/server_peers.go
@@ -377,7 +377,7 @@ func (h *ServersHandler) ToggleServerPeer(w http.ResponseWriter, r *http.Request
 //	@Security		CookieAuth
 //	@Param			name	path		string	true	"Interface name (e.g. Wireguard0)"
 //	@Param			pubkey	path		string	true	"Peer public key"
-//	@Success		200		{object}	map[string]string
+//	@Success		200		{object}	PeerConfResponse
 //	@Failure		404		{object}	APIErrorEnvelope
 //	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/servers/{name}/peers/{pubkey}/conf [get]

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -159,9 +159,9 @@ func (h *TerminalHandler) Stop(w http.ResponseWriter, r *http.Request) {
 //
 //	@Summary		Terminal WebSocket
 //	@Tags			terminal
-//	@Produce		json
+//	@Produce		plain
 //	@Security		CookieAuth
-//	@Success		200	{string}	string	"WebSocket upgrade"
+//	@Success		101	{string}	string	"Switching Protocols (WebSocket upgrade)"
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/ws [get]

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1374,6 +1374,25 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.GeoTagDTO:
+    properties:
+      count:
+        example: 1250
+        type: integer
+      name:
+        example: google
+        type: string
+    type: object
+  api.GeoTagsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.GeoTagDTO'
+        type: array
+      success:
+        example: true
+        type: boolean
+    type: object
   api.HealthData:
     properties:
       instanceId:
@@ -2616,6 +2635,37 @@ definitions:
     properties:
       data:
         $ref: '#/definitions/api.RoutingRefreshData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.RoutingTunnelDTO:
+    properties:
+      available:
+        example: true
+        type: boolean
+      iface:
+        example: nwg0
+        type: string
+      id:
+        example: tun_abc123
+        type: string
+      name:
+        example: My VPN
+        type: string
+      status:
+        example: connected
+        type: string
+      type:
+        example: managed
+        type: string
+    type: object
+  api.RoutingTunnelsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.RoutingTunnelDTO'
+        type: array
       success:
         example: true
         type: boolean
@@ -7595,9 +7645,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              type: string
-            type: array
+            $ref: '#/definitions/api.GeoTagsResponse'
       security:
       - CookieAuth: []
       summary: HydraRoute geo tags
@@ -9354,9 +9402,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              type: object
-            type: array
+            $ref: '#/definitions/api.RoutingTunnelsResponse'
         "400":
           description: Bad Request
           schema:
@@ -9586,9 +9632,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/api.PeerConfResponse'
         "404":
           description: Not Found
           schema:
@@ -14856,10 +14900,10 @@ paths:
   /terminal/ws:
     get:
       produces:
-      - application/json
+      - text/plain
       responses:
-        "200":
-          description: WebSocket upgrade
+        "101":
+          description: Switching Protocols (WebSocket upgrade)
           schema:
             type: string
         "400":


### PR DESCRIPTION
## Что сделано

Каст `return data.data as T` в `ApiClient.request()` был чистым доверием — фактическую форму ответа никто не проверял. Теперь каждый JSON-ответ валидируется в рантайме по схеме, сгенерированной из swagger-спеки бэкенда, **строго и в dev, и в prod** (по выбранному режиму): присутствующее значение неверного типа → `ApiValidationError` с точными путями расхождения.

### Генератор (`npm run gen:api`)

`scripts/gen-api-schemas.mjs` читает `internal/openapi/swagger.yaml` (swaggo, из Go-аннотаций) и эмитит `src/lib/api/schemas.gen.ts` — карту `"METHOD /path"` → valibot-схема. **317 эндпоинтов, 301 DTO** (только достижимые из 2xx-ответов — request-DTO в бандл не попадают).

Калибровка строгого режима, чтобы он ловил дрейф, но не ломался на эволюции:
| Правило | Почему |
|---|---|
| Каждое поле `optional` + `nullable` | Go `omitempty` опускает поля, nil-слайсы/мапы маршалятся в `null` |
| Объекты loose (лишние ключи ок) | Новые поля бэка не ломают закэшированный старый фронт |
| Enum → базовый тип, не picklist | Новое значение enum на бэке — не поломка |
| `$ref` → `v.lazy` | Порядок объявлений и циклы не важны |

Итого падает только «поле присутствует, но неверного типа» — это и есть реальный сигнал рассинхрона.

### Врезка

`src/lib/api/validate.ts`: статические пути — O(1) по строке, шаблонные (`{id}`, `{pubkey}`) — посегментный матчинг. Подключено в `request()` и `fetchDelete()` — через них идут все ~100 методов клиента. Эндпоинт вне спеки проходит без проверки.

### Валидация сразу окупилась: 4 бага спеки

Инвариант-тест («каждая схема обязана принять минимальный конверт») поймал 4 ленивые swaggo-аннотации, где реальный Go-ответ — конверт, а спека врала:

- `GET /routing/tunnels` — `{array} object` → `RoutingTunnelsResponse` (тип существовал, но не был указан)
- `GET /hydraroute/geo-tags` — `{array} string` → `GeoTagsResponse`
- `GET /servers/{name}/peers/{pubkey}/conf` — `map[string]string` → `PeerConfResponse`
- `GET /terminal/ws` — JSON 200 у WebSocket-upgrade → `plain` + `101 Switching Protocols`

Исправлены аннотации в Go и синхронно swagger.yaml (по конвенции проекта — хирургические правки спеки вместе с аннотациями).

### Тесты

- Матчер: статические/шаблонные пути, различение методов, срез query-строки, «лишний сегмент — не совпадение».
- Валидатор: omitempty/null/неизвестные поля проходят; неверный тип — ошибка с dot-путём и именем эндпоинта.
- Инвариант по всем 317 схемам: минимальный конверт `{success:true}` обязан проходить каждую — ловит регрессию генератора, случайно сделавшего поле обязательным.

### Цена

+10.4KB gzip в бандле (схемы 317 эндпоинтов + valibot core, замерено отдельной esbuild-сборкой).

## Проверки

- `vitest` — 1335/1335 (существующие тесты с fetch-моками прошли валидацию без правок)
- `svelte-check` — 0/0; `eslint` — 0 errors
- `go build && go vet && go test ./internal/api` — OK
- `npm run build` — OK

## База

Stacked поверх #477 (eslint typing) — общие правки package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_