### PR TITLE
fix(subscription): большие подписки — дренаж отбраковок по standalone-снапшоту (#491)

### DIFF
--- a/internal/singbox/orchestrator/check_slot_alone_test.go
+++ b/internal/singbox/orchestrator/check_slot_alone_test.go
@@ -1,0 +1,99 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// recordingAloneValidator записывает список файлов в снапшоте и отдаёт
+// заранее заданную ошибку.
+type recordingAloneValidator struct {
+	seenFiles []string
+	fail      error
+}
+
+func (v *recordingAloneValidator) Validate(_ context.Context, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	v.seenFiles = v.seenFiles[:0]
+	for _, e := range entries {
+		v.seenFiles = append(v.seenFiles, e.Name())
+	}
+	return v.fail
+}
+
+func newAloneTestOrch(t *testing.T) (*Orchestrator, *recordingAloneValidator) {
+	t.Helper()
+	dir := t.TempDir()
+	o := New(dir, nil)
+	if err := o.Register(SlotMeta{Slot: SlotRouter, Filename: "20-router.json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Register(SlotMeta{Slot: SlotSubscriptions, Filename: "40-subscriptions.json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	// Сосед включён и с файлом — merged-снапшот содержал бы его.
+	if err := o.Save(SlotRouter, []byte(`{"outbounds":[]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.SetEnabled(SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	v := &recordingAloneValidator{}
+	o.SetValidator(v)
+	return o, v
+}
+
+// CheckSlotAlone кладёт в снапшот ТОЛЬКО целевой слот (issue #491: дешёвая
+// итеративная проверка без пересъёма всех слотов).
+func TestCheckSlotAlone_SnapshotsOnlyTargetSlot(t *testing.T) {
+	o, v := newAloneTestOrch(t)
+	res, err := o.CheckSlotAlone(SlotSubscriptions, []byte(`{"outbounds":[{"type":"direct","tag":"x"}]}`))
+	if err != nil {
+		t.Fatalf("CheckSlotAlone: %v", err)
+	}
+	if !res.Ok() {
+		t.Fatalf("expected ok, got %v", res.Errors)
+	}
+	if len(v.seenFiles) != 1 || v.seenFiles[0] != "40-subscriptions.json" {
+		t.Errorf("snapshot files = %v, want only 40-subscriptions.json", v.seenFiles)
+	}
+}
+
+// Ошибки обеих форм sing-box атрибутируются к слоту и локальному индексу —
+// в standalone-снапшоте merged-индекс совпадает с локальным.
+func TestCheckSlotAlone_AttributesOutboundIndex(t *testing.T) {
+	o, v := newAloneTestOrch(t)
+	v.fail = errors.New("FATAL[0000] initialize outbound[1]: unknown method: Join,telegram")
+	res, err := o.CheckSlotAlone(SlotSubscriptions, []byte(`{"outbounds":[{"type":"direct","tag":"a"},{"type":"direct","tag":"b"}]}`))
+	if err != nil {
+		t.Fatalf("CheckSlotAlone: %v", err)
+	}
+	if res.Ok() || len(res.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %+v", res.Errors)
+	}
+	e := res.Errors[0]
+	if e.OutboundIndex == nil || *e.OutboundIndex != 1 || e.OutboundSlot != SlotSubscriptions {
+		t.Errorf("attribution = slot=%q idx=%v, want subscriptions/1", e.OutboundSlot, e.OutboundIndex)
+	}
+}
+
+// Неизвестный слот — ErrUnknownSlot; nil-валидатор — Ok (паритет с CheckMerged).
+func TestCheckSlotAlone_Guards(t *testing.T) {
+	o, _ := newAloneTestOrch(t)
+	if _, err := o.CheckSlotAlone(Slot("nope"), []byte(`{}`)); !errors.Is(err, ErrUnknownSlot) {
+		t.Fatalf("expected ErrUnknownSlot, got %v", err)
+	}
+	o.SetValidator(nil)
+	res, err := o.CheckSlotAlone(SlotSubscriptions, []byte(`{}`))
+	if err != nil || !res.Ok() {
+		t.Fatalf("nil validator must pass: res=%v err=%v", res, err)
+	}
+}

--- a/internal/singbox/orchestrator/draft.go
+++ b/internal/singbox/orchestrator/draft.go
@@ -286,6 +286,54 @@ func (o *Orchestrator) CheckMerged(slot Slot, jsonBytes []byte) (ValidationResul
 	return o.checkMergedLocked(slot, jsonBytes)
 }
 
+// CheckSlotAlone runs `sing-box check` over a tmpdir containing ONLY the
+// given slot's candidate bytes — no sibling slots, no cross-slot logical
+// validation. Intra-slot decode/initialize errors surface with the same
+// outbound-index attribution as CheckMerged, at a fraction of the cost:
+// no snapshot of every enabled slot and no parse of their contents per
+// invocation.
+//
+// Built for the subscription adapter's iterative drop loop (issue #491):
+// public share-link lists routinely carry dozens of entries sing-box
+// rejects, and the loop spawns one check per rejected entry — with
+// CheckMerged each spawn also re-parsed every other slot, which on a
+// MIPS/ARM router turned a large-subscription Create into minutes of
+// silent spinner. Cross-slot classes (duplicate tags vs 90-user, dangling
+// group refs) are NOT visible here — callers must finish with one
+// CheckMerged.
+func (o *Orchestrator) CheckSlotAlone(slot Slot, jsonBytes []byte) (ValidationResult, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	meta, ok := o.slots[slot]
+	if !ok {
+		return ValidationResult{}, ErrUnknownSlot
+	}
+	res := ValidationResult{}
+	if o.validator == nil {
+		return res, nil
+	}
+	tmpdir, err := os.MkdirTemp(o.configDir, ".alone-check-*")
+	if err != nil {
+		return ValidationResult{}, fmt.Errorf("CheckSlotAlone tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpdir)
+	if err := writeAtomic(filepath.Join(tmpdir, meta.Filename), jsonBytes); err != nil {
+		return ValidationResult{}, fmt.Errorf("CheckSlotAlone write target: %w", err)
+	}
+	if err := o.validator.Validate(context.Background(), tmpdir); err != nil {
+		ve := ValidationError{
+			Slot:    slot,
+			Kind:    "sing-box check",
+			Message: err.Error(),
+		}
+		if s, idx, ok := o.attributeOutboundIndex(err.Error(), tmpdir); ok {
+			ve.OutboundSlot, ve.OutboundIndex = s, &idx
+		}
+		res.Errors = append(res.Errors, ve)
+	}
+	return res, nil
+}
+
 // checkMergedLocked is the shared body for SaveAndValidate / CheckMerged.
 // Caller MUST hold o.mu.
 func (o *Orchestrator) checkMergedLocked(slot Slot, jsonBytes []byte) (ValidationResult, error) {

--- a/internal/singbox/orchestrator/orchestrator.go
+++ b/internal/singbox/orchestrator/orchestrator.go
@@ -168,10 +168,10 @@ func (o *Orchestrator) Bootstrap() error {
 	if err := o.ensureDirs(); err != nil {
 		return err
 	}
-	if err := o.sweepStaleApplyCheckDirs(); err != nil {
+	if err := o.sweepStaleCheckDirs(); err != nil {
 		// Sweep failure is non-fatal — log and continue. Stale dirs
 		// are harmless cosmetic noise.
-		o.log("warn", fmt.Sprintf("orchestrator: sweep .apply-check: %v", err))
+		o.log("warn", fmt.Sprintf("orchestrator: sweep check dirs: %v", err))
 	}
 	if err := o.sweepStaleTempFiles(); err != nil {
 		// Same best-effort treatment: a crash between AtomicWrite's temp write
@@ -224,10 +224,17 @@ func (o *Orchestrator) removeDisabledCopy(meta SlotMeta) error {
 	return removeIfExists(o.disabledPath(meta))
 }
 
-// sweepStaleApplyCheckDirs removes leftover .apply-check-* directories
-// from crashed Apply runs. Tmpdir creation uses MkdirTemp with a
-// well-known prefix; cleanup is best-effort.
-func (o *Orchestrator) sweepStaleApplyCheckDirs() error {
+// checkDirPrefixes are the MkdirTemp prefixes of every validation tmpdir
+// the orchestrator creates inside configDir (ApplyDraft, CheckMerged /
+// SaveAndValidate, CheckSlotAlone). The sweep must know them all: a crash
+// between MkdirTemp and the deferred RemoveAll strands the dir on flash
+// storage forever otherwise.
+var checkDirPrefixes = []string{".apply-check-", ".save-check-", ".alone-check-"}
+
+// sweepStaleCheckDirs removes leftover validation tmpdirs from crashed
+// check runs. Tmpdir creation uses MkdirTemp with a well-known prefix;
+// cleanup is best-effort.
+func (o *Orchestrator) sweepStaleCheckDirs() error {
 	entries, err := os.ReadDir(o.configDir)
 	if err != nil {
 		return err
@@ -237,7 +244,14 @@ func (o *Orchestrator) sweepStaleApplyCheckDirs() error {
 		if !e.IsDir() {
 			continue
 		}
-		if !strings.HasPrefix(e.Name(), ".apply-check-") {
+		stale := false
+		for _, p := range checkDirPrefixes {
+			if strings.HasPrefix(e.Name(), p) {
+				stale = true
+				break
+			}
+		}
+		if !stale {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(o.configDir, e.Name())); err != nil && firstErr == nil {

--- a/internal/singbox/orchestrator/orchestrator_test.go
+++ b/internal/singbox/orchestrator/orchestrator_test.go
@@ -527,15 +527,21 @@ func TestBootstrapResolvesBothLocationsConflict(t *testing.T) {
 	}
 }
 
-func TestBootstrap_SweepsStaleApplyCheckDirs(t *testing.T) {
+func TestBootstrap_SweepsStaleCheckDirs(t *testing.T) {
 	dir := t.TempDir()
-	// Pre-create a leftover from a crashed Apply.
-	stale := filepath.Join(dir, ".apply-check-abc123")
-	if err := os.MkdirAll(stale, 0755); err != nil {
-		t.Fatal(err)
+	// Pre-create leftovers from crashed Apply / CheckMerged / CheckSlotAlone runs.
+	stale := []string{
+		filepath.Join(dir, ".apply-check-abc123"),
+		filepath.Join(dir, ".save-check-def456"),
+		filepath.Join(dir, ".alone-check-ghi789"),
 	}
-	if err := os.WriteFile(filepath.Join(stale, "20-router.json"), []byte(`{}`), 0644); err != nil {
-		t.Fatal(err)
+	for _, s := range stale {
+		if err := os.MkdirAll(s, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(s, "20-router.json"), []byte(`{}`), 0644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	o := New(dir, nil)
@@ -544,8 +550,10 @@ func TestBootstrap_SweepsStaleApplyCheckDirs(t *testing.T) {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 
-	if _, err := os.Stat(stale); !os.IsNotExist(err) {
-		t.Errorf("stale .apply-check-* dir not swept: %v", err)
+	for _, s := range stale {
+		if _, err := os.Stat(s); !os.IsNotExist(err) {
+			t.Errorf("stale check dir %s not swept: %v", filepath.Base(s), err)
+		}
 	}
 }
 

--- a/internal/singbox/subscription/issue491_flush_test.go
+++ b/internal/singbox/subscription/issue491_flush_test.go
@@ -1,0 +1,135 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+)
+
+// issue491Validator скриптует sing-box check: outbound с тегом, содержащим
+// "bad", валится decode-ошибкой с индексом; считает вызовы отдельно для
+// standalone-снапшота (в директории ТОЛЬКО 40-subscriptions.json) и merged
+// (есть соседние слоты).
+type issue491Validator struct {
+	standaloneCalls int
+	mergedCalls     int
+}
+
+func (v *issue491Validator) Validate(_ context.Context, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 1 {
+		v.standaloneCalls++
+	} else {
+		v.mergedCalls++
+	}
+	path := filepath.Join(dir, "40-subscriptions.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil // наш слот не в снапшоте — нечего валидировать
+	}
+	var cfg struct {
+		Outbounds []map[string]any `json:"outbounds"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return err
+	}
+	for i, ob := range cfg.Outbounds {
+		if tag, _ := ob["tag"].(string); strings.Contains(tag, "bad") {
+			return fmt.Errorf("decode config at %s: outbounds[%d]: unknown transport type: xhttp", path, i)
+		}
+	}
+	return nil
+}
+
+func newIssue491Harness(t *testing.T) (*OperatorAdapter, *issue491Validator) {
+	t.Helper()
+	dir := t.TempDir()
+	orch := orchestrator.New(dir, nil)
+	// Соседний слот, чтобы merged-снапшот отличался от standalone (2 файла vs 1).
+	if err := orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotRouter, Filename: "20-router.json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Save(orchestrator.SlotRouter, []byte(`{"outbounds":[]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.SetEnabled(orchestrator.SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	v := &issue491Validator{}
+	orch.SetValidator(v)
+	return NewOperatorAdapter(orch, nil, nil), v
+}
+
+// Issue #491: после первой merged-отбраковки остальные невалидные
+// outbound'ы дренируются по standalone-снапшоту одного слота (дёшево);
+// merged-чеков ровно два — стартовый и финальный, не по одному на дроп.
+func TestFlush_DropLoopRunsStandalone(t *testing.T) {
+	adapter, v := newIssue491Harness(t)
+
+	tags := []string{"sub-x-good1", "sub-x-bad1", "sub-x-good2", "sub-x-bad2", "sub-x-good3"}
+	for i, tag := range tags {
+		if err := adapter.AddOutbound(tag, validVlessJSON(fmt.Sprintf("10.0.0.%d", i+1))); err != nil {
+			t.Fatalf("AddOutbound %s: %v", tag, err)
+		}
+	}
+	if err := adapter.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	declared := strings.Join(adapter.DeclaredOutboundTags(), ",")
+	if strings.Contains(declared, "bad") {
+		t.Errorf("bad outbounds must be dropped, declared: %s", declared)
+	}
+	for _, g := range []string{"good1", "good2", "good3"} {
+		if !strings.Contains(declared, g) {
+			t.Errorf("good outbound %s lost, declared: %s", g, declared)
+		}
+	}
+	// merged №1 ловит bad1 (дроп в merged-цикле), drain: standalone №1
+	// ловит bad2, standalone №2 — Ok; merged №2 подтверждает чистый слот.
+	if v.standaloneCalls != 2 {
+		t.Errorf("standalone checks = %d, want 2", v.standaloneCalls)
+	}
+	if v.mergedCalls != 2 {
+		t.Errorf("merged checks = %d, want 2 (initial + final, not one per drop)", v.mergedCalls)
+	}
+	// Причины дропов зафиксированы для UI.
+	if dropped := adapter.LastFilterDrops(); len(dropped) != 2 {
+		t.Errorf("LastDropped = %d entries, want 2: %+v", len(dropped), dropped)
+	}
+}
+
+// Исчерпание cap по числу дропов — честная ошибка, а не тихий переход в
+// медленный merged-цикл и не бесконечный спиннер.
+func TestFlush_DropLoopCapFailsHonestly(t *testing.T) {
+	oldMax := dropLoopMaxDrops
+	dropLoopMaxDrops = 2
+	defer func() { dropLoopMaxDrops = oldMax }()
+
+	adapter, _ := newIssue491Harness(t)
+	for i := 0; i < 4; i++ {
+		if err := adapter.AddOutbound(fmt.Sprintf("sub-x-bad%d", i), validVlessJSON(fmt.Sprintf("10.0.1.%d", i+1))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := adapter.Reload(context.Background())
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation on cap exhaustion, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "слишком много неподдерживаемых") {
+		t.Errorf("error must explain the cap: %v", err)
+	}
+}

--- a/internal/singbox/subscription/operator_adapter.go
+++ b/internal/singbox/subscription/operator_adapter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
@@ -493,13 +494,32 @@ func (a *OperatorAdapter) upsertOutbound(tag string, ob map[string]any) {
 //	  attributes the failing outbound index to a slot (initialize errors
 //	  index the MERGED outbounds array; decode errors index one file).
 //	  When attributed to OUR slot, drop that outbound, cascade reference
-//	  cleanup (selectors / urltests / route rules), retry — bounded by
-//	  initial outbound count.
+//	  cleanup (selectors / urltests / route rules), then drain the
+//	  remaining per-outbound rejects via cheap STANDALONE single-slot
+//	  checks (drainStandaloneRejects, issue #491) before re-checking
+//	  merged — bounded by initial outbound count.
 //
 // Finally orch.Save commits the cleaned bytes and SetEnabled flips the
 // slot on. Dropped outbounds are logged so the user (UI / /logs) sees
 // which servers were skipped and why; the subscription is not rejected
 // wholesale unless every outbound failed.
+// dropLoopMaxDrops / dropLoopBudget ограничивают drainStandaloneRejects
+// (issue #491): каждый отброшенный сервер — один спавн `sing-box check`, и
+// патологический список из сотен мусорных записей не должен держать Create
+// (и per-subscription мьютекс) минутами. Vars, не consts — тесты ужимают.
+var (
+	dropLoopMaxDrops = 64
+	dropLoopBudget   = 90 * time.Second
+)
+
+// dropLoopExhaustedErr — честная ошибка вместо бесконечного «крутится»:
+// подписка с сотнями неподдерживаемых записей прерывается с внятным
+// объяснением и списком уже отброшенного.
+func dropLoopExhaustedErr(dropped []DropReason) error {
+	return fmt.Errorf("%w: подписка содержит слишком много неподдерживаемых серверов — проверка прервана после %d отброшенных. Сузьте подписку фильтрами (filterInclude/filterExclude). Отброшено: %s",
+		ErrValidation, len(dropped), formatDropList(dropped))
+}
+
 func (a *OperatorAdapter) flush() error {
 	dropped := append([]DropReason(nil), a.preFlushDropped...)
 	a.preFlushDropped = nil
@@ -516,8 +536,13 @@ func (a *OperatorAdapter) flush() error {
 		}
 	}
 
-	// Pass 2 — sing-box check with iterative drop. Cap iterations to
-	// initial outbound count so a parser bug cannot loop forever.
+	// Pass 2 — merged sing-box check with iterative drop: cross-slot
+	// classes (duplicate tags vs 90-user, dangling group refs) plus
+	// per-outbound rejects. A clean batch costs exactly one merged check
+	// (#331); when a reject IS attributed to our slot, the remaining bad
+	// entries are drained via cheap standalone checks (issue #491) before
+	// the next merged re-check. Cap iterations to outbound count so a
+	// parser bug cannot loop forever.
 	maxIter := len(a.cfg.Outbounds) + 1
 	xSlotCleaned := map[string]bool{} // cross-slot tags already cleaned — guards against re-reporting a ref we can't actually remove
 	for iter := 0; iter < maxIter; iter++ {
@@ -577,6 +602,12 @@ func (a *OperatorAdapter) flush() error {
 		}
 		reason := strings.TrimSpace(res.Error())
 		dropped = append(dropped, DropReason{Tag: tag, Reason: reason})
+		// Остальные пер-outbound отбраковки собираем дешёвыми standalone-
+		// проверками (issue #491), чтобы не пересобирать merged-снапшот
+		// на каждый мусорный сервер из большой публичной подписки.
+		if err := a.drainStandaloneRejects(&dropped); err != nil {
+			return err
+		}
 	}
 
 	// An empty slot is fatal only for an additive op (Create/Refresh) where
@@ -601,6 +632,49 @@ func (a *OperatorAdapter) flush() error {
 
 	a.lastDropped = dropped
 	return nil
+}
+
+// drainStandaloneRejects — drop-цикл пер-outbound отбраковок поверх
+// STANDALONE-снапшота одного нашего слота (issue #491). Публичные списки
+// share-ссылок регулярно несут десятки записей, которые sing-box
+// отвергает; каждый дроп — один спавн `sing-box check`, и прогон каждого
+// спавна по merged-снапшоту (все слоты копируются и парсятся заново на
+// каждой итерации) превращал Create большой подписки в минуты немого
+// спиннера на MIPS/ARM-роутере. Cross-slot классы ошибок здесь невидимы
+// по построению — merged-цикл в flush() по-прежнему владеет ими: выход по
+// Ok или по неиндексируемой ошибке возвращает управление ему. Budget-cap:
+// патологический список падает с честной ошибкой вместо перемалывания.
+func (a *OperatorAdapter) drainStandaloneRejects(dropped *[]DropReason) error {
+	deadline := time.Now().Add(dropLoopBudget)
+	for iter := 0; iter < dropLoopMaxDrops; iter++ {
+		data, err := json.MarshalIndent(a.cfg, "", "  ")
+		if err != nil {
+			return fmt.Errorf("subscription adapter: marshal slot: %w", err)
+		}
+		res, err := a.orch.CheckSlotAlone(orchestrator.SlotSubscriptions, data)
+		if err != nil {
+			return fmt.Errorf("subscription adapter: check-slot: %w", err)
+		}
+		if res.Ok() {
+			return nil
+		}
+		idx, ok := subscriptionsOutboundIndex(res)
+		if !ok {
+			// Не индексируемая по outbound ошибка — оставляем merged-циклу,
+			// который различает конфликты с user-слотом и висячие
+			// cross-slot ссылки.
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return dropLoopExhaustedErr(*dropped)
+		}
+		tag, err := dropOutboundAndCleanRefs(&a.cfg, idx)
+		if err != nil {
+			return fmt.Errorf("subscription adapter: drop idx %d: %w", idx, err)
+		}
+		*dropped = append(*dropped, DropReason{Tag: tag, Reason: strings.TrimSpace(res.Error())})
+	}
+	return dropLoopExhaustedErr(*dropped)
 }
 
 // DeclaredOutboundTags returns the outbound tags present in the committed

--- a/internal/singbox/subscription/operator_adapter.go
+++ b/internal/singbox/subscription/operator_adapter.go
@@ -644,6 +644,13 @@ func (a *OperatorAdapter) flush() error {
 // по построению — merged-цикл в flush() по-прежнему владеет ими: выход по
 // Ok или по неиндексируемой ошибке возвращает управление ему. Budget-cap:
 // патологический список падает с честной ошибкой вместо перемалывания.
+//
+// Известное ограничение: standalone строже merged для outbound с detour
+// на тег ЧУЖОГО слота (возможно только в sb-JSON подписке, вручную
+// сшитой под конкретный router/user-конфиг) — такой outbound здесь
+// отбросится с причиной в LastFilterDrops, хотя merged-проверка его бы
+// приняла. Встроенные парсеры (vlink/mieru/Clash) внешних detour не
+// порождают; отказ не тихий, поэтому осознанно принимаем.
 func (a *OperatorAdapter) drainStandaloneRejects(dropped *[]DropReason) error {
 	deadline := time.Now().Add(dropLoopBudget)
 	for iter := 0; iter < dropLoopMaxDrops; iter++ {


### PR DESCRIPTION
## Проблема

Issue #491: большая публичная подписка (репро-файл barry-far Sub1.txt — 75 КБ, 445 ссылок: ss=343, trojan=101, hysteria2=39, hy2=8, vmess=1) «крутится» бесконечно без единой ошибки.

Замер (не догадка): парсинг мгновенный — 488 валидных outbound за ~14 мс. Узкое место — drop-цикл в `OperatorAdapter.flush()`: каждый отвергнутый sing-box'ом сервер стоил одного спавна `sing-box check` поверх **merged**-снапшота, где на каждой итерации заново копируются и парсятся ВСЕ включённые слоты. Для репро-файла — 15 отбраковок → 16 последовательных merged-проверок (~37 мс каждая на x86 → оценочно 3–8 с на MIPS/ARM-роутере = минуты удержанного HTTP-запроса и per-subscription мьютекса → «вечный спиннер»).

Исторический контекст: #331 убрал O(N²) по числу членов (батч-валидация на один flush); этот PR убирает O(количество_плохих) × стоимость merged-снапшота.

## Исправление

- **`Orchestrator.CheckSlotAlone(slot, bytes)`** — валидация снапшота из ОДНОГО целевого слота (соседние слоты не копируются и не парсятся), с той же атрибуцией индекса outbound (`initialize outbound[N]` / `decode config at <file>: outbounds[N]`).
- **`flush()`**: чистый батч по-прежнему стоит ровно один merged-чек (инвариант #331, покрыт существующим тестом батчинга). После первой merged-отбраковки остальные пер-outbound реджекты дренируются дешёвыми standalone-проверками (`drainStandaloneRejects`), затем один финальный merged re-check. Cross-slot классы ошибок (конфликт тегов с 90-user, висячие ссылки групп) остаются за merged-циклом — standalone их не видит по построению.
- **Честный предел вместо бесконечного спиннера**: 64 дропа / 90 с бюджета; при исчерпании — `ErrValidation` с числом отброшенных, советом сузить подписку `filterInclude`/`filterExclude` и списком причин.

## Тесты

- `TestFlush_DropLoopRunsStandalone` — 5 записей, 2 плохие: ровно 2 merged-чека (стартовый + финальный) и 2 standalone, плохие отброшены, хорошие сохранены, причины дропов доступны для UI.
- `TestFlush_DropLoopCapFailsHonestly` — исчерпание cap → `ErrValidation` с внятным объяснением.
- `TestCheckSlotAlone_SnapshotsOnlyTargetSlot` / `_AttributesOutboundIndex` / `_Guards` — снапшот содержит только целевой слот при включённом соседе; атрибуция `initialize outbound[1]`; ErrUnknownSlot / nil-валидатор.

Ворота: gofmt, build, vet, полный `go test ./...`, `-race` на затронутых пакетах, MIPS-кросс — всё зелёное. Фронт не тронут.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_