### PR TITLE
feat(server): смена порта и интерфейсов HTTP-сервера из настроек (живой rebind, confirm-or-revert)

### DIFF
--- a/cmd/awg-manager/main.go
+++ b/cmd/awg-manager/main.go
@@ -1463,14 +1463,6 @@ func main() {
 	var bootDone int32
 	srv.SetBootStatusFunc(func() bool { return atomic.LoadInt32(&bootDone) == 0 })
 
-	// Determine bind IP from settings
-	bindIface := settings.Server.Interface
-	ip := netif.FirstIPv4(bindIface)
-	if ip == "" {
-		fmt.Fprintf(os.Stderr, "Warning: could not get IP for interface %s, binding to all interfaces\n", bindIface)
-		ip = "0.0.0.0"
-	}
-
 	// Get port from settings, with fallback logic
 	selectedPort := settings.Server.Port
 	if selectedPort == 0 || !server.IsPortFree(selectedPort) {
@@ -1489,13 +1481,11 @@ func main() {
 		_ = settingsStore.Save(settings)
 	}
 
-	listenAddr := fmt.Sprintf("%s:%d", ip, selectedPort)
-	srv.SetListenAddr(listenAddr)
-
-	// Add loopback listener for reverse proxy support (nginx on 127.0.0.1)
-	if ip != "0.0.0.0" && ip != "127.0.0.1" {
-		srv.SetLoopbackAddr(fmt.Sprintf("127.0.0.1:%d", selectedPort))
-	}
+	// Bind-адреса применяет мультилистенер-менеджер (server/listen.go):
+	// по IPv4 на каждый интерфейс из настроек (пусто = 0.0.0.0) +
+	// безусловный loopback (реверс-прокси NDMS, health-пробы, спасательный
+	// люк). Интерфейс без IP на boot пропускается — heal-тикер добиндит.
+	srv.SetListenSpec(server.ListenSpec{Port: selectedPort, Interfaces: settings.Server.Interfaces})
 
 	// DNS routing diagnostics
 	dnsCheckService := dnscheck.NewService(
@@ -1510,7 +1500,8 @@ func main() {
 	dnsCheckService.EnsureIPHost(context.Background())
 	srv.SetDnsCheckService(dnsCheckService)
 
-	logStartup(bootLog, version, string(osdetect.Get()), listenAddr, settings)
+	logStartup(bootLog, version, string(osdetect.Get()),
+		fmt.Sprintf("port %d, interfaces: %s", selectedPort, describeListenInterfaces(settings.Server.Interfaces)), settings)
 
 	// Shutdown context — cancelled on shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
@@ -1864,6 +1855,14 @@ func (a *storeAdapter) Exists(id string) bool {
 }
 
 // logStartup logs system startup information.
+// describeListenInterfaces renders the configured bind scope for logs.
+func describeListenInterfaces(ifaces []string) string {
+	if len(ifaces) == 0 {
+		return "all (0.0.0.0)"
+	}
+	return strings.Join(ifaces, ", ")
+}
+
 func logStartup(appLog *logging.ScopedLogger, version, osVersion, listenAddr string, settings *storage.Settings) {
 	appLog.Info("startup", "", fmt.Sprintf("AWG Manager v%s started", version))
 	appLog.Info("startup", "", fmt.Sprintf("Keenetic OS: %s", osVersion))

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -13,6 +13,8 @@ import type {
 	LogsResponse,
 	WANInterface,
 	RouterInterface,
+	ServerListenState,
+	ServerListenChangeResult,
 	WANStatus,
 	ExternalTunnel,
 	SystemTunnel,
@@ -616,6 +618,26 @@ class ApiClient {
 
 	async getAllInterfaces(): Promise<RouterInterface[]> {
 		return this.request('/system/all-interfaces');
+	}
+
+	// ── HTTP-listen (живая смена порта/интерфейсов веб-интерфейса) ──
+
+	async serverListenState(): Promise<ServerListenState> {
+		return this.request('/server/listen');
+	}
+
+	async serverListenChange(port: number, interfaces: string[]): Promise<ServerListenChangeResult> {
+		return this.request('/server/listen/change', {
+			method: 'POST',
+			body: JSON.stringify({ port, interfaces }),
+		});
+	}
+
+	async serverListenConfirm(token: string): Promise<void> {
+		await this.request('/server/listen/confirm', {
+			method: 'POST',
+			body: JSON.stringify({ token }),
+		});
 	}
 
 	async getWANStatus(): Promise<WANStatus> {

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1098,8 +1098,33 @@ const api_SelectiveStatusData: v.GenericSchema = v.looseObject({
 	xtSetAvailable: v.optional(v.nullable(v.boolean())),
 });
 
+const api_ServerListenChangeData: v.GenericSchema = v.looseObject({
+	boundAddrs: v.optional(v.nullable(v.array(v.string()))),
+	confirmDeadline: v.optional(v.nullable(v.string())),
+	confirmToken: v.optional(v.nullable(v.string())),
+});
+
+const api_ServerListenChangeResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ServerListenChangeData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_ServerListenStateData: v.GenericSchema = v.looseObject({
+	boundAddrs: v.optional(v.nullable(v.array(v.string()))),
+	confirmDeadline: v.optional(v.nullable(v.string())),
+	interfaces: v.optional(v.nullable(v.array(v.string()))),
+	pendingConfirm: v.optional(v.nullable(v.boolean())),
+	port: v.optional(v.nullable(v.number())),
+});
+
+const api_ServerListenStateResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ServerListenStateData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
 const api_ServerSettingsDTO: v.GenericSchema = v.looseObject({
 	interface: v.optional(v.nullable(v.string())),
+	interfaces: v.optional(v.nullable(v.array(v.string()))),
 	port: v.optional(v.nullable(v.number())),
 });
 
@@ -2238,6 +2263,7 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /routing/resolve": v.lazy(() => api_ResolveResponse),
 	"GET /routing/static-routes": v.lazy(() => api_StaticRoutesListResponse),
 	"GET /routing/tunnels": v.lazy(() => api_RoutingTunnelsResponse),
+	"GET /server/listen": v.lazy(() => api_ServerListenStateResponse),
 	"GET /servers/{name}/peers/{pubkey}/conf": v.lazy(() => api_PeerConfResponse),
 	"GET /servers/all": v.lazy(() => api_ServersAllResponse),
 	"GET /servers/marked": v.lazy(() => api_APIEnvelope),
@@ -2376,6 +2402,8 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /proxy/instances/apply": v.lazy(() => api_APIEnvelope),
 	"POST /proxy/runtime/select": v.lazy(() => api_ProxyRuntimeResponse),
 	"POST /routing/refresh": v.lazy(() => api_RoutingRefreshResponse),
+	"POST /server/listen/change": v.lazy(() => api_ServerListenChangeResponse),
+	"POST /server/listen/confirm": v.lazy(() => api_OkResponse),
 	"POST /servers/{name}/endpoint": v.lazy(() => api_ServersAllResponse),
 	"POST /servers/{name}/nat": v.lazy(() => api_ServersAllResponse),
 	"POST /servers/{name}/peers": v.lazy(() => api_ServersAllResponse),

--- a/frontend/src/lib/components/settings/HttpServerCard.svelte
+++ b/frontend/src/lib/components/settings/HttpServerCard.svelte
@@ -23,13 +23,15 @@
 
 	let listen = $state<ServerListenState | null>(null);
 	let ifaces = $state<RouterInterface[]>([]);
-	let portDraft = $state('');
+	// number|string: Svelte на <input type="number"> присваивает в bind число,
+	// а начальное/пустое значение — строка; никаких строковых методов ниже.
+	let portDraft = $state<number | string>('');
 	let allIfaces = $state(true);
 	let selected = $state<string[]>([]);
 	let busy = $state(false);
 	let confirmOpen = $state(false);
 
-	const port = $derived(Number(portDraft.trim()));
+	const port = $derived(Number(portDraft));
 	const portValid = $derived(Number.isInteger(port) && port >= 1 && port <= 65535);
 	const dirty = $derived.by(() => {
 		if (!listen) return false;

--- a/frontend/src/lib/components/settings/HttpServerCard.svelte
+++ b/frontend/src/lib/components/settings/HttpServerCard.svelte
@@ -1,0 +1,287 @@
+<!--
+  Карточка «HTTP-сервер»: порт и интерфейсы, на которых слушает веб-интерфейс
+  awg-manager. Применение ЖИВОЕ (без рестарта демона) с confirm-or-revert:
+
+    1. POST /server/listen/change — бэкенд make-before-break перебиндивает
+       листенеры и взводит откат (~2 мин); настройки ещё НЕ сохранены.
+    2. Фронт уходит на новый origin, унося одноразовый токен в URL-фрагменте
+       (#listen-confirm=...) — cookie сессии привязана к хосту и смену
+       интерфейса не переживает, токен аутентифицирует confirm сам.
+    3. Эта же карточка на новой странице настроек в onMount видит фрагмент,
+       зовёт POST /server/listen/confirm — бэкенд гасит откат и персистит.
+       Не дошли (адрес недоступен) — бэкенд сам откатывается к старому.
+
+  Листенер 127.0.0.1 держится всегда (реверс-прокси NDMS, health-пробы,
+  спасательный люк) — потому loopback в списке не предлагается.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
+	import { ConfirmModal } from '$lib/components/ui';
+	import type { RouterInterface, ServerListenState } from '$lib/types';
+
+	let listen = $state<ServerListenState | null>(null);
+	let ifaces = $state<RouterInterface[]>([]);
+	let portDraft = $state('');
+	let allIfaces = $state(true);
+	let selected = $state<string[]>([]);
+	let busy = $state(false);
+	let confirmOpen = $state(false);
+
+	const port = $derived(Number(portDraft.trim()));
+	const portValid = $derived(Number.isInteger(port) && port >= 1 && port <= 65535);
+	const dirty = $derived.by(() => {
+		if (!listen) return false;
+		const curAll = listen.interfaces.length === 0;
+		if (portValid && port !== listen.port) return true;
+		if (allIfaces !== curAll) return true;
+		if (!allIfaces && [...selected].sort().join(',') !== [...listen.interfaces].sort().join(',')) return true;
+		return false;
+	});
+	const applyDisabled = $derived(busy || !portValid || !dirty || (!allIfaces && selected.length === 0));
+
+	async function load(): Promise<void> {
+		listen = await api.serverListenState();
+		portDraft = String(listen.port);
+		allIfaces = listen.interfaces.length === 0;
+		selected = [...listen.interfaces];
+	}
+
+	onMount(async () => {
+		// Токен подтверждения из URL-фрагмента — мы только что приехали со
+		// старого origin после живой смены адреса.
+		const m = window.location.hash.match(/listen-confirm=([0-9a-f]{16,})/);
+		if (m) {
+			history.replaceState(null, '', window.location.pathname + window.location.search);
+			try {
+				await api.serverListenConfirm(m[1]);
+				notifications.success('Новый адрес HTTP-сервера подтверждён и сохранён');
+			} catch (e) {
+				notifications.error(
+					`Не удалось подтвердить смену адреса — бэкенд откатится на старый: ${e instanceof Error ? e.message : String(e)}`,
+				);
+			}
+		}
+		try {
+			await load();
+		} catch {
+			listen = null;
+		}
+		try {
+			ifaces = (await api.getAllInterfaces()).filter((i) => i.name !== 'lo');
+		} catch {
+			ifaces = [];
+		}
+	});
+
+	function toggleIface(name: string): void {
+		selected = selected.includes(name) ? selected.filter((n) => n !== name) : [...selected, name];
+	}
+
+	// Куда редиректить после живого перебинда: порт-only смена — тот же хост;
+	// смена интерфейсов — первый не-loopback адрес из фактически забинженных
+	// (0.0.0.0 покрывает текущий хост — тоже оставляем его).
+	function redirectTarget(newPort: number, boundAddrs: string[]): string {
+		const cur = window.location;
+		const sameIfaces = listen
+			? (allIfaces && listen.interfaces.length === 0) ||
+				(!allIfaces && [...selected].sort().join(',') === [...listen.interfaces].sort().join(','))
+			: true;
+		let host = cur.hostname;
+		if (!sameIfaces && !allIfaces) {
+			const ext = boundAddrs.find((a) => !a.startsWith('127.') && !a.startsWith('0.0.0.0'));
+			if (ext) host = ext.slice(0, ext.lastIndexOf(':'));
+		}
+		return `${cur.protocol}//${host}:${newPort}`;
+	}
+
+	async function apply(): Promise<void> {
+		if (applyDisabled) return;
+		busy = true;
+		try {
+			const res = await api.serverListenChange(port, allIfaces ? [] : selected);
+			const target = redirectTarget(port, res.boundAddrs);
+			notifications.success('Адрес применён — переходим на новый и подтверждаем…');
+			window.location.href = `${target}/settings#listen-confirm=${res.confirmToken}`;
+		} catch (e) {
+			notifications.error(`Не удалось сменить адрес: ${e instanceof Error ? e.message : String(e)}`);
+			busy = false;
+		}
+	}
+</script>
+
+{#if listen}
+	<div class="hs-body">
+		{#if listen.pendingConfirm}
+			<div class="pending">
+				Предыдущая смена адреса ожидает подтверждения (откат в {new Date(listen.confirmDeadline ?? '').toLocaleTimeString()}).
+			</div>
+		{/if}
+
+		<div class="row">
+			<label class="lbl" for="hs-port">Порт</label>
+			<input id="hs-port" class="port" type="number" min="1" max="65535" bind:value={portDraft} />
+			{#if portDraft !== '' && !portValid}
+				<span class="err">1–65535</span>
+			{:else if portValid && port < 1024}
+				<span class="warn-inline">порты &lt;1024 могут конфликтовать с системными сервисами</span>
+			{/if}
+		</div>
+
+		<div class="row">
+			<span class="lbl">Интерфейсы</span>
+			<div class="chips">
+				<button type="button" class="chip" class:active={allIfaces} onclick={() => (allIfaces = true)}>
+					<span class="chip-label">Все интерфейсы</span>
+					<span class="chip-desc">0.0.0.0</span>
+				</button>
+				{#each ifaces as i (i.name)}
+					<button
+						type="button"
+						class="chip"
+						class:active={!allIfaces && selected.includes(i.name)}
+						onclick={() => {
+							allIfaces = false;
+							toggleIface(i.name);
+						}}
+					>
+						<span class="chip-label">{i.name}</span>
+						{#if i.label}<span class="chip-desc">{i.label}</span>{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<p class="hint">
+			Сейчас слушает: <code>{listen.boundAddrs.join(', ')}</code>. Применяется без перезапуска: вы будете
+			перенаправлены на новый адрес; если он не откроется — через ~2 минуты вернётся старый.
+			Loopback (127.0.0.1) остаётся всегда — реверс-прокси KeenDNS и health-проверки работают при любом выборе.
+		</p>
+
+		<div class="actions">
+			<button type="button" class="apply" disabled={applyDisabled} onclick={() => (confirmOpen = true)}>
+				{busy ? 'Применяем…' : 'Применить'}
+			</button>
+		</div>
+	</div>
+
+	<ConfirmModal
+		open={confirmOpen}
+		title="Сменить адрес HTTP-сервера"
+		message={`Веб-интерфейс переедет на порт ${portValid ? port : '?'}${allIfaces ? ' (все интерфейсы)' : ` (${selected.join(', ')})`}. Вы будете перенаправлены на новый адрес для подтверждения; без подтверждения через ~2 минуты вернётся текущий адрес.`}
+		busy={busy}
+		onConfirm={() => {
+			confirmOpen = false;
+			void apply();
+		}}
+		onClose={() => {
+			if (!busy) confirmOpen = false;
+		}}
+	/>
+{:else}
+	<p class="hint">Состояние HTTP-сервера недоступно.</p>
+{/if}
+
+<style>
+	.hs-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.pending {
+		padding: 0.5rem 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--color-warning, #d97706);
+		background: color-mix(in srgb, var(--color-warning, #d97706) 10%, transparent);
+		border-left: 2px solid var(--color-warning, #d97706);
+		border-radius: var(--radius-sm, 6px);
+	}
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+	.lbl {
+		min-width: 6.5rem;
+		color: var(--text-secondary);
+		font-size: 0.875rem;
+	}
+	.port {
+		width: 7rem;
+		padding: 0.4rem 0.6rem;
+		background: var(--color-bg-tertiary, var(--bg-tertiary));
+		border: 1px solid var(--color-border, var(--border));
+		border-radius: var(--radius-sm, 6px);
+		color: var(--text-primary);
+		font-family: var(--font-mono);
+	}
+	.err {
+		color: var(--color-error, #e06a5a);
+		font-size: 0.8125rem;
+	}
+	.warn-inline {
+		color: var(--color-warning, #d97706);
+		font-size: 0.8125rem;
+	}
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+	.chip {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.1rem;
+		padding: 0.4rem 0.7rem;
+		background: var(--color-bg-tertiary, var(--bg-tertiary));
+		border: 1px solid var(--color-border, var(--border));
+		border-radius: var(--radius-sm, 8px);
+		cursor: pointer;
+		text-align: left;
+	}
+	.chip.active {
+		border-color: var(--color-accent, var(--accent));
+		background: color-mix(in srgb, var(--color-accent, var(--accent)) 12%, transparent);
+	}
+	.chip-label {
+		color: var(--text-primary);
+		font-size: 0.8125rem;
+		font-weight: 600;
+		font-family: var(--font-mono);
+	}
+	.chip-desc {
+		color: var(--text-muted);
+		font-size: 0.6875rem;
+	}
+	.hint {
+		color: var(--text-muted);
+		font-size: 0.8125rem;
+		line-height: 1.45;
+		margin: 0;
+	}
+	.hint code {
+		font-family: var(--font-mono);
+		color: var(--text-secondary);
+	}
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+	}
+	.apply {
+		padding: 0.45rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--color-bg-secondary, #0a0a0a);
+		background: var(--color-accent, var(--accent));
+		border: none;
+		border-radius: var(--radius-sm, 8px);
+		cursor: pointer;
+	}
+	.apply:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/lib/components/settings/index.ts
+++ b/frontend/src/lib/components/settings/index.ts
@@ -11,3 +11,4 @@ export { default as SettingsFooter } from './SettingsFooter.svelte';
 export { default as DevelopChannelGateModal } from './DevelopChannelGateModal.svelte';
 export { default as ExperimentalSettingsCard } from './ExperimentalSettingsCard.svelte';
 export { default as PukhososPatrol } from './PukhososPatrol.svelte';
+export { default as HttpServerCard } from './HttpServerCard.svelte';

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -690,7 +690,28 @@ export interface TerminalStatus {
 
 export interface ServerSettings {
 	port: number;
+	// Легаси-одиночный интерфейс (downgrade-совместимость); новый код
+	// читает interfaces.
 	interface: string;
+	// kernel-имена интерфейсов, на IPv4 которых слушает HTTP-сервер;
+	// пусто = все (0.0.0.0). Живая смена — через /server/listen/change.
+	interfaces?: string[];
+}
+
+// GET /server/listen — текущее состояние HTTP-листенеров.
+export interface ServerListenState {
+	port: number;
+	interfaces: string[];
+	boundAddrs: string[];
+	pendingConfirm: boolean;
+	confirmDeadline?: string;
+}
+
+// POST /server/listen/change — живая смена адреса (confirm-or-revert).
+export interface ServerListenChangeResult {
+	confirmToken: string;
+	confirmDeadline: string;
+	boundAddrs: string[];
 }
 
 export interface PingCheckDefaults {

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -19,6 +19,7 @@
 		ThemeSchemeCard,
 		SettingsFooter,
 		UsageLevelCard,
+		HttpServerCard,
 		DevelopChannelGateModal,
 		ExperimentalSettingsCard,
 		PukhososPatrol,
@@ -56,6 +57,7 @@
 	import {
 		CircleArrowDown,
 		Lock,
+		Network,
 		CloudDownload,
 		ScrollText,
 		Activity,
@@ -808,6 +810,13 @@ $effect(() => {
 							/>
 						</div>
 					{/if}
+					</div>
+				</div>
+
+				<div class="settings-block">
+					<div class="card">
+					<SettingsSectionLabel label="HTTP-сервер" icon={Network} tone="blue" header />
+					<HttpServerCard />
 					</div>
 				</div>
 

--- a/internal/api/server_listen.go
+++ b/internal/api/server_listen.go
@@ -1,0 +1,234 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// ServerListenController — управление HTTP-листенерами демона.
+// *server.Server реализует его (server/listen.go); интерфейс живёт здесь,
+// чтобы api не импортировал server (цикл: server → api).
+type ServerListenController interface {
+	// ListenState — текущий spec, фактические адреса и confirm-окно.
+	ListenState() (port int, interfaces []string, boundAddrs []string, pending bool, deadline time.Time)
+	// BeginListenChange живо применяет новый bind (make-before-break) и
+	// взводит откат; настройки НЕ персистятся до Confirm.
+	BeginListenChange(port int, interfaces []string) (token string, deadline time.Time, addrs []string, err error)
+	// ConfirmListenChange гасит откат по одноразовому токену.
+	ConfirmListenChange(token string) (port int, interfaces []string, ok bool)
+}
+
+// ── DTOs ─────────────────────────────────────────────────────────
+
+// ServerListenStateData is the payload of GET /server/listen.
+type ServerListenStateData struct {
+	// Port the HTTP server is configured to listen on.
+	Port int `json:"port" example:"2222"`
+	// Interfaces are kernel interface names the server binds to; empty = all (0.0.0.0).
+	Interfaces []string `json:"interfaces" example:"br0"`
+	// BoundAddrs are the ip:port addresses with an active listener right now.
+	BoundAddrs []string `json:"boundAddrs" example:"192.168.1.1:2222"`
+	// PendingConfirm is true while an applied change awaits confirmation (see confirmDeadline).
+	PendingConfirm bool `json:"pendingConfirm" example:"false"`
+	// ConfirmDeadline is the RFC3339 revert moment; empty when no change is pending.
+	ConfirmDeadline string `json:"confirmDeadline,omitempty" example:"2026-07-11T12:00:00+03:00"`
+}
+
+// ServerListenStateResponse is the envelope for GET /server/listen.
+type ServerListenStateResponse struct {
+	Success bool                  `json:"success" example:"true"`
+	Data    ServerListenStateData `json:"data"`
+}
+
+// ServerListenChangeRequest is the body for POST /server/listen/change.
+type ServerListenChangeRequest struct {
+	// Port to listen on (1-65535).
+	Port int `json:"port" example:"2222"`
+	// Interfaces are kernel interface names to bind (each must have an IPv4
+	// address); empty/omitted = all interfaces (0.0.0.0). A loopback listener
+	// on 127.0.0.1 is always kept regardless of this list.
+	Interfaces []string `json:"interfaces,omitempty" example:"br0"`
+}
+
+// ServerListenChangeData is the payload of POST /server/listen/change.
+type ServerListenChangeData struct {
+	// ConfirmToken must be presented to /server/listen/confirm before
+	// confirmDeadline, otherwise the change is reverted. The token also
+	// authenticates the confirm call by itself — the session cookie does not
+	// survive a host (interface) change.
+	ConfirmToken string `json:"confirmToken" example:"9f3c..."`
+	// ConfirmDeadline is the RFC3339 revert moment.
+	ConfirmDeadline string `json:"confirmDeadline" example:"2026-07-11T12:02:00+03:00"`
+	// BoundAddrs are the ip:port addresses now listening (new bind applied).
+	BoundAddrs []string `json:"boundAddrs" example:"192.168.1.1:8080"`
+}
+
+// ServerListenChangeResponse is the envelope for POST /server/listen/change.
+type ServerListenChangeResponse struct {
+	Success bool                   `json:"success" example:"true"`
+	Data    ServerListenChangeData `json:"data"`
+}
+
+// ServerListenConfirmRequest is the body for POST /server/listen/confirm.
+type ServerListenConfirmRequest struct {
+	Token string `json:"token" example:"9f3c..."`
+}
+
+// ServerListenHandler exposes live HTTP-listen management.
+type ServerListenHandler struct {
+	ctrl     ServerListenController
+	settings *storage.SettingsStore
+	log      *logging.ScopedLogger
+}
+
+// NewServerListenHandler constructs the handler.
+func NewServerListenHandler(ctrl ServerListenController, settings *storage.SettingsStore, appLogger logging.AppLogger) *ServerListenHandler {
+	return &ServerListenHandler{
+		ctrl:     ctrl,
+		settings: settings,
+		log:      logging.NewScopedLogger(appLogger, logging.GroupSystem, "server-listen"),
+	}
+}
+
+// State returns the current listen configuration and bound addresses.
+//
+//	@Summary		Get HTTP listen state
+//	@Description	Returns the configured port/interfaces, the ip:port addresses with an active listener, and whether an applied change is still awaiting confirmation.
+//	@Tags			server
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Success		200	{object}	ServerListenStateResponse
+//	@Failure		405	{object}	APIErrorEnvelope
+//	@Router			/server/listen [get]
+func (h *ServerListenHandler) State(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	port, ifaces, addrs, pending, deadline := h.ctrl.ListenState()
+	data := ServerListenStateData{
+		Port:           port,
+		Interfaces:     emptyIfNil(ifaces),
+		BoundAddrs:     emptyIfNil(addrs),
+		PendingConfirm: pending,
+	}
+	if pending {
+		data.ConfirmDeadline = deadline.Format(time.RFC3339)
+	}
+	response.Success(w, data)
+}
+
+// Change applies a new port/interface bind live (make-before-break) and arms
+// a revert unless confirmed in time.
+//
+//	@Summary		Change HTTP listen address (live, confirm-or-revert)
+//	@Description	Applies the new port/interfaces immediately without restarting the daemon: new listeners are bound first, old ones closed after (the server is never left without a listener). The change is NOT persisted yet — call /server/listen/confirm with the returned token before confirmDeadline, otherwise listeners revert to the previous address. A 127.0.0.1 listener is always kept (NDMS reverse proxy, health probes, rescue hatch).
+//	@Tags			server
+//	@Accept			json
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			body	body		ServerListenChangeRequest	true	"New port and interface list (empty list = all interfaces)"
+//	@Success		200		{object}	ServerListenChangeResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Router			/server/listen/change [post]
+func (h *ServerListenHandler) Change(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	var req ServerListenChangeRequest
+	if err := decodeBody(r, &req); err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	if req.Port < 1 || req.Port > 65535 {
+		response.Error(w, "порт должен быть в диапазоне 1–65535", "INVALID_PORT")
+		return
+	}
+	for _, iface := range req.Interfaces {
+		if iface == "" {
+			response.Error(w, "пустое имя интерфейса", "INVALID_INTERFACE")
+			return
+		}
+	}
+	token, deadline, addrs, err := h.ctrl.BeginListenChange(req.Port, req.Interfaces)
+	if err != nil {
+		h.log.Warn("change", "", err.Error())
+		response.Error(w, err.Error(), "LISTEN_CHANGE_FAILED")
+		return
+	}
+	h.log.Warn("change", "", "HTTP-адрес изменён, ожидаю подтверждения (откат "+deadline.Format(time.RFC3339)+")")
+	response.Success(w, ServerListenChangeData{
+		ConfirmToken:    token,
+		ConfirmDeadline: deadline.Format(time.RFC3339),
+		BoundAddrs:      emptyIfNil(addrs),
+	})
+}
+
+// Confirm finalizes a pending listen change and persists it to settings.
+//
+// NB: registered WITHOUT the session guard — the one-time 256-bit token from
+// /server/listen/change is the credential. The session cookie is scoped to
+// the host and does not survive an interface change, so the confirm request
+// arriving from the NEW origin may have no session yet.
+//
+//	@Summary		Confirm a pending HTTP listen change
+//	@Description	Cancels the scheduled revert and persists the new port/interfaces to settings. Authenticated by the one-time token returned from /server/listen/change (a session is not required — it does not survive a host change).
+//	@Tags			server
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		ServerListenConfirmRequest	true	"One-time confirm token"
+//	@Success		200		{object}	OkResponse
+//	@Failure		400		{object}	APIErrorEnvelope
+//	@Failure		405		{object}	APIErrorEnvelope
+//	@Failure		500		{object}	APIErrorEnvelope
+//	@Router			/server/listen/confirm [post]
+func (h *ServerListenHandler) Confirm(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	var req ServerListenConfirmRequest
+	if err := decodeBody(r, &req); err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	port, ifaces, ok := h.ctrl.ConfirmListenChange(req.Token)
+	if !ok {
+		response.Error(w, "токен подтверждения не действителен (окно истекло или уже подтверждено)", "CONFIRM_TOKEN_INVALID")
+		return
+	}
+	settings, err := h.settings.Load()
+	if err != nil {
+		response.InternalError(w, "настройки применены к листенерам, но не прочитаны для сохранения: "+err.Error())
+		return
+	}
+	settings.Server.Port = port
+	settings.Server.Interfaces = ifaces
+	// Легаси-поле для downgrade-совместимости: старый бинарь биндится на
+	// FirstIPv4(Interface); при нескольких интерфейсах берём первый, при
+	// «всех» — пусто (0.0.0.0).
+	if len(ifaces) > 0 {
+		settings.Server.Interface = ifaces[0]
+	} else {
+		settings.Server.Interface = ""
+	}
+	if err := h.settings.Save(settings); err != nil {
+		response.InternalError(w, "настройки применены к листенерам, но не сохранены: "+err.Error())
+		return
+	}
+	h.log.Info("confirm", "", "новый HTTP-адрес подтверждён и сохранён")
+	response.Success(w, map[string]bool{"ok": true})
+}
+
+func emptyIfNil(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
+}

--- a/internal/api/server_listen_test.go
+++ b/internal/api/server_listen_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+type fakeListenCtrl struct {
+	port    int
+	ifaces  []string
+	token   string
+	beganP  int
+	beganIf []string
+}
+
+func (f *fakeListenCtrl) ListenState() (int, []string, []string, bool, time.Time) {
+	return f.port, f.ifaces, []string{"127.0.0.1:2222"}, false, time.Time{}
+}
+func (f *fakeListenCtrl) BeginListenChange(port int, interfaces []string) (string, time.Time, []string, error) {
+	f.beganP, f.beganIf = port, interfaces
+	return f.token, time.Now().Add(time.Minute), []string{"127.0.0.1:8080"}, nil
+}
+func (f *fakeListenCtrl) ConfirmListenChange(token string) (int, []string, bool) {
+	if token != f.token {
+		return 0, nil, false
+	}
+	return f.beganP, f.beganIf, true
+}
+
+func newListenHandler(t *testing.T) (*ServerListenHandler, *storage.SettingsStore, *fakeListenCtrl) {
+	t.Helper()
+	store := storage.NewSettingsStore(t.TempDir())
+	if _, err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	ctrl := &fakeListenCtrl{port: 2222, ifaces: []string{"br0"}, token: "tok-1"}
+	return NewServerListenHandler(ctrl, store, nil), store, ctrl
+}
+
+func TestServerListenChange_RejectsBadPort(t *testing.T) {
+	h, _, _ := newListenHandler(t)
+	for _, body := range []string{`{"port":0}`, `{"port":70000}`, `{"port":80,"interfaces":[""]}`} {
+		w := httptest.NewRecorder()
+		h.Change(w, httptest.NewRequest(http.MethodPost, "/api/server/listen/change", strings.NewReader(body)))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %s: code = %d, want 400", body, w.Code)
+		}
+	}
+}
+
+func TestServerListenConfirm_PersistsSettings(t *testing.T) {
+	h, store, ctrl := newListenHandler(t)
+
+	w := httptest.NewRecorder()
+	h.Change(w, httptest.NewRequest(http.MethodPost, "/api/server/listen/change",
+		strings.NewReader(`{"port":8080,"interfaces":["eth3"]}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("change code = %d: %s", w.Code, w.Body.String())
+	}
+
+	// Настройки ещё НЕ изменены — только после confirm.
+	settings, _ := store.Load()
+	if settings.Server.Port != storage.DefaultPort {
+		t.Fatalf("settings persisted before confirm: port %d", settings.Server.Port)
+	}
+
+	w = httptest.NewRecorder()
+	h.Confirm(w, httptest.NewRequest(http.MethodPost, "/api/server/listen/confirm",
+		strings.NewReader(`{"token":"tok-1"}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("confirm code = %d: %s", w.Code, w.Body.String())
+	}
+	settings, _ = store.Load()
+	if settings.Server.Port != 8080 {
+		t.Errorf("port = %d, want 8080", settings.Server.Port)
+	}
+	if len(settings.Server.Interfaces) != 1 || settings.Server.Interfaces[0] != "eth3" {
+		t.Errorf("interfaces = %v, want [eth3]", settings.Server.Interfaces)
+	}
+	if settings.Server.Interface != "eth3" {
+		t.Errorf("legacy interface = %q, want eth3 (downgrade compat)", settings.Server.Interface)
+	}
+	_ = ctrl
+}
+
+func TestServerListenConfirm_BadTokenRejected(t *testing.T) {
+	h, store, _ := newListenHandler(t)
+	w := httptest.NewRecorder()
+	h.Confirm(w, httptest.NewRequest(http.MethodPost, "/api/server/listen/confirm",
+		strings.NewReader(`{"token":"wrong"}`)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("confirm with bad token = %d, want 400", w.Code)
+	}
+	settings, _ := store.Load()
+	if settings.Server.Port != storage.DefaultPort {
+		t.Errorf("settings must be untouched, port = %d", settings.Server.Port)
+	}
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -22,8 +22,13 @@ import (
 
 // ServerSettingsDTO mirrors frontend ServerSettings.
 type ServerSettingsDTO struct {
-	Port      int    `json:"port" example:"8080"`
+	Port int `json:"port" example:"8080"`
+	// Interface is the legacy single bind interface (superseded by
+	// interfaces; kept for downgrade compatibility).
 	Interface string `json:"interface" example:""`
+	// Interfaces are kernel interface names the HTTP server binds to;
+	// empty = all (0.0.0.0). Changed live via /server/listen/change.
+	Interfaces []string `json:"interfaces,omitempty" example:"br0"`
 }
 
 // PingCheckDefaultsDTO mirrors frontend PingCheckDefaults.

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -2796,11 +2796,118 @@ definitions:
         example: 10.0.14.2/32
         type: string
     type: object
+  api.ServerListenChangeData:
+    properties:
+      boundAddrs:
+        description: BoundAddrs are the ip:port addresses now listening (new bind
+          applied).
+        example:
+        - 192.168.1.1:8080
+        items:
+          type: string
+        type: array
+      confirmDeadline:
+        description: ConfirmDeadline is the RFC3339 revert moment.
+        example: "2026-07-11T12:02:00+03:00"
+        type: string
+      confirmToken:
+        description: |-
+          ConfirmToken must be presented to /server/listen/confirm before
+          confirmDeadline, otherwise the change is reverted. The token also
+          authenticates the confirm call by itself — the session cookie does not
+          survive a host (interface) change.
+        example: 9f3c...
+        type: string
+    type: object
+  api.ServerListenChangeRequest:
+    properties:
+      interfaces:
+        description: |-
+          Interfaces are kernel interface names to bind (each must have an IPv4
+          address); empty/omitted = all interfaces (0.0.0.0). A loopback listener
+          on 127.0.0.1 is always kept regardless of this list.
+        example:
+        - br0
+        items:
+          type: string
+        type: array
+      port:
+        description: Port to listen on (1-65535).
+        example: 2222
+        type: integer
+    type: object
+  api.ServerListenChangeResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ServerListenChangeData'
+      success:
+        example: true
+        type: boolean
+    type: object
+  api.ServerListenConfirmRequest:
+    properties:
+      token:
+        example: 9f3c...
+        type: string
+    type: object
+  api.ServerListenStateData:
+    properties:
+      boundAddrs:
+        description: BoundAddrs are the ip:port addresses with an active listener
+          right now.
+        example:
+        - 192.168.1.1:2222
+        items:
+          type: string
+        type: array
+      confirmDeadline:
+        description: ConfirmDeadline is the RFC3339 revert moment; empty when no
+          change is pending.
+        example: "2026-07-11T12:00:00+03:00"
+        type: string
+      interfaces:
+        description: Interfaces are kernel interface names the server binds to;
+          empty = all (0.0.0.0).
+        example:
+        - br0
+        items:
+          type: string
+        type: array
+      pendingConfirm:
+        description: PendingConfirm is true while an applied change awaits confirmation
+          (see confirmDeadline).
+        example: false
+        type: boolean
+      port:
+        description: Port the HTTP server is configured to listen on.
+        example: 2222
+        type: integer
+    type: object
+  api.ServerListenStateResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.ServerListenStateData'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.ServerSettingsDTO:
     properties:
       interface:
+        description: |-
+          Interface is the legacy single bind interface (superseded by
+          interfaces; kept for downgrade compatibility).
         example: ""
         type: string
+      interfaces:
+        description: |-
+          Interfaces are kernel interface names the HTTP server binds to;
+          empty = all (0.0.0.0). Changed live via /server/listen/change.
+        example:
+        - br0
+        items:
+          type: string
+        type: array
       port:
         example: 8080
         type: integer
@@ -9425,6 +9532,100 @@ paths:
       summary: Routing tunnel catalog
       tags:
       - routing
+  /server/listen:
+    get:
+      description: Returns the configured port/interfaces, the ip:port addresses
+        with an active listener, and whether an applied change is still awaiting
+        confirmation.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServerListenStateResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Get HTTP listen state
+      tags:
+      - server
+  /server/listen/change:
+    post:
+      consumes:
+      - application/json
+      description: 'Applies the new port/interfaces immediately without restarting
+        the daemon: new listeners are bound first, old ones closed after (the server
+        is never left without a listener). The change is NOT persisted yet — call
+        /server/listen/confirm with the returned token before confirmDeadline, otherwise
+        listeners revert to the previous address. A 127.0.0.1 listener is always
+        kept (NDMS reverse proxy, health probes, rescue hatch).'
+      parameters:
+      - description: New port and interface list (empty list = all interfaces)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.ServerListenChangeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.ServerListenChangeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Change HTTP listen address (live, confirm-or-revert)
+      tags:
+      - server
+  /server/listen/confirm:
+    post:
+      consumes:
+      - application/json
+      description: Cancels the scheduled revert and persists the new port/interfaces
+        to settings. Authenticated by the one-time token returned from /server/listen/change
+        (a session is not required — it does not survive a host change).
+      parameters:
+      - description: One-time confirm token
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.ServerListenConfirmRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.OkResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      summary: Confirm a pending HTTP listen change
+      tags:
+      - server
   /servers/{name}/endpoint:
     post:
       consumes:

--- a/internal/server/listen.go
+++ b/internal/server/listen.go
@@ -1,0 +1,315 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/netif"
+)
+
+// listenConfirmWindow — окно confirm-or-revert для живой смены адреса.
+// 120с, а не 60: смена интерфейса уводит на другой origin, где cookie сессии
+// не действует — пользователю может понадобиться время на вход перед
+// подтверждением (сам confirm при этом принимает одноразовый токен и без
+// сессии, но токен доезжает только если редирект вообще открылся).
+const listenConfirmWindow = 120 * time.Second
+
+// listenHealInterval — период сверки активных листенеров с желаемым spec.
+// Ловит дрейф IP интерфейса (DHCP/PPPoE-переподключение) и появление IP у
+// интерфейса, который на boot ещё не поднялся.
+const listenHealInterval = 60 * time.Second
+
+// ListenSpec — желаемое состояние HTTP-листенеров: порт + kernel-имена
+// интерфейсов. Пустой список интерфейсов = слушать всё (0.0.0.0).
+type ListenSpec struct {
+	Port       int
+	Interfaces []string
+}
+
+func cloneSpec(sp ListenSpec) ListenSpec {
+	out := ListenSpec{Port: sp.Port}
+	out.Interfaces = append([]string(nil), sp.Interfaces...)
+	return out
+}
+
+// listenState — активные листенеры + confirm-окно. Живёт отдельно от Config:
+// мутируется после Start (live rebind по API, heal-тикер).
+type listenState struct {
+	mu        sync.Mutex
+	spec      ListenSpec
+	listeners map[string]net.Listener // ключ — фактический "ip:port"
+
+	// confirm-or-revert: непустой pendingToken = окно открыто.
+	pendingToken    string
+	pendingPrevSpec ListenSpec
+	pendingDeadline time.Time
+	pendingTimer    *time.Timer
+
+	healStop chan struct{}
+}
+
+// SetListenSpec задаёт желаемый bind ДО Start (из main.go после выбора порта).
+func (s *Server) SetListenSpec(spec ListenSpec) {
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	s.listen.spec = cloneSpec(spec)
+}
+
+// resolveListenAddrs разворачивает spec в конкретные "ip:port".
+//
+// strict=true (API-путь): интерфейс без IPv4 — ошибка, пользователь на связи
+// и должен увидеть её сразу. strict=false (boot/heal): такой интерфейс
+// пропускается с warning'ом — IP может появиться позже (PPPoE ещё поднимается),
+// heal-тикер добиндит.
+//
+// Loopback 127.0.0.1 добавляется всегда (кроме bind на 0.0.0.0, который его
+// уже покрывает): на нём живут реверс-прокси NDMS (KeenDNS «через облако»),
+// health-пробы init-скрипта и спасательный люк при ошибочном выборе
+// интерфейса.
+func (s *Server) resolveListenAddrs(spec ListenSpec, strict bool) ([]string, error) {
+	var addrs []string
+	seen := make(map[string]struct{})
+	add := func(ip string) {
+		a := fmt.Sprintf("%s:%d", ip, spec.Port)
+		if _, ok := seen[a]; ok {
+			return
+		}
+		seen[a] = struct{}{}
+		addrs = append(addrs, a)
+	}
+	if len(spec.Interfaces) == 0 {
+		add("0.0.0.0")
+		return addrs, nil
+	}
+	var missing []string
+	for _, iface := range spec.Interfaces {
+		ip := netif.FirstIPv4(iface)
+		if ip == "" {
+			missing = append(missing, iface)
+			continue
+		}
+		add(ip)
+	}
+	if strict && len(missing) > 0 {
+		return nil, fmt.Errorf("интерфейс(ы) без IPv4-адреса: %s", strings.Join(missing, ", "))
+	}
+	if len(missing) > 0 {
+		s.appLog.Warn("listen", "", "интерфейсы без IPv4 пропущены (heal добиндит при появлении IP): "+strings.Join(missing, ", "))
+	}
+	add("127.0.0.1")
+	return addrs, nil
+}
+
+// applyListenLocked приводит активные листенеры к want (make-before-break):
+// СНАЧАЛА биндит недостающие адреса, ПОТОМ закрывает лишние. При
+// bestEffort=false ошибка бинда любого нового адреса закрывает уже открытые
+// новые и оставляет старые нетронутыми — сервер никогда не остаётся без
+// листенера. bestEffort=true (boot/heal/revert) — недоступные адреса
+// пропускаются с warning'ом. Возвращает число активных листенеров.
+// Caller держит s.listen.mu; s.httpServer должен быть построен.
+func (s *Server) applyListenLocked(want []string, bestEffort bool) (int, error) {
+	if s.listen.listeners == nil {
+		s.listen.listeners = make(map[string]net.Listener)
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, a := range want {
+		wantSet[a] = struct{}{}
+	}
+
+	opened := make(map[string]net.Listener)
+	for _, addr := range want {
+		if _, ok := s.listen.listeners[addr]; ok {
+			continue
+		}
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			if bestEffort {
+				s.appLog.Warn("listen", addr, "bind failed: "+err.Error())
+				continue
+			}
+			for _, o := range opened {
+				o.Close()
+			}
+			return len(s.listen.listeners), fmt.Errorf("bind %s: %w", addr, err)
+		}
+		opened[addr] = ln
+	}
+
+	// Новые слушают до закрытия старых — make-before-break.
+	for addr, ln := range opened {
+		s.listen.listeners[addr] = ln
+		go s.serveListener(ln)
+		s.appLog.Info("listen", addr, "listener started")
+	}
+	for addr, ln := range s.listen.listeners {
+		if _, ok := wantSet[addr]; ok {
+			continue
+		}
+		ln.Close() // установленные соединения переживают закрытие листенера
+		delete(s.listen.listeners, addr)
+		s.appLog.Info("listen", addr, "listener closed")
+	}
+	return len(s.listen.listeners), nil
+}
+
+func (s *Server) serveListener(ln net.Listener) {
+	err := s.httpServer.Serve(ln)
+	if err != nil && err != http.ErrServerClosed && !errors.Is(err, net.ErrClosed) {
+		s.appLog.Warn("listen", ln.Addr().String(), "listener stopped: "+err.Error())
+	}
+}
+
+// startListenHeal запускает минутную сверку «желаемые адреса ↔ активные
+// листенеры»: перебиндивает дрейф IP интерфейса (DHCP/PPPoE) и добиндивает
+// интерфейсы, получившие IP после boot. Пока открыто confirm-окно — молчит,
+// чтобы не спорить с ожидающим откатом.
+func (s *Server) startListenHeal() {
+	s.listen.healStop = make(chan struct{})
+	go func() {
+		t := time.NewTicker(listenHealInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-s.listen.healStop:
+				return
+			case <-t.C:
+				s.listen.mu.Lock()
+				if s.listen.pendingToken == "" {
+					if addrs, err := s.resolveListenAddrs(s.listen.spec, false); err == nil {
+						_, _ = s.applyListenLocked(addrs, true)
+					}
+				}
+				s.listen.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// BeginListenChange живо применяет новый spec (строгий резолв: все интерфейсы
+// обязаны иметь IPv4) и взводит откат к прежнему spec через
+// listenConfirmWindow. Настройки НЕ персистятся здесь — только после
+// ConfirmListenChange, поэтому креш/рестарт в окне поднимает демона на старом
+// адресе. Возвращает одноразовый токен подтверждения: фронт уносит его на
+// новый origin в URL-фрагменте (cookie сессии привязана к хосту и смену
+// интерфейса не переживает).
+func (s *Server) BeginListenChange(port int, interfaces []string) (token string, deadline time.Time, addrs []string, err error) {
+	if port < 1 || port > 65535 {
+		return "", time.Time{}, nil, fmt.Errorf("порт %d вне диапазона 1–65535", port)
+	}
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	if s.httpServer == nil {
+		return "", time.Time{}, nil, fmt.Errorf("сервер ещё не запущен")
+	}
+	if s.listen.pendingToken != "" {
+		return "", time.Time{}, nil, fmt.Errorf("предыдущее изменение адреса ещё не подтверждено (откат в %s)", s.listen.pendingDeadline.Format("15:04:05"))
+	}
+
+	newSpec := cloneSpec(ListenSpec{Port: port, Interfaces: interfaces})
+	want, err := s.resolveListenAddrs(newSpec, true)
+	if err != nil {
+		return "", time.Time{}, nil, err
+	}
+	prev := cloneSpec(s.listen.spec)
+	if _, err := s.applyListenLocked(want, false); err != nil {
+		return "", time.Time{}, nil, err
+	}
+	s.listen.spec = newSpec
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		// Токен не получился — откатываем bind, состояние прежнее.
+		if prevAddrs, rerr := s.resolveListenAddrs(prev, false); rerr == nil {
+			_, _ = s.applyListenLocked(prevAddrs, true)
+		}
+		s.listen.spec = prev
+		return "", time.Time{}, nil, fmt.Errorf("generate confirm token: %w", err)
+	}
+	token = hex.EncodeToString(raw)
+	deadline = time.Now().Add(listenConfirmWindow)
+	s.listen.pendingToken = token
+	s.listen.pendingPrevSpec = prev
+	s.listen.pendingDeadline = deadline
+	s.listen.pendingTimer = time.AfterFunc(listenConfirmWindow, func() { s.revertListen(token) })
+	s.appLog.Warn("listen", "", fmt.Sprintf("адрес изменён (порт %d, интерфейсы: %s) — ожидаю подтверждения до %s, иначе откат",
+		port, interfacesLabel(interfaces), deadline.Format("15:04:05")))
+	return token, deadline, sortedAddrs(s.listen.listeners), nil
+}
+
+// ConfirmListenChange гасит откат по одноразовому токену (constant-time
+// сравнение). Возвращает подтверждённые порт/интерфейсы — caller (API-слой)
+// персистит их в настройки. Повторный/чужой токен → ok=false. Плоская
+// сигнатура (не ListenSpec) — под интерфейс api.ServerListenController без
+// импорта server из api.
+func (s *Server) ConfirmListenChange(token string) (port int, interfaces []string, ok bool) {
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	if s.listen.pendingToken == "" || token == "" ||
+		subtle.ConstantTimeCompare([]byte(s.listen.pendingToken), []byte(token)) != 1 {
+		return 0, nil, false
+	}
+	if s.listen.pendingTimer != nil {
+		s.listen.pendingTimer.Stop()
+	}
+	s.clearPendingLocked()
+	s.appLog.Info("listen", "", "смена адреса подтверждена")
+	sp := cloneSpec(s.listen.spec)
+	return sp.Port, sp.Interfaces, true
+}
+
+// revertListen — таймер confirm-окна: подтверждение не пришло, возвращаем
+// прежние листенеры и spec. Токен-гард отсекает гонку с успевшим Confirm.
+func (s *Server) revertListen(token string) {
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	if s.listen.pendingToken != token {
+		return // подтвердили (или это чужое окно) — откат не нужен
+	}
+	prev := s.listen.pendingPrevSpec
+	s.clearPendingLocked()
+	if addrs, err := s.resolveListenAddrs(prev, false); err == nil {
+		_, _ = s.applyListenLocked(addrs, true)
+	}
+	s.listen.spec = cloneSpec(prev)
+	s.appLog.Warn("listen", "", "смена адреса не подтверждена за отведённое окно — откат к прежнему адресу")
+}
+
+func (s *Server) clearPendingLocked() {
+	s.listen.pendingToken = ""
+	s.listen.pendingPrevSpec = ListenSpec{}
+	s.listen.pendingDeadline = time.Time{}
+	s.listen.pendingTimer = nil
+}
+
+// ListenState отдаёт текущее состояние для GET /api/server/listen.
+func (s *Server) ListenState() (port int, interfaces []string, boundAddrs []string, pending bool, deadline time.Time) {
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	sp := cloneSpec(s.listen.spec)
+	return sp.Port, sp.Interfaces, sortedAddrs(s.listen.listeners), s.listen.pendingToken != "", s.listen.pendingDeadline
+}
+
+func sortedAddrs(listeners map[string]net.Listener) []string {
+	out := make([]string, 0, len(listeners))
+	for a := range listeners {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func interfacesLabel(ifaces []string) string {
+	if len(ifaces) == 0 {
+		return "все (0.0.0.0)"
+	}
+	return strings.Join(ifaces, ", ")
+}

--- a/internal/server/listen.go
+++ b/internal/server/listen.go
@@ -144,6 +144,23 @@ func (s *Server) applyListenLocked(want []string, bestEffort bool) (int, error) 
 		opened[addr] = ln
 	}
 
+	// Zero-listener guard (best-effort пути: revert/heal): если ни один
+	// желаемый адрес не выжил (все бинды упали, пересечения с текущими нет —
+	// например, старый порт заняли за confirm-окно), НЕ закрываем текущие
+	// листенеры — недостижимый демон хуже задержавшегося отката. spec при
+	// этом остаётся желаемым: heal-тикер сойдётся к нему, когда адрес
+	// освободится, и тогда же закроет лишние.
+	survivors := len(opened)
+	for addr := range s.listen.listeners {
+		if _, ok := wantSet[addr]; ok {
+			survivors++
+		}
+	}
+	if survivors == 0 && len(s.listen.listeners) > 0 {
+		s.appLog.Warn("listen", "", "ни один желаемый адрес не забиндился — прежние листенеры сохранены до следующей попытки heal")
+		return len(s.listen.listeners), nil
+	}
+
 	// Новые слушают до закрытия старых — make-before-break.
 	for addr, ln := range opened {
 		s.listen.listeners[addr] = ln
@@ -152,7 +169,7 @@ func (s *Server) applyListenLocked(want []string, bestEffort bool) (int, error) 
 	}
 	for addr, ln := range s.listen.listeners {
 		if _, ok := wantSet[addr]; ok {
-			continue
+			continue // включает только что открытые: их адреса из want
 		}
 		ln.Close() // установленные соединения переживают закрытие листенера
 		delete(s.listen.listeners, addr)

--- a/internal/server/listen_test.go
+++ b/internal/server/listen_test.go
@@ -199,3 +199,35 @@ func TestResolveListenAddrs(t *testing.T) {
 		t.Fatal("strict resolve must fail for interface without IPv4")
 	}
 }
+
+// Zero-listener guard: если на откате прежний адрес уже занят другим
+// процессом, текущие листенеры сохраняются — демон не остаётся без единого
+// листенера (heal сойдётся к желаемому spec, когда адрес освободится).
+func TestListen_RevertKeepsCurrentWhenOldAddrStolen(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	p1, p2 := freeTCPPort(t), freeTCPPort(t)
+	bindInitial(t, s, p1)
+
+	token, _, _, err := s.BeginListenChange(p2, nil)
+	if err != nil {
+		t.Fatalf("BeginListenChange: %v", err)
+	}
+	// «Крадём» старый порт, пока окно открыто.
+	blocker, err := net.Listen("tcp", fmt.Sprintf(":%d", p1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blocker.Close()
+
+	s.revertListen(token)
+
+	if !dialOK(t, p2) {
+		t.Fatal("new port lost: revert with stolen old port must keep current listeners")
+	}
+	// spec при этом — желаемый (прежний): heal добиндит p1, когда освободится.
+	port, _, _, pending, _ := s.ListenState()
+	if port != p1 || pending {
+		t.Fatalf("state after guarded revert: port=%d pending=%v, want %d/false", port, pending, p1)
+	}
+}

--- a/internal/server/listen_test.go
+++ b/internal/server/listen_test.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+)
+
+// newListenTestServer — минимальный Server для тестов listen.go: только
+// httpServer (handler не важен) и nil-safe логгер.
+func newListenTestServer(t *testing.T) *Server {
+	t.Helper()
+	return &Server{
+		appLog:     logging.NewScopedLogger(nil, logging.GroupServer, logging.SubHTTP),
+		httpServer: &http.Server{Handler: http.NewServeMux()},
+	}
+}
+
+// freeTCPPort выделяет свободный порт (bind :0 → close). Небольшая гонка
+// между close и повторным bind допустима для юнит-теста.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+func dialOK(t *testing.T, port int) bool {
+	t.Helper()
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	c.Close()
+	return true
+}
+
+// bindInitial имитирует bind-часть Start: применяет spec как boot.
+func bindInitial(t *testing.T, s *Server, port int) {
+	t.Helper()
+	s.SetListenSpec(ListenSpec{Port: port})
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	addrs, err := s.resolveListenAddrs(s.listen.spec, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if n, err := s.applyListenLocked(addrs, true); err != nil || n == 0 {
+		t.Fatalf("initial bind: n=%d err=%v", n, err)
+	}
+}
+
+func shutdownListeners(s *Server) {
+	s.listen.mu.Lock()
+	defer s.listen.mu.Unlock()
+	if s.listen.pendingTimer != nil {
+		s.listen.pendingTimer.Stop()
+	}
+	for a, ln := range s.listen.listeners {
+		ln.Close()
+		delete(s.listen.listeners, a)
+	}
+}
+
+// Begin → новый порт слушается, старый закрыт → Confirm фиксирует spec.
+func TestListen_BeginThenConfirm(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	p1, p2 := freeTCPPort(t), freeTCPPort(t)
+	bindInitial(t, s, p1)
+
+	token, deadline, addrs, err := s.BeginListenChange(p2, nil)
+	if err != nil {
+		t.Fatalf("BeginListenChange: %v", err)
+	}
+	if token == "" || time.Until(deadline) <= 0 || len(addrs) == 0 {
+		t.Fatalf("bad begin result: token=%q deadline=%v addrs=%v", token, deadline, addrs)
+	}
+	if !dialOK(t, p2) {
+		t.Fatal("new port not listening after Begin")
+	}
+	if dialOK(t, p1) {
+		t.Fatal("old port still listening after Begin (make-before-break must close it)")
+	}
+
+	port, _, ok := s.ConfirmListenChange(token)
+	if !ok || port != p2 {
+		t.Fatalf("Confirm: ok=%v port=%d, want ok/%d", ok, port, p2)
+	}
+	gotPort, _, _, pending, _ := s.ListenState()
+	if gotPort != p2 || pending {
+		t.Fatalf("state after confirm: port=%d pending=%v", gotPort, pending)
+	}
+}
+
+// Без подтверждения revert возвращает старый bind и spec.
+func TestListen_RevertRestoresPreviousBind(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	p1, p2 := freeTCPPort(t), freeTCPPort(t)
+	bindInitial(t, s, p1)
+
+	token, _, _, err := s.BeginListenChange(p2, nil)
+	if err != nil {
+		t.Fatalf("BeginListenChange: %v", err)
+	}
+	// Имитируем срабатывание таймера окна (сам таймер 120с — в тесте зовём напрямую).
+	s.revertListen(token)
+
+	if !dialOK(t, p1) {
+		t.Fatal("old port not restored after revert")
+	}
+	if dialOK(t, p2) {
+		t.Fatal("new port still listening after revert")
+	}
+	port, _, _, pending, _ := s.ListenState()
+	if port != p1 || pending {
+		t.Fatalf("state after revert: port=%d pending=%v, want %d/false", port, pending, p1)
+	}
+	// Токен уже потрачен откатом — подтверждение больше не проходит.
+	if _, _, ok := s.ConfirmListenChange(token); ok {
+		t.Fatal("Confirm must fail after revert")
+	}
+}
+
+// Занятый новый порт: Begin ошибается, старые листенеры живы, окно не взводится.
+func TestListen_BeginFailureKeepsOldBind(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	p1 := freeTCPPort(t)
+	bindInitial(t, s, p1)
+
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blocker.Close()
+	busy := blocker.Addr().(*net.TCPAddr).Port
+
+	if _, _, _, err := s.BeginListenChange(busy, nil); err == nil {
+		t.Fatal("BeginListenChange must fail on busy port")
+	}
+	if !dialOK(t, p1) {
+		t.Fatal("old port lost after failed Begin")
+	}
+	port, _, _, pending, _ := s.ListenState()
+	if port != p1 || pending {
+		t.Fatalf("state after failed Begin: port=%d pending=%v", port, pending)
+	}
+}
+
+// Второе изменение при открытом окне отклоняется; чужой токен не подтверждает.
+func TestListen_PendingGuards(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	p1, p2, p3 := freeTCPPort(t), freeTCPPort(t), freeTCPPort(t)
+	bindInitial(t, s, p1)
+
+	token, _, _, err := s.BeginListenChange(p2, nil)
+	if err != nil {
+		t.Fatalf("BeginListenChange: %v", err)
+	}
+	if _, _, _, err := s.BeginListenChange(p3, nil); err == nil {
+		t.Fatal("second Begin while pending must be rejected")
+	}
+	if _, _, ok := s.ConfirmListenChange("deadbeef"); ok {
+		t.Fatal("foreign token must not confirm")
+	}
+	if _, _, ok := s.ConfirmListenChange(token); !ok {
+		t.Fatal("real token must confirm")
+	}
+}
+
+// resolveListenAddrs: пустой список — 0.0.0.0; loopback дедуплицируется с "lo".
+func TestResolveListenAddrs(t *testing.T) {
+	s := newListenTestServer(t)
+	addrs, err := s.resolveListenAddrs(ListenSpec{Port: 1234}, true)
+	if err != nil || len(addrs) != 1 || addrs[0] != "0.0.0.0:1234" {
+		t.Fatalf("all-interfaces resolve = %v (%v), want [0.0.0.0:1234]", addrs, err)
+	}
+	// "lo" резолвится в 127.0.0.1 — совпадает с безусловным loopback'ом, дубля нет.
+	addrs, err = s.resolveListenAddrs(ListenSpec{Port: 1234, Interfaces: []string{"lo"}}, true)
+	if err != nil {
+		t.Fatalf("lo resolve: %v", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "127.0.0.1:1234" {
+		t.Fatalf("lo resolve = %v, want deduped [127.0.0.1:1234]", addrs)
+	}
+	// strict: несуществующий интерфейс — ошибка.
+	if _, err := s.resolveListenAddrs(ListenSpec{Port: 1234, Interfaces: []string{"no-such-iface0"}}, true); err == nil {
+		t.Fatal("strict resolve must fail for interface without IPv4")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,10 +64,8 @@ const (
 
 // Config holds server configuration.
 type Config struct {
-	ListenAddr         string
-	LoopbackListenAddr string // optional: 127.0.0.1:port for reverse proxy support
-	FrontendFS         fs.FS
-	Version            string
+	FrontendFS fs.FS
+	Version    string
 
 	// PprofStandaloneAddr, if non-empty, starts an additional listener that
 	// serves only Go's /debug/pprof/* endpoints (recommended: 127.0.0.1:6060).
@@ -136,7 +134,12 @@ type Server struct {
 	dnsCheckService            *dnscheck.Service
 	authMiddleware             *auth.Middleware
 	httpServer                 *http.Server
-	loopbackListener           net.Listener // optional loopback listener for reverse proxy
+
+	// listen владеет всеми HTTP-листенерами (по адресам из ListenSpec +
+	// безусловный loopback) и confirm-окном живой смены адреса. См. listen.go.
+	listen         listenState
+	listenDone     chan struct{} // закрывается в Shutdown — отпускает Start
+	listenDoneOnce sync.Once
 
 	ndmsDispatcher api.HookDispatcher
 	ndmsTransport  *ndmstransport.Client
@@ -424,18 +427,8 @@ func IsPortFree(port int) bool {
 	return true
 }
 
-// SetListenAddr sets the listen address after port selection.
-func (s *Server) SetListenAddr(addr string) {
-	s.config.ListenAddr = addr
-}
-
-// SetLoopbackAddr sets the loopback listen address for reverse proxy support.
 func (s *Server) SetBootStatusFunc(fn func() bool) {
 	s.bootStatusFn = fn
-}
-
-func (s *Server) SetLoopbackAddr(addr string) {
-	s.config.LoopbackListenAddr = addr
 }
 
 // Start starts the HTTP server.
@@ -478,37 +471,38 @@ func (s *Server) Start() error {
 		// Individual handlers use context timeouts where needed.
 	}
 
-	listener, err := net.Listen("tcp", s.config.ListenAddr)
-	if err != nil {
-		return err
+	// Мультилистенеры (listen.go): по одному на IPv4 каждого выбранного
+	// интерфейса + безусловный loopback. Boot — best-effort: интерфейс без
+	// IP пропускается (heal-тикер добиндит, когда IP появится); фатально
+	// только «не открылся ни один листенер».
+	s.listenDone = make(chan struct{})
+	s.listen.mu.Lock()
+	addrs, _ := s.resolveListenAddrs(s.listen.spec, false)
+	n, _ := s.applyListenLocked(addrs, true)
+	s.listen.mu.Unlock()
+	if n == 0 {
+		return fmt.Errorf("не удалось открыть ни одного HTTP-листенера (порт %d)", s.listen.spec.Port)
 	}
+	s.startListenHeal()
 
-	// Start loopback listener for reverse proxy support (e.g. Keenetic nginx)
-	if s.config.LoopbackListenAddr != "" {
-		ln, err := net.Listen("tcp", s.config.LoopbackListenAddr)
-		if err != nil {
-			s.appLog.Warn("loopback-listener", s.config.LoopbackListenAddr, "failed to start: "+err.Error())
-		} else {
-			s.loopbackListener = ln
-			loopbackSrv := &http.Server{
-				Handler:           handler,
-				ReadHeaderTimeout: 5 * time.Second,
-				IdleTimeout:       120 * time.Second,
-				MaxHeaderBytes:    8192,
-			}
-			go loopbackSrv.Serve(ln)
-			s.appLog.Info("loopback-listener", s.config.LoopbackListenAddr, "started")
-		}
-	}
-
-	return s.httpServer.Serve(listener)
+	// Блокируемся до Shutdown — контракт прежнего Serve-вызова для main.go.
+	<-s.listenDone
+	return http.ErrServerClosed
 }
 
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.loopbackListener != nil {
-		s.loopbackListener.Close()
+	s.listen.mu.Lock()
+	if s.listen.healStop != nil {
+		close(s.listen.healStop)
+		s.listen.healStop = nil
 	}
+	if s.listen.pendingTimer != nil {
+		s.listen.pendingTimer.Stop()
+	}
+	s.clearPendingLocked()
+	s.listen.mu.Unlock()
+
 	if s.pprofServer != nil {
 		shutdownCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		_ = s.pprofServer.Shutdown(shutdownCtx)
@@ -518,7 +512,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.httpServer == nil {
 		return nil
 	}
-	return s.httpServer.Shutdown(ctx)
+	// httpServer.Shutdown закрывает все листенеры (Serve-горутины выходят)
+	// и дожидается соединений; после него отпускаем заблокированный Start.
+	err := s.httpServer.Shutdown(ctx)
+	if s.listenDone != nil {
+		s.listenDoneOnce.Do(func() { close(s.listenDone) })
+	}
+	return err
 }
 
 // AddShutdownHook registers a function to call before syscall.Exec restart.
@@ -733,6 +733,15 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/system/all-interfaces", guarded(systemHandler.AllInterfaces))
 	mux.HandleFunc("/api/system/hydraroute-status", guarded(systemHandler.HydraRouteStatus))
 	mux.HandleFunc("/api/system/hydraroute-control", guarded(systemHandler.HydraRouteControl))
+
+	// HTTP-listen management (live rebind + confirm-or-revert, listen.go).
+	// confirm нарочно БЕЗ session-гарда: его аутентифицирует одноразовый
+	// 256-битный токен из /change — cookie сессии привязана к хосту и смену
+	// интерфейса не переживает.
+	serverListenHandler := api.NewServerListenHandler(s, s.settings, appLog)
+	mux.HandleFunc("/api/server/listen", guarded(serverListenHandler.State))
+	mux.HandleFunc("/api/server/listen/change", guarded(serverListenHandler.Change))
+	mux.HandleFunc("/api/server/listen/confirm", serverListenHandler.Confirm)
 	downloadHandler := api.NewDownloadHandler(s.downloadSvc)
 	mux.HandleFunc("/api/download/outbounds", guarded(downloadHandler.ListOutbounds))
 

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	CurrentSchemaVersion        = 29
+	CurrentSchemaVersion        = 30
 	DefaultPort                 = 2222
 	DefaultInterface            = "br0"
 	DefaultPingCheckTarget      = "8.8.8.8"
@@ -174,6 +174,9 @@ func (s *SettingsStore) Load() (*Settings, error) {
 		if settings.SchemaVersion < 29 {
 			s.migrateToV29(&settings)
 		}
+		if settings.SchemaVersion < 30 {
+			s.migrateToV30(&settings)
+		}
 	}
 
 	// Self-heal duplicated managed servers — see dedupManagedServers comment.
@@ -213,8 +216,9 @@ func (s *SettingsStore) defaultSettings() *Settings {
 		SessionTtlHours: DefaultSessionTTLHours,
 		UsageLevel:      UsageLevelBasic,
 		Server: ServerSettings{
-			Port:      DefaultPort,
-			Interface: DefaultInterface,
+			Port:       DefaultPort,
+			Interface:  DefaultInterface,
+			Interfaces: []string{DefaultInterface},
 		},
 		PingCheck: PingCheckSettings{
 			Enabled: false,
@@ -541,6 +545,18 @@ func (s *SettingsStore) migrateToV29(settings *Settings) {
 		settings.SessionTtlHours = DefaultSessionTTLHours
 	}
 	settings.SchemaVersion = 29
+}
+
+// migrateToV30 lifts the legacy single Server.Interface into the new
+// Server.Interfaces list (HTTP-listen settings). The old field keeps its
+// value so a downgraded binary still binds where it used to; new code
+// reads Interfaces only. An explicitly empty legacy Interface ("" = bind
+// all) migrates to an empty list — same 0.0.0.0 semantics.
+func (s *SettingsStore) migrateToV30(settings *Settings) {
+	if len(settings.Server.Interfaces) == 0 && settings.Server.Interface != "" {
+		settings.Server.Interfaces = []string{settings.Server.Interface}
+	}
+	settings.SchemaVersion = 30
 }
 
 // dedupManagedServers returns servers with duplicate InterfaceName entries

--- a/internal/storage/settings_migrate30_test.go
+++ b/internal/storage/settings_migrate30_test.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// migrateToV30: легаси-одиночный Server.Interface поднимается в Interfaces[],
+// старое поле сохраняет значение (downgrade-совместимость).
+func TestMigrateToV30_LiftsLegacyInterface(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":29,"server":{"port":2222,"interface":"br0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewSettingsStore(dir)
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(settings.Server.Interfaces) != 1 || settings.Server.Interfaces[0] != "br0" {
+		t.Errorf("Interfaces = %v, want [br0]", settings.Server.Interfaces)
+	}
+	if settings.Server.Interface != "br0" {
+		t.Errorf("legacy Interface = %q, want br0 (kept for downgrade)", settings.Server.Interface)
+	}
+	if settings.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", settings.SchemaVersion, CurrentSchemaVersion)
+	}
+}
+
+// Пустой легаси-Interface ("" = 0.0.0.0) мигрирует в пустой список — та же
+// семантика «все интерфейсы».
+func TestMigrateToV30_EmptyLegacyStaysAll(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"schemaVersion":29,"server":{"port":2222,"interface":""}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewSettingsStore(dir)
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(settings.Server.Interfaces) != 0 {
+		t.Errorf("Interfaces = %v, want empty (bind all)", settings.Server.Interfaces)
+	}
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -274,8 +274,17 @@ type ManagedPeer struct {
 
 // ServerSettings contains HTTP server configuration.
 type ServerSettings struct {
-	Port      int    `json:"port"`
+	Port int `json:"port"`
+	// Interface is the legacy single bind interface. Superseded by
+	// Interfaces (migrateToV30 copies it there); kept populated so a
+	// downgrade to an older release still binds where it used to.
+	// New code must read Interfaces only.
 	Interface string `json:"interface"`
+	// Interfaces lists kernel interface names (e.g. "br0") whose IPv4
+	// addresses the HTTP server binds to (one listener per interface, plus
+	// an always-on 127.0.0.1 listener for the NDMS reverse proxy and health
+	// probes). Empty = bind all interfaces (0.0.0.0).
+	Interfaces []string `json:"interfaces,omitempty"`
 }
 
 // PingCheckSettings contains global ping check configuration.


### PR DESCRIPTION
## Что сделано

В «Настройках» появилась карточка **«HTTP-сервер»**: порт + мультиселект интерфейсов (чипы из `/system/all-interfaces`, пункт «Все интерфейсы» = 0.0.0.0). Применение **живое, без перезапуска демона**, с защитой от «отпилил себе доступ».

## Как работает применение

1. `POST /api/server/listen/change` — бэкенд **make-before-break** перебиндивает листенеры (новые адреса открываются до закрытия старых; ошибка бинда откатывает новые и оставляет старые — демон никогда не остаётся без листенера) и взводит **откат через 120с**. Настройки ещё не сохранены — креш/рестарт в окне поднимает демона на старом адресе.
2. Фронт автоматически переходит на новый origin, унося **одноразовый 256-битный токен** в URL-фрагменте: cookie сессии привязана к хосту и смену интерфейса не переживает — токен аутентифицирует подтверждение сам (constant-time, single-use; эндпоинт confirm поэтому без session-гарда).
3. Страница настроек на новом адресе видит фрагмент → `POST /api/server/listen/confirm` → откат гасится, настройки персистятся. Не дошли — бэкенд сам вернул старый адрес через 2 минуты.

## Устойчивость

- **Loopback 127.0.0.1 всегда жив** независимо от выбора: реверс-прокси NDMS/KeenDNS «через облако», health-пробы init-скрипта и спасательный люк (SSH + правка настроек), — поэтому и в списке интерфейсов не предлагается.
- **Heal-тикер (60с)**: смена IP интерфейса (DHCP/PPPoE) перебиндивается сама; интерфейс без IP на boot (PPPoE ещё поднимается) добиндится при появлении адреса. Boot — best-effort, фатально только «ни одного листенера».
- Установленные соединения (SSE/мониторинг) переживают закрытие листенера — рвётся только приём новых.

## Модель данных

`ServerSettings.Interfaces []string` (миграция schemaVersion 30 поднимает легаси-одиночный `Server.Interface` в список; старое поле сохраняет значение — downgrade-совместимость, и заполняется первым интерфейсом при confirm). Дефолт установки не изменился: `["br0"]`. Существовавший boot-путь (порт из настроек + подбор свободного) сохранён.

## API

- `GET /api/server/listen` — порт/интерфейсы/фактические адреса/pending-окно;
- `POST /api/server/listen/change` — живой rebind, `{confirmToken, confirmDeadline, boundAddrs}`;
- `POST /api/server/listen/confirm` — токен → персист.

Общий `PUT /settings` для `server.*` не менялся (персист + restart-apply, как раньше). swagger.yaml + regen `schemas.gen.ts` (+3 эндпоинта).

## Тесты

- **listen-менеджер на реальных TCP-биндах**: Begin→Confirm (старый порт закрыт, новый слушает — проверено dial'ом), revert (старый bind возвращается, токен сгорает), занятый порт (Begin ошибается, старый bind жив), guards (второй Begin при открытом окне, чужой токен), `resolveListenAddrs` (0.0.0.0 / дедуп loopback с `lo` / strict-ошибка на интерфейсе без IP);
- API-хендлер: валидация, персист строго после confirm, неверный токен не трогает настройки;
- миграция V30.

Ворота: gofmt, `go build/vet/test ./...`, MIPS-кросс, eslint 0, svelte-check 0/0, vitest 1343/1343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_