### PR TITLE
refactor(frontend): класс 2 — декомпозиция +page.svelte со скриншот-верификацией

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -70,6 +70,12 @@ async function getUnifiedPresets() {
 }
 
 const UPSTREAM = process.env.UPSTREAM ?? 'http://127.0.0.1:8080';
+// MOCK_DETERMINISTIC=1: вся "живость" (jitter трафика, delay-пробы,
+// вероятностные сбои) становится воспроизводимой — скриншот-сравнение
+// рефакторингов UI требует бит-в-бит одинаковых ответов между прогонами.
+const DETERMINISTIC = ['1', 'true'].includes(String(process.env.MOCK_DETERMINISTIC ?? ''));
+const rand = () => (DETERMINISTIC ? 0.5 : rand());
+
 const PORT = Number(process.env.PORT ?? 8081);
 const VALID = new Set(['basic', 'advanced', 'expert']);
 
@@ -1087,7 +1093,7 @@ const AWG_BASE_LATENCY = (() => {
 	};
 	const map = {};
 	for (const [id, range] of Object.entries(ranges)) {
-		map[id] = range ? range[0] + Math.floor(Math.random() * (range[1] - range[0] + 1)) : null;
+		map[id] = range ? range[0] + Math.floor(rand() * (range[1] - range[0] + 1)) : null;
 	}
 	return map;
 })();
