### PR TITLE
fix(#486): спящий селективный перехват не блокирует настройки в fakeip-режиме

### DIFF
--- a/internal/singbox/router/service_selective.go
+++ b/internal/singbox/router/service_selective.go
@@ -26,7 +26,21 @@ var errSelectiveIncompatible = errors.New("selective bypass incompatible")
 // it validates against the EFFECTIVE config — including a staged draft — so
 // the UI rejects enabling selective bypass against the route.final the user
 // is currently editing.
+//
+// Вне tproxy селективный перехват СПИТ: fakeip-пути ipset-цепочки не ставят
+// (Reconcile и Enable диспатчатся по режиму раньше tproxy-ветки), поэтому
+// унаследованный включённый флаг — валидное «спящее» состояние и не должен
+// блокировать несвязанные изменения настроек в fakeip (смену TCP/IP-стека
+// и т.п., #486). Отклоняется только ПОПЫТКА включения вне tproxy.
 func (s *ServiceImpl) validateSelectiveBypassSettings(ctx context.Context, sr storage.SingboxRouterSettings) error {
+	if sr.SelectiveBypass && sr.RoutingMode != "tproxy" {
+		if s.deps.Settings != nil {
+			if prev, err := s.deps.Settings.Load(); err == nil && prev.SingboxRouter.SelectiveBypass {
+				return nil // dormant: был включён — остаётся включённым-спящим
+			}
+		}
+		return fmt.Errorf("%w: selectiveBypass можно включить только в режиме tproxy", errSelectiveIncompatible)
+	}
 	return s.validateSelectiveBypass(sr, s.loadRouterConfig)
 }
 

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -533,6 +533,75 @@ func TestUpdateSettings_SelectiveBypassRejectedWhenFinalNotDirect(t *testing.T) 
 	}
 }
 
+// #486: селективный перехват, включённый в tproxy, вне tproxy СПИТ и не
+// должен блокировать несвязанные изменения настроек в fakeip-режиме —
+// в частности переключение TCP/IP-стека.
+func TestUpdateSettings_FakeIPStackChangeAllowedWithDormantSelective(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+
+	// Наследие tproxy: selectiveBypass уже включён в персисте.
+	all, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	all.SingboxRouter.SelectiveBypass = true
+	all.SingboxRouter.RoutingMode = "fakeip-tun"
+	if err := svc.deps.Settings.Save(all); err != nil {
+		t.Fatal(err)
+	}
+
+	// Репро issue: фронт мержит патч стека с текущими настройками и шлёт
+	// полный объект, включая унаследованный selectiveBypass=true.
+	err = svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		PolicyName:      "Policy0",
+		WANAutoDetect:   true,
+		RoutingMode:     "fakeip-tun",
+		SelectiveBypass: true,
+		FakeIPStack:     "system",
+	})
+	if err != nil {
+		t.Fatalf("stack switch must not be blocked by dormant selectiveBypass: %v", err)
+	}
+
+	saved, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.SingboxRouter.FakeIPStack != "system" {
+		t.Errorf("fakeipStack not persisted: %q", saved.SingboxRouter.FakeIPStack)
+	}
+	if !saved.SingboxRouter.SelectiveBypass {
+		t.Error("dormant selectiveBypass must survive the settings update (не сбрасывается молча)")
+	}
+}
+
+// #486 (обратная сторона): ВКЛЮЧИТЬ селективный перехват, находясь вне
+// tproxy, по-прежнему нельзя — dormant-послабление касается только уже
+// включённого флага.
+func TestUpdateSettings_SelectiveEnableRejectedOutsideTproxy(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+
+	err := svc.UpdateSettings(context.Background(), storage.SingboxRouterSettings{
+		PolicyName:      "Policy0",
+		WANAutoDetect:   true,
+		RoutingMode:     "fakeip-tun",
+		SelectiveBypass: true,
+	})
+	if err == nil {
+		t.Fatal("expected enabling selectiveBypass outside tproxy to be rejected")
+	}
+	if !strings.Contains(err.Error(), "tproxy") {
+		t.Errorf("error should mention tproxy, got %q", err.Error())
+	}
+	saved, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.SingboxRouter.SelectiveBypass {
+		t.Error("selectiveBypass must not be persisted when enable is rejected")
+	}
+}
+
 func TestSetRouteFinal_DisablesSelectiveBypass(t *testing.T) {
 	singbox := newTestSingbox(t)
 	settingsStore := newTestSettingsStore(t, storage.SingboxRouterSettings{


### PR DESCRIPTION
Closes #486

## Репро (из issue)

1. Включить Sing-box (TProxy) → включить «Селективный перехват»
2. Переключиться на Sing-box (fakeIP)
3. Попытаться сменить TCP/IP-стек → **«ошибка совместимости»**

## Цепочка бага (по коду)

1. **Флаг застревает.** `SwitchRoutingMode` не сбрасывает `SelectiveBypass`, а self-heal ресонсайла живёт в `reconcileInstalled` — tproxy-ветке: `Reconcile` в fakeip уходит в `reconcileFakeIPTun` **раньше**, так что унаследованный `selectiveBypass=true` остаётся в персисте навсегда.
2. **Фронт шлёт его обратно.** Смена стека идёт через `mergeAndSaveSettings`: патч `{fakeipStack}` мержится с текущими настройками стора → PUT несёт `routingMode:'fakeip-tun'` + `selectiveBypass:true`.
3. **Бэкенд отбивает всё подряд.** `UpdateSettings` безусловно валидировал selective → `selectiveBypass only applies to routingMode "tproxy"` → 400 на **любое** изменение настроек в fakeip, не только на стек.

## Фикс — семантика «спящего» флага

Вне tproxy селективный перехват **инертен**: fakeip-пути ipset-инфраструктуру не ставят (проверено — `sr.SelectiveBypass` читается только в `enableLocked` и `reconcileInstalled`, оба достижимы только в tproxy). Поэтому:

- уже включённый флаг вне tproxy — **валидное спящее состояние**, не блокирует несвязанные изменения настроек (ровно ожидание автора issue: «селективный перехват должен работать только для TProxy»);
- отклоняется только **попытка включения** вне tproxy (prev=false → true): «selectiveBypass можно включить только в режиме tproxy»;
- тумблер переживает roundtrip tproxy→fakeip→tproxy — при возврате selective поднимается как был; если за это время `route.final` стал несовместим, существующий self-heal выключит его с логом (механика не тронута);
- чинит **уже застрявшие** инсталляции (как у автора) без миграции персиста.

## Тесты

- `TestUpdateSettings_FakeIPStackChangeAllowedWithDormantSelective` — репро issue: смена стека в fakeip при dormant-флаге проходит, `fakeipStack` персистится, флаг **не сбрасывается молча**;
- `TestUpdateSettings_SelectiveEnableRejectedOutsideTproxy` — включение вне tproxy отклоняется и не персистится;
- прежний `TestUpdateSettings_SelectiveBypassRejectedWhenFinalNotDirect` (tproxy + route.final) — без изменений, зелёный.

## Проверки

`gofmt` чисто, `go build ./...`, `go vet`, `go test ./internal/singbox/router/` (включая `-race`) — зелёные. Фронт не тронут (PUT теперь проходит).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_