### PR TITLE
feat(sb-router): пресет-тумблер исключения IP KeenDNS/CrazeDNS

### DIFF
--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -476,9 +476,9 @@
         onPatch={(patch) => applyPatch(patch)}
       />
 
-      <!-- Исключения портов -->
+      <!-- Исключения: порт-пресеты + IP-пресеты (keendns) + ручные порты/подсети -->
       <section class="sec">
-        <div class="sec-cap">Исключения портов</div>
+        <div class="sec-cap">Исключения</div>
         <div class="chips">
           {#each BYPASS_PRESETS as p (p.id)}
             {@const active = (cfg.bypassPresets ?? []).includes(p.id)}

--- a/frontend/src/lib/components/sb-router/settingsActions.test.ts
+++ b/frontend/src/lib/components/sb-router/settingsActions.test.ts
@@ -35,10 +35,10 @@ describe('settingsActions', () => {
     mockCurrent(baseSettings);
   });
 
-  it('BYPASS_PRESETS has 3 entries with correct ids', () => {
-    expect(BYPASS_PRESETS).toHaveLength(3);
+  it('BYPASS_PRESETS has 4 entries with correct ids', () => {
+    expect(BYPASS_PRESETS).toHaveLength(4);
     const ids = BYPASS_PRESETS.map((p) => p.id).sort();
-    expect(ids).toEqual(['l2tp', 'netbios-smb', 'ntp']);
+    expect(ids).toEqual(['keendns', 'l2tp', 'netbios-smb', 'ntp']);
     for (const p of BYPASS_PRESETS) {
       expect(p.label).toBeTruthy();
       expect(p.desc).toBeTruthy();

--- a/frontend/src/lib/components/sb-router/settingsActions.ts
+++ b/frontend/src/lib/components/sb-router/settingsActions.ts
@@ -12,6 +12,10 @@ export const BYPASS_PRESETS: readonly BypassPresetMeta[] = [
   { id: 'l2tp', label: 'L2TP / IPsec VPN', desc: 'UDP 500, 1701, 4500' },
   { id: 'ntp', label: 'NTP (синхронизация времени)', desc: 'UDP 123' },
   { id: 'netbios-smb', label: 'NetBIOS / SMB', desc: 'UDP 137/138, TCP 139/445' },
+  // Не порты, а destination-IP: статическая A-запись KeenDNS/CrazeDNS-доменов
+  // (my.keenetic.net / my.netcraze.net и 4-го уровня) указывает на этот IP,
+  // который роутер обслуживает локально — перехват ломает доступ (#490).
+  { id: 'keendns', label: 'KeenDNS / CrazeDNS', desc: 'IP 78.47.125.180' },
 ];
 
 export async function mergeAndSaveSettings(

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -88,7 +88,8 @@ type SingboxRouterSettingsData struct {
 	WANAutoDetect bool   `json:"wanAutoDetect" example:"false"`
 	WANInterface  string `json:"wanInterface,omitempty" example:"ppp0"`
 	// BypassPresets lists active named port-bypass presets.
-	// Valid values: "l2tp", "ntp", "netbios-smb".
+	// Valid values: "l2tp", "ntp", "netbios-smb" (port-based), "keendns"
+	// (destination-IP 78.47.125.180, KeenDNS/CrazeDNS).
 	BypassPresets []string `json:"bypassPresets,omitempty" example:"l2tp"`
 	// BypassExtraPorts is a user-defined comma-separated list of extra
 	// port exclusions in "PORT UDP|TCP" format (e.g. "51820 UDP, 1194 TCP").

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -4031,7 +4031,8 @@ definitions:
       bypassPresets:
         description: |-
           BypassPresets lists active named port-bypass presets.
-          Valid values: "l2tp", "ntp", "netbios-smb".
+          Valid values: "l2tp", "ntp", "netbios-smb" (port-based), "keendns"
+          (destination-IP 78.47.125.180, KeenDNS/CrazeDNS).
         example:
         - l2tp
         items:

--- a/internal/singbox/router/iptables_test.go
+++ b/internal/singbox/router/iptables_test.go
@@ -1701,3 +1701,36 @@ func TestIsXtDscpAvailable_PositiveResultCachedForever(t *testing.T) {
 		t.Fatalf("positive result must be cached forever, got %d probes", *calls)
 	}
 }
+
+// Issue #490: keendns-пресет (destination-IP) должен долетать до всех трёх
+// цепочек ранним `-d <ip> -j RETURN` — ДО DNS-перехвата в mangle и до
+// catch-all в nat, ровно как ручные bypassExtraSubnets.
+func TestBuildRestoreInput_KeenDNSPresetCIDR(t *testing.T) {
+	cidrs, err := resolveBypassCIDRs([]string{"keendns"}, "")
+	if err != nil {
+		t.Fatalf("resolveBypassCIDRs: %v", err)
+	}
+	spec := RestoreInputSpec{PolicyMark: "0xffffaaa", BypassCIDRs: cidrs}
+
+	out := buildRestoreInput(spec)
+	ret := "-d 78.47.125.180/32 -j RETURN"
+	tproxyRet := "-A " + ChainName + " " + ret
+	redirectRet := "-A " + RedirectChain + " " + ret
+	if !strings.Contains(out, tproxyRet) {
+		t.Errorf("TPROXY chain missing keendns bypass: %s", out)
+	}
+	if !strings.Contains(out, redirectRet) {
+		t.Errorf("REDIRECT chain missing keendns bypass: %s", out)
+	}
+	// RETURN стоит раньше DNS-перехвата — иначе DNS к роутеру на этом IP
+	// всё равно уходил бы в sing-box.
+	dnsIntercept := strings.Index(out, "--dport 53 -j TPROXY")
+	if bypassIdx := strings.Index(out, tproxyRet); dnsIntercept >= 0 && bypassIdx > dnsIntercept {
+		t.Errorf("keendns bypass must precede DNS intercept: bypass@%d, dns@%d", bypassIdx, dnsIntercept)
+	}
+
+	bh := buildBlackholeRestoreInput(spec)
+	if !strings.Contains(bh, "-A "+BlackholeChain+" "+ret) {
+		t.Errorf("blackhole chain missing keendns bypass: %s", bh)
+	}
+}

--- a/internal/singbox/router/presets.go
+++ b/internal/singbox/router/presets.go
@@ -28,16 +28,27 @@ func portRangeKey(pr PortRange) string {
 	return fmt.Sprintf("%d-%d", pr.From, pr.To)
 }
 
-type portSet struct {
+type bypassPreset struct {
 	UDP []int
 	TCP []int
+	// CIDRs — destination-IP исключения пресета (канонические IPv4 CIDR).
+	// Вливаются в spec.BypassCIDRs наравне с bypassExtraSubnets, т.е. весь
+	// трафик к этим адресам идёт мимо sing-box (включая DNS/53).
+	CIDRs []string
 }
 
-// knownPresets maps preset name → UDP and TCP ports to exclude from TPROXY/REDIRECT.
-var knownPresets = map[string]portSet{
+// knownPresets maps preset name → UDP/TCP ports and destination CIDRs to
+// exclude from TPROXY/REDIRECT.
+var knownPresets = map[string]bypassPreset{
 	"l2tp":        {UDP: []int{500, 4500, 1701}},
 	"ntp":         {UDP: []int{123}},
 	"netbios-smb": {UDP: []int{137, 138}, TCP: []int{139, 445}},
+	// KeenDNS/CrazeDNS (issue #490): статическая A-запись доменов
+	// my.keenetic.net / my.netcraze.net и доменов 4-го уровня указывает на
+	// анонсируемый Keenetic'ом IP 78.47.125.180, который роутер при локальном
+	// доступе обслуживает сам. TPROXY-перехват уводит эти соединения в
+	// туннель → ERR_CONNECTION_REFUSED; исключение возвращает их роутеру.
+	"keendns": {CIDRs: []string{"78.47.125.180/32"}},
 }
 
 // resolveBypassPorts collects the final UDP and TCP port/range lists from
@@ -63,6 +74,39 @@ func resolveBypassPorts(presets []string, extra string) (udp, tcp []PortRange, e
 	udp = append(udp, eu...)
 	tcp = append(tcp, et...)
 	return udp, tcp, nil
+}
+
+// resolveBypassCIDRs собирает итоговый список destination-CIDR исключений:
+// CIDR-часть именованных пресетов + пользовательский extra-список
+// (resolveBypassSubnets). Дедуп со стабильным порядком — пользователь мог
+// продублировать IP пресета вручную, а дубли в iptables-правилах не нужны.
+func resolveBypassCIDRs(presets []string, extra string) ([]string, error) {
+	var out []string
+	seen := make(map[string]struct{})
+	add := func(c string) {
+		if _, ok := seen[c]; ok {
+			return
+		}
+		seen[c] = struct{}{}
+		out = append(out, c)
+	}
+	for _, name := range presets {
+		ps, ok := knownPresets[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown bypass preset %q", name)
+		}
+		for _, c := range ps.CIDRs {
+			add(c)
+		}
+	}
+	subnets, err := resolveBypassSubnets(extra)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range subnets {
+		add(c)
+	}
+	return out, nil
 }
 
 // resolveBypassSubnets парсит список IPv4 IP/CIDR (через запятую/пробел) в

--- a/internal/singbox/router/presets_test.go
+++ b/internal/singbox/router/presets_test.go
@@ -195,3 +195,60 @@ func TestResolveBypassSubnets(t *testing.T) {
 		})
 	}
 }
+
+// ── resolveBypassCIDRs (issue #490: IP-пресеты, keendns) ─────────────────
+
+func TestResolveBypassCIDRs_Empty(t *testing.T) {
+	got, err := resolveBypassCIDRs(nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %v", got)
+	}
+}
+
+func TestResolveBypassCIDRs_KeenDNSPreset(t *testing.T) {
+	got, err := resolveBypassCIDRs([]string{"keendns"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "78.47.125.180/32" {
+		t.Fatalf("keendns preset CIDRs = %v, want [78.47.125.180/32]", got)
+	}
+}
+
+func TestResolveBypassCIDRs_PortPresetsContributeNoCIDRs(t *testing.T) {
+	got, err := resolveBypassCIDRs([]string{"l2tp", "ntp", "netbios-smb"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("port presets must not contribute CIDRs, got %v", got)
+	}
+}
+
+func TestResolveBypassCIDRs_DedupAgainstExtra(t *testing.T) {
+	// Пользователь мог продублировать IP пресета вручную (так все и чинили
+	// #490 до пресета) — дубль схлопывается, порядок стабильный.
+	got, err := resolveBypassCIDRs([]string{"keendns"}, "78.47.125.180, 10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"78.47.125.180/32", "10.0.0.0/8"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveBypassCIDRs_UnknownPreset(t *testing.T) {
+	if _, err := resolveBypassCIDRs([]string{"nonexistent"}, ""); err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+}
+
+func TestResolveBypassCIDRs_ExtraError(t *testing.T) {
+	if _, err := resolveBypassCIDRs([]string{"keendns"}, "not-an-ip"); err == nil {
+		t.Fatal("expected error for malformed extra subnets")
+	}
+}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -1243,7 +1243,7 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	}
 
 	bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
-	bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+	bypassSubnets, _ := resolveBypassCIDRs(sr.BypassPresets, sr.BypassExtraSubnets)
 
 	// Pre-create the AWGM-SELECTIVE ipset (empty) before iptables-restore
 	// when selective bypass is enabled. iptables-restore fails immediately
@@ -1996,7 +1996,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 	wantBlackhole := jumpsMissing && engineDown
 	if wantBlackhole {
 		bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
-		bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+		bypassSubnets, _ := resolveBypassCIDRs(sr.BypassPresets, sr.BypassExtraSubnets)
 		// Selective guard references the AWGM-SELECTIVE ipset; ensure it exists so
 		// iptables-restore of the blackhole doesn't fail with "Set ... doesn't
 		// exist" (same pre-create the real Install path does below).
@@ -2071,7 +2071,7 @@ func (s *ServiceImpl) reconcileInstalled(ctx context.Context, sr storage.Singbox
 		}
 
 		bypassUDP, bypassTCP, _ := resolveBypassPorts(sr.BypassPresets, sr.BypassExtraPorts)
-		bypassSubnets, _ := resolveBypassSubnets(sr.BypassExtraSubnets)
+		bypassSubnets, _ := resolveBypassCIDRs(sr.BypassPresets, sr.BypassExtraSubnets)
 		s.mu.Lock()
 		if err := s.deps.IPTables.Install(ctx, RestoreInputSpec{
 			PolicyMark:        mark,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -122,7 +122,8 @@ type SingboxRouterSettings struct {
 	// Only meaningful when WANAutoDetect == false.
 	WANInterface string `json:"wanInterface,omitempty"`
 	// BypassPresets lists named protocol presets to exclude from TPROXY/REDIRECT.
-	// Valid values: "l2tp", "ntp", "netbios-smb". nil/[] = nothing excluded.
+	// Valid values: "l2tp", "ntp", "netbios-smb" (port-based), "keendns"
+	// (destination-IP 78.47.125.180, KeenDNS/CrazeDNS). nil/[] = nothing excluded.
 	BypassPresets []string `json:"bypassPresets,omitempty"`
 	// BypassExtraPorts is a user-supplied comma-separated list of extra port
 	// exclusions in "PORT UDP|TCP" format (e.g. "51820 UDP, 1194 TCP").


### PR DESCRIPTION
Closes #490

## Что сделано

Новый тумблер **«KeenDNS / CrazeDNS»** в блоке исключений sb-router — рядом с L2TP/NTP/SMB, как и просил автор issue. Включение исключает destination-IP `78.47.125.180` из перехвата: статическая A-запись доменов `my.keenetic.net` / `my.netcraze.net` и доменов 4-го уровня указывает на этот IP, который роутер при локальном доступе обслуживает сам — TPROXY уводил такие соединения в туннель → `ERR_CONNECTION_REFUSED`.

## Реализация

Пресеты получили вторую ось — **destination-CIDR** (раньше были только порты):

- `bypassPreset.CIDRs` + пресет `"keendns"` → `78.47.125.180/32`;
- новый `resolveBypassCIDRs(presets, extra)`: CIDR-часть пресетов + пользовательские `bypassExtraSubnets`, дедуп со стабильным порядком — если пользователь уже добавил этот IP вручную (старый обход из issue), дубля правил не будет;
- все три места сборки `spec.BypassCIDRs` (enable-install, reconcile-install, fail-closed blackhole) переведены на него — исключение эмитится ранним `-d 78.47.125.180/32 -j RETURN` в головах цепочек **TPROXY / REDIRECT / BLACKHOLE**, до DNS-перехвата и catch-all (то есть мимо sing-box идёт весь трафик к IP, включая DNS/53) — ровно та же семантика, что у ручных «Доп. подсетей»;
- переустановка iptables при переключении тумблера срабатывает существующим триггером `bypassPresetsChanged`; валидация значения — автоматически через `knownPresets`;
- фронт: чип `KeenDNS / CrazeDNS · IP 78.47.125.180` в StatusDrawer, заголовок секции «Исключения портов» → «Исключения» (теперь там и IP-пресет);
- доки: storage/DTO/swagger — `keendns` в списке валидных значений `bypassPresets` (schemas.gen.ts не изменился — описания в схемы не эмитятся).

## Тесты

- `resolveBypassCIDRs`: пресет keendns, дедуп с ручным дублем + порядок, порт-пресеты не дают CIDR, unknown preset, ошибка в extra;
- chain-уровень (`TestBuildRestoreInput_KeenDNSPresetCIDR`): CIDR попадает во все три цепочки и стоит **до** DNS-перехвата в mangle;
- фронт: `BYPASS_PRESETS` 4 записи.

Ворота: gofmt, `go build/vet/test ./...`, MIPS-кросс, eslint 0, svelte-check 0/0, vitest 1343/1343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_