@@ -1226,8 +1232,8 @@ function buildConnectivityMatrixEvent({ forced = false } = {}) {
 			const failed = !profile.up || profile.failedTargets?.has(target.id);
 			const base = Number(profile.base) || 80;
 			const hash = hashNumber(target.id, tunnel.id);
-			const drift = Math.round(Math.sin((Date.now() / 1800) + hash) * 9);
-			const forceJitter = forced ? Math.floor(Math.random() * 15) - 7 : 0;
+			const drift = DETERMINISTIC ? 0 : Math.round(Math.sin((Date.now() / 1800) + hash) * 9);
+			const forceJitter = forced ? Math.floor(rand() * 15) - 7 : 0;
 			const latency = blank || failed
 				? null
 				: Math.max(10, Math.min(520, base + (hash % 55) + drift + forceJitter + ti * 6));
@@ -1382,14 +1388,14 @@ function tickAwgTraffic() {
 		traffic.rxBytes +=
 			traffic.rxStep +
 			Math.round(Math.sin(traffic.tick / 3) * profile.waveRx * 0.25) +
-			Math.floor(Math.random() * profile.jitterRx) +
+			Math.floor(rand() * profile.jitterRx) +
 			(burst ? profile.burstRx : 0);
 		traffic.txBytes +=
 			traffic.txStep +
 			Math.round(Math.cos(traffic.tick / 4) * profile.waveTx * 0.25) +
-			Math.floor(Math.random() * profile.jitterTx) +
+			Math.floor(rand() * profile.jitterTx) +
 			(burst ? profile.burstTx : 0);
-		traffic.lastHandshake = new Date(Date.now() - (20_000 + Math.floor(Math.random() * 70_000))).toISOString();
+		traffic.lastHandshake = new Date(Date.now() - (20_000 + Math.floor(rand() * 70_000))).toISOString();
 		events.push({
 			id: traffic.eventId,
 			rxBytes: traffic.rxBytes,
@@ -1418,12 +1424,12 @@ function tickSingboxTraffic() {
 		traffic.download +=
 			traffic.downloadStep +
 			Math.round(Math.sin(traffic.tick / 3.2) * profile.waveRx * 0.35) +
-			Math.floor(Math.random() * profile.jitterRx) +
+			Math.floor(rand() * profile.jitterRx) +
 			(burst ? profile.burstRx : 0);
 		traffic.upload +=
 			traffic.uploadStep +
 			Math.round(Math.cos(traffic.tick / 4.1) * profile.waveTx * 0.35) +
-			Math.floor(Math.random() * profile.jitterTx) +
+			Math.floor(rand() * profile.jitterTx) +
 			(burst ? profile.burstTx : 0);
 		return {
 			tag: traffic.tag,
@@ -1454,8 +1460,8 @@ function tickSubscriptionTraffic() {
 		const baseUp = 8_000_000 + (hash % 7) * 1_500_000;
 		const waveDown = Math.round(Math.sin(phase / 12) * profile.waveRx * 0.4);
 		const waveUp = Math.round(Math.cos(phase / 15) * profile.waveTx * 0.4);
-		const jitterDown = Math.floor(Math.random() * Math.max(1, Math.floor(profile.jitterRx * 0.8)));
-		const jitterUp = Math.floor(Math.random() * Math.max(1, Math.floor(profile.jitterTx * 0.8)));
+		const jitterDown = Math.floor(rand() * Math.max(1, Math.floor(profile.jitterRx * 0.8)));
+		const jitterUp = Math.floor(rand() * Math.max(1, Math.floor(profile.jitterTx * 0.8)));
 
 		events.push({
 			tag: activeTag,
@@ -1480,8 +1486,8 @@ function buildSingboxTrafficEvent() {
 
 /** Clamp mock latency to 10..600 ms (0 = timeout). */
 function mockDelayJitter(base, spread = 70) {
-	if (Math.random() < 0.05) return 0;
-	const jitter = Math.round((Math.random() - 0.5) * spread);
+	if (rand() < 0.05) return 0;
+	const jitter = Math.round((rand() - 0.5) * spread);
 	return Math.max(10, Math.min(600, base + jitter));
 }
 
@@ -3317,12 +3323,12 @@ function maybeInjectDownloadFault(req, res, path) {
 	if (!downloadFaultsEnabled) return false;
 	const route = DOWNLOAD_FAULT_ROUTES.find((r) => r.method === req.method && r.path === path);
 	if (!route) return false;
-	if (Math.random() >= downloadFaultProbability) return false;
+	if (rand() >= downloadFaultProbability) return false;
 
 	// Drain any request body so keep-alive sockets don't stall.
 	if (req.method !== 'GET' && req.method !== 'HEAD') req.resume();
 
-	const message = DOWNLOAD_FAULT_MESSAGES[Math.floor(Math.random() * DOWNLOAD_FAULT_MESSAGES.length)];
+	const message = DOWNLOAD_FAULT_MESSAGES[Math.floor(rand() * DOWNLOAD_FAULT_MESSAGES.length)];
 	if (route.style === 'updateInfo') {
 		send(res, 200, {
 			success: true,
@@ -4478,7 +4484,7 @@ const server = http.createServer(async (req, res) => {
 					let h = 0;
 					for (let i = 0; i < tag.length; i++) h = ((h << 5) - h + tag.charCodeAt(i)) | 0;
 					const base = Math.abs(h) % 370 + 30;
-					const jitter = Math.floor(Math.random() * 40) - 20;
+					const jitter = Math.floor(rand() * 40) - 20;
 					delays[tag] = Math.max(1, base + jitter);
 				}
 				send(res, 200, { success: true, data: { delays } });
@@ -6138,7 +6144,8 @@ const server = http.createServer(async (req, res) => {
 		let now = sub.activeMember || '';
 		if (sub.mode === 'urltest' && sub.memberTags && sub.memberTags.length > 0) {
 			// Rotate every 15 seconds — visible auto-switching for testing.
-			const idx = Math.floor(Date.now() / 15000) % sub.memberTags.length;
+			// (в детерминированном режиме — фиксированный первый член)
+			const idx = DETERMINISTIC ? 0 : Math.floor(Date.now() / 15000) % sub.memberTags.length;
 			now = sub.memberTags[idx];
 		}
 		send(res, 200, { success: true, data: { now } });
@@ -6455,9 +6462,9 @@ const server = http.createServer(async (req, res) => {
 			return;
 		}
 		const base = AWG_BASE_LATENCY[id];
-		const jitter = Math.floor(Math.random() * 25) - 12;
+		const jitter = Math.floor(rand() * 25) - 12;
 		const latency =
-			base !== null ? Math.max(10, Math.min(300, base + jitter)) : 42 + Math.floor(Math.random() * 40);
+			base !== null ? Math.max(10, Math.min(300, base + jitter)) : 42 + Math.floor(rand() * 40);
 		send(res, 200, {
 			success: true,
 			data: { connected: true, latency, httpCode: 204 },
@@ -6473,7 +6480,7 @@ const server = http.createServer(async (req, res) => {
 			send(res, 200, {
 				success: true,
 				data: up
-					? { connected: true, latency: 38 + Math.floor(Math.random() * 20) }
+					? { connected: true, latency: 38 + Math.floor(rand() * 20) }
 					: { connected: false, reason: 'interface down' },
 			});
 		}, 800);
@@ -6519,7 +6526,7 @@ const server = http.createServer(async (req, res) => {
 		const totalSeconds = 5;
 		const iv = setInterval(() => {
 			second++;
-			const bw = baseBw + Math.floor((Math.random() - 0.5) * 2_000_000);
+			const bw = baseBw + Math.floor((rand() - 0.5) * 2_000_000);
 			const bytes = Math.floor(bw);
 			sent += bytes;
 			res.write(`event: interval\ndata: ${JSON.stringify({ second, bandwidth: bw })}\n\n`);
@@ -7000,7 +7007,7 @@ function makeMockSnapshot() {
 	const outbounds = ['vless-1', 'urltest:auto', 'DIRECT'];
 	const rules = ['DOMAIN-SUFFIX', 'RULE-SET', 'GEOIP'];
 	const networks = ['tcp', 'tcp', 'tcp', 'udp'];
-	const conns = Array.from({ length: 6 + Math.floor(Math.random() * 4) }, (_, i) => {
+	const conns = Array.from({ length: 6 + Math.floor(rand() * 4) }, (_, i) => {
 		const out = outbounds[i % outbounds.length];
 		return {
 			id: `mock-${i}-${Date.now()}`,
@@ -7013,8 +7020,8 @@ function makeMockSnapshot() {
 				destinationPort: '443',
 				host: hosts[i % hosts.length],
 			},
-			upload: 1024 * (50 + Math.floor(Math.random() * 5000)),
-			download: 1024 * (200 + Math.floor(Math.random() * 50000)),
+			upload: 1024 * (50 + Math.floor(rand() * 5000)),
+			download: 1024 * (200 + Math.floor(rand() * 50000)),
 			start: new Date(Date.now() - (60 + i * 30) * 1000).toISOString(),
 			chains: [out],
 			rule: rules[i % rules.length],

--- a/frontend/src/lib/components/singbox/SingboxTunnelsTabSection.svelte
+++ b/frontend/src/lib/components/singbox/SingboxTunnelsTabSection.svelte
@@ -1,0 +1,420 @@
+<script lang="ts">
+	// Вкладка «Sing-box туннели» страницы туннелей — выделено из
+	// routes/+page.svelte (класс 2): разметка дословно, состояние — пропсами.
+	import { StatStrip, Stat, LayoutViewToggle, Button, Badge, TableSortHeader } from '$lib/components/ui';
+	import { TunnelToolbarViewRow } from '$lib/components/tunnels';
+	import { SingboxInstallBanner, SingboxTunnelCard } from '$lib/components/singbox';
+	import { singboxTunnelTableSort, type SingboxTunnelSortKey } from '$lib/stores/tunnelTableSort';
+	import { formatRunningSub, pluralForm, TUNNEL_WORDS } from '$lib/utils/pluralize';
+	import { formatBytes } from '$lib/utils/format';
+	import { ariaSort } from '$lib/utils/tunnelTableSort';
+	import type { SingboxLayoutMode, TunnelRenderMode } from '$lib/constants/singboxLayout';
+	import type { SingboxTunnel } from '$lib/types';
+	import type { SubscriptionActiveCardVM, SingboxTunnelListStats } from '$lib/components/subscriptions/subscriptionVMs';
+	import { Globe, LayoutGrid, Link } from 'lucide-svelte';
+	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+
+	interface Props {
+		dashboardOn: boolean;
+		dashboardSingboxTunnels: SingboxTunnel[];
+		singboxTunnelsList: SingboxTunnel[];
+		sortedFilteredSingboxTunnels: SingboxTunnel[];
+		singboxTunnelListStats: SingboxTunnelListStats;
+		singboxTunnelsSourceRowCount: number;
+		singboxTunnelsSearchEmpty: boolean;
+		singboxAutoDelayCheckNonce: number;
+		showSingboxGridListToggle: boolean;
+		effectiveSingboxTunnelsEffectiveLayout: SingboxLayoutMode;
+		effectiveSingboxTunnelsRenderMode: TunnelRenderMode;
+		subscriptionsActiveCards: SubscriptionActiveCardVM[];
+		singboxTunnelsSearchQuery: string;
+		singboxTunnelsLayoutMode: SingboxLayoutMode;
+		handleSingboxTunnelSortChange: (key: SingboxTunnelSortKey) => void;
+		openSingboxDetail: (tag: string) => void;
+		openWizard: (preselect: 'choose' | 'single' | 'inline' | 'url') => void;
+	}
+
+	let {
+		dashboardOn,
+		dashboardSingboxTunnels,
+		singboxTunnelsList,
+		sortedFilteredSingboxTunnels,
+		singboxTunnelListStats,
+		singboxTunnelsSourceRowCount,
+		singboxTunnelsSearchEmpty,
+		singboxAutoDelayCheckNonce,
+		showSingboxGridListToggle,
+		effectiveSingboxTunnelsEffectiveLayout,
+		effectiveSingboxTunnelsRenderMode,
+		subscriptionsActiveCards,
+		singboxTunnelsSearchQuery = $bindable(),
+		singboxTunnelsLayoutMode = $bindable(),
+		handleSingboxTunnelSortChange,
+		openSingboxDetail,
+		openWizard,
+	}: Props = $props();
+</script>
+
+{#snippet createIcon()}
+	<CreateIcon />
+{/snippet}
+
+	{#if !dashboardOn}
+	<SingboxInstallBanner />
+	{#if singboxTunnelsList.length > 0 || subscriptionsActiveCards.length > 0}
+		<div class="tunnels-toolbar">
+			<span class="tunnel-count">
+				{singboxTunnelsList.length}
+				{pluralForm(singboxTunnelsList.length, TUNNEL_WORDS)}
+			</span>
+			<div class="toolbar-actions">
+				<TunnelToolbarViewRow
+					sourceRowCount={singboxTunnelsSourceRowCount}
+					showViewToggle={singboxTunnelsList.length > 0}
+					searchQuery={singboxTunnelsSearchQuery}
+					onSearchChange={(value) => (singboxTunnelsSearchQuery = value)}
+				>
+					{#snippet viewToggle()}
+						<LayoutViewToggle
+							value={singboxTunnelsLayoutMode}
+							showListOption={showSingboxGridListToggle}
+							ariaLabel="Вид туннелей"
+							onchange={(v) => (singboxTunnelsLayoutMode = v)}
+						/>
+					{/snippet}
+				</TunnelToolbarViewRow>
+				<Button
+					variant="primary"
+					size="md"
+					onclick={() => openWizard('choose')}
+					iconBefore={createIcon}
+				>
+					Добавить
+				</Button>
+			</div>
+		</div>
+	{/if}
+	{/if}
+	{#if !dashboardOn && singboxTunnelsList.length === 0}
+		<div class="empty-kinds">
+			<button type="button" class="empty-kind-card" onclick={() => openWizard('single')}>
+				<Link class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
+				<div class="empty-kind-title">Один сервер</div>
+				<div class="empty-kind-desc">
+					Вставь share-link — получишь sing-box туннель со своим Proxy NDMS.
+				</div>
+			</button>
+			<button type="button" class="empty-kind-card" onclick={() => openWizard('inline')}>
+				<LayoutGrid class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
+				<div class="empty-kind-title">Группа серверов</div>
+				<div class="empty-kind-desc">
+					Несколько ссылок одной группой с общим Proxy: ручной выбор или автовыбор по скорости.
+				</div>
+			</button>
+			<button type="button" class="empty-kind-card" onclick={() => openWizard('url')}>
+				<Globe class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
+				<div class="empty-kind-title">Подписка по URL</div>
+				<div class="empty-kind-desc">
+					Адрес подписки провайдера — список обновляется автоматически.
+				</div>
+			</button>
+		</div>
+		<div class="info-card">
+			<h3 class="info-title">О Sing-box</h3>
+			<p class="info-section-desc">
+				Универсальный прокси с поддержкой современных протоколов:
+			</p>
+			<div class="info-versions">
+				<div class="info-version">
+					<Badge variant="accent" size="sm" mono>VLESS</Badge>
+					<span class="info-version-desc">Лёгкий протокол без шифрования на уровне протокола. Поддерживает <strong>Reality</strong> (маскировка под настоящий TLS-сервер) и транспорт gRPC для обхода DPI.</span>
+				</div>
+				<div class="info-version">
+					<Badge variant="error" size="sm" mono>Trojan</Badge>
+					<span class="info-version-desc">TLS-туннель с парольной аутентификацией. Работает поверх TCP, поддерживает WebSocket и gRPC как транспорт.</span>
+				</div>
+				<div class="info-version">
+					<Badge variant="success" size="sm" mono>Shadowsocks</Badge>
+					<span class="info-version-desc">Классический прокси с шифрованием на уровне приложения. Современные шифры (AES-GCM, ChaCha20) и плагины obfs-local / v2ray-plugin.</span>
+				</div>
+				<div class="info-version">
+					<Badge variant="warning" size="sm" mono>Hysteria2</Badge>
+					<span class="info-version-desc">QUIC-based, устойчив к потерям пакетов и работает поверх UDP. Паролевая аутентификация, обфускация salamander.</span>
+				</div>
+				<div class="info-version">
+					<Badge variant="info" size="sm" mono>NaiveProxy</Badge>
+					<span class="info-version-desc">HTTP/2 с полноценным TLS-маскированием под обычный HTTPS-сервер. Сложно отличим от браузерного трафика.</span>
+				</div>
+				<div class="info-version">
+					<Badge variant="purple" size="sm" mono>Mieru</Badge>
+					<span class="info-version-desc">Мультиплексированный прокси с парольной аутентификацией. TCP и UDP в одном профиле, несколько портов и транспортов.</span>
+				</div>
+			</div>
+		</div>
+	{:else if singboxTunnelsList.length > 0 || (dashboardOn && dashboardSingboxTunnels.length > 0)}
+		{#if !dashboardOn}
+			<div class="awg-summary-row">
+				<StatStrip>
+					<Stat
+						value={`${singboxTunnelListStats.running}/${singboxTunnelListStats.count}`}
+						label={pluralForm(singboxTunnelListStats.running, TUNNEL_WORDS)}
+						sub={formatRunningSub(singboxTunnelListStats.running, singboxTunnelListStats.count)}
+					/>
+					<Stat
+						value={formatBytes(singboxTunnelListStats.down + singboxTunnelListStats.up)}
+						label="Суммарный трафик"
+						sub={`↓ ${formatBytes(singboxTunnelListStats.down)} · ↑ ${formatBytes(singboxTunnelListStats.up)}`}
+					/>
+					<Stat
+						value={singboxTunnelListStats.avgDelayMs !== null
+							? `${singboxTunnelListStats.avgDelayMs} ms`
+							: '—'}
+						label="Средний delay"
+						sub="по последним проверкам"
+					/>
+					<Stat
+						value={singboxTunnelListStats.leaderBytes > 0
+							? formatBytes(singboxTunnelListStats.leaderBytes)
+							: '—'}
+						label="Лидер по трафику"
+						sub={singboxTunnelListStats.leaderName}
+					/>
+					</StatStrip>
+				</div>
+		{/if}
+		{#if effectiveSingboxTunnelsRenderMode === 'table'}
+			<div class="tunnel-table-wrap">
+				<table class="tunnel-data-table singbox-tunnel-table">
+					<colgroup>
+						<col class="col-delay" />
+						<col class="col-name" />
+						<col class="col-protocol" />
+						<col class="col-run" />
+						<col class="col-traffic" />
+						<col class="col-ping" />
+						<col class="col-actions" />
+					</colgroup>
+					<thead>
+						<tr>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'delay', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Delay" sortKey={'delay'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'name', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Туннель" sortKey={'name'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'protocol', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Протокол" sortKey={'protocol'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'running', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Процесс" sortKey={'running'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'traffic', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Трафик" sortKey={'traffic'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'ping', $singboxTunnelTableSort.sortAsc)}>
+								<TableSortHeader label="Ping" sortKey={'ping'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
+							</th>
+							<th class="col-actions">Действия</th>
+						</tr>
+					</thead>
+					<tbody>
+				{#each sortedFilteredSingboxTunnels as tunnel, i (tunnel.tag)}
+					<SingboxTunnelCard
+						{tunnel}
+						layout="list"
+						renderMode="table"
+						autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+						autoDelayCheckDelayMs={i * 180}
+						ondetail={(tag) => openSingboxDetail(tag)}
+					/>
+				{/each}
+				{#if singboxTunnelsSearchEmpty}
+					<tr class="tunnel-empty-row">
+						<td colspan="7">Ничего не найдено</td>
+					</tr>
+				{/if}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			{@const sbTunnelCardLayout = effectiveSingboxTunnelsRenderMode === 'list-card' ? 'list' : effectiveSingboxTunnelsEffectiveLayout}
+			<div
+				class="tunnel-grid"
+				class:tunnel-grid--list={effectiveSingboxTunnelsRenderMode === 'list-card'}
+				class:tunnel-grid--dense={effectiveSingboxTunnelsRenderMode !== 'list-card' && effectiveSingboxTunnelsEffectiveLayout === 'dense'}
+				class:tunnel-grid--compact={effectiveSingboxTunnelsRenderMode !== 'list-card' && effectiveSingboxTunnelsEffectiveLayout === 'compact'}
+			>
+				{#each sortedFilteredSingboxTunnels as tunnel, i (tunnel.tag)}
+					<SingboxTunnelCard
+						{tunnel}
+						layout={sbTunnelCardLayout}
+						renderMode={effectiveSingboxTunnelsRenderMode}
+						autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+						autoDelayCheckDelayMs={i * 180}
+						ondetail={(tag) => openSingboxDetail(tag)}
+					/>
+				{/each}
+			</div>
+			{#if singboxTunnelsSearchEmpty}
+				<p class="tunnel-list-empty">Ничего не найдено</p>
+			{/if}
+		{/if}
+{/if}
+
+<style>
+
+	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
+	   Движок вертикальный, поэтому на время активного drag сетка
+	   схлопывается в одну колонку — индексы вставки и индикатор
+	   становятся однозначными на любой плотности. ── */
+
+	/* Toolbar (count + actions row above the tunnel grid) */
+	.tunnels-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+	}
+
+	.tunnel-count {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+
+	.toolbar-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.toolbar-actions :global(.btn.size-md) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 32px;
+		min-height: 32px;
+		max-height: 32px;
+		padding-block: 0;
+	}
+
+	.toolbar-actions :global(.btn.variant-primary:hover:not(:disabled):not(.is-disabled)) {
+		background: transparent;
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+		filter: none;
+	}
+
+	/* Empty-state kind picker — three clickable cards opening the wizard
+	   on the matching step 2. Mirrors the wizard's step-1 visual so the
+	   transition into the modal feels continuous. */
+	.empty-kinds {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.7rem;
+		margin-top: 0.5rem;
+	}
+
+	@media (min-width: 600px) {
+	.empty-kinds { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+	.empty-kind-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+		padding: 1.1rem 1.2rem;
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: 8px;
+		text-align: left;
+		cursor: pointer;
+		font: inherit;
+		color: var(--color-text-primary);
+		transition: border-color 120ms, transform 120ms, background 120ms;
+	}
+
+	.empty-kind-card:hover {
+		border-color: var(--color-primary, #3b82f6);
+		background: rgba(59, 130, 246, 0.04);
+		transform: translateY(-1px);
+	}
+
+	.empty-kind-card:focus-visible {
+		outline: 2px solid var(--color-primary, #3b82f6);
+		outline-offset: 2px;
+	}
+
+	:global(.empty-kind-icon) { color: var(--color-primary, #3b82f6); }
+
+	.empty-kind-title { font-weight: 600; font-size: 0.95rem; }
+
+	.empty-kind-desc { color: var(--color-text-muted); font-size: 0.8rem; line-height: 1.4; }
+
+	/* "About AmneziaWG / Sing-box" info card — page-specific */
+	.info-card {
+		border-left: 3px solid var(--color-accent);
+		background: var(--color-bg-secondary);
+		border-radius: 0 var(--radius) var(--radius) 0;
+		padding: 1.25rem 1.5rem;
+		margin-top: 1.5rem;
+	}
+
+	.info-title {
+		font-size: 1rem;
+		font-weight: 600;
+		margin-bottom: 0.75rem;
+	}
+
+	.info-section-desc {
+		font-size: 0.85rem;
+		color: var(--color-text-muted);
+		margin: 0 0 0.75rem 0;
+	}
+
+	.info-versions {
+		display: flex;
+		flex-direction: column;
+		gap: 0.625rem;
+		margin: 0.75rem 0;
+	}
+
+	.info-version {
+		display: flex;
+		gap: 0.75rem;
+		align-items: baseline;
+	}
+
+	.info-version-desc {
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		line-height: 1.5;
+	}
+
+	@media (max-width: 760px) {
+	.tunnels-toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
+	.toolbar-actions {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			align-items: stretch;
+			gap: 0.5rem;
+			width: 100%;
+		}
+	.toolbar-actions :global(.toolbar-view-row) {
+			grid-column: 1 / -1;
+		}
+	.toolbar-actions > :global(.btn) {
+			width: 100%;
+			min-height: 32px;
+		}
+	.toolbar-actions > :global(.btn:only-of-type) {
+			grid-column: 1 / -1;
+		}
+}
+</style>

--- a/frontend/src/lib/components/subscriptions/SubscriptionsTabSection.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionsTabSection.svelte
@@ -16,26 +16,11 @@
 	import { formatBytes } from '$lib/utils/format';
 	import { ariaSort } from '$lib/utils/tunnelTableSort';
 	import type { SingboxLayoutMode, TunnelRenderMode } from '$lib/constants/singboxLayout';
-	import type { Subscription, SubscriptionMember } from '$lib/types';
+	import type { Subscription } from '$lib/types';
+	import type { SubscriptionActiveCardVM, SubscriptionsTrafficStats } from './subscriptionVMs';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
 
-	export interface SubscriptionActiveCardVM {
-		subscription: Subscription;
-		activeMember: SubscriptionMember;
-	}
 
-	export interface SubscriptionsTrafficStats {
-		count: number;
-		activeCount: number;
-		inactiveCount: number;
-		down: number;
-		up: number;
-		avgDelayMs: number | null;
-		delaySamples: number;
-		leaderBytes: number;
-		leaderName: string;
-		leaderSharePct: number;
-	}
 
 	interface Props {
 		loading: boolean;

--- a/frontend/src/lib/components/subscriptions/SubscriptionsTabSection.svelte
+++ b/frontend/src/lib/components/subscriptions/SubscriptionsTabSection.svelte
@@ -1,0 +1,498 @@
+<script lang="ts">
+	// Вкладка «Sing-box подписки» страницы туннелей. Выделено из
+	// routes/+page.svelte (класс 2 реструктуризации): разметка перенесена
+	// дословно, состояние страницы приходит пропсами, сквозные сторы
+	// (singboxSubscriptionTableSort) импортируются напрямую.
+	import { LoadingSpinner, EmptyState } from '$lib/components/layout';
+	import { StatStrip, Stat, LayoutViewToggle, Button, TableSortHeader } from '$lib/components/ui';
+	import { TunnelToolbarViewRow } from '$lib/components/tunnels';
+	import TunnelSectionHeader from '$lib/components/tunnels/TunnelSectionHeader.svelte';
+	import { SingboxInstallBanner } from '$lib/components/singbox';
+	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
+	import SubscriptionCard from '$lib/components/subscriptions/SubscriptionCard.svelte';
+	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
+	import { singboxSubscriptionTableSort, type SubscriptionSortKey } from '$lib/stores/tunnelTableSort';
+	import { formatRunningSub, pluralForm, SUBSCRIPTION_WORDS } from '$lib/utils/pluralize';
+	import { formatBytes } from '$lib/utils/format';
+	import { ariaSort } from '$lib/utils/tunnelTableSort';
+	import type { SingboxLayoutMode, TunnelRenderMode } from '$lib/constants/singboxLayout';
+	import type { Subscription, SubscriptionMember } from '$lib/types';
+	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+
+	export interface SubscriptionActiveCardVM {
+		subscription: Subscription;
+		activeMember: SubscriptionMember;
+	}
+
+	export interface SubscriptionsTrafficStats {
+		count: number;
+		activeCount: number;
+		inactiveCount: number;
+		down: number;
+		up: number;
+		avgDelayMs: number | null;
+		delaySamples: number;
+		leaderBytes: number;
+		leaderName: string;
+		leaderSharePct: number;
+	}
+
+	interface Props {
+		loading: boolean;
+		dashboardOn: boolean;
+		dashboardSectionsLayout: boolean;
+		subscriptionsInitialLoading: boolean;
+		subscriptionsFetchFailed: boolean;
+		subscriptionsError: string | null;
+		subscriptionsList: Subscription[];
+		subscriptionsActiveCards: SubscriptionActiveCardVM[];
+		sortedFilteredSubscriptionsActiveCards: SubscriptionActiveCardVM[];
+		sortedFilteredSubscriptionsListRows: Subscription[];
+		singboxSubscriptionsTrafficStats: SubscriptionsTrafficStats;
+		singboxSubscriptionsSourceRowCount: number;
+		singboxSubscriptionsSearchEmpty: boolean;
+		singboxInstalled: boolean;
+		singboxStatusLoading: boolean;
+		singboxAutoDelayCheckNonce: number;
+		showSingboxGridListToggle: boolean;
+		effectiveSingboxSubscriptionsEffectiveLayout: SingboxLayoutMode;
+		effectiveSingboxSubscriptionsRenderMode: TunnelRenderMode;
+		liveActives: Record<string, string>;
+		singboxSubscriptionsSearchQuery: string;
+		singboxSubscriptionsLayoutMode: SingboxLayoutMode;
+		handleSubscriptionSortChange: (key: SubscriptionSortKey) => void;
+		openSingboxDetail: (tag: string) => void;
+		openWizard: (mode: 'url') => void;
+		requestSubscriptionDelete: (id: string) => void;
+	}
+
+	let {
+		loading,
+		dashboardOn,
+		dashboardSectionsLayout,
+		subscriptionsInitialLoading,
+		subscriptionsFetchFailed,
+		subscriptionsError,
+		subscriptionsList,
+		subscriptionsActiveCards,
+		sortedFilteredSubscriptionsActiveCards,
+		sortedFilteredSubscriptionsListRows,
+		singboxSubscriptionsTrafficStats,
+		singboxSubscriptionsSourceRowCount,
+		singboxSubscriptionsSearchEmpty,
+		singboxInstalled,
+		singboxStatusLoading,
+		singboxAutoDelayCheckNonce,
+		showSingboxGridListToggle,
+		effectiveSingboxSubscriptionsEffectiveLayout,
+		effectiveSingboxSubscriptionsRenderMode,
+		liveActives,
+		singboxSubscriptionsSearchQuery = $bindable(),
+		singboxSubscriptionsLayoutMode = $bindable(),
+		handleSubscriptionSortChange,
+		openSingboxDetail,
+		openWizard,
+		requestSubscriptionDelete,
+	}: Props = $props();
+</script>
+
+{#snippet createIcon()}
+	<CreateIcon />
+{/snippet}
+
+	{#if subscriptionsInitialLoading}
+		<div class="loading-centered">
+			<LoadingSpinner size="md" message="Загружаем подписки..." />
+		</div>
+	{:else if subscriptionsFetchFailed}
+		<EmptyState
+			title="Не удалось загрузить подписки"
+			description={subscriptionsError ?? 'Проверьте соединение с роутером и обновите страницу.'}
+		/>
+	{:else}
+		{#if !dashboardOn && !singboxStatusLoading}
+			<SingboxInstallBanner />
+		{/if}
+
+		{#if singboxStatusLoading || singboxInstalled}
+			{#if !dashboardOn}
+			<div class="tunnels-toolbar">
+				<span class="tunnel-count">
+					{subscriptionsList.length}
+					{pluralForm(subscriptionsList.length, SUBSCRIPTION_WORDS)}
+				</span>
+				<div class="toolbar-actions">
+					<TunnelToolbarViewRow
+						sourceRowCount={singboxSubscriptionsSourceRowCount}
+						showViewToggle={subscriptionsList.length > 0}
+						searchQuery={singboxSubscriptionsSearchQuery}
+						onSearchChange={(value) => (singboxSubscriptionsSearchQuery = value)}
+					>
+						{#snippet viewToggle()}
+							<LayoutViewToggle
+								value={singboxSubscriptionsLayoutMode}
+								showListOption={showSingboxGridListToggle}
+								ariaLabel="Вид подписок"
+								onchange={(v) => (singboxSubscriptionsLayoutMode = v)}
+							/>
+						{/snippet}
+					</TunnelToolbarViewRow>
+					<Button
+						variant="primary"
+						size="md"
+						onclick={() => openWizard('url')}
+						iconBefore={createIcon}
+					>
+						Добавить
+					</Button>
+				</div>
+			</div>
+			{/if}
+			{#if subscriptionsList.length === 0}
+				<div class="subscription-empty">
+					<div class="subscription-empty-title">Нет подписок</div>
+					<p class="subscription-empty-desc">
+						Добавьте подписку — мастер скачает список серверов и создаст selector-туннель.
+					</p>
+					<Button
+						variant="primary"
+						size="md"
+						onclick={() => openWizard('url')}
+						iconBefore={createIcon}
+					>
+						Добавить подписку
+					</Button>
+				</div>
+			{:else}
+				{#if !dashboardOn}
+					<div class="awg-summary-row">
+						<StatStrip>
+							<Stat
+								value={`${singboxSubscriptionsTrafficStats.activeCount}/${singboxSubscriptionsTrafficStats.count}`}
+								label={pluralForm(singboxSubscriptionsTrafficStats.activeCount, SUBSCRIPTION_WORDS)}
+								sub={formatRunningSub(
+									singboxSubscriptionsTrafficStats.activeCount,
+									singboxSubscriptionsTrafficStats.count,
+								)}
+							/>
+							<Stat
+								value={formatBytes(
+									singboxSubscriptionsTrafficStats.down + singboxSubscriptionsTrafficStats.up,
+								)}
+								label="Суммарный трафик"
+								sub={`↓ ${formatBytes(singboxSubscriptionsTrafficStats.down)} · ↑ ${formatBytes(singboxSubscriptionsTrafficStats.up)}`}
+							/>
+							<Stat
+								value={singboxSubscriptionsTrafficStats.avgDelayMs !== null
+									? `${singboxSubscriptionsTrafficStats.avgDelayMs} ms`
+									: '—'}
+								label="Средний delay"
+								sub={singboxSubscriptionsTrafficStats.delaySamples > 0
+									? `по ${singboxSubscriptionsTrafficStats.delaySamples} активным подпискам`
+									: 'нет активных замеров'}
+							/>
+							<Stat
+								value={singboxSubscriptionsTrafficStats.leaderBytes > 0
+									? formatBytes(singboxSubscriptionsTrafficStats.leaderBytes)
+									: '—'}
+								label="Лидер по трафику"
+								sub={singboxSubscriptionsTrafficStats.leaderBytes > 0
+									? `${singboxSubscriptionsTrafficStats.leaderName} · ${singboxSubscriptionsTrafficStats.leaderSharePct}% всего`
+									: '—'}
+							/>
+						</StatStrip>
+					</div>
+				{/if}
+				{#if effectiveSingboxSubscriptionsRenderMode === 'table'}
+				<div class="tunnel-table-wrap">
+					<table class="tunnel-data-table singbox-sub-table">
+						<colgroup>
+							<col class="col-delay" />
+							<col class="col-name" />
+							<col class="col-active" />
+							<col class="col-traffic" />
+							<col class="col-ping" />
+							<col class="col-actions" />
+						</colgroup>
+						<thead>
+							<tr>
+								<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'delay', $singboxSubscriptionTableSort.sortAsc)}>
+									<TableSortHeader label="Delay" sortKey={'delay'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
+								</th>
+								<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'label', $singboxSubscriptionTableSort.sortAsc)}>
+									<TableSortHeader label="Подписка" sortKey={'label'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
+								</th>
+								<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'active', $singboxSubscriptionTableSort.sortAsc)}>
+									<TableSortHeader label="Активный сервер" sortKey={'active'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
+								</th>
+								<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'traffic', $singboxSubscriptionTableSort.sortAsc)}>
+									<TableSortHeader label="Трафик" sortKey={'traffic'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
+								</th>
+								<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'ping', $singboxSubscriptionTableSort.sortAsc)}>
+									<TableSortHeader label="Ping" sortKey={'ping'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
+								</th>
+								<th class="col-actions">Действия</th>
+							</tr>
+						</thead>
+						<tbody>
+					{#if sortedFilteredSubscriptionsActiveCards.length > 0}
+						{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
+							<SubscriptionActiveCard
+								subscription={card.subscription}
+								activeMember={card.activeMember}
+								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+								autoDelayCheckDelayMs={i * 180}
+								layout="list"
+								renderMode="table"
+								ondetail={(tag) => openSingboxDetail(tag)}
+							/>
+						{/each}
+					{/if}
+					{#if sortedFilteredSubscriptionsListRows.length > 0}
+						{#if dashboardSectionsLayout}
+							<TunnelSectionHeader
+								variant="table-row"
+								title="Остановлено"
+								count={sortedFilteredSubscriptionsListRows.length}
+								countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
+								colspan={6}
+							/>
+						{:else}
+							<tr class="tunnel-section-row">
+								<td colspan="6">Остановлено · {sortedFilteredSubscriptionsListRows.length}</td>
+							</tr>
+						{/if}
+						{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
+							<SubscriptionCard
+								subscription={sub}
+								liveActiveMember={liveActives[sub.id] || null}
+								layout="list"
+								renderMode="table"
+								ondelete={requestSubscriptionDelete}
+								ondetail={(tag) => openSingboxDetail(tag)}
+							/>
+						{/each}
+					{/if}
+					{#if singboxSubscriptionsSearchEmpty}
+						<tr class="tunnel-empty-row">
+							<td colspan="6">Ничего не найдено</td>
+						</tr>
+					{/if}
+						</tbody>
+					</table>
+				</div>
+				{:else if effectiveSingboxSubscriptionsRenderMode === 'list-card'}
+				{#snippet subscriptionActiveListCards()}
+					{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
+						<SubscriptionActiveCard
+							subscription={card.subscription}
+							activeMember={card.activeMember}
+							autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+							autoDelayCheckDelayMs={i * 180}
+							layout="list"
+							renderMode="list-card"
+							ondetail={(tag) => openSingboxDetail(tag)}
+						/>
+					{/each}
+				{/snippet}
+				{#snippet subscriptionStoppedListCards()}
+					{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
+						<SubscriptionCard
+							subscription={sub}
+							liveActiveMember={liveActives[sub.id] || null}
+							layout="list"
+							renderMode="list-card"
+							ondelete={requestSubscriptionDelete}
+							ondetail={(tag) => openSingboxDetail(tag)}
+						/>
+					{/each}
+				{/snippet}
+				{#if dashboardOn}
+					{#if sortedFilteredSubscriptionsActiveCards.length > 0}
+						<div class="tunnel-grid tunnel-grid--list">
+							{@render subscriptionActiveListCards()}
+						</div>
+					{/if}
+					{#if sortedFilteredSubscriptionsListRows.length > 0}
+						{#if dashboardSectionsLayout}
+							<TunnelSectionHeader
+								nested
+								title="Остановлено"
+								count={sortedFilteredSubscriptionsListRows.length}
+								countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
+							/>
+						{/if}
+						<div class="tunnel-grid tunnel-grid--list">
+							{@render subscriptionStoppedListCards()}
+						</div>
+					{/if}
+				{:else}
+				<div class="tunnel-grid tunnel-grid--list">
+					{@render subscriptionActiveListCards()}
+					{@render subscriptionStoppedListCards()}
+				</div>
+				{/if}
+				{#if singboxSubscriptionsSearchEmpty}
+					<p class="tunnel-list-empty">Ничего не найдено</p>
+				{/if}
+				{:else}
+				{#if subscriptionsActiveCards.length > 0}
+					<div
+						class="tunnel-grid"
+						class:tunnel-grid--dense={effectiveSingboxSubscriptionsEffectiveLayout === 'dense'}
+						class:tunnel-grid--compact={effectiveSingboxSubscriptionsEffectiveLayout === 'compact'}
+					>
+						{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
+							<SubscriptionActiveCard
+								subscription={card.subscription}
+								activeMember={card.activeMember}
+								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
+								autoDelayCheckDelayMs={i * 180}
+								layout={effectiveSingboxSubscriptionsEffectiveLayout}
+								renderMode={effectiveSingboxSubscriptionsRenderMode}
+								ondetail={(tag) => openSingboxDetail(tag)}
+							/>
+						{/each}
+					</div>
+				{/if}
+				{#if sortedFilteredSubscriptionsListRows.length > 0}
+					{#snippet subscriptionStoppedGrid()}
+						<div
+							class="tunnel-grid"
+							class:tunnel-grid--dense={effectiveSingboxSubscriptionsEffectiveLayout === 'dense'}
+							class:tunnel-grid--compact={effectiveSingboxSubscriptionsEffectiveLayout === 'compact'}
+						>
+							{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
+								<SubscriptionCard
+									subscription={sub}
+									liveActiveMember={liveActives[sub.id] || null}
+									layout={effectiveSingboxSubscriptionsEffectiveLayout}
+									renderMode={effectiveSingboxSubscriptionsRenderMode}
+									ondelete={requestSubscriptionDelete}
+									ondetail={(tag) => openSingboxDetail(tag)}
+								/>
+							{/each}
+						</div>
+					{/snippet}
+					{#if dashboardSectionsLayout}
+						<TunnelSectionHeader
+							nested
+							title="Остановлено"
+							count={sortedFilteredSubscriptionsListRows.length}
+							countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
+						/>
+						{@render subscriptionStoppedGrid()}
+					{:else}
+						<div
+							class="external-section"
+							class:singbox-sub-inactive-section={sortedFilteredSubscriptionsActiveCards.length === 0}
+						>
+							<h2 class="section-title">Остановлено</h2>
+							{@render subscriptionStoppedGrid()}
+						</div>
+					{/if}
+				{/if}
+				{#if singboxSubscriptionsSearchEmpty}
+					<p class="tunnel-list-empty">Ничего не найдено</p>
+				{/if}
+				{/if}
+			{/if}
+			{#if !dashboardOn}
+				<SubscriptionGroupsSection subscriptions={subscriptionsList} />
+			{/if}
+		{/if}
+	{/if}
+
+
+<style>
+
+	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
+	   Движок вертикальный, поэтому на время активного drag сетка
+	   схлопывается в одну колонку — индексы вставки и индикатор
+	   становятся однозначными на любой плотности. ── */
+
+	/* Toolbar (count + actions row above the tunnel grid) */
+	.tunnels-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+	}
+
+	.tunnel-count {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+
+	.toolbar-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.toolbar-actions :global(.btn.size-md) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 32px;
+		min-height: 32px;
+		max-height: 32px;
+		padding-block: 0;
+	}
+
+	.toolbar-actions :global(.btn.variant-primary:hover:not(:disabled):not(.is-disabled)) {
+		background: transparent;
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+		filter: none;
+	}
+
+	.external-section {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border);
+	}
+
+	.section-title {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin-bottom: 1rem;
+	}
+
+	.subscription-empty {
+		padding: 3rem 1.5rem;
+		text-align: center;
+		border: 1px dashed var(--color-border);
+		border-radius: 6px;
+		margin-top: 0.5rem;
+	}
+
+	@media (max-width: 760px) {
+	.tunnels-toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
+	.toolbar-actions {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			align-items: stretch;
+			gap: 0.5rem;
+			width: 100%;
+		}
+	.toolbar-actions :global(.toolbar-view-row) {
+			grid-column: 1 / -1;
+		}
+	.toolbar-actions > :global(.btn) {
+			width: 100%;
+			min-height: 32px;
+		}
+	.toolbar-actions > :global(.btn:only-of-type) {
+			grid-column: 1 / -1;
+		}
+}
+</style>

--- a/frontend/src/lib/components/subscriptions/subscriptionVMs.ts
+++ b/frontend/src/lib/components/subscriptions/subscriptionVMs.ts
@@ -1,0 +1,32 @@
+// View-модели вкладок туннельной страницы, разделяемые секциями
+// (выделено при декомпозиции routes/+page.svelte).
+import type { Subscription, SubscriptionMember } from '$lib/types';
+
+export interface SubscriptionActiveCardVM {
+	subscription: Subscription;
+	activeMember: SubscriptionMember;
+}
+
+export interface SubscriptionsTrafficStats {
+	count: number;
+	activeCount: number;
+	inactiveCount: number;
+	down: number;
+	up: number;
+	avgDelayMs: number | null;
+	delaySamples: number;
+	leaderBytes: number;
+	leaderName: string;
+	leaderSharePct: number;
+}
+
+export interface SingboxTunnelListStats {
+	count: number;
+	running: number;
+	stopped: number;
+	down: number;
+	up: number;
+	avgDelayMs: number | null;
+	leaderBytes: number;
+	leaderName: string;
+}

--- a/frontend/src/lib/components/tunnels/AwgTunnelsTabSection.svelte
+++ b/frontend/src/lib/components/tunnels/AwgTunnelsTabSection.svelte
@@ -1,0 +1,1012 @@
+<script lang="ts">
+	// Вкладка «AWG» страницы туннелей — выделено из routes/+page.svelte
+	// (класс 2). Разметка перенесена дословно с заменой обращений к
+	// состоянию страницы на ctx.* — единый проп-контекст с live-геттерами
+	// (см. awgTabContext.ts). Сторы сортировки — прямым импортом.
+	import { StatStrip, Stat, LayoutViewToggle, Button, Badge, TableSortHeader, StatusDot, TrafficSparkline, StoreStatusBadge, Toggle } from '$lib/components/ui';
+	import { TunnelCard, ExternalTunnelCard, SystemTunnelCard, TunnelToolbarViewRow, AdoptTunnelDialog } from '$lib/components/tunnels';
+	import { EmptyState } from '$lib/components/layout';
+	import { awgTunnelTableSort } from '$lib/stores/tunnelTableSort';
+	import { formatBitRate, formatBytes } from '$lib/utils/format';
+	import { pluralForm, TUNNEL_WORDS } from '$lib/utils/pluralize';
+	import { ariaSort } from '$lib/utils/tunnelTableSort';
+	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+	import TunnelSectionHeader from '$lib/components/tunnels/TunnelSectionHeader.svelte';
+	import TunnelTitleRow from '$lib/components/tunnels/TunnelTitleRow.svelte';
+	import TunnelMetaText from '$lib/components/tunnels/TunnelMetaText.svelte';
+	import TunnelListTrafficCell from '$lib/components/tunnels/TunnelListTrafficCell.svelte';
+	import { formatRelativeTime, formatDuration } from '$lib/utils/format';
+	import { type AwgTunnelSortKey } from '$lib/stores/tunnelTableSort';
+	import { goto } from '$app/navigation';
+	import { tunnels } from '$lib/stores/tunnels';
+	import TunnelListActions from '$lib/components/ui/TunnelListActions.svelte';
+	import DefaultRouteBadge from '$lib/components/tunnels/DefaultRouteBadge.svelte';
+	import TunnelPingButton from '$lib/components/tunnels/TunnelPingButton.svelte';
+	import { secondsSince } from '$lib/utils/format';
+	import { awgManagedStatusDot } from '$lib/utils/statusDot';
+	import { awgPingStatusNote, awgShowConnectivityRow, awgRecoveringVisual, awgToggleTint } from '$lib/utils/awgPingStatus';
+	import { Eye, EyeOff, Upload, Download, Server } from 'lucide-svelte';
+	import type { AwgTabContext } from './awgTabContext';
+
+	let { ctx }: { ctx: AwgTabContext } = $props();
+</script>
+
+{#snippet createIcon()}
+	<CreateIcon />
+{/snippet}
+
+{#snippet exportIcon()}
+	<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+{/snippet}
+
+{#if (!ctx.dashboardOn || ctx.dashboardNothingAtAll) && ctx.awgList.length === 0 && ctx.systemList.length === 0}
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="ghost-terminal"
+	class:drag-over={ctx.dragOver}
+	ondrop={ctx.handleDrop}
+	ondragover={ctx.handleDragOver}
+	ondragleave={ctx.handleDragLeave}
+>
+	{#if ctx.dragOver}
+		<div class="drop-overlay">
+			<Upload size={40} strokeWidth={1.5} aria-hidden="true" />
+			<span class="drop-text">Отпустите для импорта</span>
+		</div>
+	{:else if ctx.importing}
+		<div class="drop-overlay">
+			<div class="spinner"></div>
+			<span class="drop-text">Импорт...</span>
+		</div>
+	{:else}
+		<div class="term-status">
+			<span class="term-prompt">$ awg status</span>
+			{#if ctx.statusLine}
+				<span class="term-info">{ctx.statusLine}</span>
+			{/if}
+		</div>
+
+		<div class="term-action-group">
+			<div class="term-drop-hint">
+				<Upload size={28} strokeWidth={1.5} aria-hidden="true" />
+				<span>Перетащите .conf сюда</span>
+			</div>
+
+			<div class="term-backend-selector">
+				<button
+					type="button"
+					class="term-backend-btn"
+					class:selected={ctx.selectedBackend === 'nativewg'}
+					class:disabled={ctx.sysInfo !== null && !ctx.sysInfo.backendAvailability?.nativewg}
+					disabled={ctx.sysInfo !== null && !ctx.sysInfo.backendAvailability?.nativewg}
+					title={ctx.nativewgHint}
+					onclick={() => ctx.selectedBackend = 'nativewg'}
+				>
+					NativeWG
+				</button>
+				<button
+					type="button"
+					class="term-backend-btn"
+					class:selected={ctx.selectedBackend === 'kernel'}
+					class:disabled={ctx.sysInfo !== null && !ctx.sysInfo.backendAvailability?.kernel}
+					disabled={ctx.sysInfo !== null && !ctx.sysInfo.backendAvailability?.kernel}
+					onclick={() => ctx.selectedBackend = 'kernel'}
+				>
+					Kernel
+				</button>
+			</div>
+			{#if ctx.nativewgHint}
+				<p class="term-backend-hint">{ctx.nativewgHint}</p>
+			{/if}
+
+			<div class="term-commands">
+				{#if ctx.externalList.length > 0}
+					<span class="term-found">
+						найдено {ctx.externalList.length} внешних интерфейс{ctx.externalList.length === 1 ? '' : 'а'}
+					</span>
+					<button class="term-cmd term-cmd-primary" onclick={() => {
+						ctx.adoptingInterface = ctx.externalList[0].interfaceName;
+						ctx.adoptDialogOpen = true;
+					}}>
+						<span class="term-arrow">{'>'}</span> подхватить интерфейсы
+					</button>
+				{/if}
+				<button class="term-cmd" onclick={() => ctx.fileInput?.click()}>
+					<span class="term-arrow">{'>'}</span> импортировать файл
+				</button>
+				<button class="term-cmd" onclick={() => goto('/tunnels/new?tab=vpn')}>
+					<span class="term-arrow">{'>'}</span> импортировать ссылку
+				</button>
+			</div>
+		</div>
+
+		<input
+			type="file"
+			accept=".conf"
+			bind:this={ctx.fileInput}
+			onchange={ctx.handleFileSelect}
+			style="display: none"
+		/>
+	{/if}
+</div>
+
+<div class="info-card">
+	<h3 class="info-title">Об AmneziaWG</h3>
+	<p class="info-section-desc">
+		Форк WireGuard с обфускацией трафика. Три поколения протокола:
+	</p>
+	<div class="info-versions">
+		<div class="info-version">
+			<Badge variant="accent" size="sm" mono>AWG 1.0</Badge>
+			<span class="info-version-desc">Базовая обфускация: модификация заголовков (H1–H4), junk-пакеты (Jc/Jmin/Jmax), размеры сообщений (S1–S2).</span>
+		</div>
+		<div class="info-version">
+			<Badge variant="info" size="sm" mono>AWG 1.5</Badge>
+			<span class="info-version-desc">Мимикрия протоколов: initiation-пакеты (I1–I5) маскируют соединение под QUIC, DTLS, STUN, DNS.</span>
+		</div>
+		<div class="info-version">
+			<Badge variant="success" size="sm" mono>AWG 2.0</Badge>
+			<span class="info-version-desc">Рандомизация заголовков: H1–H4 задаются диапазонами, генерируются при каждом хэндшейке.</span>
+		</div>
+	</div>
+	<p class="info-text info-kernel">
+		Работает через <strong>модуль ядра</strong> — трафик обрабатывается напрямую в ядре Linux, что снижает нагрузку на CPU.
+	</p>
+</div>
+
+{:else}
+	{@const totalCount = ctx.awgSummaryTotal}
+	{#if !ctx.dashboardOn}
+	<div class="tunnels-toolbar">
+		<div class="count-group">
+			<span class="tunnel-count">{totalCount} {pluralForm(totalCount, TUNNEL_WORDS)}</span>
+			<StoreStatusBadge store={tunnels} />
+		</div>
+		<div class="toolbar-actions">
+			<TunnelToolbarViewRow
+				sourceRowCount={ctx.awgSourceRowCount}
+				showViewToggle={ctx.showAwgViewModeSwitch}
+				searchQuery={ctx.awgListSearchQuery}
+				onSearchChange={(value) => (ctx.awgListSearchQuery = value)}
+			>
+				{#snippet viewToggle()}
+					<LayoutViewToggle
+						value={ctx.awgViewMode}
+						denseValue="cards"
+						ariaLabel="Вид туннелей"
+						onchange={(mode) => (ctx.awgViewMode = mode)}
+					/>
+				{/snippet}
+			</TunnelToolbarViewRow>
+			<Button variant="secondary" size="md" onclick={ctx.handleExportAll} disabled={ctx.exporting} iconBefore={exportIcon}>
+				Экспорт
+			</Button>
+			<Button variant="primary" size="md" onclick={() => goto('/tunnels/new')} iconBefore={createIcon}>
+				Создать
+			</Button>
+		</div>
+	</div>
+	{/if}
+	{#if !ctx.dashboardOn}
+		<div class="awg-summary-row">
+			<StatStrip>
+				<Stat
+					value={`${ctx.awgSummaryActive}/${ctx.awgSummaryTotal}`}
+					label={pluralForm(ctx.awgSummaryActive, TUNNEL_WORDS)}
+					sub={`AWG ${ctx.awgList.length} · system ${ctx.visibleSystemList.length} · external ${ctx.externalList.length}`}
+				/>
+				<Stat
+					value={formatBitRate(ctx.awgSummaryPeak.rate)}
+					label="Пиковая скорость"
+					sub={ctx.awgSummaryPeak.name}
+				/>
+				<Stat
+					value={formatBytes(ctx.awgSummaryRx + ctx.awgSummaryTx)}
+					label="Суммарный обмен"
+					sub={`↓ ${formatBytes(ctx.awgSummaryRx)} · ↑ ${formatBytes(ctx.awgSummaryTx)}`}
+				/>
+				<Stat
+					value={ctx.awgTrafficLeader.bytes > 0 ? formatBytes(ctx.awgTrafficLeader.bytes) : '—'}
+					label="Лидер по трафику"
+					sub={ctx.awgTrafficLeader.name}
+				/>
+			</StatStrip>
+		</div>
+	{/if}
+	{#if ctx.effectiveAwgRenderMode === 'table'}
+		<div class="awg-list-table">
+			<div class="awg-list-table-track">
+			<div class="awg-list-row awg-list-row--head">
+				<span></span>
+				<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'name', $awgTunnelTableSort.sortAsc)}>
+					<TableSortHeader
+						label="Туннель"
+						sortKey={'name'}
+						activeSortKey={$awgTunnelTableSort.sortBy}
+						sortAsc={$awgTunnelTableSort.sortAsc}
+						onchange={(key) => ctx.handleAwgSortChange(key as AwgTunnelSortKey)}
+					/>
+				</span>
+				<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'status', $awgTunnelTableSort.sortAsc)}>
+					<TableSortHeader
+						label="Статус"
+						sortKey={'status'}
+						activeSortKey={$awgTunnelTableSort.sortBy}
+						sortAsc={$awgTunnelTableSort.sortAsc}
+						onchange={(key) => ctx.handleAwgSortChange(key as AwgTunnelSortKey)}
+					/>
+				</span>
+				<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'endpoint', $awgTunnelTableSort.sortAsc)}>
+					<TableSortHeader
+						label="Endpoint"
+						sortKey={'endpoint'}
+						activeSortKey={$awgTunnelTableSort.sortBy}
+						sortAsc={$awgTunnelTableSort.sortAsc}
+						onchange={(key) => ctx.handleAwgSortChange(key as AwgTunnelSortKey)}
+					/>
+				</span>
+				<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'traffic', $awgTunnelTableSort.sortAsc)}>
+					<TableSortHeader
+						label="Трафик"
+						sortKey={'traffic'}
+						activeSortKey={$awgTunnelTableSort.sortBy}
+						sortAsc={$awgTunnelTableSort.sortAsc}
+						onchange={(key) => ctx.handleAwgSortChange(key as AwgTunnelSortKey)}
+					/>
+				</span>
+				<span class="awg-list-head-actions">Действия</span>
+			</div>
+
+		{#each ctx.sortedFilteredAwgList as tunnel (tunnel.id)}
+			{@const connectivity = ctx.awgConnectivityMap.get(tunnel.id)}
+			{@const isEndpointShown = ctx.endpointVisible('managed', tunnel.id)}
+			{@const rate = ctx.latestRate(tunnel.id)}
+			{@const spark = ctx.sparklineSeries(tunnel.id)}
+			{@const isActive = ctx.isManagedTunnelOn(tunnel)}
+			{@const checkDisabled = (tunnel.connectivityCheck?.method ?? 'http') === 'disabled'}
+			{@const connState = !isActive ? 'idle'
+				: connectivity === undefined ? 'checking'
+				: connectivity.connected ? 'connected' : 'disconnected'}
+			{@const statusDot = awgManagedStatusDot(tunnel, connectivity)}
+			{@const pingStatusNote = awgPingStatusNote(tunnel, 'short')}
+			{@const showPing = ctx.showManagedPing(tunnel, connectivity) || pingStatusNote !== null}
+			{@const showConnectivityRow = awgShowConnectivityRow(tunnel.status)}
+				<div class="awg-list-row">
+				<div class="awg-list-cell awg-list-cell-toggle" data-label="Старт">
+					<Toggle
+						checked={ctx.isManagedTunnelOn(tunnel)}
+						size="sm"
+						variant="flip"
+						tint={awgToggleTint(tunnel, connectivity)}
+						disabled={(ctx.toggleLoading[tunnel.id] ?? false) || tunnel.hasAddressConflict === true}
+						onchange={() => ctx.handleToggleOnOff(tunnel.id)}
+					/>
+				</div>
+					<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
+						<div class="tunnel-list-name-stack">
+							<TunnelTitleRow
+								title={tunnel.name}
+								showDot={false}
+								onTitleClick={() => ctx.openDetail(tunnel.id)}
+							>
+								{#snippet badges()}
+									<DefaultRouteBadge defaultRoute={tunnel.defaultRoute} />
+									{#if tunnel.backend}
+										<span class="awg-inline-badge">{tunnel.backend}</span>
+									{/if}
+									{#if tunnel.awgVersion}
+										<span class="awg-inline-badge awg-inline-badge--muted">{tunnel.awgVersion}</span>
+									{/if}
+								{/snippet}
+							</TunnelTitleRow>
+							<TunnelMetaText>
+								{tunnel.address || '—'}
+								<span class="meta-dot" aria-hidden="true">·</span>
+								{tunnel.interfaceName || tunnel.id}
+								<span class="meta-dot" aria-hidden="true">·</span>
+								MTU {tunnel.mtu ?? '—'}
+							</TunnelMetaText>
+							<TunnelMetaText mono>
+								Uptime {tunnel.startedAt ? formatDuration(secondsSince(tunnel.startedAt)) : '—'}
+							</TunnelMetaText>
+						</div>
+					</div>
+					<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
+						<div class="awg-list-status-stack">
+							<div class="awg-list-status-line">
+							<StatusDot
+								variant={statusDot.variant}
+								pulse={statusDot.pulse}
+								ariaLabel={statusDot.label}
+							/>
+							<span class="awg-list-status-text">{statusDot.label}</span>
+							</div>
+							<div class="awg-list-sub awg-list-handshake">
+								Handshake {tunnel.lastHandshake ? formatRelativeTime(tunnel.lastHandshake) : '—'}
+							</div>
+							{#if tunnel.hasAddressConflict}
+						<div class="awg-list-sub awg-list-sub--error">Дублирует адрес уже запущенного туннеля</div>
+					{:else if showConnectivityRow}
+						<div
+							class="awg-list-connectivity-row"
+							class:recovering={awgRecoveringVisual(tunnel)}
+						>
+							{#if showPing}
+								<TunnelPingButton
+									layout="list"
+									connectivity={connState}
+									latencyMs={connectivity?.latency ?? null}
+									statusNote={pingStatusNote?.text}
+									statusNoteTone={pingStatusNote?.tone}
+									checking={ctx.pingChecking[tunnel.id] ?? false}
+									onclick={() => ctx.checkPing(tunnel.id)}
+								/>
+							{/if}
+							<button
+								type="button"
+								class="awg-connectivity-gear"
+								onclick={() => ctx.openConnectivitySettings(tunnel)}
+								title="Настройки проверки связности"
+							>
+								<svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+									<path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+								</svg>
+							</button>
+						</div>
+					{:else if isActive && checkDisabled}
+						<div class="awg-list-sub">Проверка связи выключена</div>
+					{/if}
+					</div>
+					</div>
+					<div class="awg-list-cell" data-label="Endpoint">
+						<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
+							<span class="awg-endpoint-value" title={isEndpointShown ? ctx.endpointHost(tunnel.endpoint) : ''}>
+								{#if tunnel.endpoint}
+									{isEndpointShown ? ctx.endpointHost(tunnel.endpoint) : '•••••••••'}
+								{:else}
+									—
+								{/if}
+							</span>
+							{#if tunnel.endpoint}
+								<button
+									type="button"
+									class="awg-endpoint-eye"
+									onclick={() => ctx.toggleEndpointVisible('managed', tunnel.id)}
+									title={isEndpointShown ? 'Скрыть' : 'Показать'}
+								>
+									{#if isEndpointShown}
+										<Eye size={14} aria-hidden="true" />
+									{:else}
+										<EyeOff size={14} aria-hidden="true" />
+									{/if}
+								</button>
+							{/if}
+							{#if ctx.endpointPort(tunnel.endpoint)}
+								<span class="awg-endpoint-port">:{ctx.endpointPort(tunnel.endpoint)}</span>
+							{/if}
+						</div>
+						<div class="awg-list-sub">{ctx.managedRouteMeta(tunnel)}</div>
+					</div>
+					<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
+						<TunnelListTrafficCell
+							rxRate={rate.rx}
+							txRate={rate.tx}
+							rxData={spark.rx}
+							txData={spark.tx}
+							onclick={() => ctx.openDetail(tunnel.id)}
+							title="Открыть детали туннеля"
+						/>
+					</div>
+					<div class="awg-list-cell awg-list-cell-actions tunnel-list-cell--actions" data-label="Действия">
+						<TunnelListActions
+							editHref="/tunnels/{tunnel.id}"
+							editTitle="Изменить туннель «{tunnel.name}»"
+							onTest={() => ctx.openAwgDiagnostics(tunnel.id, tunnel.name)}
+							testTitle="Тест туннеля «{tunnel.name}»"
+							onDelete={() => ctx.requestDelete(tunnel.id)}
+							deleteTitle="Удалить туннель «{tunnel.name}»"
+							deleting={ctx.deleteLoading[tunnel.id] ?? false}
+						/>
+					</div>
+				</div>
+			{/each}
+
+			{#if ctx.sortedFilteredSystemList.length > 0}
+				{#if ctx.dashboardSectionsLayout}
+					<TunnelSectionHeader
+						nested
+						title="Системные"
+						count={ctx.sortedFilteredSystemList.length}
+						countLabel={pluralForm(ctx.sortedFilteredSystemList.length, TUNNEL_WORDS)}
+					/>
+				{:else}
+					<div class="awg-list-row awg-list-row--section">
+						<div class="awg-list-section-title">Системные · {ctx.sortedFilteredSystemList.length}</div>
+					</div>
+				{/if}
+				{#each ctx.sortedFilteredSystemList as tunnel (tunnel.id)}
+					{@const isEndpointShown = ctx.endpointVisible('system', tunnel.id)}
+					{@const rate = ctx.latestRate(tunnel.id)}
+					{@const spark = ctx.sparklineSeries(tunnel.id)}
+					<div class="awg-list-row">
+						<div class="awg-list-cell awg-list-cell-toggle" data-label="Тип">
+							<span class="awg-row-placeholder">SYS</span>
+						</div>
+						<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
+							<div class="tunnel-list-name-stack">
+								<TunnelTitleRow
+									title={tunnel.description || tunnel.id}
+									showDot={false}
+									onTitleClick={() => ctx.openDetail(tunnel.id)}
+								>
+									{#snippet badges()}
+										<span class="awg-inline-badge awg-inline-badge--muted">system</span>
+									{/snippet}
+								</TunnelTitleRow>
+								<TunnelMetaText mono>
+									{tunnel.interfaceName}
+									{#if tunnel.address}
+										<span class="meta-dot" aria-hidden="true">·</span>
+										{tunnel.address}
+									{/if}
+									<span class="meta-dot" aria-hidden="true">·</span>
+									MTU {tunnel.mtu}
+								</TunnelMetaText>
+								<TunnelMetaText mono>
+									Uptime {tunnel.status === 'up' && tunnel.uptime ? formatDuration(tunnel.uptime) : '—'}
+								</TunnelMetaText>
+							</div>
+						</div>
+						<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
+							<div class="awg-list-status-line">
+								<StatusDot
+									variant={ctx.systemStatusVariant(tunnel)}
+									ariaLabel={ctx.systemStatusLabel(tunnel)}
+								/>
+								<span class="awg-list-status-text">{ctx.systemStatusLabel(tunnel)}</span>
+							</div>
+							<div class="awg-list-sub awg-list-handshake">
+								Handshake {tunnel.peer?.lastHandshake ? formatRelativeTime(tunnel.peer.lastHandshake) : '—'}
+							</div>
+							<div class="awg-list-sub">{tunnel.peer?.via || 'Маршрут не определён'}</div>
+						</div>
+						<div class="awg-list-cell" data-label="Endpoint">
+						<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
+							<span class="awg-endpoint-value" title={isEndpointShown ? ctx.endpointHost(tunnel.peer?.endpoint) : ''}>
+								{#if tunnel.peer?.endpoint}
+									{isEndpointShown ? ctx.endpointHost(tunnel.peer.endpoint) : '•••••••••'}
+								{:else}
+									—
+								{/if}
+							</span>
+							{#if tunnel.peer?.endpoint}
+								<button
+									type="button"
+									class="awg-endpoint-eye"
+									onclick={() => ctx.toggleEndpointVisible('system', tunnel.id)}
+									title={isEndpointShown ? 'Скрыть' : 'Показать'}
+								>
+									{#if isEndpointShown}
+										<Eye size={14} aria-hidden="true" />
+									{:else}
+										<EyeOff size={14} aria-hidden="true" />
+									{/if}
+								</button>
+							{/if}
+							{#if ctx.endpointPort(tunnel.peer?.endpoint)}
+								<span class="awg-endpoint-port">:{ctx.endpointPort(tunnel.peer?.endpoint)}</span>
+							{/if}
+						</div>
+							<div class="awg-list-sub">{tunnel.address || '—'}</div>
+						</div>
+						<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
+							<TunnelListTrafficCell
+								rxRate={rate.rx}
+								txRate={rate.tx}
+								rxData={spark.rx}
+								txData={spark.tx}
+								onclick={() => ctx.openDetail(tunnel.id)}
+								title="Открыть детали туннеля"
+							/>
+						</div>
+						<div class="awg-list-cell awg-list-cell-actions tunnel-list-cell--actions" data-label="Действия">
+							<TunnelListActions
+								editHref="/system-tunnels/{tunnel.id}"
+								editTitle="Изменить туннель «{tunnel.description || tunnel.id}»"
+								onTest={() => ctx.openAwgDiagnostics(tunnel.id, tunnel.description || tunnel.id, 'system')}
+								testTitle="Тест туннеля «{tunnel.description || tunnel.id}»"
+							>
+								{#snippet extra()}
+									<button
+										type="button"
+										class="tunnel-list-actions__btn tunnel-list-actions__btn--primary"
+										title="Перенести туннель «{tunnel.description || tunnel.id}» в серверы"
+										aria-label="Перенести туннель «{tunnel.description || tunnel.id}» в серверы"
+										onclick={() => ctx.markAsServer(tunnel.id)}
+									>
+										<Server size={14} aria-hidden="true" />
+									</button>
+								{/snippet}
+							</TunnelListActions>
+						</div>
+					</div>
+				{/each}
+			{/if}
+
+			{#if ctx.sortedFilteredExternalList.length > 0}
+				{#if ctx.dashboardSectionsLayout}
+					<TunnelSectionHeader
+						nested
+						title="Внешние"
+						count={ctx.sortedFilteredExternalList.length}
+						countLabel={pluralForm(ctx.sortedFilteredExternalList.length, TUNNEL_WORDS)}
+					/>
+				{:else}
+					<div class="awg-list-row awg-list-row--section">
+						<div class="awg-list-section-title">Внешние · {ctx.sortedFilteredExternalList.length}</div>
+					</div>
+				{/if}
+				{#each ctx.sortedFilteredExternalList as tunnel (tunnel.interfaceName)}
+					{@const isEndpointShown = ctx.endpointVisible('external', tunnel.interfaceName)}
+					<div class="awg-list-row">
+						<div class="awg-list-cell awg-list-cell-toggle" data-label="Тип">
+							<span class="awg-row-placeholder">ext</span>
+						</div>
+						<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
+							<div class="awg-list-name-line">
+								<span class="awg-list-name-static">{tunnel.interfaceName}</span>
+								<span class="awg-inline-badge awg-inline-badge--muted">external</span>
+								{#if tunnel.isAWG}
+									<span class="awg-inline-badge">AWG</span>
+								{/if}
+							</div>
+							<div class="awg-list-sub">
+								{#if tunnel.publicKey}
+									{tunnel.publicKey.slice(0, 16)}…
+									<span class="awg-list-dot">·</span>
+								{/if}
+								#{tunnel.tunnelNumber}
+							</div>
+						</div>
+						<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
+							<div class="awg-list-status-line">
+								<StatusDot
+									variant={ctx.externalStatusVariant(tunnel)}
+									ariaLabel={ctx.externalStatusLabel(tunnel)}
+								/>
+								<span class="awg-list-status-text">{ctx.externalStatusLabel(tunnel)}</span>
+							</div>
+							<div class="awg-list-sub awg-list-handshake">
+								Handshake {tunnel.lastHandshake ? formatRelativeTime(tunnel.lastHandshake) : '—'}
+							</div>
+							<div class="awg-list-sub">Не управляется AWG Manager</div>
+						</div>
+						<div class="awg-list-cell" data-label="Endpoint">
+							<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
+								<span class="awg-endpoint-value" title={isEndpointShown ? ctx.endpointHost(tunnel.endpoint) : ''}>
+									{#if tunnel.endpoint}
+										{isEndpointShown ? ctx.endpointHost(tunnel.endpoint) : '•••••••••'}
+									{:else}
+										—
+									{/if}
+								</span>
+								{#if tunnel.endpoint}
+									<button
+										type="button"
+										class="awg-endpoint-eye"
+										onclick={() => ctx.toggleEndpointVisible('external', tunnel.interfaceName)}
+										title={isEndpointShown ? 'Скрыть' : 'Показать'}
+									>
+										{#if isEndpointShown}
+											<Eye size={14} aria-hidden="true" />
+										{:else}
+											<EyeOff size={14} aria-hidden="true" />
+										{/if}
+									</button>
+								{/if}
+								{#if ctx.endpointPort(tunnel.endpoint)}
+									<span class="awg-endpoint-port">:{ctx.endpointPort(tunnel.endpoint)}</span>
+								{/if}
+							</div>
+							<div class="awg-list-sub">WG интерфейс</div>
+						</div>
+						<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
+							<div class="awg-list-rate-stack awg-list-mono">
+								<div class="traffic-rate rx">↓ {formatBytes(tunnel.rxBytes)}</div>
+								<TrafficSparkline rxData={[]} txData={[]} responsive height={18} />
+								<div class="traffic-rate tx">↑ {formatBytes(tunnel.txBytes)}</div>
+							</div>
+						</div>
+						<div class="awg-list-cell awg-list-cell-actions" data-label="Действия">
+							<Button variant="primary" size="sm" onclick={() => ctx.handleAdoptClick(tunnel.interfaceName)}>
+								Взять под управление
+							</Button>
+						</div>
+					</div>
+				{/each}
+			{/if}
+			{#if ctx.awgSearchEmpty}
+				<div class="awg-list-row awg-list-row--section">
+					<div class="awg-list-section-title">Ничего не найдено</div>
+				</div>
+			{/if}
+			</div>
+		</div>
+	{:else}
+		{@const awgGridView = ctx.effectiveAwgRenderMode === 'list-card' ? 'list' : ctx.effectiveAwgCardViewMode}
+		<div
+			class="tunnel-grid"
+			class:tunnel-grid--list={ctx.effectiveAwgRenderMode === 'list-card'}
+			class:tunnel-grid--dense={ctx.effectiveAwgRenderMode !== 'list-card' && ctx.effectiveAwgEffectiveViewMode === 'cards'}
+			class:tunnel-grid--compact={ctx.effectiveAwgRenderMode !== 'list-card' && ctx.effectiveAwgEffectiveViewMode === 'compact'}
+		>
+			{#each ctx.sortedFilteredAwgList as tunnel, i (tunnel.id)}
+				<TunnelCard
+					{tunnel}
+					view={awgGridView}
+					toggleLoading={ctx.toggleLoading[tunnel.id] ?? false}
+					deleteLoading={ctx.deleteLoading[tunnel.id] ?? false}
+					autoConnectivityNonce={ctx.awgAutoConnectivityNonce}
+					autoConnectivityDelayMs={i * 180}
+					onToggleOnOff={() => ctx.handleToggleOnOff(tunnel.id)}
+					ondelete={() => ctx.requestDelete(tunnel.id)}
+					ondetail={(id) => ctx.openDetail(id)}
+				/>
+			{/each}
+			{#each ctx.sortedFilteredSystemList as tunnel (tunnel.id)}
+				<SystemTunnelCard
+					{tunnel}
+					view={awgGridView}
+					onMarkServer={ctx.markAsServer}
+					ondetail={(id) => ctx.openDetail(id)}
+					ontest={(id, name) => ctx.openAwgDiagnostics(id, name, 'system')}
+				/>
+			{/each}
+		</div>
+
+		{#if ctx.sortedFilteredExternalList.length > 0}
+			<div
+				class:external-section={!ctx.dashboardSectionsLayout}
+			>
+				{#if ctx.dashboardSectionsLayout}
+					<TunnelSectionHeader
+						nested
+						title="Внешние"
+						count={ctx.sortedFilteredExternalList.length}
+						countLabel={pluralForm(ctx.sortedFilteredExternalList.length, TUNNEL_WORDS)}
+					/>
+				{:else}
+					<h2 class="section-title">Внешние туннели</h2>
+				{/if}
+				<div
+					class="tunnel-grid"
+					class:tunnel-grid--list={ctx.effectiveAwgRenderMode === 'list-card'}
+					class:tunnel-grid--dense={ctx.effectiveAwgRenderMode !== 'list-card' && ctx.effectiveAwgEffectiveViewMode === 'cards'}
+					class:tunnel-grid--compact={ctx.effectiveAwgRenderMode !== 'list-card' && ctx.effectiveAwgEffectiveViewMode === 'compact'}
+				>
+					{#each ctx.sortedFilteredExternalList as extTunnel (extTunnel.interfaceName)}
+						<ExternalTunnelCard
+							tunnel={extTunnel}
+							view={awgGridView}
+							onadopt={(name) => ctx.handleAdoptClick(name)}
+						/>
+					{/each}
+				</div>
+			</div>
+		{/if}
+		{#if ctx.awgSearchEmpty}
+			<p class="tunnel-list-empty">Ничего не найдено</p>
+		{/if}
+	{/if}
+{/if}
+
+<style>
+
+	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
+	   Движок вертикальный, поэтому на время активного drag сетка
+	   схлопывается в одну колонку — индексы вставки и индикатор
+	   становятся однозначными на любой плотности. ── */
+
+	/* Toolbar (count + actions row above the tunnel grid) */
+	.tunnels-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+	}
+
+	.tunnel-count {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+
+	.count-group {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.toolbar-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.toolbar-actions :global(.btn.size-md) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 32px;
+		min-height: 32px;
+		max-height: 32px;
+		padding-block: 0;
+	}
+
+	.toolbar-actions :global(.btn.variant-primary:hover:not(:disabled):not(.is-disabled)) {
+		background: transparent;
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+		filter: none;
+	}
+
+	/* Empty-state ghost terminal — page-specific */
+	.ghost-terminal {
+		margin: 3rem 0;
+		border: 2px dashed var(--color-border);
+		border-radius: var(--radius);
+		padding: 2rem 2rem 1.5rem;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.5rem;
+		transition: border-color var(--t-fast) ease, background var(--t-fast) ease;
+	}
+
+	.ghost-terminal.drag-over {
+		border-color: var(--color-accent);
+		border-style: solid;
+		background: var(--color-accent-tint);
+	}
+
+	.term-status {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.25rem;
+		font-family: var(--font-mono);
+	}
+
+	.term-prompt {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+
+	.term-info {
+		font-size: 0.75rem;
+		color: var(--color-text-muted);
+		opacity: 0.7;
+	}
+
+	.term-action-group {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.5rem;
+	}
+
+	.term-drop-hint {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		color: var(--color-accent);
+		font-size: 1.0625rem;
+		font-weight: 500;
+	}
+
+	.term-drop-hint :global(svg) {
+		flex-shrink: 0;
+		opacity: 0.8;
+	}
+
+	.term-commands {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.125rem;
+		font-family: var(--font-mono);
+	}
+
+	.term-found {
+		font-size: 0.8125rem;
+		color: var(--color-accent);
+		margin-bottom: 0.375rem;
+	}
+
+	.term-cmd {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		background: none;
+		border: none;
+		color: var(--color-text-secondary);
+		font-family: inherit;
+		font-size: 0.875rem;
+		padding: 0.375rem 0.5rem;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		transition: color var(--t-fast) ease, background var(--t-fast) ease;
+		text-decoration: none;
+	}
+
+	.term-cmd:hover {
+		color: var(--color-text-primary);
+		background: var(--color-bg-hover);
+	}
+
+	.term-cmd-primary {
+		color: var(--color-accent);
+	}
+
+	.term-cmd-primary:hover {
+		color: var(--color-accent-hover);
+	}
+
+	.term-arrow {
+		color: var(--color-text-muted);
+	}
+
+	/* Backend selector — chip-like toggles for nativewg/kernel */
+	.term-backend-selector {
+		display: flex;
+		gap: 8px;
+	}
+
+	.term-backend-btn {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		padding: 0.375rem 1rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		transition: border-color var(--t-fast) ease, color var(--t-fast) ease, background var(--t-fast) ease;
+	}
+
+	.term-backend-btn:hover:not(.disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-text-secondary);
+	}
+
+	.term-backend-btn.selected {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+		background: var(--color-accent-tint);
+	}
+
+	.term-backend-btn.disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.term-backend-hint {
+		margin: 8px 0 0;
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		line-height: 1.4;
+		color: var(--color-text-muted);
+	}
+
+	/* Drag-over / importing overlays */
+	.drop-overlay {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 2rem 0;
+		color: var(--color-accent);
+	}
+
+	.drop-text {
+		font-size: 1.0625rem;
+		font-weight: 500;
+	}
+
+	/* "About AmneziaWG / Sing-box" info card — page-specific */
+	.info-card {
+		border-left: 3px solid var(--color-accent);
+		background: var(--color-bg-secondary);
+		border-radius: 0 var(--radius) var(--radius) 0;
+		padding: 1.25rem 1.5rem;
+		margin-top: 1.5rem;
+	}
+
+	.info-title {
+		font-size: 1rem;
+		font-weight: 600;
+		margin-bottom: 0.75rem;
+	}
+
+	.info-text {
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		line-height: 1.6;
+		margin: 0;
+	}
+
+	.info-section-desc {
+		font-size: 0.85rem;
+		color: var(--color-text-muted);
+		margin: 0 0 0.75rem 0;
+	}
+
+	.info-versions {
+		display: flex;
+		flex-direction: column;
+		gap: 0.625rem;
+		margin: 0.75rem 0;
+	}
+
+	.info-version {
+		display: flex;
+		gap: 0.75rem;
+		align-items: baseline;
+	}
+
+	.info-version-desc {
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		line-height: 1.5;
+	}
+
+	.info-kernel {
+		margin-top: 0.75rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid var(--color-border);
+	}
+
+	.info-kernel strong {
+		color: var(--color-text-primary);
+	}
+
+	.external-section {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border);
+	}
+
+	.section-title {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin-bottom: 1rem;
+	}
+
+	@media (max-width: 760px) {
+	.tunnels-toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
+	.toolbar-actions {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			align-items: stretch;
+			gap: 0.5rem;
+			width: 100%;
+		}
+	.toolbar-actions :global(.toolbar-view-row) {
+			grid-column: 1 / -1;
+		}
+	.toolbar-actions > :global(.btn) {
+			width: 100%;
+			min-height: 32px;
+		}
+	.toolbar-actions > :global(.btn:only-of-type) {
+			grid-column: 1 / -1;
+		}
+}
+</style>

--- a/frontend/src/lib/components/tunnels/AwgTunnelsTabSection.svelte
+++ b/frontend/src/lib/components/tunnels/AwgTunnelsTabSection.svelte
@@ -36,7 +36,7 @@
 {/snippet}
 
 {#snippet exportIcon()}
-	<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+	<Download size={14} strokeWidth={2} aria-hidden="true" />
 {/snippet}
 
 {#if (!ctx.dashboardOn || ctx.dashboardNothingAtAll) && ctx.awgList.length === 0 && ctx.systemList.length === 0}

--- a/frontend/src/lib/components/tunnels/awgTabContext.ts
+++ b/frontend/src/lib/components/tunnels/awgTabContext.ts
@@ -1,0 +1,86 @@
+// Контекст вкладки AWG страницы туннелей (класс 2 декомпозиции
+// +page.svelte). Страница собирает объект с live-геттерами поверх своих
+// $state/$derived и передаёт одним пропом в AwgTunnelsTabSection — чтение
+// геттера в шаблоне секции отслеживает исходную реактивность, запись в
+// сеттеры мутирует состояние страницы.
+import type { TunnelListItem, SystemTunnel, ExternalTunnel, SystemInfo } from '$lib/types';
+import type { AwgTunnelViewMode } from '$lib/components/ui/layoutViewToggle';
+import type { AwgTunnelSortKey } from '$lib/stores/tunnelTableSort';
+import type { TunnelRenderMode } from '$lib/constants/singboxLayout';
+
+export type EndpointScope = 'managed' | 'system' | 'external';
+
+export interface AwgTabContext {
+	// --- derived (только чтение) ---
+	readonly awgList: TunnelListItem[];
+	readonly systemList: SystemTunnel[];
+	readonly visibleSystemList: SystemTunnel[];
+	readonly externalList: ExternalTunnel[];
+	readonly sortedFilteredAwgList: TunnelListItem[];
+	readonly sortedFilteredSystemList: SystemTunnel[];
+	readonly sortedFilteredExternalList: ExternalTunnel[];
+	readonly awgConnectivityMap: Map<string, { connected: boolean; latency: number | null }>;
+	readonly statusLine: string;
+	readonly sysInfo: SystemInfo | null;
+	readonly awgSummaryActive: number;
+	readonly awgSummaryPeak: { rate: number; name: string };
+	readonly awgSummaryRx: number;
+	readonly awgSummaryTx: number;
+	readonly awgSummaryTotal: number;
+	readonly awgTrafficLeader: { bytes: number; name: string };
+	readonly nativewgHint: string;
+	readonly dashboardOn: boolean;
+	readonly dashboardSectionsLayout: boolean;
+	readonly dashboardNothingAtAll: boolean;
+	readonly awgSearchEmpty: boolean;
+	readonly awgSourceRowCount: number;
+	readonly showAwgViewModeSwitch: boolean;
+	readonly effectiveAwgCardViewMode: 'cards' | 'compact';
+	readonly effectiveAwgEffectiveViewMode: AwgTunnelViewMode;
+	readonly effectiveAwgRenderMode: TunnelRenderMode;
+	// --- state (страница владеет; часть пишется секцией) ---
+	adoptDialogOpen: boolean;
+	adoptingInterface: string;
+	awgListSearchQuery: string;
+	awgViewMode: AwgTunnelViewMode;
+	selectedBackend: 'nativewg' | 'kernel';
+	fileInput: HTMLInputElement | undefined;
+	readonly awgAutoConnectivityNonce: number;
+	readonly deleteLoading: Record<string, boolean>;
+	readonly dragOver: boolean;
+	readonly exporting: boolean;
+	readonly importing: boolean;
+	readonly pingChecking: Record<string, boolean>;
+	readonly toggleLoading: Record<string, boolean>;
+	// --- обработчики ---
+	endpointHost(endpoint?: string | null): string;
+	endpointPort(endpoint?: string | null): string;
+	endpointVisible(scope: EndpointScope, id: string): boolean;
+	toggleEndpointVisible(scope: EndpointScope, id: string): void;
+	externalStatusLabel(tunnel: ExternalTunnel): string;
+	externalStatusVariant(tunnel: ExternalTunnel): 'success' | 'muted';
+	systemStatusLabel(tunnel: SystemTunnel): string;
+	systemStatusVariant(tunnel: SystemTunnel): 'success' | 'muted';
+	isManagedTunnelOn(tunnel: TunnelListItem): boolean;
+	managedRouteMeta(tunnel: TunnelListItem): string;
+	showManagedPing(
+		tunnel: TunnelListItem,
+		connectivity: { connected: boolean; latency: number | null } | undefined,
+	): boolean;
+	latestRate(id: string): { rx: number; tx: number };
+	sparklineSeries(id: string): { rx: number[]; tx: number[] };
+	handleAdoptClick(interfaceName: string): void;
+	handleAwgSortChange(key: AwgTunnelSortKey): void;
+	handleDragLeave(): void;
+	handleDragOver(event: DragEvent): void;
+	handleDrop(event: DragEvent): void;
+	handleFileSelect(event: Event): void;
+	openAwgDiagnostics(id: string, name: string, kind?: 'awg' | 'system'): void;
+	openConnectivitySettings(tunnel: TunnelListItem): void;
+	openDetail(id: string): void;
+	requestDelete(id: string): void;
+	markAsServer(id: string): Promise<void>;
+	handleToggleOnOff(id: string): Promise<void>;
+	checkPing(id: string): Promise<void>;
+	handleExportAll(): Promise<void>;
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -49,6 +49,7 @@
 	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
 	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
 	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
+	import SingboxTunnelsTabSection from '$lib/components/singbox/SingboxTunnelsTabSection.svelte';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
 	import { showOutboundReferencedError } from '$lib/utils/outboundReferenced';
@@ -2789,207 +2790,25 @@
 			/>
 		{/if}
 		{#if showSingboxBlock}
-			{#if !dashboardOn}
-			<SingboxInstallBanner />
-			{#if singboxTunnelsList.length > 0 || subscriptionsActiveCards.length > 0}
-				<div class="tunnels-toolbar">
-					<span class="tunnel-count">
-						{singboxTunnelsList.length}
-						{pluralForm(singboxTunnelsList.length, TUNNEL_WORDS)}
-					</span>
-					<div class="toolbar-actions">
-						<TunnelToolbarViewRow
-							sourceRowCount={singboxTunnelsSourceRowCount}
-							showViewToggle={singboxTunnelsList.length > 0}
-							searchQuery={singboxTunnelsSearchQuery}
-							onSearchChange={(value) => (singboxTunnelsSearchQuery = value)}
-						>
-							{#snippet viewToggle()}
-								<LayoutViewToggle
-									value={singboxTunnelsLayoutMode}
-									showListOption={showSingboxGridListToggle}
-									ariaLabel="Вид туннелей"
-									onchange={(v) => (singboxTunnelsLayoutMode = v)}
-								/>
-							{/snippet}
-						</TunnelToolbarViewRow>
-						<Button
-							variant="primary"
-							size="md"
-							onclick={() => openWizard('choose')}
-							iconBefore={createIcon}
-						>
-							Добавить
-						</Button>
-					</div>
-				</div>
-			{/if}
-			{/if}
-			{#if !dashboardOn && singboxTunnelsList.length === 0}
-				<div class="empty-kinds">
-					<button type="button" class="empty-kind-card" onclick={() => openWizard('single')}>
-						<Link class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
-						<div class="empty-kind-title">Один сервер</div>
-						<div class="empty-kind-desc">
-							Вставь share-link — получишь sing-box туннель со своим Proxy NDMS.
-						</div>
-					</button>
-					<button type="button" class="empty-kind-card" onclick={() => openWizard('inline')}>
-						<LayoutGrid class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
-						<div class="empty-kind-title">Группа серверов</div>
-						<div class="empty-kind-desc">
-							Несколько ссылок одной группой с общим Proxy: ручной выбор или автовыбор по скорости.
-						</div>
-					</button>
-					<button type="button" class="empty-kind-card" onclick={() => openWizard('url')}>
-						<Globe class="empty-kind-icon" size={28} strokeWidth={1.6} aria-hidden="true" />
-						<div class="empty-kind-title">Подписка по URL</div>
-						<div class="empty-kind-desc">
-							Адрес подписки провайдера — список обновляется автоматически.
-						</div>
-					</button>
-				</div>
-				<div class="info-card">
-					<h3 class="info-title">О Sing-box</h3>
-					<p class="info-section-desc">
-						Универсальный прокси с поддержкой современных протоколов:
-					</p>
-					<div class="info-versions">
-						<div class="info-version">
-							<Badge variant="accent" size="sm" mono>VLESS</Badge>
-							<span class="info-version-desc">Лёгкий протокол без шифрования на уровне протокола. Поддерживает <strong>Reality</strong> (маскировка под настоящий TLS-сервер) и транспорт gRPC для обхода DPI.</span>
-						</div>
-						<div class="info-version">
-							<Badge variant="error" size="sm" mono>Trojan</Badge>
-							<span class="info-version-desc">TLS-туннель с парольной аутентификацией. Работает поверх TCP, поддерживает WebSocket и gRPC как транспорт.</span>
-						</div>
-						<div class="info-version">
-							<Badge variant="success" size="sm" mono>Shadowsocks</Badge>
-							<span class="info-version-desc">Классический прокси с шифрованием на уровне приложения. Современные шифры (AES-GCM, ChaCha20) и плагины obfs-local / v2ray-plugin.</span>
-						</div>
-						<div class="info-version">
-							<Badge variant="warning" size="sm" mono>Hysteria2</Badge>
-							<span class="info-version-desc">QUIC-based, устойчив к потерям пакетов и работает поверх UDP. Паролевая аутентификация, обфускация salamander.</span>
-						</div>
-						<div class="info-version">
-							<Badge variant="info" size="sm" mono>NaiveProxy</Badge>
-							<span class="info-version-desc">HTTP/2 с полноценным TLS-маскированием под обычный HTTPS-сервер. Сложно отличим от браузерного трафика.</span>
-						</div>
-						<div class="info-version">
-							<Badge variant="purple" size="sm" mono>Mieru</Badge>
-							<span class="info-version-desc">Мультиплексированный прокси с парольной аутентификацией. TCP и UDP в одном профиле, несколько портов и транспортов.</span>
-						</div>
-					</div>
-				</div>
-			{:else if singboxTunnelsList.length > 0 || (dashboardOn && dashboardSingboxTunnels.length > 0)}
-				{#if !dashboardOn}
-					<div class="awg-summary-row">
-						<StatStrip>
-							<Stat
-								value={`${singboxTunnelListStats.running}/${singboxTunnelListStats.count}`}
-								label={pluralForm(singboxTunnelListStats.running, TUNNEL_WORDS)}
-								sub={formatRunningSub(singboxTunnelListStats.running, singboxTunnelListStats.count)}
-							/>
-							<Stat
-								value={formatBytes(singboxTunnelListStats.down + singboxTunnelListStats.up)}
-								label="Суммарный трафик"
-								sub={`↓ ${formatBytes(singboxTunnelListStats.down)} · ↑ ${formatBytes(singboxTunnelListStats.up)}`}
-							/>
-							<Stat
-								value={singboxTunnelListStats.avgDelayMs !== null
-									? `${singboxTunnelListStats.avgDelayMs} ms`
-									: '—'}
-								label="Средний delay"
-								sub="по последним проверкам"
-							/>
-							<Stat
-								value={singboxTunnelListStats.leaderBytes > 0
-									? formatBytes(singboxTunnelListStats.leaderBytes)
-									: '—'}
-								label="Лидер по трафику"
-								sub={singboxTunnelListStats.leaderName}
-							/>
-							</StatStrip>
-						</div>
-				{/if}
-				{#if effectiveSingboxTunnelsRenderMode === 'table'}
-					<div class="tunnel-table-wrap">
-						<table class="tunnel-data-table singbox-tunnel-table">
-							<colgroup>
-								<col class="col-delay" />
-								<col class="col-name" />
-								<col class="col-protocol" />
-								<col class="col-run" />
-								<col class="col-traffic" />
-								<col class="col-ping" />
-								<col class="col-actions" />
-							</colgroup>
-							<thead>
-								<tr>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'delay', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Delay" sortKey={'delay'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'name', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Туннель" sortKey={'name'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'protocol', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Протокол" sortKey={'protocol'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'running', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Процесс" sortKey={'running'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'traffic', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Трафик" sortKey={'traffic'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th aria-sort={ariaSort($singboxTunnelTableSort.sortBy, 'ping', $singboxTunnelTableSort.sortAsc)}>
-										<TableSortHeader label="Ping" sortKey={'ping'} activeSortKey={$singboxTunnelTableSort.sortBy} sortAsc={$singboxTunnelTableSort.sortAsc} onchange={(key) => handleSingboxTunnelSortChange(key as SingboxTunnelSortKey)} />
-									</th>
-									<th class="col-actions">Действия</th>
-								</tr>
-							</thead>
-							<tbody>
-						{#each sortedFilteredSingboxTunnels as tunnel, i (tunnel.tag)}
-							<SingboxTunnelCard
-								{tunnel}
-								layout="list"
-								renderMode="table"
-								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-								autoDelayCheckDelayMs={i * 180}
-								ondetail={(tag) => openSingboxDetail(tag)}
-							/>
-						{/each}
-						{#if singboxTunnelsSearchEmpty}
-							<tr class="tunnel-empty-row">
-								<td colspan="7">Ничего не найдено</td>
-							</tr>
-						{/if}
-							</tbody>
-						</table>
-					</div>
-				{:else}
-					{@const sbTunnelCardLayout = effectiveSingboxTunnelsRenderMode === 'list-card' ? 'list' : effectiveSingboxTunnelsEffectiveLayout}
-					<div
-						class="tunnel-grid"
-						class:tunnel-grid--list={effectiveSingboxTunnelsRenderMode === 'list-card'}
-						class:tunnel-grid--dense={effectiveSingboxTunnelsRenderMode !== 'list-card' && effectiveSingboxTunnelsEffectiveLayout === 'dense'}
-						class:tunnel-grid--compact={effectiveSingboxTunnelsRenderMode !== 'list-card' && effectiveSingboxTunnelsEffectiveLayout === 'compact'}
-					>
-						{#each sortedFilteredSingboxTunnels as tunnel, i (tunnel.tag)}
-							<SingboxTunnelCard
-								{tunnel}
-								layout={sbTunnelCardLayout}
-								renderMode={effectiveSingboxTunnelsRenderMode}
-								autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-								autoDelayCheckDelayMs={i * 180}
-								ondetail={(tag) => openSingboxDetail(tag)}
-							/>
-						{/each}
-					</div>
-					{#if singboxTunnelsSearchEmpty}
-						<p class="tunnel-list-empty">Ничего не найдено</p>
-					{/if}
-				{/if}
-		{/if}
+			<SingboxTunnelsTabSection
+				{dashboardOn}
+				{dashboardSingboxTunnels}
+				{singboxTunnelsList}
+				{sortedFilteredSingboxTunnels}
+				{singboxTunnelListStats}
+				{singboxTunnelsSourceRowCount}
+				{singboxTunnelsSearchEmpty}
+				{singboxAutoDelayCheckNonce}
+				{showSingboxGridListToggle}
+				{effectiveSingboxTunnelsEffectiveLayout}
+				{effectiveSingboxTunnelsRenderMode}
+				{subscriptionsActiveCards}
+				bind:singboxTunnelsSearchQuery
+				bind:singboxTunnelsLayoutMode
+				{handleSingboxTunnelSortChange}
+				{openSingboxDetail}
+				{openWizard}
+			/>
 		{/if}
 
 		{#if dashboardTypeSections && dashboardSubscriptionsCount > 0}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -50,6 +50,8 @@
 	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
 	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
 	import SingboxTunnelsTabSection from '$lib/components/singbox/SingboxTunnelsTabSection.svelte';
+	import AwgTunnelsTabSection from '$lib/components/tunnels/AwgTunnelsTabSection.svelte';
+	import type { AwgTabContext } from '$lib/components/tunnels/awgTabContext';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
 	import { showOutboundReferencedError } from '$lib/utils/outboundReferenced';
@@ -1851,6 +1853,57 @@
 			},
 		];
 	});
+
+	// Live-контекст AWG-вкладки: геттеры замыкают $state/$derived страницы,
+	// сеттеры мутируют её состояние (см. awgTabContext.ts).
+	const awgTabCtx: AwgTabContext = {
+		get awgList() { return awgList; },
+		get systemList() { return systemList; },
+		get visibleSystemList() { return visibleSystemList; },
+		get externalList() { return externalList; },
+		get sortedFilteredAwgList() { return sortedFilteredAwgList; },
+		get sortedFilteredSystemList() { return sortedFilteredSystemList; },
+		get sortedFilteredExternalList() { return sortedFilteredExternalList; },
+		get awgConnectivityMap() { return awgConnectivityMap; },
+		get statusLine() { return statusLine; },
+		get sysInfo() { return sysInfo; },
+		get awgSummaryActive() { return awgSummaryActive; },
+		get awgSummaryPeak() { return awgSummaryPeak; },
+		get awgSummaryRx() { return awgSummaryRx; },
+		get awgSummaryTx() { return awgSummaryTx; },
+		get awgSummaryTotal() { return awgSummaryTotal; },
+		get awgTrafficLeader() { return awgTrafficLeader; },
+		get nativewgHint() { return nativewgHint; },
+		get dashboardOn() { return dashboardOn; },
+		get dashboardSectionsLayout() { return dashboardSectionsLayout; },
+		get dashboardNothingAtAll() { return dashboardNothingAtAll; },
+		get awgSearchEmpty() { return awgSearchEmpty; },
+		get awgSourceRowCount() { return awgSourceRowCount; },
+		get showAwgViewModeSwitch() { return showAwgViewModeSwitch; },
+		get effectiveAwgCardViewMode() { return effectiveAwgCardViewMode; },
+		get effectiveAwgEffectiveViewMode() { return effectiveAwgEffectiveViewMode; },
+		get effectiveAwgRenderMode() { return effectiveAwgRenderMode; },
+		get awgAutoConnectivityNonce() { return awgAutoConnectivityNonce; },
+		get deleteLoading() { return deleteLoading; },
+		get dragOver() { return dragOver; },
+		get exporting() { return exporting; },
+		get importing() { return importing; },
+		get pingChecking() { return pingChecking; },
+		get toggleLoading() { return toggleLoading; },
+		get adoptDialogOpen() { return adoptDialogOpen; },
+		set adoptDialogOpen(v) { adoptDialogOpen = v; },
+		get adoptingInterface() { return adoptingInterface; },
+		set adoptingInterface(v) { adoptingInterface = v; },
+		get awgListSearchQuery() { return awgListSearchQuery; },
+		set awgListSearchQuery(v) { awgListSearchQuery = v; },
+		get awgViewMode() { return awgViewMode; },
+		set awgViewMode(v) { awgViewMode = v; },
+		get selectedBackend() { return selectedBackend; },
+		set selectedBackend(v) { selectedBackend = v; },
+		get fileInput() { return fileInput; },
+		set fileInput(v) { fileInput = v; },
+		endpointHost, endpointPort, endpointVisible, toggleEndpointVisible, externalStatusLabel, externalStatusVariant, systemStatusLabel, systemStatusVariant, isManagedTunnelOn, managedRouteMeta, showManagedPing, latestRate, sparklineSeries, handleAdoptClick, handleAwgSortChange, handleDragLeave, handleDragOver, handleDrop, handleFileSelect, openAwgDiagnostics, openConnectivitySettings, openDetail, requestDelete, markAsServer, handleToggleOnOff, checkPing, handleExportAll,
+	};
 </script>
 
 {#snippet createIcon()}
@@ -2120,666 +2173,7 @@
 			/>
 		{/if}
 		{#if showAwgBlock}
-		{#if (!dashboardOn || dashboardNothingAtAll) && awgList.length === 0 && systemList.length === 0}
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			class="ghost-terminal"
-			class:drag-over={dragOver}
-			ondrop={handleDrop}
-			ondragover={handleDragOver}
-			ondragleave={handleDragLeave}
-		>
-			{#if dragOver}
-				<div class="drop-overlay">
-					<Upload size={40} strokeWidth={1.5} aria-hidden="true" />
-					<span class="drop-text">Отпустите для импорта</span>
-				</div>
-			{:else if importing}
-				<div class="drop-overlay">
-					<div class="spinner"></div>
-					<span class="drop-text">Импорт...</span>
-				</div>
-			{:else}
-				<div class="term-status">
-					<span class="term-prompt">$ awg status</span>
-					{#if statusLine}
-						<span class="term-info">{statusLine}</span>
-					{/if}
-				</div>
-
-				<div class="term-action-group">
-					<div class="term-drop-hint">
-						<Upload size={28} strokeWidth={1.5} aria-hidden="true" />
-						<span>Перетащите .conf сюда</span>
-					</div>
-
-					<div class="term-backend-selector">
-						<button
-							type="button"
-							class="term-backend-btn"
-							class:selected={selectedBackend === 'nativewg'}
-							class:disabled={sysInfo !== null && !sysInfo.backendAvailability?.nativewg}
-							disabled={sysInfo !== null && !sysInfo.backendAvailability?.nativewg}
-							title={nativewgHint}
-							onclick={() => selectedBackend = 'nativewg'}
-						>
-							NativeWG
-						</button>
-						<button
-							type="button"
-							class="term-backend-btn"
-							class:selected={selectedBackend === 'kernel'}
-							class:disabled={sysInfo !== null && !sysInfo.backendAvailability?.kernel}
-							disabled={sysInfo !== null && !sysInfo.backendAvailability?.kernel}
-							onclick={() => selectedBackend = 'kernel'}
-						>
-							Kernel
-						</button>
-					</div>
-					{#if nativewgHint}
-						<p class="term-backend-hint">{nativewgHint}</p>
-					{/if}
-
-					<div class="term-commands">
-						{#if externalList.length > 0}
-							<span class="term-found">
-								найдено {externalList.length} внешних интерфейс{externalList.length === 1 ? '' : 'а'}
-							</span>
-							<button class="term-cmd term-cmd-primary" onclick={() => {
-								adoptingInterface = externalList[0].interfaceName;
-								adoptDialogOpen = true;
-							}}>
-								<span class="term-arrow">{'>'}</span> подхватить интерфейсы
-							</button>
-						{/if}
-						<button class="term-cmd" onclick={() => fileInput?.click()}>
-							<span class="term-arrow">{'>'}</span> импортировать файл
-						</button>
-						<button class="term-cmd" onclick={() => goto('/tunnels/new?tab=vpn')}>
-							<span class="term-arrow">{'>'}</span> импортировать ссылку
-						</button>
-					</div>
-				</div>
-
-				<input
-					type="file"
-					accept=".conf"
-					bind:this={fileInput}
-					onchange={handleFileSelect}
-					style="display: none"
-				/>
-			{/if}
-		</div>
-
-		<div class="info-card">
-			<h3 class="info-title">Об AmneziaWG</h3>
-			<p class="info-section-desc">
-				Форк WireGuard с обфускацией трафика. Три поколения протокола:
-			</p>
-			<div class="info-versions">
-				<div class="info-version">
-					<Badge variant="accent" size="sm" mono>AWG 1.0</Badge>
-					<span class="info-version-desc">Базовая обфускация: модификация заголовков (H1–H4), junk-пакеты (Jc/Jmin/Jmax), размеры сообщений (S1–S2).</span>
-				</div>
-				<div class="info-version">
-					<Badge variant="info" size="sm" mono>AWG 1.5</Badge>
-					<span class="info-version-desc">Мимикрия протоколов: initiation-пакеты (I1–I5) маскируют соединение под QUIC, DTLS, STUN, DNS.</span>
-				</div>
-				<div class="info-version">
-					<Badge variant="success" size="sm" mono>AWG 2.0</Badge>
-					<span class="info-version-desc">Рандомизация заголовков: H1–H4 задаются диапазонами, генерируются при каждом хэндшейке.</span>
-				</div>
-			</div>
-			<p class="info-text info-kernel">
-				Работает через <strong>модуль ядра</strong> — трафик обрабатывается напрямую в ядре Linux, что снижает нагрузку на CPU.
-			</p>
-		</div>
-
-		{:else}
-			{@const totalCount = awgSummaryTotal}
-			{#if !dashboardOn}
-			<div class="tunnels-toolbar">
-				<div class="count-group">
-					<span class="tunnel-count">{totalCount} {pluralForm(totalCount, TUNNEL_WORDS)}</span>
-					<StoreStatusBadge store={tunnels} />
-				</div>
-				<div class="toolbar-actions">
-					<TunnelToolbarViewRow
-						sourceRowCount={awgSourceRowCount}
-						showViewToggle={showAwgViewModeSwitch}
-						searchQuery={awgListSearchQuery}
-						onSearchChange={(value) => (awgListSearchQuery = value)}
-					>
-						{#snippet viewToggle()}
-							<LayoutViewToggle
-								value={awgViewMode}
-								denseValue="cards"
-								ariaLabel="Вид туннелей"
-								onchange={(mode) => (awgViewMode = mode)}
-							/>
-						{/snippet}
-					</TunnelToolbarViewRow>
-					<Button variant="secondary" size="md" onclick={handleExportAll} disabled={exporting} iconBefore={exportIcon}>
-						Экспорт
-					</Button>
-					<Button variant="primary" size="md" onclick={() => goto('/tunnels/new')} iconBefore={createIcon}>
-						Создать
-					</Button>
-				</div>
-			</div>
-			{/if}
-			{#if !dashboardOn}
-				<div class="awg-summary-row">
-					<StatStrip>
-						<Stat
-							value={`${awgSummaryActive}/${awgSummaryTotal}`}
-							label={pluralForm(awgSummaryActive, TUNNEL_WORDS)}
-							sub={`AWG ${awgList.length} · system ${visibleSystemList.length} · external ${externalList.length}`}
-						/>
-						<Stat
-							value={formatBitRate(awgSummaryPeak.rate)}
-							label="Пиковая скорость"
-							sub={awgSummaryPeak.name}
-						/>
-						<Stat
-							value={formatBytes(awgSummaryRx + awgSummaryTx)}
-							label="Суммарный обмен"
-							sub={`↓ ${formatBytes(awgSummaryRx)} · ↑ ${formatBytes(awgSummaryTx)}`}
-						/>
-						<Stat
-							value={awgTrafficLeader.bytes > 0 ? formatBytes(awgTrafficLeader.bytes) : '—'}
-							label="Лидер по трафику"
-							sub={awgTrafficLeader.name}
-						/>
-					</StatStrip>
-				</div>
-			{/if}
-			{#if effectiveAwgRenderMode === 'table'}
-				<div class="awg-list-table">
-					<div class="awg-list-table-track">
-					<div class="awg-list-row awg-list-row--head">
-						<span></span>
-						<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'name', $awgTunnelTableSort.sortAsc)}>
-							<TableSortHeader
-								label="Туннель"
-								sortKey={'name'}
-								activeSortKey={$awgTunnelTableSort.sortBy}
-								sortAsc={$awgTunnelTableSort.sortAsc}
-								onchange={(key) => handleAwgSortChange(key as AwgTunnelSortKey)}
-							/>
-						</span>
-						<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'status', $awgTunnelTableSort.sortAsc)}>
-							<TableSortHeader
-								label="Статус"
-								sortKey={'status'}
-								activeSortKey={$awgTunnelTableSort.sortBy}
-								sortAsc={$awgTunnelTableSort.sortAsc}
-								onchange={(key) => handleAwgSortChange(key as AwgTunnelSortKey)}
-							/>
-						</span>
-						<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'endpoint', $awgTunnelTableSort.sortAsc)}>
-							<TableSortHeader
-								label="Endpoint"
-								sortKey={'endpoint'}
-								activeSortKey={$awgTunnelTableSort.sortBy}
-								sortAsc={$awgTunnelTableSort.sortAsc}
-								onchange={(key) => handleAwgSortChange(key as AwgTunnelSortKey)}
-							/>
-						</span>
-						<span role="columnheader" aria-sort={ariaSort($awgTunnelTableSort.sortBy, 'traffic', $awgTunnelTableSort.sortAsc)}>
-							<TableSortHeader
-								label="Трафик"
-								sortKey={'traffic'}
-								activeSortKey={$awgTunnelTableSort.sortBy}
-								sortAsc={$awgTunnelTableSort.sortAsc}
-								onchange={(key) => handleAwgSortChange(key as AwgTunnelSortKey)}
-							/>
-						</span>
-						<span class="awg-list-head-actions">Действия</span>
-					</div>
-
-				{#each sortedFilteredAwgList as tunnel (tunnel.id)}
-					{@const connectivity = awgConnectivityMap.get(tunnel.id)}
-					{@const isEndpointShown = endpointVisible('managed', tunnel.id)}
-					{@const rate = latestRate(tunnel.id)}
-					{@const spark = sparklineSeries(tunnel.id)}
-					{@const isActive = isManagedTunnelOn(tunnel)}
-					{@const checkDisabled = (tunnel.connectivityCheck?.method ?? 'http') === 'disabled'}
-					{@const connState = !isActive ? 'idle'
-						: connectivity === undefined ? 'checking'
-						: connectivity.connected ? 'connected' : 'disconnected'}
-					{@const statusDot = awgManagedStatusDot(tunnel, connectivity)}
-					{@const pingStatusNote = awgPingStatusNote(tunnel, 'short')}
-					{@const showPing = showManagedPing(tunnel, connectivity) || pingStatusNote !== null}
-					{@const showConnectivityRow = awgShowConnectivityRow(tunnel.status)}
-						<div class="awg-list-row">
-						<div class="awg-list-cell awg-list-cell-toggle" data-label="Старт">
-							<Toggle
-								checked={isManagedTunnelOn(tunnel)}
-								size="sm"
-								variant="flip"
-								tint={awgToggleTint(tunnel, connectivity)}
-								disabled={(toggleLoading[tunnel.id] ?? false) || tunnel.hasAddressConflict === true}
-								onchange={() => handleToggleOnOff(tunnel.id)}
-							/>
-						</div>
-							<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
-								<div class="tunnel-list-name-stack">
-									<TunnelTitleRow
-										title={tunnel.name}
-										showDot={false}
-										onTitleClick={() => openDetail(tunnel.id)}
-									>
-										{#snippet badges()}
-											<DefaultRouteBadge defaultRoute={tunnel.defaultRoute} />
-											{#if tunnel.backend}
-												<span class="awg-inline-badge">{tunnel.backend}</span>
-											{/if}
-											{#if tunnel.awgVersion}
-												<span class="awg-inline-badge awg-inline-badge--muted">{tunnel.awgVersion}</span>
-											{/if}
-										{/snippet}
-									</TunnelTitleRow>
-									<TunnelMetaText>
-										{tunnel.address || '—'}
-										<span class="meta-dot" aria-hidden="true">·</span>
-										{tunnel.interfaceName || tunnel.id}
-										<span class="meta-dot" aria-hidden="true">·</span>
-										MTU {tunnel.mtu ?? '—'}
-									</TunnelMetaText>
-									<TunnelMetaText mono>
-										Uptime {tunnel.startedAt ? formatDuration(secondsSince(tunnel.startedAt)) : '—'}
-									</TunnelMetaText>
-								</div>
-							</div>
-							<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
-								<div class="awg-list-status-stack">
-									<div class="awg-list-status-line">
-									<StatusDot
-										variant={statusDot.variant}
-										pulse={statusDot.pulse}
-										ariaLabel={statusDot.label}
-									/>
-									<span class="awg-list-status-text">{statusDot.label}</span>
-									</div>
-									<div class="awg-list-sub awg-list-handshake">
-										Handshake {tunnel.lastHandshake ? formatRelativeTime(tunnel.lastHandshake) : '—'}
-									</div>
-									{#if tunnel.hasAddressConflict}
-								<div class="awg-list-sub awg-list-sub--error">Дублирует адрес уже запущенного туннеля</div>
-							{:else if showConnectivityRow}
-								<div
-									class="awg-list-connectivity-row"
-									class:recovering={awgRecoveringVisual(tunnel)}
-								>
-									{#if showPing}
-										<TunnelPingButton
-											layout="list"
-											connectivity={connState}
-											latencyMs={connectivity?.latency ?? null}
-											statusNote={pingStatusNote?.text}
-											statusNoteTone={pingStatusNote?.tone}
-											checking={pingChecking[tunnel.id] ?? false}
-											onclick={() => checkPing(tunnel.id)}
-										/>
-									{/if}
-									<button
-										type="button"
-										class="awg-connectivity-gear"
-										onclick={() => openConnectivitySettings(tunnel)}
-										title="Настройки проверки связности"
-									>
-										<svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-											<path fill-rule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.331 1.652a6.993 6.993 0 011.929 1.115l1.598-.54a1 1 0 011.186.447l1.18 2.044a1 1 0 01-.205 1.251l-1.267 1.113a7.047 7.047 0 010 2.228l1.267 1.113a1 1 0 01.206 1.25l-1.18 2.045a1 1 0 01-1.187.447l-1.598-.54a6.993 6.993 0 01-1.929 1.115l-.33 1.652a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.331-1.652a6.993 6.993 0 01-1.929-1.115l-1.598.54a1 1 0 01-1.186-.447l-1.18-2.044a1 1 0 01.205-1.251l1.267-1.114a7.05 7.05 0 010-2.227L1.821 7.773a1 1 0 01-.206-1.25l1.18-2.045a1 1 0 011.187-.447l1.598.54A6.993 6.993 0 017.51 3.456l.33-1.652zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
-										</svg>
-									</button>
-								</div>
-							{:else if isActive && checkDisabled}
-								<div class="awg-list-sub">Проверка связи выключена</div>
-							{/if}
-							</div>
-							</div>
-							<div class="awg-list-cell" data-label="Endpoint">
-								<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
-									<span class="awg-endpoint-value" title={isEndpointShown ? endpointHost(tunnel.endpoint) : ''}>
-										{#if tunnel.endpoint}
-											{isEndpointShown ? endpointHost(tunnel.endpoint) : '•••••••••'}
-										{:else}
-											—
-										{/if}
-									</span>
-									{#if tunnel.endpoint}
-										<button
-											type="button"
-											class="awg-endpoint-eye"
-											onclick={() => toggleEndpointVisible('managed', tunnel.id)}
-											title={isEndpointShown ? 'Скрыть' : 'Показать'}
-										>
-											{#if isEndpointShown}
-												<Eye size={14} aria-hidden="true" />
-											{:else}
-												<EyeOff size={14} aria-hidden="true" />
-											{/if}
-										</button>
-									{/if}
-									{#if endpointPort(tunnel.endpoint)}
-										<span class="awg-endpoint-port">:{endpointPort(tunnel.endpoint)}</span>
-									{/if}
-								</div>
-								<div class="awg-list-sub">{managedRouteMeta(tunnel)}</div>
-							</div>
-							<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
-								<TunnelListTrafficCell
-									rxRate={rate.rx}
-									txRate={rate.tx}
-									rxData={spark.rx}
-									txData={spark.tx}
-									onclick={() => openDetail(tunnel.id)}
-									title="Открыть детали туннеля"
-								/>
-							</div>
-							<div class="awg-list-cell awg-list-cell-actions tunnel-list-cell--actions" data-label="Действия">
-								<TunnelListActions
-									editHref="/tunnels/{tunnel.id}"
-									editTitle="Изменить туннель «{tunnel.name}»"
-									onTest={() => openAwgDiagnostics(tunnel.id, tunnel.name)}
-									testTitle="Тест туннеля «{tunnel.name}»"
-									onDelete={() => requestDelete(tunnel.id)}
-									deleteTitle="Удалить туннель «{tunnel.name}»"
-									deleting={deleteLoading[tunnel.id] ?? false}
-								/>
-							</div>
-						</div>
-					{/each}
-
-					{#if sortedFilteredSystemList.length > 0}
-						{#if dashboardSectionsLayout}
-							<TunnelSectionHeader
-								nested
-								title="Системные"
-								count={sortedFilteredSystemList.length}
-								countLabel={pluralForm(sortedFilteredSystemList.length, TUNNEL_WORDS)}
-							/>
-						{:else}
-							<div class="awg-list-row awg-list-row--section">
-								<div class="awg-list-section-title">Системные · {sortedFilteredSystemList.length}</div>
-							</div>
-						{/if}
-						{#each sortedFilteredSystemList as tunnel (tunnel.id)}
-							{@const isEndpointShown = endpointVisible('system', tunnel.id)}
-							{@const rate = latestRate(tunnel.id)}
-							{@const spark = sparklineSeries(tunnel.id)}
-							<div class="awg-list-row">
-								<div class="awg-list-cell awg-list-cell-toggle" data-label="Тип">
-									<span class="awg-row-placeholder">SYS</span>
-								</div>
-								<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
-									<div class="tunnel-list-name-stack">
-										<TunnelTitleRow
-											title={tunnel.description || tunnel.id}
-											showDot={false}
-											onTitleClick={() => openDetail(tunnel.id)}
-										>
-											{#snippet badges()}
-												<span class="awg-inline-badge awg-inline-badge--muted">system</span>
-											{/snippet}
-										</TunnelTitleRow>
-										<TunnelMetaText mono>
-											{tunnel.interfaceName}
-											{#if tunnel.address}
-												<span class="meta-dot" aria-hidden="true">·</span>
-												{tunnel.address}
-											{/if}
-											<span class="meta-dot" aria-hidden="true">·</span>
-											MTU {tunnel.mtu}
-										</TunnelMetaText>
-										<TunnelMetaText mono>
-											Uptime {tunnel.status === 'up' && tunnel.uptime ? formatDuration(tunnel.uptime) : '—'}
-										</TunnelMetaText>
-									</div>
-								</div>
-								<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
-									<div class="awg-list-status-line">
-										<StatusDot
-											variant={systemStatusVariant(tunnel)}
-											ariaLabel={systemStatusLabel(tunnel)}
-										/>
-										<span class="awg-list-status-text">{systemStatusLabel(tunnel)}</span>
-									</div>
-									<div class="awg-list-sub awg-list-handshake">
-										Handshake {tunnel.peer?.lastHandshake ? formatRelativeTime(tunnel.peer.lastHandshake) : '—'}
-									</div>
-									<div class="awg-list-sub">{tunnel.peer?.via || 'Маршрут не определён'}</div>
-								</div>
-								<div class="awg-list-cell" data-label="Endpoint">
-								<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
-									<span class="awg-endpoint-value" title={isEndpointShown ? endpointHost(tunnel.peer?.endpoint) : ''}>
-										{#if tunnel.peer?.endpoint}
-											{isEndpointShown ? endpointHost(tunnel.peer.endpoint) : '•••••••••'}
-										{:else}
-											—
-										{/if}
-									</span>
-									{#if tunnel.peer?.endpoint}
-										<button
-											type="button"
-											class="awg-endpoint-eye"
-											onclick={() => toggleEndpointVisible('system', tunnel.id)}
-											title={isEndpointShown ? 'Скрыть' : 'Показать'}
-										>
-											{#if isEndpointShown}
-												<Eye size={14} aria-hidden="true" />
-											{:else}
-												<EyeOff size={14} aria-hidden="true" />
-											{/if}
-										</button>
-									{/if}
-									{#if endpointPort(tunnel.peer?.endpoint)}
-										<span class="awg-endpoint-port">:{endpointPort(tunnel.peer?.endpoint)}</span>
-									{/if}
-								</div>
-									<div class="awg-list-sub">{tunnel.address || '—'}</div>
-								</div>
-								<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
-									<TunnelListTrafficCell
-										rxRate={rate.rx}
-										txRate={rate.tx}
-										rxData={spark.rx}
-										txData={spark.tx}
-										onclick={() => openDetail(tunnel.id)}
-										title="Открыть детали туннеля"
-									/>
-								</div>
-								<div class="awg-list-cell awg-list-cell-actions tunnel-list-cell--actions" data-label="Действия">
-									<TunnelListActions
-										editHref="/system-tunnels/{tunnel.id}"
-										editTitle="Изменить туннель «{tunnel.description || tunnel.id}»"
-										onTest={() => openAwgDiagnostics(tunnel.id, tunnel.description || tunnel.id, 'system')}
-										testTitle="Тест туннеля «{tunnel.description || tunnel.id}»"
-									>
-										{#snippet extra()}
-											<button
-												type="button"
-												class="tunnel-list-actions__btn tunnel-list-actions__btn--primary"
-												title="Перенести туннель «{tunnel.description || tunnel.id}» в серверы"
-												aria-label="Перенести туннель «{tunnel.description || tunnel.id}» в серверы"
-												onclick={() => markAsServer(tunnel.id)}
-											>
-												<Server size={14} aria-hidden="true" />
-											</button>
-										{/snippet}
-									</TunnelListActions>
-								</div>
-							</div>
-						{/each}
-					{/if}
-
-					{#if sortedFilteredExternalList.length > 0}
-						{#if dashboardSectionsLayout}
-							<TunnelSectionHeader
-								nested
-								title="Внешние"
-								count={sortedFilteredExternalList.length}
-								countLabel={pluralForm(sortedFilteredExternalList.length, TUNNEL_WORDS)}
-							/>
-						{:else}
-							<div class="awg-list-row awg-list-row--section">
-								<div class="awg-list-section-title">Внешние · {sortedFilteredExternalList.length}</div>
-							</div>
-						{/if}
-						{#each sortedFilteredExternalList as tunnel (tunnel.interfaceName)}
-							{@const isEndpointShown = endpointVisible('external', tunnel.interfaceName)}
-							<div class="awg-list-row">
-								<div class="awg-list-cell awg-list-cell-toggle" data-label="Тип">
-									<span class="awg-row-placeholder">ext</span>
-								</div>
-								<div class="awg-list-cell awg-list-cell-name" data-label="Туннель">
-									<div class="awg-list-name-line">
-										<span class="awg-list-name-static">{tunnel.interfaceName}</span>
-										<span class="awg-inline-badge awg-inline-badge--muted">external</span>
-										{#if tunnel.isAWG}
-											<span class="awg-inline-badge">AWG</span>
-										{/if}
-									</div>
-									<div class="awg-list-sub">
-										{#if tunnel.publicKey}
-											{tunnel.publicKey.slice(0, 16)}…
-											<span class="awg-list-dot">·</span>
-										{/if}
-										#{tunnel.tunnelNumber}
-									</div>
-								</div>
-								<div class="awg-list-cell awg-list-cell-status" data-label="Статус">
-									<div class="awg-list-status-line">
-										<StatusDot
-											variant={externalStatusVariant(tunnel)}
-											ariaLabel={externalStatusLabel(tunnel)}
-										/>
-										<span class="awg-list-status-text">{externalStatusLabel(tunnel)}</span>
-									</div>
-									<div class="awg-list-sub awg-list-handshake">
-										Handshake {tunnel.lastHandshake ? formatRelativeTime(tunnel.lastHandshake) : '—'}
-									</div>
-									<div class="awg-list-sub">Не управляется AWG Manager</div>
-								</div>
-								<div class="awg-list-cell" data-label="Endpoint">
-									<div class="awg-list-kv-primary awg-list-mono awg-endpoint-line">
-										<span class="awg-endpoint-value" title={isEndpointShown ? endpointHost(tunnel.endpoint) : ''}>
-											{#if tunnel.endpoint}
-												{isEndpointShown ? endpointHost(tunnel.endpoint) : '•••••••••'}
-											{:else}
-												—
-											{/if}
-										</span>
-										{#if tunnel.endpoint}
-											<button
-												type="button"
-												class="awg-endpoint-eye"
-												onclick={() => toggleEndpointVisible('external', tunnel.interfaceName)}
-												title={isEndpointShown ? 'Скрыть' : 'Показать'}
-											>
-												{#if isEndpointShown}
-													<Eye size={14} aria-hidden="true" />
-												{:else}
-													<EyeOff size={14} aria-hidden="true" />
-												{/if}
-											</button>
-										{/if}
-										{#if endpointPort(tunnel.endpoint)}
-											<span class="awg-endpoint-port">:{endpointPort(tunnel.endpoint)}</span>
-										{/if}
-									</div>
-									<div class="awg-list-sub">WG интерфейс</div>
-								</div>
-								<div class="awg-list-cell awg-list-cell-rate" data-label="Трафик">
-									<div class="awg-list-rate-stack awg-list-mono">
-										<div class="traffic-rate rx">↓ {formatBytes(tunnel.rxBytes)}</div>
-										<TrafficSparkline rxData={[]} txData={[]} responsive height={18} />
-										<div class="traffic-rate tx">↑ {formatBytes(tunnel.txBytes)}</div>
-									</div>
-								</div>
-								<div class="awg-list-cell awg-list-cell-actions" data-label="Действия">
-									<Button variant="primary" size="sm" onclick={() => handleAdoptClick(tunnel.interfaceName)}>
-										Взять под управление
-									</Button>
-								</div>
-							</div>
-						{/each}
-					{/if}
-					{#if awgSearchEmpty}
-						<div class="awg-list-row awg-list-row--section">
-							<div class="awg-list-section-title">Ничего не найдено</div>
-						</div>
-					{/if}
-					</div>
-				</div>
-			{:else}
-				{@const awgGridView = effectiveAwgRenderMode === 'list-card' ? 'list' : effectiveAwgCardViewMode}
-				<div
-					class="tunnel-grid"
-					class:tunnel-grid--list={effectiveAwgRenderMode === 'list-card'}
-					class:tunnel-grid--dense={effectiveAwgRenderMode !== 'list-card' && effectiveAwgEffectiveViewMode === 'cards'}
-					class:tunnel-grid--compact={effectiveAwgRenderMode !== 'list-card' && effectiveAwgEffectiveViewMode === 'compact'}
-				>
-					{#each sortedFilteredAwgList as tunnel, i (tunnel.id)}
-						<TunnelCard
-							{tunnel}
-							view={awgGridView}
-							toggleLoading={toggleLoading[tunnel.id] ?? false}
-							deleteLoading={deleteLoading[tunnel.id] ?? false}
-							autoConnectivityNonce={awgAutoConnectivityNonce}
-							autoConnectivityDelayMs={i * 180}
-							onToggleOnOff={() => handleToggleOnOff(tunnel.id)}
-							ondelete={() => requestDelete(tunnel.id)}
-							ondetail={(id) => openDetail(id)}
-						/>
-					{/each}
-					{#each sortedFilteredSystemList as tunnel (tunnel.id)}
-						<SystemTunnelCard
-							{tunnel}
-							view={awgGridView}
-							onMarkServer={markAsServer}
-							ondetail={(id) => openDetail(id)}
-							ontest={(id, name) => openAwgDiagnostics(id, name, 'system')}
-						/>
-					{/each}
-				</div>
-
-				{#if sortedFilteredExternalList.length > 0}
-					<div
-						class:external-section={!dashboardSectionsLayout}
-					>
-						{#if dashboardSectionsLayout}
-							<TunnelSectionHeader
-								nested
-								title="Внешние"
-								count={sortedFilteredExternalList.length}
-								countLabel={pluralForm(sortedFilteredExternalList.length, TUNNEL_WORDS)}
-							/>
-						{:else}
-							<h2 class="section-title">Внешние туннели</h2>
-						{/if}
-						<div
-							class="tunnel-grid"
-							class:tunnel-grid--list={effectiveAwgRenderMode === 'list-card'}
-							class:tunnel-grid--dense={effectiveAwgRenderMode !== 'list-card' && effectiveAwgEffectiveViewMode === 'cards'}
-							class:tunnel-grid--compact={effectiveAwgRenderMode !== 'list-card' && effectiveAwgEffectiveViewMode === 'compact'}
-						>
-							{#each sortedFilteredExternalList as extTunnel (extTunnel.interfaceName)}
-								<ExternalTunnelCard
-									tunnel={extTunnel}
-									view={awgGridView}
-									onadopt={(name) => handleAdoptClick(name)}
-								/>
-							{/each}
-						</div>
-					</div>
-				{/if}
-				{#if awgSearchEmpty}
-					<p class="tunnel-list-empty">Ничего не найдено</p>
-				{/if}
-			{/if}
-		{/if}
+			<AwgTunnelsTabSection ctx={awgTabCtx} />
 		{/if}
 
 		{#if dashboardTypeSections && dashboardSingboxTunnels.length > 0}
@@ -3574,9 +2968,6 @@
 		border-top: 1px solid var(--color-border);
 	}
 
-	.info-kernel strong {
-		color: var(--color-text-primary);
-	}
 
 	/* "Kernel module unavailable" full-screen overlay — page-specific */
 	.unsupported-overlay {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -48,6 +48,7 @@
 	import AddTunnelWizard from '$lib/components/subscriptions/AddTunnelWizard.svelte';
 	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
 	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
+	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
 	import { showOutboundReferencedError } from '$lib/utils/outboundReferenced';
@@ -2999,308 +3000,34 @@
 			/>
 		{/if}
 		{#if showSubscriptionsBlock}
-			{#if subscriptionsInitialLoading}
-				<div class="loading-centered">
-					<LoadingSpinner size="md" message="Загружаем подписки..." />
-				</div>
-			{:else if subscriptionsFetchFailed}
-				<EmptyState
-					title="Не удалось загрузить подписки"
-					description={subscriptionsState.error ?? 'Проверьте соединение с роутером и обновите страницу.'}
-				/>
-			{:else}
-				{#if !dashboardOn && !singboxStatusLoading}
-					<SingboxInstallBanner />
-				{/if}
-
-				{#if singboxStatusLoading || singboxInstalled}
-					{#if !dashboardOn}
-					<div class="tunnels-toolbar">
-						<span class="tunnel-count">
-							{subscriptionsList.length}
-							{pluralForm(subscriptionsList.length, SUBSCRIPTION_WORDS)}
-						</span>
-						<div class="toolbar-actions">
-							<TunnelToolbarViewRow
-								sourceRowCount={singboxSubscriptionsSourceRowCount}
-								showViewToggle={subscriptionsList.length > 0}
-								searchQuery={singboxSubscriptionsSearchQuery}
-								onSearchChange={(value) => (singboxSubscriptionsSearchQuery = value)}
-							>
-								{#snippet viewToggle()}
-									<LayoutViewToggle
-										value={singboxSubscriptionsLayoutMode}
-										showListOption={showSingboxGridListToggle}
-										ariaLabel="Вид подписок"
-										onchange={(v) => (singboxSubscriptionsLayoutMode = v)}
-									/>
-								{/snippet}
-							</TunnelToolbarViewRow>
-							<Button
-								variant="primary"
-								size="md"
-								onclick={() => openWizard('url')}
-								iconBefore={createIcon}
-							>
-								Добавить
-							</Button>
-						</div>
-					</div>
-					{/if}
-					{#if subscriptionsList.length === 0}
-						<div class="subscription-empty">
-							<div class="subscription-empty-title">Нет подписок</div>
-							<p class="subscription-empty-desc">
-								Добавьте подписку — мастер скачает список серверов и создаст selector-туннель.
-							</p>
-							<Button
-								variant="primary"
-								size="md"
-								onclick={() => openWizard('url')}
-								iconBefore={createIcon}
-							>
-								Добавить подписку
-							</Button>
-						</div>
-					{:else}
-						{#if !dashboardOn}
-							<div class="awg-summary-row">
-								<StatStrip>
-									<Stat
-										value={`${singboxSubscriptionsTrafficStats.activeCount}/${singboxSubscriptionsTrafficStats.count}`}
-										label={pluralForm(singboxSubscriptionsTrafficStats.activeCount, SUBSCRIPTION_WORDS)}
-										sub={formatRunningSub(
-											singboxSubscriptionsTrafficStats.activeCount,
-											singboxSubscriptionsTrafficStats.count,
-										)}
-									/>
-									<Stat
-										value={formatBytes(
-											singboxSubscriptionsTrafficStats.down + singboxSubscriptionsTrafficStats.up,
-										)}
-										label="Суммарный трафик"
-										sub={`↓ ${formatBytes(singboxSubscriptionsTrafficStats.down)} · ↑ ${formatBytes(singboxSubscriptionsTrafficStats.up)}`}
-									/>
-									<Stat
-										value={singboxSubscriptionsTrafficStats.avgDelayMs !== null
-											? `${singboxSubscriptionsTrafficStats.avgDelayMs} ms`
-											: '—'}
-										label="Средний delay"
-										sub={singboxSubscriptionsTrafficStats.delaySamples > 0
-											? `по ${singboxSubscriptionsTrafficStats.delaySamples} активным подпискам`
-											: 'нет активных замеров'}
-									/>
-									<Stat
-										value={singboxSubscriptionsTrafficStats.leaderBytes > 0
-											? formatBytes(singboxSubscriptionsTrafficStats.leaderBytes)
-											: '—'}
-										label="Лидер по трафику"
-										sub={singboxSubscriptionsTrafficStats.leaderBytes > 0
-											? `${singboxSubscriptionsTrafficStats.leaderName} · ${singboxSubscriptionsTrafficStats.leaderSharePct}% всего`
-											: '—'}
-									/>
-								</StatStrip>
-							</div>
-						{/if}
-						{#if effectiveSingboxSubscriptionsRenderMode === 'table'}
-						<div class="tunnel-table-wrap">
-							<table class="tunnel-data-table singbox-sub-table">
-								<colgroup>
-									<col class="col-delay" />
-									<col class="col-name" />
-									<col class="col-active" />
-									<col class="col-traffic" />
-									<col class="col-ping" />
-									<col class="col-actions" />
-								</colgroup>
-								<thead>
-									<tr>
-										<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'delay', $singboxSubscriptionTableSort.sortAsc)}>
-											<TableSortHeader label="Delay" sortKey={'delay'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
-										</th>
-										<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'label', $singboxSubscriptionTableSort.sortAsc)}>
-											<TableSortHeader label="Подписка" sortKey={'label'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
-										</th>
-										<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'active', $singboxSubscriptionTableSort.sortAsc)}>
-											<TableSortHeader label="Активный сервер" sortKey={'active'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
-										</th>
-										<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'traffic', $singboxSubscriptionTableSort.sortAsc)}>
-											<TableSortHeader label="Трафик" sortKey={'traffic'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
-										</th>
-										<th aria-sort={ariaSort($singboxSubscriptionTableSort.sortBy, 'ping', $singboxSubscriptionTableSort.sortAsc)}>
-											<TableSortHeader label="Ping" sortKey={'ping'} activeSortKey={$singboxSubscriptionTableSort.sortBy} sortAsc={$singboxSubscriptionTableSort.sortAsc} onchange={(key) => handleSubscriptionSortChange(key as SubscriptionSortKey)} />
-										</th>
-										<th class="col-actions">Действия</th>
-									</tr>
-								</thead>
-								<tbody>
-							{#if sortedFilteredSubscriptionsActiveCards.length > 0}
-								{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
-									<SubscriptionActiveCard
-										subscription={card.subscription}
-										activeMember={card.activeMember}
-										autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-										autoDelayCheckDelayMs={i * 180}
-										layout="list"
-										renderMode="table"
-										ondetail={(tag) => openSingboxDetail(tag)}
-									/>
-								{/each}
-							{/if}
-							{#if sortedFilteredSubscriptionsListRows.length > 0}
-								{#if dashboardSectionsLayout}
-									<TunnelSectionHeader
-										variant="table-row"
-										title="Остановлено"
-										count={sortedFilteredSubscriptionsListRows.length}
-										countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
-										colspan={6}
-									/>
-								{:else}
-									<tr class="tunnel-section-row">
-										<td colspan="6">Остановлено · {sortedFilteredSubscriptionsListRows.length}</td>
-									</tr>
-								{/if}
-								{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
-									<SubscriptionCard
-										subscription={sub}
-										liveActiveMember={liveActives[sub.id] || null}
-										layout="list"
-										renderMode="table"
-										ondelete={requestSubscriptionDelete}
-										ondetail={(tag) => openSingboxDetail(tag)}
-									/>
-								{/each}
-							{/if}
-							{#if singboxSubscriptionsSearchEmpty}
-								<tr class="tunnel-empty-row">
-									<td colspan="6">Ничего не найдено</td>
-								</tr>
-							{/if}
-								</tbody>
-							</table>
-						</div>
-						{:else if effectiveSingboxSubscriptionsRenderMode === 'list-card'}
-						{#snippet subscriptionActiveListCards()}
-							{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
-								<SubscriptionActiveCard
-									subscription={card.subscription}
-									activeMember={card.activeMember}
-									autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-									autoDelayCheckDelayMs={i * 180}
-									layout="list"
-									renderMode="list-card"
-									ondetail={(tag) => openSingboxDetail(tag)}
-								/>
-							{/each}
-						{/snippet}
-						{#snippet subscriptionStoppedListCards()}
-							{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
-								<SubscriptionCard
-									subscription={sub}
-									liveActiveMember={liveActives[sub.id] || null}
-									layout="list"
-									renderMode="list-card"
-									ondelete={requestSubscriptionDelete}
-									ondetail={(tag) => openSingboxDetail(tag)}
-								/>
-							{/each}
-						{/snippet}
-						{#if dashboardOn}
-							{#if sortedFilteredSubscriptionsActiveCards.length > 0}
-								<div class="tunnel-grid tunnel-grid--list">
-									{@render subscriptionActiveListCards()}
-								</div>
-							{/if}
-							{#if sortedFilteredSubscriptionsListRows.length > 0}
-								{#if dashboardSectionsLayout}
-									<TunnelSectionHeader
-										nested
-										title="Остановлено"
-										count={sortedFilteredSubscriptionsListRows.length}
-										countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
-									/>
-								{/if}
-								<div class="tunnel-grid tunnel-grid--list">
-									{@render subscriptionStoppedListCards()}
-								</div>
-							{/if}
-						{:else}
-						<div class="tunnel-grid tunnel-grid--list">
-							{@render subscriptionActiveListCards()}
-							{@render subscriptionStoppedListCards()}
-						</div>
-						{/if}
-						{#if singboxSubscriptionsSearchEmpty}
-							<p class="tunnel-list-empty">Ничего не найдено</p>
-						{/if}
-						{:else}
-						{#if subscriptionsActiveCards.length > 0}
-							<div
-								class="tunnel-grid"
-								class:tunnel-grid--dense={effectiveSingboxSubscriptionsEffectiveLayout === 'dense'}
-								class:tunnel-grid--compact={effectiveSingboxSubscriptionsEffectiveLayout === 'compact'}
-							>
-								{#each sortedFilteredSubscriptionsActiveCards as card, i (card.subscription.id)}
-									<SubscriptionActiveCard
-										subscription={card.subscription}
-										activeMember={card.activeMember}
-										autoDelayCheckNonce={singboxAutoDelayCheckNonce}
-										autoDelayCheckDelayMs={i * 180}
-										layout={effectiveSingboxSubscriptionsEffectiveLayout}
-										renderMode={effectiveSingboxSubscriptionsRenderMode}
-										ondetail={(tag) => openSingboxDetail(tag)}
-									/>
-								{/each}
-							</div>
-						{/if}
-						{#if sortedFilteredSubscriptionsListRows.length > 0}
-							{#snippet subscriptionStoppedGrid()}
-								<div
-									class="tunnel-grid"
-									class:tunnel-grid--dense={effectiveSingboxSubscriptionsEffectiveLayout === 'dense'}
-									class:tunnel-grid--compact={effectiveSingboxSubscriptionsEffectiveLayout === 'compact'}
-								>
-									{#each sortedFilteredSubscriptionsListRows as sub (sub.id)}
-										<SubscriptionCard
-											subscription={sub}
-											liveActiveMember={liveActives[sub.id] || null}
-											layout={effectiveSingboxSubscriptionsEffectiveLayout}
-											renderMode={effectiveSingboxSubscriptionsRenderMode}
-											ondelete={requestSubscriptionDelete}
-											ondetail={(tag) => openSingboxDetail(tag)}
-										/>
-									{/each}
-								</div>
-							{/snippet}
-							{#if dashboardSectionsLayout}
-								<TunnelSectionHeader
-									nested
-									title="Остановлено"
-									count={sortedFilteredSubscriptionsListRows.length}
-									countLabel={pluralForm(sortedFilteredSubscriptionsListRows.length, SUBSCRIPTION_WORDS)}
-								/>
-								{@render subscriptionStoppedGrid()}
-							{:else}
-								<div
-									class="external-section"
-									class:singbox-sub-inactive-section={sortedFilteredSubscriptionsActiveCards.length === 0}
-								>
-									<h2 class="section-title">Остановлено</h2>
-									{@render subscriptionStoppedGrid()}
-								</div>
-							{/if}
-						{/if}
-						{#if singboxSubscriptionsSearchEmpty}
-							<p class="tunnel-list-empty">Ничего не найдено</p>
-						{/if}
-						{/if}
-					{/if}
-					{#if !dashboardOn}
-						<SubscriptionGroupsSection subscriptions={subscriptionsList} />
-					{/if}
-				{/if}
-			{/if}
+			<SubscriptionsTabSection
+				{loading}
+				{dashboardOn}
+				{dashboardSectionsLayout}
+				{subscriptionsInitialLoading}
+				{subscriptionsFetchFailed}
+				subscriptionsError={subscriptionsState.error ?? null}
+				{subscriptionsList}
+				{subscriptionsActiveCards}
+				{sortedFilteredSubscriptionsActiveCards}
+				{sortedFilteredSubscriptionsListRows}
+				{singboxSubscriptionsTrafficStats}
+				{singboxSubscriptionsSourceRowCount}
+				{singboxSubscriptionsSearchEmpty}
+				{singboxInstalled}
+				{singboxStatusLoading}
+				{singboxAutoDelayCheckNonce}
+				{showSingboxGridListToggle}
+				{effectiveSingboxSubscriptionsEffectiveLayout}
+				{effectiveSingboxSubscriptionsRenderMode}
+				{liveActives}
+				bind:singboxSubscriptionsSearchQuery
+				bind:singboxSubscriptionsLayoutMode
+				{handleSubscriptionSortChange}
+				{openSingboxDetail}
+				{openWizard}
+				{requestSubscriptionDelete}
+			/>
 		{/if}
 	{/if}
 </PageContainer>


### PR DESCRIPTION
## Что это

Декомпозиция `routes/+page.svelte` (4178 строк) — «класс 2» реструктуризации фронта, где дословные переносы невозможны и нужна страховочная сетка визуальной эквивалентности.

## Страховочная сетка

- **Детерминированный mock-режим** (`MOCK_DETERMINISTIC=1` для `mock-proxy.mjs`): фиксируются jitter трафика/delay (22 места `Math.random`), синусоидальный дрейф латентности, 15-секундная ротация active-now urltest-подписок. Без флага мок остаётся «живым».
- **Скриншот-харнес** (Playwright + chromium): 6 кадров (desktop dark/light/list-режим, mobile, все три вкладки), замороженное время, отключённые анимации, спрятанные принципиально волатильные элементы. Доказанная стабильность: два независимых прогона со свежими mock-стеками — **0 differing pixels**.

## Извлечения (каждое верифицировано пиксель-в-пиксель + interaction-smoke)

1. **`SubscriptionsTabSection`** (~300 строк + 11 CSS-правил): 26 пропсов, 2 `$bindable`.
2. **`SingboxTunnelsTabSection`** (~200 строк + 20 правил): 17 пропсов, 2 `$bindable`; общие view-модели — `subscriptionVMs.ts`.
3. **`AwgTunnelsTabSection`** (662 строки + 41 правило) — блок держался за **63 идентификатора** состояния страницы; вместо 63-пропового компонента введён **live-контекст `AwgTabContext`**: страница собирает объект с геттерами поверх своих `$state`/`$derived` (33 геттера, 6 аксессоров с сеттерами вкл. `bind:this`, 27 обработчиков) и передаёт одним пропом. Чтение геттера в шаблоне отслеживает исходную реактивность; сеттеры мутируют состояние страницы.

**`+page.svelte`: 4178 → 3115 строк** (вся разметка трёх вкладок — в компонентах).

## Верификация каждого шага

- 6 скриншотов **бит-в-бит** с базлайном (покрывает и пересадку scoped-CSS; list-режим покрывает табличные рендеры);
- interaction-smoke: `$bindable`/ctx-сеттер поиска фильтрует карточки на всех трёх вкладках;
- svelte-check 0/0, eslint 0, vitest 1343 passed, production build — на каждом шаге.

## Остаётся (следующими PR)

flat-режим дашборда (~140 строк + снипеты), модалки/детали, скрипт страницы (~1900 строк — кандидат на вынос derived-цепочек в модули).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg