### PR TITLE
install: убрать curl из health_check, wget-путь установки как основной (#482)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@
 
 ## Установка (стабильная версия)
 
+curl не требуется — установка идёт встроенным busybox wget (полезно на устройствах с малой внутренней памятью):
+
 ```sh
 opkg update && opkg upgrade
-opkg install curl
-curl -sL https://raw.githubusercontent.com/hoaxisr/awg-manager/master/scripts/install.sh | sh
+wget -qO- http://repo.hoaxisr.ru/install.sh | sh
 ```
 
-Если у вас недоступен GitHub или при выполнении скрипта установки он "зависает", можете воспользоваться зеркалом: 
+Вариант через GitHub (HTTPS): нужен curl, т.к. busybox wget прошивки может не поддерживать HTTPS:
 ```sh
-wget -qO- http://repo.hoaxisr.ru/install.sh | sh
+opkg install curl
+curl -sL https://raw.githubusercontent.com/hoaxisr/awg-manager/master/scripts/install.sh | sh
 ```
 
 После установки веб-интерфейс доступен по адресу роутера и обычно по 2222 порту.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # AWG Manager — установщик для роутеров Keenetic
 #
-# Установка / обновление:
+# Установка / обновление. curl не требуется: busybox wget есть на любом
+# Keenetic, а зеркало отдаёт скрипт по plain-HTTP (busybox wget прошивки
+# может не уметь HTTPS — для GitHub-варианта нужен curl или полноценный wget):
+#   wget -qO- http://repo.hoaxisr.ru/install.sh | sh
 #   curl -sL https://raw.githubusercontent.com/hoaxisr/awg-manager/master/scripts/install.sh | sh
-#   wget -qO- https://raw.githubusercontent.com/hoaxisr/awg-manager/master/scripts/install.sh | sh
 #
 # Скрипт добавляет репозиторий http://repo.hoaxisr.ru и делает
 # `opkg update && opkg install awg-manager`. Повторный запуск —
@@ -80,14 +82,12 @@ start_service() {
 }
 
 # --- Проверка работоспособности ---
-# curl не входит в зависимости пакета и на свежем Entware его обычно нет —
-# без fallback на busybox wget проверка всегда «падала» с ложным warning.
+# Только busybox wget: он есть на любом Keenetic/Entware, а проба — plain-HTTP
+# на localhost, где curl не даёт ничего сверх wget. curl намеренно не
+# используется, чтобы установка не поощряла лишнюю зависимость (#482) —
+# awg-manager не требует curl/libcurl ни на одном этапе.
 probe_health() {
-    if command -v curl >/dev/null 2>&1; then
-        curl -sf "$1" >/dev/null 2>&1
-    else
-        wget -q -O /dev/null "$1" 2>/dev/null
-    fi
+    wget -q -O /dev/null "$1" 2>/dev/null
 }
 
 health_check() {


### PR DESCRIPTION
Closes #482

## Ответ на вопрос issue

> Если, конечно, сам AWGM не использует в работе curl/libcurl или зависимости.

**Не использует — проверено по всему дереву:**

| Место | Факт |
|---|---|
| ipk `Depends` (`build-ipk.sh`) | `iptables, ip-full, wireguard-tools` — curl/libcurl **нет** |
| Go-бинарь | `CGO_ENABLED=0` (pure Go `net/http`) — libcurl не линкуется, `exec` curl отсутствует |
| NDMS hook-script (runtime-события) | `/bin/wget` → `/opt/bin/wget`; curl — лишь третий **опциональный** fallback за guard'ом `[ -x /opt/bin/curl ]` |
| `install.sh probe_health` | предпочитал curl «если есть», но уже имел wget-fallback |

То есть `opkg install awg-manager` curl не тянет — цель «поставить во внутреннюю память без curl» достижима. Мешали две вещи, обе исправлены здесь.

## Изменения

1. **`probe_health` — только busybox wget.** Он есть на любом Keenetic/Entware (прежний fallback это уже предполагал), а проба — plain-HTTP на `127.0.0.1`, где curl не даёт ничего сверх wget. Семантика не меняется: non-2xx/refused → non-zero у обоих.

2. **README: основной путь установки — без curl.** Раньше README сам предписывал `opkg install curl`. Теперь первым идёт `wget -qO- http://repo.hoaxisr.ru/install.sh | sh` (busybox wget, зеркало отдаёт по plain-HTTP). GitHub-вариант оставлен вторым с пояснением, зачем ему curl: busybox wget прошивки может не поддерживать HTTPS — потому «wget с GitHub» и не предлагается.

3. **Шапка install.sh** синхронизирована: wget-однострочник указывает на зеркало (HTTP), curl-вариант — на GitHub (HTTPS).

## Проверки

- `sh -n scripts/install.sh` — OK
- Никаких изменений в рантайме/пакете — только установочный скрипт и документация; hook-script не тронут (его опциональный curl-fallback повышает живучесть и зависимости не создаёт)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_