### PR TITLE
sing-box: синк embedded.go SHA256/Size для 1.14.0-alpha.42

### DIFF
--- a/internal/singbox/installer/embedded.go
+++ b/internal/singbox/installer/embedded.go
@@ -4,7 +4,7 @@ package installer
 const RequiredVersion = "1.14.0-alpha.42"
 
 var EmbeddedBinaries = map[string]BinarySpec{
-	"mipsel-3.4":   {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-mipsel-3.4", SHA256: "a60b9a23e43d706ab04a9506a136f1a09b485ea5854965e34ecadd4744112ced", Size: 90709316},
-	"mips-3.4":     {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-mips-3.4", SHA256: "11a2aba2120c767b6aea03a65ad064e85822efb0b4f61c255dd19993b5fea98c", Size: 73466013},
-	"aarch64-3.10": {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-aarch64-3.10", SHA256: "d83f80b4b89bd2c8f6ff4d1a272e6d600eb56ecede5476d01848abf781b57ce1", Size: 76122136},
+	"mipsel-3.4":   {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-mipsel-3.4", SHA256: "a6591fc2200747532198119d892643f129247f1b322d2d50eae8d5ce46e2b8ca", Size: 91181136},
+	"mips-3.4":     {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-mips-3.4", SHA256: "6886cbacc7bc6b085ad6c35031548ca35ad833a6bcad078844fdbf2298263348", Size: 73924765},
+	"aarch64-3.10": {Version: RequiredVersion, URL: "http://repo.hoaxisr.ru/develop/singbox/1.14.0-alpha.42/sing-box-1.14.0-alpha.42-aarch64-3.10", SHA256: "ef6d4274ac3b5f69dd2d545df88f53c4437c8c71712dc379ca1675018890c53c", Size: 76528824},
 }


### PR DESCRIPTION
## Что

Phase-2 бампа #483: авторитетные SHA256/Size вместо плейсхолдеров от alpha.39. Диф — 3 строки в `internal/singbox/installer/embedded.go` (версия и URL уже были на alpha.42).

## Откуда значения

Из develop pre-release `latest` (собран merge-коммитом `96a30615` в CI-ране [29087012431](https://github.com/hoaxisr/awg-manager/actions/runs/29087012431)). Для каждого бинаря **GitHub asset digest совпал байт-в-байт с опубликованным `.sha256`-сайдкаром**, который CI посчитал через `update-singbox-embedded.sh` из фактического собранного бинаря — это ровно тот источник, что использует `scripts/regen-embedded.sh` (эквивалент его запуска, но `gh` CLI в окружении нет).

| Арка | SHA256 | Size |
|---|---|---|
| mipsel-3.4 | `a6591fc2…e2b8ca` | 91181136 |
| mips-3.4 | `6886cbac…263348` | 73924765 |
| aarch64-3.10 | `ef6d4274…890c53c` | 76528824 |

## Проверки

- `go build` / `go vet` / `go test ./internal/singbox/installer/` — зелёные
- Значения тройне подтверждены: GitHub asset digest == CI `.sha256` sidecar (для всех 3 арок)

Примечание: HEAD к mirror `repo.hoaxisr.ru` из CI-песочницы недоступен (агент-прокси отдаёт 403 на внешний хост), но синк mirror ← GitHub-релиз — инфра-сторона; хэши авторитетны из релиза.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_