### PR TITLE
frontend: валидация недоверенных границ + ноль any во всём дереве

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,7 +14,8 @@ export default tseslint.config(
 			'static/',
 			'scripts/',
 			'**/*.cjs',
-			'src/app.d.ts',
+			// Генерированный вывод npm run gen:api — не линтится, как и любой codegen.
+			'src/lib/api/schemas.gen.ts',
 		],
 	},
 	{
@@ -52,16 +53,6 @@ export default tseslint.config(
 		},
 		rules: {
 			'@typescript-eslint/no-explicit-any': 'error',
-		},
-	},
-	{
-		// Test files legitimately build partial mocks and stub subscribers, where
-		// forcing a full typed shape (or an `as unknown as T` double-cast) adds
-		// noise without buying real safety. Keep `any` visible as a warning so it
-		// stays discouraged and greppable, but don't fail the lint on it.
-		files: ['**/*.test.ts', '**/*.spec.ts'],
-		rules: {
-			'@typescript-eslint/no-explicit-any': 'warn',
 		},
 	},
 );

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,9 +1,10 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 
 // swagger-ui-dist ships a plain UMD bundle with no TypeScript types.
+// `unknown` вместо `any`: единственный потребитель (routes/api-docs) и так
+// сужает значение до вызываемой сигнатуры на месте использования.
 declare module 'swagger-ui-dist/swagger-ui-bundle.js' {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const SwaggerUIBundle: any;
+	const SwaggerUIBundle: unknown;
 	export = SwaggerUIBundle;
 }
 

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -144,7 +144,9 @@ export interface SSEEventHandlers {
 
 export function parseConnectedEvent(data: string): { ok?: boolean; instanceId?: string } | undefined {
 	try {
-		return JSON.parse(data) as { ok?: boolean; instanceId?: string };
+		const parsed: unknown = JSON.parse(data);
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+		return parsed;
 	} catch {
 		return undefined;
 	}

--- a/frontend/src/lib/stores/modeSwitch.test.ts
+++ b/frontend/src/lib/stores/modeSwitch.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
+import type { SingboxRouterStatus, SingboxRouterSettings } from '$lib/types';
+
+// Тесты кормят currentMode и стор частичными фикстурами (читаются только
+// enabled/routingMode); один явный каст в хелпере вместо рассыпанных as any.
+const asStatus = (p: Partial<SingboxRouterStatus>) => p as SingboxRouterStatus;
+const asSettings = (p: Partial<SingboxRouterSettings>) => p as SingboxRouterSettings;
 
 // vi.hoisted: vi.mock factories are hoisted above these declarations, so the
 // shared spy fns must be hoisted too (vitest only auto-hoists `mock*`-prefixed
@@ -10,14 +16,27 @@ const { switchMode, begin, fail, reset, loadAll, refs } = vi.hoisted(() => ({
 	fail: vi.fn(),
 	reset: vi.fn(),
 	loadAll: vi.fn().mockResolvedValue(undefined),
-	refs: { statusVal: null as any, settingsVal: null as any },
+	refs: {
+		statusVal: null as Partial<SingboxRouterStatus> | null,
+		settingsVal: null as Partial<SingboxRouterSettings> | null,
+	},
 }));
 vi.mock('$lib/api/client', () => ({ api: { singboxRouterSwitchMode: (m: string) => switchMode(m) } }));
 vi.mock('$lib/stores/fakeipTransition', () => ({ fakeipTransition: { begin, fail, reset } }));
 vi.mock('$lib/stores/singboxRouter', () => ({
 	singboxRouter: {
-		status: { subscribe: (run: any) => { run(refs.statusVal); return () => {}; } },
-		settings: { subscribe: (run: any) => { run(refs.settingsVal); return () => {}; } },
+		status: {
+			subscribe: (run: (v: Partial<SingboxRouterStatus> | null) => void) => {
+				run(refs.statusVal);
+				return () => {};
+			},
+		},
+		settings: {
+			subscribe: (run: (v: Partial<SingboxRouterSettings> | null) => void) => {
+				run(refs.settingsVal);
+				return () => {};
+			},
+		},
 		loadAll,
 	},
 }));
@@ -34,13 +53,17 @@ beforeEach(() => {
 
 describe('currentMode', () => {
 	it('off when not enabled (ignores stale routingMode)', () => {
-		expect(currentMode({ enabled: false } as any, { routingMode: 'fakeip-tun' } as any)).toBe('off');
+		expect(
+			currentMode(asStatus({ enabled: false }), asSettings({ routingMode: 'fakeip-tun' })),
+		).toBe('off');
 	});
 	it('routingMode when enabled', () => {
-		expect(currentMode({ enabled: true } as any, { routingMode: 'tproxy' } as any)).toBe('tproxy');
+		expect(currentMode(asStatus({ enabled: true }), asSettings({ routingMode: 'tproxy' }))).toBe(
+			'tproxy',
+		);
 	});
 	it('defaults to tproxy when enabled but routingMode missing', () => {
-		expect(currentMode({ enabled: true } as any, {} as any)).toBe('tproxy');
+		expect(currentMode(asStatus({ enabled: true }), asSettings({}))).toBe('tproxy');
 	});
 });
 

--- a/frontend/src/lib/stores/monitoring.cache.test.ts
+++ b/frontend/src/lib/stores/monitoring.cache.test.ts
@@ -81,4 +81,20 @@ describe('monitoring.loadCached — недоверенный localStorage', () =
 		expect(() => monitoring.loadCached()).not.toThrow();
 		expect(get(monitoring).snapshot).toBeNull();
 	});
+
+	it('null-слайсы (Go nil без omitempty, пустой роутер) валидны и нормализуются в []', () => {
+		// Бэкенд-DTO маршалит nil-слайсы в null: {"targets":null,...} — это
+		// легитимный кэш текущей версии, а не мусор.
+		localStorage.setItem(
+			CACHE_KEY,
+			JSON.stringify({ targets: null, tunnels: null, cells: null, updatedAt: '2026-07-08T10:00:00Z' }),
+		);
+		monitoring.loadCached();
+		const s = get(monitoring);
+		expect(s.snapshot).not.toBeNull();
+		expect(s.snapshot?.targets).toEqual([]);
+		expect(s.snapshot?.tunnels).toEqual([]);
+		expect(s.snapshot?.cells).toEqual([]);
+		expect(s.stale).toBe(true);
+	});
 });

--- a/frontend/src/lib/stores/monitoring.cache.test.ts
+++ b/frontend/src/lib/stores/monitoring.cache.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { monitoringStore as monitoring } from './monitoring';
+import type { MonitoringSnapshot } from '$lib/types';
+
+const CACHE_KEY = 'awgm_monitoring_snapshot_v1';
+
+const validSnapshot: MonitoringSnapshot = {
+	targets: [{ id: 't1', host: '1.1.1.1', name: 'Cloudflare' }],
+	tunnels: [
+		{
+			id: 'tun1',
+			name: 'Home',
+			ifaceName: 'nwg0',
+			pingcheckTarget: '1.1.1.1',
+			selfTarget: '10.0.0.1',
+			selfMethod: 'ping',
+		},
+	],
+	cells: [
+		{
+			targetId: 't1',
+			tunnelId: 'tun1',
+			latencyMs: 12,
+			ok: true,
+			activeForRestart: false,
+			isSelf: false,
+			ts: '2026-07-08T10:00:00Z',
+		},
+	],
+	updatedAt: '2026-07-08T10:00:00Z',
+};
+
+beforeEach(() => {
+	localStorage.clear();
+	// Сбрасываем состояние стора между тестами (loadCached — единственный вход).
+	monitoring.reset();
+});
+
+describe('monitoring.loadCached — недоверенный localStorage', () => {
+	it('валидный кэш загружается как stale-снапшот', () => {
+		localStorage.setItem(CACHE_KEY, JSON.stringify(validSnapshot));
+		monitoring.loadCached();
+		const s = get(monitoring);
+		expect(s.snapshot?.targets).toHaveLength(1);
+		expect(s.stale).toBe(true);
+	});
+
+	it('кэш от старой версии с неверной формой молча игнорируется', () => {
+		// cells: объект вместо массива — форма из гипотетической прошлой версии
+		localStorage.setItem(
+			CACHE_KEY,
+			JSON.stringify({ ...validSnapshot, cells: { legacy: true } }),
+		);
+		monitoring.loadCached();
+		expect(get(monitoring).snapshot).toBeNull();
+	});
+
+	it('запись с неверным типом поля внутри массива игнорируется', () => {
+		const bad = structuredClone(validSnapshot) as unknown as {
+			cells: Array<Record<string, unknown>>;
+		};
+		bad.cells[0].latencyMs = 'fast'; // должен быть number | null
+		localStorage.setItem(CACHE_KEY, JSON.stringify(bad));
+		monitoring.loadCached();
+		expect(get(monitoring).snapshot).toBeNull();
+	});
+
+	it('лишние поля (эволюция формата вперёд) не мешают загрузке', () => {
+		localStorage.setItem(
+			CACHE_KEY,
+			JSON.stringify({ ...validSnapshot, futureField: { anything: 1 } }),
+		);
+		monitoring.loadCached();
+		expect(get(monitoring).snapshot).not.toBeNull();
+	});
+
+	it('не-JSON мусор игнорируется без исключений', () => {
+		localStorage.setItem(CACHE_KEY, '{broken json');
+		expect(() => monitoring.loadCached()).not.toThrow();
+		expect(get(monitoring).snapshot).toBeNull();
+	});
+});

--- a/frontend/src/lib/stores/monitoring.ts
+++ b/frontend/src/lib/stores/monitoring.ts
@@ -1,7 +1,41 @@
 import { writable } from 'svelte/store';
+import * as v from 'valibot';
 import type { MonitoringSnapshot } from '$lib/types';
 
 const CACHE_KEY = 'awgm_monitoring_snapshot_v1';
+
+// Кэш в localStorage переживает обновления awg-manager, поэтому форма
+// снапшота из прошлой версии — недоверенный вход: слепой каст здесь уже
+// приводил бы к падению матрицы на deref'ах до первого свежего снапшота.
+// Валидируются поля, которые UI читает структурно; лишние ключи допустимы
+// (looseObject), несовпадение — кэш молча игнорируется (self-heal).
+const cachedSnapshotSchema = v.looseObject({
+	targets: v.array(
+		v.looseObject({ id: v.string(), host: v.string(), name: v.string() }),
+	),
+	tunnels: v.array(
+		v.looseObject({
+			id: v.string(),
+			name: v.string(),
+			ifaceName: v.string(),
+			pingcheckTarget: v.string(),
+			selfTarget: v.string(),
+			selfMethod: v.string(),
+		}),
+	),
+	cells: v.array(
+		v.looseObject({
+			targetId: v.string(),
+			tunnelId: v.string(),
+			latencyMs: v.nullable(v.number()),
+			ok: v.boolean(),
+			activeForRestart: v.boolean(),
+			isSelf: v.boolean(),
+			ts: v.string(),
+		}),
+	),
+	updatedAt: v.string(),
+});
 
 interface MonitoringState {
 	snapshot: MonitoringSnapshot | null;
@@ -27,7 +61,9 @@ function createMonitoringStore() {
 			try {
 				const raw = localStorage.getItem(CACHE_KEY);
 				if (!raw) return;
-				const snap: MonitoringSnapshot = JSON.parse(raw);
+				const result = v.safeParse(cachedSnapshotSchema, JSON.parse(raw));
+				if (!result.success) return;
+				const snap = result.output as MonitoringSnapshot;
 				update((s) => ({
 					...s,
 					snapshot: snap,

--- a/frontend/src/lib/stores/monitoring.ts
+++ b/frontend/src/lib/stores/monitoring.ts
@@ -9,30 +9,37 @@ const CACHE_KEY = 'awgm_monitoring_snapshot_v1';
 // приводил бы к падению матрицы на deref'ах до первого свежего снапшота.
 // Валидируются поля, которые UI читает структурно; лишние ключи допустимы
 // (looseObject), несовпадение — кэш молча игнорируется (self-heal).
+// Массивы nullable: Go-DTO без omitempty маршалит nil-слайс в null (пустой
+// роутер отдаёт {"targets":null,...}) — это валидный кэш, а не мусор;
+// null нормализуется в [] в loadCached, потому что UI ждёт массивы.
 const cachedSnapshotSchema = v.looseObject({
-	targets: v.array(
-		v.looseObject({ id: v.string(), host: v.string(), name: v.string() }),
+	targets: v.nullable(
+		v.array(v.looseObject({ id: v.string(), host: v.string(), name: v.string() })),
 	),
-	tunnels: v.array(
-		v.looseObject({
-			id: v.string(),
-			name: v.string(),
-			ifaceName: v.string(),
-			pingcheckTarget: v.string(),
-			selfTarget: v.string(),
-			selfMethod: v.string(),
-		}),
+	tunnels: v.nullable(
+		v.array(
+			v.looseObject({
+				id: v.string(),
+				name: v.string(),
+				ifaceName: v.string(),
+				pingcheckTarget: v.string(),
+				selfTarget: v.string(),
+				selfMethod: v.string(),
+			}),
+		),
 	),
-	cells: v.array(
-		v.looseObject({
-			targetId: v.string(),
-			tunnelId: v.string(),
-			latencyMs: v.nullable(v.number()),
-			ok: v.boolean(),
-			activeForRestart: v.boolean(),
-			isSelf: v.boolean(),
-			ts: v.string(),
-		}),
+	cells: v.nullable(
+		v.array(
+			v.looseObject({
+				targetId: v.string(),
+				tunnelId: v.string(),
+				latencyMs: v.nullable(v.number()),
+				ok: v.boolean(),
+				activeForRestart: v.boolean(),
+				isSelf: v.boolean(),
+				ts: v.string(),
+			}),
+		),
 	),
 	updatedAt: v.string(),
 });
@@ -63,7 +70,14 @@ function createMonitoringStore() {
 				if (!raw) return;
 				const result = v.safeParse(cachedSnapshotSchema, JSON.parse(raw));
 				if (!result.success) return;
-				const snap = result.output as MonitoringSnapshot;
+				const out = result.output;
+				const snap: MonitoringSnapshot = {
+					...out,
+					targets: out.targets ?? [],
+					tunnels: out.tunnels ?? [],
+					cells: out.cells ?? [],
+					updatedAt: out.updatedAt,
+				};
 				update((s) => ({
 					...s,
 					snapshot: snap,

--- a/frontend/src/lib/utils/serverPeerOptions.test.ts
+++ b/frontend/src/lib/utils/serverPeerOptions.test.ts
@@ -5,9 +5,30 @@ import {
   buildServerPeerDropdownOptions,
 } from './serverPeerOptions';
 import type { ServersSnapshot } from '$lib/stores/servers';
+import type { ManagedServer, WireguardServer } from '$lib/types';
 
 function snap(over: Partial<ServersSnapshot> = {}): ServersSnapshot {
   return { servers: [], managed: [], managedStats: {}, ...over };
+}
+
+// Фикстуры покрывают только поля, которые читает buildServerPeerDropdownOptions
+// (id/interfaceName/description/peers); один явный каст в фабрике вместо
+// рассыпанных as any.
+function sysServer(p: {
+  id: string;
+  interfaceName: string;
+  description: string;
+  peers: Array<{ publicKey: string; description: string; confAvailable?: boolean }>;
+}): WireguardServer {
+  return p as unknown as WireguardServer;
+}
+
+function mngServer(p: {
+  interfaceName: string;
+  description: string;
+  peers: Array<{ publicKey: string; description: string }>;
+}): ManagedServer {
+  return p as unknown as ManagedServer;
 }
 
 describe('serverPeerOptions value codec', () => {
@@ -30,7 +51,7 @@ describe('buildServerPeerDropdownOptions', () => {
   it('filters system peers by confAvailable, keeps managed peers always', () => {
     const s = snap({
       servers: [
-        {
+        sysServer({
           id: 'sys1',
           interfaceName: 'Wireguard0',
           description: 'Sys',
@@ -39,14 +60,14 @@ describe('buildServerPeerDropdownOptions', () => {
             { publicKey: 'SYS_NO', description: 'no', confAvailable: false },
             { publicKey: 'SYS_UNDEF', description: 'undef' },
           ],
-        } as any,
+        }),
       ],
       managed: [
-        {
+        mngServer({
           interfaceName: 'awg-mng0',
           description: 'Mng',
           peers: [{ publicKey: 'MNG1', description: 'm1' }],
-        } as any,
+        }),
       ],
     });
 
@@ -67,12 +88,12 @@ describe('buildServerPeerDropdownOptions', () => {
     // values so a swap is caught here, not only at runtime.
     const s = snap({
       servers: [
-        {
+        sysServer({
           id: 'sys1',
           interfaceName: 'Wireguard0',
           description: 'Sys',
           peers: [{ publicKey: 'SYS_OK', description: 'ok', confAvailable: true }],
-        } as any,
+        }),
       ],
     });
     const opt = buildServerPeerDropdownOptions(s)[0];

--- a/frontend/src/lib/utils/singboxConnections.test.ts
+++ b/frontend/src/lib/utils/singboxConnections.test.ts
@@ -93,6 +93,23 @@ describe('parseSnapshot', () => {
 		expect(snap.uploadTotal).toBe(567);
 		expect(snap.connectionsTotal).toBe(1);
 	});
+
+	it('пропускает битые записи (нет metadata/sourceIP/chains), не роняя снапшот', () => {
+		const raw = structuredClone(baseRaw);
+		// Данные приходят по WS без проверки формы — эмулируем мусор.
+		raw.connections!.push(
+			{ id: 'broken-1' } as unknown as NonNullable<ClashConnectionsRaw['connections']>[number],
+			{
+				id: 'broken-2',
+				metadata: { sourceIP: 42 },
+				chains: 'not-an-array',
+			} as unknown as NonNullable<ClashConnectionsRaw['connections']>[number],
+		);
+		const snap = parseSnapshot(raw, new Map());
+		expect(snap.connections).toHaveLength(1);
+		expect(snap.connections[0].id).toBe('a');
+		expect(snap.connectionsTotal).toBe(1);
+	});
 });
 
 function makeConn(

--- a/frontend/src/lib/utils/singboxConnections.ts
+++ b/frontend/src/lib/utils/singboxConnections.ts
@@ -24,15 +24,22 @@ export function parseSnapshot(
 	clientsByIP: Map<string, string>,
 ): ConnectionsSnapshot {
 	const rawConns = raw.connections ?? [];
-	const connections: Connection[] = rawConns.map((c) => {
-		const ip = c.metadata.sourceIP.toLowerCase();
-		const clientName = clientsByIP.get(ip);
-		return {
-			...c,
-			clientName,
-			outboundLabel: chainOutboundLabel(c.chains),
-		};
-	});
+	const connections: Connection[] = rawConns
+		// Снапшот приходит по WS без проверки формы: одна битая запись
+		// (metadata/sourceIP/chains не той формы) не должна ронять весь
+		// live-поток шапки и FlowGraph — пропускаем её, остальные живут.
+		.filter(
+			(c) => typeof c?.metadata?.sourceIP === 'string' && Array.isArray(c.chains),
+		)
+		.map((c) => {
+			const ip = c.metadata.sourceIP.toLowerCase();
+			const clientName = clientsByIP.get(ip);
+			return {
+				...c,
+				clientName,
+				outboundLabel: chainOutboundLabel(c.chains),
+			};
+		});
 	return {
 		connections,
 		downloadTotal: raw.downloadTotal ?? 0,

--- a/frontend/src/routes/subscriptions/[id]/+page.svelte
+++ b/frontend/src/routes/subscriptions/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores';
 	import { onMount, onDestroy } from 'svelte';
 	import { api } from '$lib/api/client';
-	import type { Subscription } from '$lib/types';
+	import type { Subscription, SubscriptionMember } from '$lib/types';
 	import { PageContainer, PageHeader, LoadingSpinner } from '$lib/components/layout';
 	import { Tabs, LayoutViewToggle } from '$lib/components/ui';
 	import SubscriptionMembersTab from '$lib/components/subscriptions/SubscriptionMembersTab.svelte';
@@ -111,8 +111,23 @@
 		let streamDone = false;
 		let fallbackTried = false;
 
+		// SSE-события парсятся без проверки формы, а хендлеры ниже читают их
+		// структурно (spread в Subscription, member.tag): битое событие не
+		// должно убивать прогрессивную загрузку — оно молча пропускается.
+		const parseEventObject = (e: Event): Record<string, unknown> | null => {
+			try {
+				const parsed: unknown = JSON.parse((e as MessageEvent).data);
+				return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+					? (parsed as Record<string, unknown>)
+					: null;
+			} catch {
+				return null;
+			}
+		};
+
 		evtSrc.addEventListener('meta', (e) => {
-			const meta = JSON.parse((e as MessageEvent).data);
+			const meta = parseEventObject(e) as (Partial<Subscription> & { total?: number }) | null;
+			if (!meta) return;
 			subscription = {
 				...meta,
 				members: [],
@@ -125,20 +140,22 @@
 				excludedMembers: [],
 				filteredMembers: [],
 			} as Subscription;
-			progressTotal = meta.total ?? 0;
+			progressTotal = typeof meta.total === 'number' ? meta.total : 0;
 		});
 
 		evtSrc.addEventListener('member', (e) => {
 			if (!subscription) return;
-			const { member } = JSON.parse((e as MessageEvent).data);
+			const payload = parseEventObject(e);
+			const member = payload?.member as SubscriptionMember | undefined;
+			if (!member || typeof member !== 'object' || typeof member.tag !== 'string') return;
 			subscription.members = [...(subscription.members ?? []), member];
 			subscription.memberTags = [...subscription.memberTags, member.tag];
 			progressLoaded += 1;
 		});
 
 		evtSrc.addEventListener('done', (e) => {
-			if (subscription) {
-				const data = JSON.parse((e as MessageEvent).data);
+			const data = parseEventObject(e) as Partial<Subscription> | null;
+			if (subscription && data) {
 				subscription.orphanTags = data.orphanTags ?? [];
 				subscription.activeMember = data.activeMember ?? '';
 				subscription.rejectedMembers = data.rejectedMembers ?? subscription.rejectedMembers ?? [];


### PR DESCRIPTION
## Что сделано

Завершение runtime-типобезопасности после API-границы (#479): проверены **все** места, где фронт парсит внешний JSON — localStorage, WebSocket, SSE, файловые импорты, vpn://-вставка. Вторым коммитом добиты последние `any` в тестах и `app.d.ts` — правило `no-explicit-any` теперь **error без исключений**.

## Часть 1: недоверенные границы

### Результат инвентаризации

Большинство границ **уже были защищены** предыдущей работой — это подтверждено, а не переделано:

| Граница | Состояние |
|---|---|
| `persisted.ts` фабрика | контракт «junk → default» + try/catch ✅ |
| `theme.ts`, `sortStore.ts` | пофилдовое сужение с fallback ✅ |
| `notificationCenter.ts` | гард `isCenterEntry` ✅ |
| Backup-импорт файла | гард `isManagedServerBackupFile` ✅ |
| vpn://-вставка (`vpnlink.ts`) | ручное сужение через `unknown` ✅ |
| `DownloadSettings` | round-trip собственного ключа + defaults ✅ |

### Исправлены 4 реально слепых места

1. **`monitoring.ts` `loadCached()`** — кэш снапшота мониторинга в localStorage переживает обновления awg-manager, но форма бралась голым кастом `JSON.parse(raw)`. Теперь valibot-схема (loose-объекты, поля структурного потребления UI); несовпадение — кэш молча игнорируется (self-heal).

2. **`parseSnapshot()`** (Clash WS) — одна запись без `metadata.sourceIP` бросала `TypeError` и роняла весь live-поток шапки и FlowGraph. Битые записи отфильтровываются, остальные живут.

3. **SSE страницы подписки** (`subscriptions/[id]`) — хендлеры `meta`/`member`/`done` читали `JSON.parse` структурно без гардов: `member.tag` на битом событии убивал прогрессивную загрузку. Общий `parseEventObject`: не-объект или невалидный JSON — событие молча пропускается.

4. **`parseConnectedEvent()`** — каст произвольного JSON заменён сужением через `unknown`.

Калибровка та же, что в #479: схемы loose (эволюция формата вперёд не ломает), режимы отказа по типу границы — localStorage self-heal к дефолту, потоковые события — drop одной записи/события без убийства потока.

## Часть 2: ноль `any` во всём дереве

- **`modeSwitch.test.ts`** (10 any): refs и подписчики моков типизированы `Partial<SingboxRouterStatus/Settings>`; частичные фикстуры `currentMode` — через хелперы `asStatus`/`asSettings` с одним явным кастом.
- **`serverPeerOptions.test.ts`** (3 any): фабрики `sysServer`/`mngServer` с типизированным входом (ровно поля, которые читает функция под тестом) и одним `as unknown as` внутри фабрики.
- **`app.d.ts`**: `SwaggerUIBundle: any` → `unknown` (потребитель в api-docs и так сужает на месте вызова); файл убран из ignores линта.
- **`eslint.config.js`**: warn-override для тестов удалён — `no-explicit-any: error` действует на весь проект; генерируемый `schemas.gen.ts` добавлен в ignores (codegen-вывод не линтится).

## Тесты

6 новых: кэш мониторинга (валидный / чужая форма / неверный тип поля / эволюция вперёд / не-JSON мусор) и parseSnapshot (битые записи не роняют снапшот).

## Проверки

- `vitest` — 1341/1341
- `svelte-check` — 0/0; `eslint` — **0 problems** (ни errors, ни warnings)
- CI прогонит всё то же на PR

## База

Stacked поверх #479 (использует valibot, введённый там). Цепочка: #477 → #479 → этот PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg