### PR TITLE
fix(inspector): инспектор маршрутов ходит по слоту активного режима

### DIFF
--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -2999,23 +2999,48 @@ func (s *ServiceImpl) UnbindDevice(ctx context.Context, mac string) error {
 	return s.deps.Policies.UnassignDevice(ctx, mac)
 }
 
+// inspectSlotConfig returns the EFFECTIVE config the inspector must walk —
+// the slot that is live under the CURRENT routing mode — plus that slot for
+// draft reporting. Issue #488: the inspector always walked the tproxy slot
+// (20-router.json), so in fakeip-tun mode it explained decisions by DNS/route
+// rules and rule-set names sing-box wasn't even running; the live rules were
+// in the fakeip slot (21-fakeip.json).
+func (s *ServiceImpl) inspectSlotConfig() (*RouterConfig, orchestrator.Slot, error) {
+	mode := ""
+	if s.deps.Settings != nil {
+		if settings, err := s.deps.Settings.Load(); err == nil && settings != nil {
+			mode = settings.SingboxRouter.RoutingMode
+		}
+	}
+	slot := orchestrator.SlotRouter
+	if mode == "fakeip-tun" {
+		slot = orchestrator.SlotFakeIP
+	}
+	cfg, err := s.loadRouterConfigForMode(mode)
+	if err != nil {
+		return nil, slot, err
+	}
+	if cfg == nil {
+		cfg = NewEmptyConfig()
+	}
+	return cfg, slot, nil
+}
+
 // Inspect simulates which router rule would match the given input
 // (a domain or an IP). The matcher walk is purely Go; only rule_set
 // matchers shell out to `sing-box rule-set match` to consult the
-// binary or downloaded JSON list. Reads the current persisted config so
-// the result reflects what the user would observe at runtime.
+// binary or downloaded JSON list. Reads the persisted config of the
+// ACTIVE routing mode (tproxy or fakeip-tun slot) so the result reflects
+// what the user would observe at runtime.
 //
 // When the sing-box binary is unavailable (dev machine, fresh install
 // before the user has installed the package) rule_set matchers degrade
 // to no-match and a Note is appended to the result — the rest of the
 // inspector still works.
 func (s *ServiceImpl) Inspect(ctx context.Context, input InspectInput) (InspectResult, error) {
-	cfg, err := s.loadRouterConfig()
+	cfg, _, err := s.inspectSlotConfig()
 	if err != nil {
 		return InspectResult{}, err
-	}
-	if cfg == nil {
-		cfg = NewEmptyConfig()
 	}
 	final := cfg.Route.Final
 	if final == "" {
@@ -3036,14 +3061,12 @@ func (s *ServiceImpl) Inspect(ctx context.Context, input InspectInput) (InspectR
 // real → upstream / local → router). It is the DNS-resolution branch that
 // precedes the route inspector: a domain that gets a fakeip is then routed
 // by Inspect. The matcher walk is purely Go; only rule_set matchers shell
-// out to `sing-box rule-set match`. Reads the current persisted config.
+// out to `sing-box rule-set match`. Reads the persisted config of the
+// ACTIVE routing mode (tproxy or fakeip-tun slot).
 func (s *ServiceImpl) InspectDNS(ctx context.Context, input InspectDNSInput) (InspectDNSResult, error) {
-	cfg, err := s.loadRouterConfig()
+	cfg, _, err := s.inspectSlotConfig()
 	if err != nil {
 		return InspectDNSResult{}, err
-	}
-	if cfg == nil {
-		cfg = NewEmptyConfig()
 	}
 	dnsRules := s.ruleSetMaterializer().restoreConfig(cfg).DNS.Rules
 	binary := ""
@@ -3074,13 +3097,10 @@ func (s *ServiceImpl) InspectStream(ctx context.Context, input InspectInput) (<-
 		if !emitEvent(InspectStreamEvent{Type: "progress", Progress: &InspectProgress{Phase: "load_config", Message: "Загружаем конфигурацию маршрутизации…"}}) {
 			return
 		}
-		cfg, err := s.loadRouterConfig()
+		cfg, slot, err := s.inspectSlotConfig()
 		if err != nil {
 			emitEvent(InspectStreamEvent{Type: "inspect-error", Error: err.Error()})
 			return
-		}
-		if cfg == nil {
-			cfg = NewEmptyConfig()
 		}
 		final := cfg.Route.Final
 		if final == "" {
@@ -3088,7 +3108,7 @@ func (s *ServiceImpl) InspectStream(ctx context.Context, input InspectInput) (<-
 		}
 		usingDraft := false
 		if s.deps.Orch != nil {
-			usingDraft = s.deps.Orch.DraftInfo(orchestrator.SlotRouter).HasDraft
+			usingDraft = s.deps.Orch.DraftInfo(slot).HasDraft
 		}
 		if !emitEvent(InspectStreamEvent{Type: "progress", Progress: &InspectProgress{
 			Phase:        "config_loaded",

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -3008,7 +3008,14 @@ func (s *ServiceImpl) UnbindDevice(ctx context.Context, mac string) error {
 func (s *ServiceImpl) inspectSlotConfig() (*RouterConfig, orchestrator.Slot, error) {
 	mode := ""
 	if s.deps.Settings != nil {
-		if settings, err := s.deps.Settings.Load(); err == nil && settings != nil {
+		settings, err := s.deps.Settings.Load()
+		if err != nil {
+			// Fail loud, not wrong: silently falling back to the tproxy slot
+			// on a transient settings read error would reproduce the very
+			// #488 bug (inspector explains decisions by the parked slot).
+			return nil, orchestrator.SlotRouter, fmt.Errorf("inspector: load settings: %w", err)
+		}
+		if settings != nil {
 			mode = settings.SingboxRouter.RoutingMode
 		}
 	}

--- a/internal/singbox/router/service_inspect_mode_test.go
+++ b/internal/singbox/router/service_inspect_mode_test.go
@@ -1,0 +1,142 @@
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+)
+
+// Issue #488: в fakeip-режиме инспектор маршрутов объяснял решения по
+// правилам TPROXY-слота (20-router.json), а не по живому fakeip-слоту
+// (21-fakeip.json). Тесты фиксируют выбор слота по persisted routingMode
+// для всех трёх входов инспектора (Inspect / InspectDNS / InspectStream).
+
+// seedInspectSlots writes DISTINCT configs into both slots so a wrong-slot
+// read is unambiguous: the tproxy slot routes tproxy.example → tproxy-out,
+// the fakeip slot routes fakeip.example → fakeip-out (each with its own DNS
+// rule server tag as well).
+func seedInspectSlots(t *testing.T, svc *ServiceImpl) {
+	t.Helper()
+	// newFakeIPTestService enables only SlotFakeIP; enable SlotRouter too so
+	// persistSlotDirect writes its file to the active path LoadEffective reads.
+	if err := svc.deps.Orch.SetEnabled(orchestrator.SlotRouter, true); err != nil {
+		t.Fatalf("enable SlotRouter: %v", err)
+	}
+	routerCfg := NewEmptyConfig()
+	routerCfg.Route.Rules = []Rule{{Action: "route", DomainSuffix: []string{"tproxy.example"}, Outbound: "tproxy-out"}}
+	routerCfg.DNS.Servers = []DNSServer{{Tag: "dns-tproxy", Type: "udp", Server: "1.1.1.1"}}
+	routerCfg.DNS.Rules = []DNSRule{{Action: "route", DomainSuffix: []string{"tproxy.example"}, Server: "dns-tproxy"}}
+	routerCfg.DNS.Final = "dns-tproxy"
+	if err := svc.persistSlotDirect(orchestrator.SlotRouter, routerCfg, false); err != nil {
+		t.Fatalf("persist router slot: %v", err)
+	}
+
+	fakeipCfg := NewEmptyConfig()
+	fakeipCfg.Route.Rules = []Rule{{Action: "route", DomainSuffix: []string{"fakeip.example"}, Outbound: "fakeip-out"}}
+	fakeipCfg.DNS.Servers = []DNSServer{
+		{Tag: "fakeip", Type: "fakeip", Inet4Range: "198.18.0.0/15"},
+		{Tag: "real", Type: "udp", Server: "1.1.1.1"},
+	}
+	fakeipCfg.DNS.Rules = []DNSRule{{Action: "route", DomainSuffix: []string{"fakeip.example"}, Server: "fakeip"}}
+	fakeipCfg.DNS.Final = "real"
+	if err := svc.persistSlotDirect(orchestrator.SlotFakeIP, fakeipCfg, true); err != nil {
+		t.Fatalf("persist fakeip slot: %v", err)
+	}
+}
+
+// setRoutingMode flips the persisted routingMode without touching anything else.
+func setRoutingMode(t *testing.T, svc *ServiceImpl, mode string) {
+	t.Helper()
+	all, err := svc.deps.Settings.Load()
+	if err != nil {
+		t.Fatalf("settings load: %v", err)
+	}
+	all.SingboxRouter.RoutingMode = mode
+	if err := svc.deps.Settings.Save(all); err != nil {
+		t.Fatalf("settings save: %v", err)
+	}
+}
+
+func TestInspect_UsesSlotOfActiveRoutingMode(t *testing.T) {
+	svc, _ := newFakeIPTestService(t) // RoutingMode: "fakeip-tun", both slots registered
+	ctx := context.Background()
+	seedInspectSlots(t, svc)
+
+	// fakeip mode → fakeip slot rules.
+	res, err := svc.Inspect(ctx, InspectInput{Domain: "sub.fakeip.example"})
+	if err != nil {
+		t.Fatalf("Inspect (fakeip mode): %v", err)
+	}
+	if res.Destination != "fakeip-out" {
+		t.Errorf("fakeip mode: Destination = %q, want fakeip-out (walked wrong slot?)", res.Destination)
+	}
+	// The tproxy-only domain must NOT resolve to the tproxy outbound here.
+	res, err = svc.Inspect(ctx, InspectInput{Domain: "sub.tproxy.example"})
+	if err != nil {
+		t.Fatalf("Inspect (fakeip mode, tproxy domain): %v", err)
+	}
+	if res.Destination == "tproxy-out" {
+		t.Errorf("fakeip mode: tproxy-slot rule matched — inspector walked the tproxy slot")
+	}
+
+	// tproxy mode → router slot rules.
+	setRoutingMode(t, svc, "tproxy")
+	res, err = svc.Inspect(ctx, InspectInput{Domain: "sub.tproxy.example"})
+	if err != nil {
+		t.Fatalf("Inspect (tproxy mode): %v", err)
+	}
+	if res.Destination != "tproxy-out" {
+		t.Errorf("tproxy mode: Destination = %q, want tproxy-out", res.Destination)
+	}
+}
+
+func TestInspectDNS_UsesSlotOfActiveRoutingMode(t *testing.T) {
+	svc, _ := newFakeIPTestService(t)
+	ctx := context.Background()
+	seedInspectSlots(t, svc)
+
+	res, err := svc.InspectDNS(ctx, InspectDNSInput{Domain: "sub.fakeip.example"})
+	if err != nil {
+		t.Fatalf("InspectDNS (fakeip mode): %v", err)
+	}
+	if res.Server != "fakeip" {
+		t.Errorf("fakeip mode: Server = %q, want fakeip (walked wrong slot?)", res.Server)
+	}
+
+	setRoutingMode(t, svc, "tproxy")
+	res, err = svc.InspectDNS(ctx, InspectDNSInput{Domain: "sub.tproxy.example"})
+	if err != nil {
+		t.Fatalf("InspectDNS (tproxy mode): %v", err)
+	}
+	if res.Server != "dns-tproxy" {
+		t.Errorf("tproxy mode: Server = %q, want dns-tproxy", res.Server)
+	}
+}
+
+func TestInspectStream_UsesSlotOfActiveRoutingMode(t *testing.T) {
+	svc, _ := newFakeIPTestService(t)
+	ctx := context.Background()
+	seedInspectSlots(t, svc)
+
+	ch, err := svc.InspectStream(ctx, InspectInput{Domain: "sub.fakeip.example"})
+	if err != nil {
+		t.Fatalf("InspectStream: %v", err)
+	}
+	var result *InspectResult
+	for ev := range ch {
+		if ev.Type == "inspect-error" {
+			t.Fatalf("inspect-error: %s", ev.Error)
+		}
+		if ev.Type == "result" {
+			r := *ev.Result
+			result = &r
+		}
+	}
+	if result == nil {
+		t.Fatal("stream ended without a result event")
+	}
+	if result.Destination != "fakeip-out" {
+		t.Errorf("stream fakeip mode: Destination = %q, want fakeip-out", result.Destination)
+	}
+}


### PR DESCRIPTION
Closes #488

## Проблема

В Sing-box (fakeIP) инспектор маршрутов показывал DNS-правила, правила маршрутизации и имена rule-set'ов из **TProxy**-конфига. Причина: все три входа инспектора — `Inspect`, `InspectDNS`, `InspectStream` — безусловно грузили `loadRouterConfig()` (SlotRouter, `20-router.json`). Живые правила fakeip-режима лежат в отдельном слоте `21-fakeip.json` (slot XOR: в fakeip-режиме SlotRouter вообще припаркован и sing-box его не исполняет).

## Решение

Новый `inspectSlotConfig()`: выбирает слот по persisted `routingMode` — `fakeip-tun` → SlotFakeIP (`loadFakeIPConfig`, effective/draft-preferring), иначе SlotRouter. Построен поверх уже существующего `loadRouterConfigForMode` (тот же паттерн, что у device-proxy). Все три входа переведены на него; `InspectStream` заодно репортит `usingDraft` по выбранному слоту, а не всегда по SlotRouter.

Семантика — «правда рантайма»: инспектор объясняет, что произойдёт с запросом в **активном** режиме, на какой бы вкладке его ни открыли (обе страницы — sb-router и fakeip — используют одни и те же эндпоинты, фронт не менялся). Бонус для fakeip: `InspectDNS` теперь видит настоящий `fakeip`-сервер с пулами, так что классификация fakeip/real/local и Pool в ответе становятся осмысленными.

## Тесты

`service_inspect_mode_test.go`: оба слота засеиваются заведомо разными конфигами (`tproxy.example → tproxy-out` против `fakeip.example → fakeip-out`, разные DNS-серверы):
- `TestInspect_UsesSlotOfActiveRoutingMode` — в fakeip-режиме матчится fakeip-правило и НЕ матчится tproxy-правило; после смены `routingMode` на tproxy — наоборот;
- `TestInspectDNS_UsesSlotOfActiveRoutingMode` — DNS-ветка отвечает сервером своего слота (`fakeip` / `dns-tproxy`);
- `TestInspectStream_UsesSlotOfActiveRoutingMode` — SSE-поток доносит результат по fakeip-слоту.

Без фикса все три теста падают (проверено откатом service.go).

Ворота: gofmt, `go build ./...`, `go vet`, `go test ./internal/singbox/router/` (+ `-race` на Inspect-тестах), кросс-компиляция MIPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_