### PR TITLE
fix username in credits (cherry-pick #481 в develop)

### DIFF
--- a/frontend/src/lib/components/settings/SettingsFooter.svelte
+++ b/frontend/src/lib/components/settings/SettingsFooter.svelte
@@ -33,7 +33,7 @@
 		'@ig*****@g*******m', '@Да**** Т***в', '@vi*****@g*******.m', '@ku*******@g*******m',
 		'@d****8@y***u', '@PolarPriest', '@augin', '@me***-***r@y***u', '@Byrnane',
 		'@a******r@g*******m', '@k*******7@g*******m', '@Лохматая Чупакабра', '@Proxy', '@DELETED',
-		'@2*****6@g*******m', '@S A', '@Ig**M**v***v', '@A Tu', '@metalnalks',
+		'@2*****6@g*******m', '@S A', '@Ig**M**v***v', '@A Tu', '@metalnakls',
 		'@LazIv', '@AverTV', '@xxxaaach', '@defylives', '@AndreyPristup',
 		'@Lethal F',
 		'@Stein_123', '@Tanovitsky',


### PR DESCRIPTION
Черри-пик коммита @metalnakls из #481 (`metalnalks` → `metalnakls` в кредитах SettingsFooter) в develop с сохранением авторства — сам #481 открыт в master из форка, и смена его base притащила бы master-историю в develop.

Заменяет #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_