### PR TITLE
refactor(frontend): хвосты декомпозиции +page.svelte — flat-дашборд, модалки, селекторы списков

### DIFF
--- a/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
+++ b/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
@@ -3,7 +3,7 @@
 	// (класс 2): снипеты карточек всех видов + тулбар/сетка/группировка по
 	// тегам. Состояние страницы приходит live-контекстом (ctx); ghost-слой
 	// drag-переупорядочивания остался в странице (fixed-позиционирование).
-	import { TunnelCard, ExternalTunnelCard, SystemTunnelCard, AdoptTunnelDialog } from '$lib/components/tunnels';
+	import { TunnelCard, ExternalTunnelCard, SystemTunnelCard } from '$lib/components/tunnels';
 	import DashboardToolbar from '$lib/components/tunnels/DashboardToolbar.svelte';
 	import { Button, StoreStatusBadge } from '$lib/components/ui';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';

--- a/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
+++ b/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
@@ -1,0 +1,564 @@
+<script lang="ts">
+	// Flat-режим дашборда туннелей — выделено из routes/+page.svelte
+	// (класс 2): снипеты карточек всех видов + тулбар/сетка/группировка по
+	// тегам. Состояние страницы приходит live-контекстом (ctx); ghost-слой
+	// drag-переупорядочивания остался в странице (fixed-позиционирование).
+	import { TunnelCard, ExternalTunnelCard, SystemTunnelCard, AdoptTunnelDialog } from '$lib/components/tunnels';
+	import DashboardToolbar from '$lib/components/tunnels/DashboardToolbar.svelte';
+	import { Button, StoreStatusBadge } from '$lib/components/ui';
+	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+	import { tunnelDashboardOrderMode, tunnelDashboardTags, tunnelDashboardGroupMode } from '$lib/stores/tunnelDashboardPrefs';
+	import { getItemTags } from '$lib/utils/tunnelDashboardTags';
+	import TunnelTagChips from '$lib/components/tunnels/TunnelTagChips.svelte';
+	import { tunnels } from '$lib/stores/tunnels';
+	import { goto } from '$app/navigation';
+	import { tunnelDashboardLayout, tunnelDashboardView } from '$lib/stores/tunnelDashboardMode';
+	import DashboardSummary from '$lib/components/tunnels/DashboardSummary.svelte';
+	import TunnelSectionHeader from '$lib/components/tunnels/TunnelSectionHeader.svelte';
+	import { SingboxInstallBanner, SingboxTunnelCard } from '$lib/components/singbox';
+	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
+	import SubscriptionCard from '$lib/components/subscriptions/SubscriptionCard.svelte';
+	import { EmptyState } from '$lib/components/layout';
+	import { pluralForm, TUNNEL_WORDS } from '$lib/utils/pluralize';
+	import { GripVertical, Download } from 'lucide-svelte';
+	import type { TunnelDashboardFlatItem } from '$lib/utils/tunnelDashboardFlat';
+	import type { DashboardFlatContext } from './dashboardFlatContext';
+
+	let { ctx }: { ctx: DashboardFlatContext } = $props();
+</script>
+
+{#snippet createIcon()}
+	<CreateIcon />
+{/snippet}
+
+{#snippet exportIcon()}
+	<Download size={14} strokeWidth={2} aria-hidden="true" />
+{/snippet}
+
+{#snippet dashboardFlatCard(item: TunnelDashboardFlatItem, suppressAutoCheck: boolean = false)}
+	{#if item.kind === 'awg-managed'}
+		<TunnelCard
+			tunnel={item.tunnel}
+			view={ctx.effectiveAwgRenderMode === 'list-card' ? 'list' : ctx.effectiveAwgCardViewMode}
+			toggleLoading={ctx.toggleLoading[item.tunnel.id] ?? false}
+			deleteLoading={ctx.deleteLoading[item.tunnel.id] ?? false}
+			autoConnectivityNonce={suppressAutoCheck ? 0 : ctx.awgAutoConnectivityNonce}
+			autoConnectivityDelayMs={item.index * 180}
+			onToggleOnOff={() => ctx.handleToggleOnOff(item.tunnel.id)}
+			ondelete={() => ctx.requestDelete(item.tunnel.id)}
+			ondetail={(id) => ctx.openDetail(id)}
+		/>
+	{:else if item.kind === 'awg-system'}
+		<SystemTunnelCard
+			tunnel={item.tunnel}
+			view={ctx.effectiveAwgRenderMode === 'list-card' ? 'list' : ctx.effectiveAwgCardViewMode}
+			onMarkServer={ctx.markAsServer}
+			ondetail={(id) => ctx.openDetail(id)}
+			ontest={(id, name) => ctx.openAwgDiagnostics(id, name, 'system')}
+		/>
+	{:else if item.kind === 'awg-external'}
+		<ExternalTunnelCard
+			tunnel={item.tunnel}
+			view={ctx.effectiveAwgRenderMode === 'list-card' ? 'list' : ctx.effectiveAwgCardViewMode}
+			onadopt={(name) => ctx.handleAdoptClick(name)}
+		/>
+	{:else if item.kind === 'singbox'}
+		<SingboxTunnelCard
+			tunnel={item.tunnel}
+			layout={ctx.effectiveSingboxTunnelsRenderMode === 'list-card' ? 'list' : ctx.effectiveSingboxTunnelsEffectiveLayout}
+			renderMode={ctx.effectiveSingboxTunnelsRenderMode}
+			autoDelayCheckNonce={suppressAutoCheck ? 0 : ctx.singboxAutoDelayCheckNonce}
+			autoDelayCheckDelayMs={item.index * 180}
+			ondetail={(tag) => ctx.openSingboxDetail(tag)}
+		/>
+	{:else if item.kind === 'sub-active'}
+		<SubscriptionActiveCard
+			subscription={item.card.subscription}
+			activeMember={item.card.activeMember}
+			autoDelayCheckNonce={suppressAutoCheck ? 0 : ctx.singboxAutoDelayCheckNonce}
+			autoDelayCheckDelayMs={item.index * 180}
+			layout={ctx.effectiveSingboxSubscriptionsEffectiveLayout}
+			renderMode={ctx.effectiveSingboxSubscriptionsRenderMode}
+			ondetail={(tag) => ctx.openSingboxDetail(tag)}
+		/>
+	{:else if item.kind === 'sub-stopped'}
+		<SubscriptionCard
+			subscription={item.subscription}
+			liveActiveMember={ctx.liveActives[item.subscription.id] || null}
+			layout={ctx.effectiveSingboxSubscriptionsEffectiveLayout}
+			renderMode={ctx.effectiveSingboxSubscriptionsRenderMode}
+			ondelete={ctx.requestSubscriptionDelete}
+			ondetail={(tag) => ctx.openSingboxDetail(tag)}
+		/>
+	{/if}
+{/snippet}
+
+{#snippet dashboardItemFooter(item: TunnelDashboardFlatItem, dragIndex: number | null, dragDisabled: boolean = false)}
+	{@const itemTags = getItemTags($tunnelDashboardTags, item.key)}
+	<!-- Футер рендерится только когда в нём есть содержимое: грип ручного
+	     порядка и/или чипы тегов. Без тегов и вне тегового вида ряд с одиноким
+	     «+» под каждой карточкой не показывается; редактирование тегов живёт в
+	     группировке «Теги», в сплошном виде чипы readonly (клик = фильтр). -->
+	{#if dragIndex !== null || itemTags.length > 0 || ctx.dashboardGroupByTags}
+		<div class="dashboard-item-footer">
+			{#if dragIndex !== null}
+				<button
+					type="button"
+					class="dashboard-item-grip"
+					class:is-busy={ctx.flatDrag.busy}
+					disabled={dragDisabled}
+					title={dragDisabled
+						? 'Перетаскивание недоступно при поиске и фильтре'
+						: 'Перетащить для изменения порядка'}
+					aria-label="Перетащить «{item.name}»"
+					onpointerdown={dragDisabled || ctx.flatDrag.busy
+						? undefined
+						: (e) => ctx.handleGripPointerDown(dragIndex, e)}
+					onkeydown={dragDisabled ? undefined : (e) => ctx.handleGripKeydown(dragIndex, e)}
+				>
+					<GripVertical size={14} strokeWidth={2} aria-hidden="true" />
+				</button>
+			{/if}
+			{#if itemTags.length > 0 || ctx.dashboardGroupByTags}
+				<TunnelTagChips
+					tags={itemTags}
+					readonly={!ctx.dashboardGroupByTags}
+					onAdd={(raw) => tunnelDashboardTags.addTag(item.key, raw)}
+					onRemove={(tag) => tunnelDashboardTags.removeTag(item.key, tag)}
+					onSelect={(tag) => (ctx.dashboardTagFilter = tag)}
+					activeTag={ctx.dashboardTagFilter}
+				/>
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+{#if ctx.showSingboxSections}
+	<SingboxInstallBanner />
+{/if}
+<div class="dashboard-sticky">
+	<div class="tunnels-toolbar">
+		<div class="toolbar-actions">
+			<DashboardToolbar
+				searchQuery={ctx.dashboardSearchQuery}
+				onSearchChange={(value) => (ctx.dashboardSearchQuery = value)}
+				layout={$tunnelDashboardLayout}
+				onLayoutChange={(layout) => tunnelDashboardLayout.setLayout(layout)}
+				viewMode={$tunnelDashboardView}
+				onViewModeChange={tunnelDashboardView.setViewMode}
+				showViewToggle={ctx.showSingboxListOption}
+				showListOption={ctx.showSingboxListOption}
+				orderMode={$tunnelDashboardOrderMode}
+				onOrderModeChange={tunnelDashboardOrderMode.setMode}
+				showOrderControl={ctx.dashboardFlatLayout}
+				groupMode={$tunnelDashboardGroupMode}
+				onGroupModeChange={tunnelDashboardGroupMode.setMode}
+				showGroupControl={!ctx.dashboardFlatLayout}
+				activeTagFilter={ctx.dashboardTagFilter}
+				onClearTagFilter={() => (ctx.dashboardTagFilter = null)}
+				showSingboxCreate={ctx.showSingboxSections}
+				onCreateAwg={() => goto('/tunnels/new')}
+				onCreateSingboxSingle={() => ctx.openWizard('single')}
+				onCreateSingboxGroup={() => ctx.openWizard('inline')}
+				onCreateSingboxSubscription={() => ctx.openWizard('url')}
+				{createIcon}
+			>
+				{#snippet actions()}
+					<StoreStatusBadge store={tunnels} />
+					<Button variant="secondary" size="md" onclick={ctx.handleExportAll} disabled={ctx.exporting} iconBefore={exportIcon}>
+						Экспорт
+					</Button>
+				{/snippet}
+			</DashboardToolbar>
+		</div>
+	</div>
+	<DashboardSummary stats={ctx.dashboardSummaryStats} />
+</div>
+{#if ctx.dashboardFlatCardMode}
+	<div
+		bind:this={ctx.flatGridEl}
+		class={ctx.dashboardGridClass}
+		class:dashboard-grid--reordering={ctx.flatDrag.active}
+		style={ctx.dashboardDndEnabled ? ctx.flatDrag.cardsMotionStyle() : undefined}
+	>
+		{#each ctx.dashboardRenderItems as item, i (item.key)}
+			<div
+				class="dashboard-flat-item"
+				class:drag-source-exiting={ctx.flatDrag.isDragSource(i)}
+				class:drag-source-collapsed={ctx.flatDrag.sourceCollapsed(i)}
+				style={ctx.flatDrag.isDragSource(i) ? ctx.flatDrag.dropIndicatorStyle() : undefined}
+				bind:this={ctx.flatRowEls[i]}
+			>
+				{#if ctx.flatDrag.showsDropBefore(i)}
+					<div
+						class="drop-indicator"
+						class:expanded={ctx.flatDrag.dropBeforeExpanded(i)}
+						class:collapsing={ctx.flatDrag.dropBeforeCollapsing(i)}
+						style={ctx.flatDrag.dropIndicatorStyle()}
+					></div>
+				{/if}
+				{#if ctx.flatDrag.active}
+					<!-- Во время drag карточки (с графиками) заменяются
+					     компактными рядами фиксированной высоты: без двух
+					     полных релэйаутов страницы, и длинный список влезает
+					     на экран. Ключи те же — ключи снапшота. -->
+					<div class="dashboard-reorder-row">
+						<span class="dashboard-kind-badge">{ctx.DASHBOARD_KIND_LABELS[item.kind]}</span>
+						<span class="dashboard-reorder-name">{item.name}</span>
+					</div>
+				{:else}
+					{@render dashboardFlatCard(item)}
+					{@render dashboardItemFooter(
+						item,
+						$tunnelDashboardOrderMode === 'manual' ? i : null,
+						!ctx.dashboardDndEnabled,
+					)}
+				{/if}
+			</div>
+		{/each}
+		{#if ctx.flatDrag.showsDropAtEnd()}
+			<div
+				class="drop-indicator drop-indicator-end"
+				class:expanded={ctx.flatDrag.dropEndExpanded()}
+				class:collapsing={ctx.flatDrag.dropEndCollapsing()}
+				style={ctx.flatDrag.dropIndicatorStyle()}
+			></div>
+		{/if}
+	</div>
+{:else if ctx.dashboardGroupByTags}
+	{#each ctx.dashboardTagGroups as group (group.tag ?? ' untagged')}
+		<TunnelSectionHeader
+			title={group.tag ?? 'Без тегов'}
+			count={group.items.length}
+			countLabel={pluralForm(group.items.length, TUNNEL_WORDS)}
+		/>
+		<div class={ctx.dashboardGridClass}>
+			{#each group.items as entry (entry.item.key)}
+				<div class="dashboard-flat-item">
+					{@render dashboardFlatCard(entry.item, !entry.autoCheck)}
+					{@render dashboardItemFooter(entry.item, null)}
+				</div>
+			{/each}
+		</div>
+	{/each}
+{/if}
+{#if ctx.dashboardFilterEmpty}
+	<EmptyState
+		title="Ничего не найдено"
+		description={ctx.dashboardTagFilter !== null
+			? `Нет туннелей с тегом «${ctx.dashboardTagFilter}»${ctx.dashboardSearchQuery.trim() !== '' ? ' по этому запросу' : ''}.`
+			: 'По запросу не нашлось ни одного туннеля.'}
+	>
+		{#snippet action()}
+			{#if ctx.dashboardTagFilter !== null}
+				<Button variant="secondary" size="md" onclick={() => (ctx.dashboardTagFilter = null)}>
+					Сбросить фильтр
+				</Button>
+			{:else}
+				<Button variant="secondary" size="md" onclick={() => (ctx.dashboardSearchQuery = '')}>
+					Очистить поиск
+				</Button>
+			{/if}
+		{/snippet}
+	</EmptyState>
+{/if}
+
+<style>
+	/* Комбинированная сводка дашборда (issue #353): липкий блок «тулбар +
+	   сводка» под AppHeader — тот же паттерн, что sticky-header в
+	   TunnelEditHeader.svelte. */
+	.dashboard-sticky {
+		position: sticky;
+		top: 56px;
+		z-index: var(--z-sticky-secondary);
+		background: var(--color-bg-primary);
+		padding-bottom: 0.75rem;
+		border-bottom: 1px solid var(--color-border);
+		margin-bottom: 1rem;
+	}
+
+	.dashboard-sticky .tunnels-toolbar {
+		margin-bottom: 0.75rem;
+	}
+
+	@media (max-width: 760px) {
+	.dashboard-sticky {
+			position: static;
+		}
+}
+
+	/* Обёртка карточки в сплошном/теговом дашборде: карточка + футер
+	   (грип ручного порядка + чипы тегов). */
+	.dashboard-flat-item {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		min-width: 0;
+	}
+
+	.dashboard-item-footer {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		min-width: 0;
+		margin-top: auto;
+	}
+
+	.dashboard-item-grip {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		background: transparent;
+		border: none;
+		padding: 0.125rem;
+		color: var(--color-text-muted);
+		opacity: 0.55;
+		cursor: grab;
+		touch-action: none;
+		border-radius: 4px;
+	}
+
+	.dashboard-item-grip:hover {
+		color: var(--color-text-primary);
+		opacity: 1;
+	}
+
+	.dashboard-item-grip:active {
+		cursor: grabbing;
+	}
+
+	.dashboard-item-grip.is-busy {
+		cursor: wait;
+		opacity: 0.3;
+		pointer-events: none;
+	}
+
+	/* Ручной порядок включён, но dnd заблокирован (поиск/фильтр/загрузка
+	   данных): грип виден, но неактивен — не исчезает молча. */
+	.dashboard-item-grip:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
+	   Движок вертикальный, поэтому на время активного drag сетка
+	   схлопывается в одну колонку — индексы вставки и индикатор
+	   становятся однозначными на любой плотности. ── */
+	.tunnel-grid.dashboard-grid--reordering {
+		--reorder-row-height: 40px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--card-gap, 6px);
+		user-select: none;
+	}
+
+	/* Компактный ряд на время drag и ghost-токен: бейдж вида + имя. */
+	.dashboard-reorder-row,
+	.drag-ghost-token {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		box-sizing: border-box;
+		height: var(--reorder-row-height, 40px);
+		padding: 0 0.75rem;
+		min-width: 0;
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+	}
+
+	.dashboard-kind-badge {
+		flex: 0 0 auto;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		line-height: 1.3;
+		color: var(--color-text-muted);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		padding: 1px 6px;
+		white-space: nowrap;
+	}
+
+	.dashboard-reorder-name {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--color-text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+
+	/* Во время drag строки компактные — слот источника и раскрытый
+	   drop-скелетон ужимаются до высоты ряда, а не исходной карточки
+	   (--drop-height меряется на pointerdown по полной карточке). */
+	.dashboard-grid--reordering .dashboard-flat-item.drag-source-exiting:not(.drag-source-collapsed) {
+		height: var(--reorder-row-height, 40px);
+	}
+
+	.dashboard-grid--reordering .drop-indicator.expanded:not(.collapsing) {
+		height: var(--reorder-row-height, 40px);
+	}
+
+	.dashboard-flat-item.drag-source-exiting {
+		overflow: hidden;
+		height: var(--drop-height);
+		opacity: 1;
+		transition:
+			height var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			opacity var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			margin var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
+	}
+
+	.dashboard-flat-item.drag-source-exiting.drag-source-collapsed {
+		height: 0;
+		max-height: 0;
+		opacity: 0;
+		margin-bottom: calc(-1 * var(--card-gap, 6px));
+	}
+
+	.drop-indicator {
+		box-sizing: border-box;
+		overflow: hidden;
+		border: 1px solid transparent;
+		border-radius: 999px;
+		background: var(--color-accent);
+		box-shadow: 0 0 10px color-mix(in srgb, var(--color-accent) 45%, transparent);
+		opacity: 1;
+		pointer-events: none;
+		transition:
+			height var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			margin var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			border-radius calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			background calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			box-shadow calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			border-color calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			opacity calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
+	}
+
+	.drop-indicator:not(.expanded):not(.collapsing) {
+		position: absolute;
+		top: -1px;
+		left: 0;
+		right: 0;
+		height: 2px;
+		margin: 0;
+		z-index: 2;
+	}
+
+	.drop-indicator.expanded:not(.collapsing) {
+		position: static;
+		top: auto;
+		height: var(--drop-height);
+		margin: 0 0 var(--card-gap, 6px);
+		border-radius: var(--radius-sm, 6px);
+		background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+		border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+		border-style: dashed;
+		box-shadow: none;
+	}
+
+	.drop-indicator.collapsing {
+		margin: 0 !important;
+		opacity: 0;
+		border-color: transparent;
+		background: transparent;
+		box-shadow: none;
+	}
+
+	.drop-indicator.collapsing.expanded {
+		position: static;
+		height: 0 !important;
+	}
+
+	.drop-indicator.collapsing:not(.expanded) {
+		position: absolute;
+		top: -1px;
+		left: 0;
+		right: 0;
+		height: 2px !important;
+		z-index: 2;
+		transition:
+			opacity var(--drop-line-collapse-ms, 240ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			box-shadow calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			background calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
+			border-color calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
+	}
+
+	.drop-indicator-end:not(.expanded):not(.collapsing) {
+		position: relative;
+		top: auto;
+		height: 2px;
+		margin: -1px 0 0;
+	}
+
+	.drop-indicator-end.collapsing:not(.expanded) {
+		position: relative;
+		top: auto;
+		left: auto;
+		right: auto;
+		height: 2px !important;
+		margin: -1px 0 0 !important;
+	}
+
+	/* Toolbar (count + actions row above the tunnel grid) */
+	.tunnels-toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+	}
+
+	.toolbar-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.toolbar-actions :global(.btn.size-md) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 32px;
+		min-height: 32px;
+		max-height: 32px;
+		padding-block: 0;
+	}
+
+	.toolbar-actions :global(.btn.variant-primary:hover:not(:disabled):not(.is-disabled)) {
+		background: transparent;
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+		filter: none;
+	}
+
+	@media (max-width: 760px) {
+	.tunnels-toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
+	.toolbar-actions {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			align-items: stretch;
+			gap: 0.5rem;
+			width: 100%;
+		}
+	.toolbar-actions :global(.toolbar-view-row) {
+			grid-column: 1 / -1;
+		}
+	.toolbar-actions > :global(.btn) {
+			width: 100%;
+			min-height: 32px;
+		}
+	.toolbar-actions > :global(.btn:only-of-type) {
+			grid-column: 1 / -1;
+		}
+}
+</style>

--- a/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
+++ b/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
@@ -354,9 +354,9 @@
 		user-select: none;
 	}
 
-	/* Компактный ряд на время drag и ghost-токен: бейдж вида + имя. */
-	.dashboard-reorder-row,
-	.drag-ghost-token {
+	/* Компактный ряд на время drag: бейдж вида + имя (ghost-токен остался в
+	   странице вместе со своим fixed-слоем и дублем этого правила). */
+	.dashboard-reorder-row {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;

--- a/frontend/src/lib/components/tunnels/TunnelPageModals.svelte
+++ b/frontend/src/lib/components/tunnels/TunnelPageModals.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	// Модалки страницы туннелей — выделено из routes/+page.svelte (класс 2):
+	// подтверждения удаления, графики трафика, диагностика, мастер создания,
+	// импорт внешнего интерфейса, настройки connectivity. Состояние страницы
+	// приходит live-контекстом (ctx), стили — глобальные (app.css).
+	import { AdoptTunnelDialog, TunnelReferencedModal, ConnectivitySettingsModal } from '$lib/components/tunnels';
+	import { Modal, TrafficChartModal, Button } from '$lib/components/ui';
+	import TunnelDiagnosticsModal from '$lib/components/testing/TunnelDiagnosticsModal.svelte';
+	import AddTunnelWizard from '$lib/components/subscriptions/AddTunnelWizard.svelte';
+	import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
+	import type { TunnelPageModalsContext } from './tunnelPageModalsContext';
+
+	let { ctx }: { ctx: TunnelPageModalsContext } = $props();
+</script>
+
+<AdoptTunnelDialog
+	interfaceName={ctx.adoptingInterface}
+	bind:open={ctx.adoptDialogOpen}
+	bind:error={ctx.adoptError}
+	bind:loading={ctx.adoptLoading}
+	onclose={() => ctx.adoptDialogOpen = false}
+	onadopt={ctx.handleAdopt}
+/>
+
+{#if ctx.deleteConfirmId}
+	{@const tunnelName = ctx.awgList.find(t => t.id === ctx.deleteConfirmId)?.name ?? ctx.deleteConfirmId}
+	<Modal
+		open={true}
+		title="Удалить туннель"
+		size="sm"
+		onclose={() => ctx.deleteConfirmId = null}
+	>
+		<p class="confirm-text">Удалить туннель <strong>{tunnelName}</strong>?</p>
+		{#snippet actions()}
+			<Button variant="secondary" size="md" onclick={() => ctx.deleteConfirmId = null}>Отмена</Button>
+			<Button variant="danger" size="md" onclick={() => ctx.handleDelete(ctx.deleteConfirmId!)}>Удалить</Button>
+		{/snippet}
+	</Modal>
+{/if}
+
+<TunnelReferencedModal
+	open={ctx.referencedDetails !== null}
+	details={ctx.referencedDetails}
+	tunnelName={ctx.referencedTunnelName}
+	onclose={() => { ctx.referencedDetails = null; ctx.referencedTunnelName = ''; }}
+/>
+
+<AddTunnelWizard bind:open={ctx.createModalOpen} preselect={ctx.wizardPreselect} />
+
+<Modal
+	open={ctx.pendingSubscriptionDelete !== null}
+	title="Удалить подписку?"
+	size="md"
+	onclose={() => {
+		if (ctx.deletingSubscription) return;
+		ctx.pendingSubscriptionDelete = null;
+	}}
+>
+	<p>
+		Подписка <strong>{ctx.pendingSubscriptionLabel}</strong> будет удалена
+		вместе с её sing-box outbound'ами и NDMS Proxy-интерфейсом.
+	</p>
+	{#snippet actions()}
+		<Button
+			variant="ghost"
+			disabled={ctx.deletingSubscription}
+			onclick={() => (ctx.pendingSubscriptionDelete = null)}
+		>
+			Отмена
+		</Button>
+		<Button
+			variant="danger"
+			disabled={ctx.deletingSubscription}
+			loading={ctx.deletingSubscription}
+			onclick={ctx.confirmSubscriptionDelete}
+		>
+			{ctx.deletingSubscription ? 'Удаляем...' : 'Удалить'}
+		</Button>
+	{/snippet}
+</Modal>
+
+{#if ctx.detailId}
+	{@const managed = ctx.awgList.find((x) => x.id === ctx.detailId)}
+	{@const sys = ctx.systemList.find((x) => x.id === ctx.detailId)}
+	{#if managed || sys}
+		<TrafficChartModal
+			open={true}
+			tunnelId={ctx.detailId}
+			tunnelName={managed?.name ?? sys?.description ?? ctx.detailId}
+			ifaceName={managed?.interfaceName ?? sys?.interfaceName ?? ''}
+			onclose={ctx.closeDetail}
+		/>
+	{/if}
+{/if}
+
+{#if ctx.singboxDetailTag}
+	{@const sb = ctx.singboxTunnelsList.find((x) => x.tag === ctx.singboxDetailTag)}
+	{@const subActiveCard = ctx.subscriptionsActiveCards.find((c) => c.activeMember.tag === ctx.singboxDetailTag)}
+	{@const subListRow = ctx.subscriptionsListRows.find(
+		(s) => resolveSubscriptionMemberTag(s, ctx.liveActives[s.id] || null) === ctx.singboxDetailTag,
+	)}
+	{@const detailName =
+		subActiveCard?.subscription.label
+		?? subListRow?.label
+		?? sb?.tag
+		?? ctx.singboxDetailTag}
+	{@const detailIface =
+		subActiveCard
+			? (subActiveCard.subscription.proxyIndex >= 0 ? `Proxy${subActiveCard.subscription.proxyIndex}` : '')
+			: (subListRow
+				? (subListRow.proxyIndex >= 0 ? `Proxy${subListRow.proxyIndex}` : '')
+				: (sb?.proxyInterface ?? ''))}
+	<TrafficChartModal
+		open={true}
+		tunnelId={ctx.singboxDetailTag}
+		tunnelName={detailName}
+		ifaceName={detailIface}
+		onclose={ctx.closeSingboxDetail}
+	/>
+{/if}
+
+{#if ctx.awgDiagnosticsTarget}
+	<TunnelDiagnosticsModal
+		open={true}
+		kind={ctx.awgDiagnosticsTarget.kind}
+		targetId={ctx.awgDiagnosticsTarget.id}
+		displayName={ctx.awgDiagnosticsTarget.name}
+		subjectLabel="туннель"
+		onclose={ctx.closeAwgDiagnostics}
+	/>
+{/if}
+
+{#if ctx.connectivitySettingsTunnel}
+	<ConnectivitySettingsModal
+		bind:open={ctx.connectivitySettingsOpen}
+		tunnelId={ctx.connectivitySettingsTunnel.id}
+		tunnelAddress={ctx.connectivitySettingsTunnel.address}
+		onclose={ctx.closeConnectivitySettings}
+		onSaved={ctx.closeConnectivitySettings}
+	/>
+{/if}

--- a/frontend/src/lib/components/tunnels/dashboardFlatContext.ts
+++ b/frontend/src/lib/components/tunnels/dashboardFlatContext.ts
@@ -1,11 +1,9 @@
 // Контекст flat-режима дашборда (класс 2 декомпозиции +page.svelte):
 // страница собирает объект с live-геттерами поверх своих $state/$derived
 // и передаёт одним пропом в DashboardFlatSection.
-import type { TunnelListItem, SystemTunnel, ExternalTunnel } from '$lib/types';
 import type { TunnelDashboardFlatItem } from '$lib/utils/tunnelDashboardFlat';
 import type { SingboxLayoutMode, TunnelRenderMode } from '$lib/constants/singboxLayout';
 import type { createReorderDrag } from '$lib/components/sb-router/reorderDrag.svelte';
-import type { SubscriptionActiveCardVM } from '$lib/components/subscriptions/subscriptionVMs';
 
 export interface DashboardTagGroupEntry {
 	item: TunnelDashboardFlatItem;
@@ -15,7 +13,6 @@ export interface DashboardTagGroupEntry {
 export interface DashboardFlatContext {
 	// --- derived ---
 	readonly DASHBOARD_KIND_LABELS: Record<TunnelDashboardFlatItem['kind'], string>;
-	readonly dashboardOn: boolean;
 	readonly dashboardDndEnabled: boolean;
 	readonly dashboardFilterEmpty: boolean;
 	readonly dashboardFlatCardMode: boolean;
@@ -33,9 +30,7 @@ export interface DashboardFlatContext {
 	readonly effectiveSingboxSubscriptionsRenderMode: TunnelRenderMode;
 	readonly showSingboxListOption: boolean;
 	readonly showSingboxSections: boolean;
-	readonly loading: boolean;
 	readonly exporting: boolean;
-	readonly adoptingInterface: string;
 	readonly awgAutoConnectivityNonce: number;
 	readonly singboxAutoDelayCheckNonce: number;
 	readonly deleteLoading: Record<string, boolean>;
@@ -44,14 +39,10 @@ export interface DashboardFlatContext {
 	readonly flatDrag: ReturnType<typeof createReorderDrag>;
 	readonly flatRowEls: Array<HTMLElement | null>;
 	// --- state с записью из секции ---
-	adoptDialogOpen: boolean;
-	adoptError: string;
-	adoptLoading: boolean;
 	dashboardSearchQuery: string;
 	dashboardTagFilter: string | null;
 	flatGridEl: HTMLElement | null;
 	// --- обработчики ---
-	handleAdopt(data: { content: string; name: string }): Promise<void>;
 	handleAdoptClick(interfaceName: string): void;
 	handleExportAll(): Promise<void>;
 	handleGripKeydown(index: number, event: KeyboardEvent): void;
@@ -65,4 +56,3 @@ export interface DashboardFlatContext {
 	requestDelete(id: string): void;
 	requestSubscriptionDelete(id: string): void;
 }
-export type { TunnelListItem, SystemTunnel, ExternalTunnel, SubscriptionActiveCardVM };

--- a/frontend/src/lib/components/tunnels/dashboardFlatContext.ts
+++ b/frontend/src/lib/components/tunnels/dashboardFlatContext.ts
@@ -1,0 +1,68 @@
+// Контекст flat-режима дашборда (класс 2 декомпозиции +page.svelte):
+// страница собирает объект с live-геттерами поверх своих $state/$derived
+// и передаёт одним пропом в DashboardFlatSection.
+import type { TunnelListItem, SystemTunnel, ExternalTunnel } from '$lib/types';
+import type { TunnelDashboardFlatItem } from '$lib/utils/tunnelDashboardFlat';
+import type { SingboxLayoutMode, TunnelRenderMode } from '$lib/constants/singboxLayout';
+import type { createReorderDrag } from '$lib/components/sb-router/reorderDrag.svelte';
+import type { SubscriptionActiveCardVM } from '$lib/components/subscriptions/subscriptionVMs';
+
+export interface DashboardTagGroupEntry {
+	item: TunnelDashboardFlatItem;
+	autoCheck: boolean;
+}
+
+export interface DashboardFlatContext {
+	// --- derived ---
+	readonly DASHBOARD_KIND_LABELS: Record<TunnelDashboardFlatItem['kind'], string>;
+	readonly dashboardOn: boolean;
+	readonly dashboardDndEnabled: boolean;
+	readonly dashboardFilterEmpty: boolean;
+	readonly dashboardFlatCardMode: boolean;
+	readonly dashboardFlatLayout: boolean;
+	readonly dashboardGridClass: string;
+	readonly dashboardGroupByTags: boolean;
+	readonly dashboardRenderItems: TunnelDashboardFlatItem[];
+	readonly dashboardSummaryStats: Array<{ value: string; label: string; sub?: string }>;
+	readonly dashboardTagGroups: Array<{ tag: string | null; items: DashboardTagGroupEntry[] }>;
+	readonly effectiveAwgCardViewMode: 'cards' | 'compact';
+	readonly effectiveAwgRenderMode: TunnelRenderMode;
+	readonly effectiveSingboxTunnelsEffectiveLayout: SingboxLayoutMode;
+	readonly effectiveSingboxTunnelsRenderMode: TunnelRenderMode;
+	readonly effectiveSingboxSubscriptionsEffectiveLayout: SingboxLayoutMode;
+	readonly effectiveSingboxSubscriptionsRenderMode: TunnelRenderMode;
+	readonly showSingboxListOption: boolean;
+	readonly showSingboxSections: boolean;
+	readonly loading: boolean;
+	readonly exporting: boolean;
+	readonly adoptingInterface: string;
+	readonly awgAutoConnectivityNonce: number;
+	readonly singboxAutoDelayCheckNonce: number;
+	readonly deleteLoading: Record<string, boolean>;
+	readonly toggleLoading: Record<string, boolean>;
+	readonly liveActives: Record<string, string>;
+	readonly flatDrag: ReturnType<typeof createReorderDrag>;
+	readonly flatRowEls: Array<HTMLElement | null>;
+	// --- state с записью из секции ---
+	adoptDialogOpen: boolean;
+	adoptError: string;
+	adoptLoading: boolean;
+	dashboardSearchQuery: string;
+	dashboardTagFilter: string | null;
+	flatGridEl: HTMLElement | null;
+	// --- обработчики ---
+	handleAdopt(data: { content: string; name: string }): Promise<void>;
+	handleAdoptClick(interfaceName: string): void;
+	handleExportAll(): Promise<void>;
+	handleGripKeydown(index: number, event: KeyboardEvent): void;
+	handleGripPointerDown(index: number, event: PointerEvent): void;
+	handleToggleOnOff(id: string): Promise<void>;
+	markAsServer(id: string): Promise<void>;
+	openAwgDiagnostics(id: string, name: string, kind?: 'awg' | 'system'): void;
+	openDetail(id: string): void;
+	openSingboxDetail(tag: string): void;
+	openWizard(preselect: 'choose' | 'single' | 'inline' | 'url'): void;
+	requestDelete(id: string): void;
+	requestSubscriptionDelete(id: string): void;
+}
+export type { TunnelListItem, SystemTunnel, ExternalTunnel, SubscriptionActiveCardVM };

--- a/frontend/src/lib/components/tunnels/tunnelPageModalsContext.ts
+++ b/frontend/src/lib/components/tunnels/tunnelPageModalsContext.ts
@@ -1,0 +1,49 @@
+// Контекст модалок страницы туннелей (класс 2 декомпозиции +page.svelte).
+// Страница собирает объект с live-геттерами поверх своих $state/$derived и
+// передаёт одним пропом в TunnelPageModals — чтение геттера в шаблоне
+// отслеживает исходную реактивность, запись в сеттеры мутирует состояние
+// страницы.
+import type {
+	TunnelListItem,
+	SystemTunnel,
+	SingboxTunnel,
+	Subscription,
+	TunnelReferencedError,
+} from '$lib/types';
+import type { SubscriptionActiveCardVM } from '$lib/components/subscriptions/subscriptionVMs';
+
+export interface TunnelPageModalsContext {
+	// --- derived (только чтение) ---
+	readonly awgList: TunnelListItem[];
+	readonly systemList: SystemTunnel[];
+	readonly singboxTunnelsList: SingboxTunnel[];
+	readonly subscriptionsActiveCards: SubscriptionActiveCardVM[];
+	readonly subscriptionsListRows: Subscription[];
+	readonly liveActives: Record<string, string>;
+	readonly pendingSubscriptionLabel: string;
+	// --- state (страница владеет; часть пишется модалками) ---
+	adoptDialogOpen: boolean;
+	adoptError: string;
+	adoptLoading: boolean;
+	readonly adoptingInterface: string;
+	deleteConfirmId: string | null;
+	referencedDetails: TunnelReferencedError | null;
+	referencedTunnelName: string;
+	createModalOpen: boolean;
+	readonly wizardPreselect: 'choose' | 'single' | 'inline' | 'url';
+	pendingSubscriptionDelete: string | null;
+	readonly deletingSubscription: boolean;
+	readonly detailId: string | null;
+	readonly singboxDetailTag: string | null;
+	readonly awgDiagnosticsTarget: { id: string; name: string; kind: 'awg' | 'system' } | null;
+	readonly connectivitySettingsTunnel: TunnelListItem | null;
+	connectivitySettingsOpen: boolean;
+	// --- обработчики страницы ---
+	handleAdopt: (data: { content: string; name: string }) => Promise<void>;
+	handleDelete: (id: string) => Promise<void>;
+	confirmSubscriptionDelete: () => Promise<void>;
+	closeDetail: () => void;
+	closeSingboxDetail: () => void;
+	closeAwgDiagnostics: () => void;
+	closeConnectivitySettings: () => void;
+}

--- a/frontend/src/lib/components/tunnels/tunnelPageSelectors.test.ts
+++ b/frontend/src/lib/components/tunnels/tunnelPageSelectors.test.ts
@@ -71,10 +71,10 @@ describe('статусные хелперы', () => {
 	});
 
 	it('awgStatusRank даёт порядок running < starting < broken < stopped < disabled', () => {
-		const ranks = ['running', 'starting', 'broken', 'stopped', 'disabled'].map((s) =>
+		const ranks = ['running', 'starting', 'broken', 'stopped', 'disabled', '???'].map((s) =>
 			awgStatusRank(awg({ status: s })),
 		);
-		expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+		expect(ranks).toEqual([0, 1, 2, 3, 4, 5]);
 	});
 
 	it('isManagedTunnelOn true для running/starting/broken', () => {
@@ -129,11 +129,12 @@ describe('sortFilterAwgList', () => {
 describe('sortFilterSystemList / sortFilterExternalList', () => {
 	it('system: фильтр по описанию, сортировка по handshake', () => {
 		const list = [
-			sys({ id: 'wg1', description: 'Moscow', peer: { lastHandshake: '2026-01-02T00:00:00Z' } as SystemTunnel['peer'] }),
 			sys({ id: 'wg2', description: 'Piter', peer: { lastHandshake: '2026-01-03T00:00:00Z' } as SystemTunnel['peer'] }),
+			sys({ id: 'wg1', description: 'Moscow', peer: { lastHandshake: '2026-01-02T00:00:00Z' } as SystemTunnel['peer'] }),
 		];
 		expect(sortFilterSystemList(list, 'mosc', null, true).map((t) => t.id)).toEqual(['wg1']);
 		expect(sortFilterSystemList(list, '', 'handshake', true).map((t) => t.id)).toEqual(['wg1', 'wg2']);
+		expect(sortFilterSystemList(list, '', 'handshake', false).map((t) => t.id)).toEqual(['wg2', 'wg1']);
 	});
 
 	it('external: фильтр по awg/wg метке', () => {
@@ -153,14 +154,13 @@ describe('sing-box туннели', () => {
 
 	it('сортировка по delay: null-задержки в конец', () => {
 		const dm = buildSingboxDelayMap(list, delays([['a-fast', [50]], ['b-slow', []]]));
-		const sorted = sortFilterSingboxTunnels(list, '', 'delay', true, dm, traffic([]));
+		const sorted = sortFilterSingboxTunnels(list, '', 'delay', true, () => dm, () => traffic([]));
 		expect(sorted.map((t) => t.tag)).toEqual(['a-fast', 'b-slow']);
 	});
 
 	it('сортировка по трафику', () => {
 		const tr = traffic([['a-fast', 10, 0], ['b-slow', 100, 5]]);
-		const dm = new Map<string, number | null>();
-		const sorted = sortFilterSingboxTunnels(list, '', 'traffic', false, dm, tr);
+		const sorted = sortFilterSingboxTunnels(list, '', 'traffic', false, () => new Map(), () => tr);
 		expect(sorted.map((t) => t.tag)).toEqual(['b-slow', 'a-fast']);
 	});
 });
@@ -177,12 +177,12 @@ describe('подписки', () => {
 
 	it('активные карточки: фильтр по member-тегу и сортировка по updated', () => {
 		expect(
-			sortFilterSubscriptionsActiveCards([cardA, cardB], 'm2', null, true, traffic([]), delays([])).map(
+			sortFilterSubscriptionsActiveCards([cardA, cardB], 'm2', null, true, () => traffic([]), () => delays([])).map(
 				(c) => c.subscription.id,
 			),
 		).toEqual(['s2']);
 		expect(
-			sortFilterSubscriptionsActiveCards([cardA, cardB], '', 'updated', true, traffic([]), delays([])).map(
+			sortFilterSubscriptionsActiveCards([cardB, cardA], '', 'updated', true, () => traffic([]), () => delays([])).map(
 				(c) => c.subscription.id,
 			),
 		).toEqual(['s1', 's2']);
@@ -196,8 +196,8 @@ describe('подписки', () => {
 		const sorted = sortFilterSubscriptionsListRows(
 			rows, '', 'delay', true,
 			{ s1: 'a', s2: 'b' },
-			traffic([]),
-			delays([['a', [200]], ['b', [30]]]),
+			() => traffic([]),
+			() => delays([['a', [200]], ['b', [30]]]),
 		);
 		expect(sorted.map((s) => s.id)).toEqual(['s2', 's1']);
 	});

--- a/frontend/src/lib/components/tunnels/tunnelPageSelectors.test.ts
+++ b/frontend/src/lib/components/tunnels/tunnelPageSelectors.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import {
+	awgStatusRank,
+	buildSingboxDelayMap,
+	computeAwgSummaryPeak,
+	computeAwgTrafficLeader,
+	computeSingboxTunnelListStats,
+	computeSubscriptionsTrafficStats,
+	externalStatusLabel,
+	externalStatusVariant,
+	isManagedTunnelOn,
+	managedRouteMeta,
+	matchQuery,
+	sortFilterAwgList,
+	sortFilterExternalList,
+	sortFilterSingboxTunnels,
+	sortFilterSubscriptionsActiveCards,
+	sortFilterSubscriptionsListRows,
+	sortFilterSystemList,
+	systemStatusLabel,
+	systemStatusVariant,
+	tunnelStatusBucket,
+} from './tunnelPageSelectors';
+import type {
+	TunnelListItem,
+	SystemTunnel,
+	ExternalTunnel,
+	SingboxTunnel,
+	Subscription,
+	SingboxTraffic,
+} from '$lib/types';
+import type { SubscriptionActiveCardVM } from '$lib/components/subscriptions/subscriptionVMs';
+
+function awg(over: Partial<TunnelListItem>): TunnelListItem {
+	return {
+		id: 'id',
+		name: 'name',
+		status: 'running',
+		...over,
+	} as TunnelListItem;
+}
+
+function sys(over: Partial<SystemTunnel>): SystemTunnel {
+	return { id: 'wg0', status: 'up', ...over } as SystemTunnel;
+}
+
+function ext(over: Partial<ExternalTunnel>): ExternalTunnel {
+	return { interfaceName: 'ext0', rxBytes: 0, txBytes: 0, isAWG: false, ...over } as ExternalTunnel;
+}
+
+function sbt(over: Partial<SingboxTunnel>): SingboxTunnel {
+	return { tag: 'tag', protocol: 'vless', server: 's', port: 443, running: true, ...over } as SingboxTunnel;
+}
+
+function sub(over: Partial<Subscription>): Subscription {
+	return { id: 'sub1', label: 'Sub', url: 'https://x', mode: 'urltest', proxyIndex: 0, ...over } as Subscription;
+}
+
+const traffic = (entries: Array<[string, number, number]>): Map<string, SingboxTraffic> =>
+	new Map(entries.map(([tag, download, upload]) => [tag, { download, upload } as SingboxTraffic]));
+
+const delays = (entries: Array<[string, number[]]>): Map<string, number[]> => new Map(entries);
+
+describe('статусные хелперы', () => {
+	it('tunnelStatusBucket сводит статусы к вёдрам', () => {
+		expect(tunnelStatusBucket('running')).toBe('running');
+		expect(tunnelStatusBucket('needs_stop')).toBe('starting');
+		expect(tunnelStatusBucket('not_created')).toBe('stopped');
+		expect(tunnelStatusBucket('disabled')).toBe('disabled');
+		expect(tunnelStatusBucket('???')).toBe('other');
+	});
+
+	it('awgStatusRank даёт порядок running < starting < broken < stopped < disabled', () => {
+		const ranks = ['running', 'starting', 'broken', 'stopped', 'disabled'].map((s) =>
+			awgStatusRank(awg({ status: s })),
+		);
+		expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+	});
+
+	it('isManagedTunnelOn true для running/starting/broken', () => {
+		expect(isManagedTunnelOn(awg({ status: 'running' }))).toBe(true);
+		expect(isManagedTunnelOn(awg({ status: 'broken' }))).toBe(true);
+		expect(isManagedTunnelOn(awg({ status: 'stopped' }))).toBe(false);
+	});
+
+	it('managedRouteMeta собирает метку маршрута', () => {
+		expect(managedRouteMeta(awg({ ispInterface: 'ppp0', ispInterfaceLabel: 'Dom.Ru' }))).toBe('Dom.Ru (ppp0)');
+		expect(managedRouteMeta(awg({ ispInterface: 'ppp0', ispInterfaceLabel: 'ppp0' }))).toBe('ppp0');
+		expect(managedRouteMeta(awg({}))).toBe('Маршрут не установлен');
+	});
+
+	it('system/external статусы', () => {
+		expect(systemStatusVariant(sys({ status: 'up' }))).toBe('success');
+		expect(systemStatusLabel(sys({ status: 'down' }))).toBe('Выключен');
+		expect(systemStatusLabel(sys({ status: 'up', peer: { online: true } as SystemTunnel['peer'] }))).toBe('Активен');
+		expect(externalStatusVariant(ext({ lastHandshake: 'x' }))).toBe('success');
+		expect(externalStatusLabel(ext({}))).toBe('Неактивен');
+	});
+
+	it('matchQuery: пустой запрос всегда true, поиск без регистра', () => {
+		expect(matchQuery(['Abc'], '')).toBe(true);
+		expect(matchQuery(['Frankfurt', null], 'frank')).toBe(true);
+		expect(matchQuery([undefined, 'x'], 'zzz')).toBe(false);
+	});
+});
+
+describe('sortFilterAwgList', () => {
+	const list = [
+		awg({ id: 'a', name: 'Beta', status: 'stopped', endpoint: 'b.example:51820', rxBytes: 10, txBytes: 0 }),
+		awg({ id: 'b', name: 'alpha', status: 'running', endpoint: 'a.example:51820', rxBytes: 5, txBytes: 100 }),
+	];
+
+	it('фильтрует по любому из полей', () => {
+		expect(sortFilterAwgList(list, 'beta', null, true).map((t) => t.id)).toEqual(['a']);
+		expect(sortFilterAwgList(list, 'A.EXAMPLE', null, true).map((t) => t.id)).toEqual(['b']);
+	});
+
+	it('без sortBy сохраняет исходный порядок', () => {
+		expect(sortFilterAwgList(list, '', null, true).map((t) => t.id)).toEqual(['a', 'b']);
+	});
+
+	it('сортирует по имени/статусу/трафику с направлением', () => {
+		expect(sortFilterAwgList(list, '', 'name', true).map((t) => t.name)).toEqual(['alpha', 'Beta']);
+		expect(sortFilterAwgList(list, '', 'status', true).map((t) => t.status)).toEqual(['running', 'stopped']);
+		expect(sortFilterAwgList(list, '', 'traffic', false).map((t) => t.id)).toEqual(['b', 'a']);
+	});
+});
+
+describe('sortFilterSystemList / sortFilterExternalList', () => {
+	it('system: фильтр по описанию, сортировка по handshake', () => {
+		const list = [
+			sys({ id: 'wg1', description: 'Moscow', peer: { lastHandshake: '2026-01-02T00:00:00Z' } as SystemTunnel['peer'] }),
+			sys({ id: 'wg2', description: 'Piter', peer: { lastHandshake: '2026-01-03T00:00:00Z' } as SystemTunnel['peer'] }),
+		];
+		expect(sortFilterSystemList(list, 'mosc', null, true).map((t) => t.id)).toEqual(['wg1']);
+		expect(sortFilterSystemList(list, '', 'handshake', true).map((t) => t.id)).toEqual(['wg1', 'wg2']);
+	});
+
+	it('external: фильтр по awg/wg метке', () => {
+		const list = [ext({ interfaceName: 'e1', isAWG: true }), ext({ interfaceName: 'e2', isAWG: false })];
+		expect(sortFilterExternalList(list, 'awg', null, true).map((t) => t.interfaceName)).toEqual(['e1']);
+	});
+});
+
+describe('sing-box туннели', () => {
+	const list = [sbt({ tag: 'b-slow' }), sbt({ tag: 'a-fast' })];
+
+	it('buildSingboxDelayMap берёт последний положительный замер', () => {
+		const map = buildSingboxDelayMap(list, delays([['a-fast', [100, 50]], ['b-slow', [0]]]));
+		expect(map.get('a-fast')).toBe(50);
+		expect(map.get('b-slow')).toBeNull();
+	});
+
+	it('сортировка по delay: null-задержки в конец', () => {
+		const dm = buildSingboxDelayMap(list, delays([['a-fast', [50]], ['b-slow', []]]));
+		const sorted = sortFilterSingboxTunnels(list, '', 'delay', true, dm, traffic([]));
+		expect(sorted.map((t) => t.tag)).toEqual(['a-fast', 'b-slow']);
+	});
+
+	it('сортировка по трафику', () => {
+		const tr = traffic([['a-fast', 10, 0], ['b-slow', 100, 5]]);
+		const dm = new Map<string, number | null>();
+		const sorted = sortFilterSingboxTunnels(list, '', 'traffic', false, dm, tr);
+		expect(sorted.map((t) => t.tag)).toEqual(['b-slow', 'a-fast']);
+	});
+});
+
+describe('подписки', () => {
+	const cardA: SubscriptionActiveCardVM = {
+		subscription: sub({ id: 's1', label: 'Alpha', lastFetched: '2026-01-01T00:00:00Z' }),
+		activeMember: { tag: 'm1', label: 'M1', server: 'srv1' } as SubscriptionActiveCardVM['activeMember'],
+	};
+	const cardB: SubscriptionActiveCardVM = {
+		subscription: sub({ id: 's2', label: 'Beta', lastFetched: '2026-01-02T00:00:00Z' }),
+		activeMember: { tag: 'm2', label: 'M2', server: 'srv2' } as SubscriptionActiveCardVM['activeMember'],
+	};
+
+	it('активные карточки: фильтр по member-тегу и сортировка по updated', () => {
+		expect(
+			sortFilterSubscriptionsActiveCards([cardA, cardB], 'm2', null, true, traffic([]), delays([])).map(
+				(c) => c.subscription.id,
+			),
+		).toEqual(['s2']);
+		expect(
+			sortFilterSubscriptionsActiveCards([cardA, cardB], '', 'updated', true, traffic([]), delays([])).map(
+				(c) => c.subscription.id,
+			),
+		).toEqual(['s1', 's2']);
+	});
+
+	it('строки списка: сортировка по delay активного member из liveActives', () => {
+		const rows = [
+			sub({ id: 's1', label: 'One', members: [{ tag: 'a' }] as Subscription['members'] }),
+			sub({ id: 's2', label: 'Two', members: [{ tag: 'b' }] as Subscription['members'] }),
+		];
+		const sorted = sortFilterSubscriptionsListRows(
+			rows, '', 'delay', true,
+			{ s1: 'a', s2: 'b' },
+			traffic([]),
+			delays([['a', [200]], ['b', [30]]]),
+		);
+		expect(sorted.map((s) => s.id)).toEqual(['s2', 's1']);
+	});
+});
+
+describe('сводные статистики', () => {
+	it('computeAwgSummaryPeak учитывает только включённые туннели', () => {
+		const rates: Record<string, { rx: number; tx: number }> = {
+			t1: { rx: 100, tx: 100 },
+			t2: { rx: 5, tx: 5 },
+			w1: { rx: 50, tx: 0 },
+		};
+		const peak = computeAwgSummaryPeak(
+			[awg({ id: 't1', name: 'Off', status: 'stopped' }), awg({ id: 't2', name: 'On', status: 'running' })],
+			[sys({ id: 'w1', description: 'Sys', status: 'up' })],
+			(id) => rates[id] ?? { rx: 0, tx: 0 },
+		);
+		expect(peak).toEqual({ rate: 50, name: 'Sys' });
+	});
+
+	it('computeAwgTrafficLeader выбирает максимум по трём спискам', () => {
+		const leader = computeAwgTrafficLeader(
+			[awg({ name: 'A', rxBytes: 10, txBytes: 10 })],
+			[sys({ description: 'S', peer: { rxBytes: 100, txBytes: 0 } as SystemTunnel['peer'] })],
+			[ext({ interfaceName: 'E', rxBytes: 30, txBytes: 30 })],
+		);
+		expect(leader).toEqual({ bytes: 100, name: 'S' });
+	});
+
+	it('computeSingboxTunnelListStats: счётчики, лидер, средняя задержка', () => {
+		const stats = computeSingboxTunnelListStats(
+			[sbt({ tag: 'a', running: true }), sbt({ tag: 'b', running: false })],
+			traffic([['a', 100, 50], ['b', 10, 0]]),
+			delays([['a', [100]], ['b', [200]]]),
+		);
+		expect(stats.count).toBe(2);
+		expect(stats.running).toBe(1);
+		expect(stats.stopped).toBe(1);
+		expect(stats.down).toBe(110);
+		expect(stats.up).toBe(50);
+		expect(stats.leaderName).toBe('a');
+		expect(stats.avgDelayMs).toBe(150);
+	});
+
+	it('computeSubscriptionsTrafficStats: активные сэмплируют delay, лидер и доля', () => {
+		const active: SubscriptionActiveCardVM[] = [
+			{
+				subscription: sub({ id: 's1', label: 'Act' }),
+				activeMember: { tag: 'm1', label: 'M1' } as SubscriptionActiveCardVM['activeMember'],
+			},
+		];
+		const rows = [
+			sub({ id: 's2', label: 'Row', memberTags: ['m2'], members: [{ tag: 'm2' }] as Subscription['members'] }),
+		];
+		const stats = computeSubscriptionsTrafficStats(
+			[...active.map((a) => a.subscription), ...rows],
+			active,
+			rows,
+			{ s2: 'm2' },
+			traffic([['m1', 75, 0], ['m2', 25, 0]]),
+			delays([['m1', [40]], ['m2', [999]]]),
+		);
+		expect(stats.count).toBe(2);
+		expect(stats.activeCount).toBe(1);
+		expect(stats.inactiveCount).toBe(1);
+		expect(stats.down).toBe(100);
+		expect(stats.avgDelayMs).toBe(40); // только активные сэмплируют
+		expect(stats.leaderName).toBe('Act');
+		expect(stats.leaderSharePct).toBe(75);
+	});
+});

--- a/frontend/src/lib/components/tunnels/tunnelPageSelectors.ts
+++ b/frontend/src/lib/components/tunnels/tunnelPageSelectors.ts
@@ -1,0 +1,605 @@
+// Чистые селекторы списков страницы туннелей (класс 2 декомпозиции
+// +page.svelte): фильтрация по поисковому запросу + сортировка табличных
+// представлений и сводные статистики. Никакой реактивности — страница
+// оборачивает вызовы в $derived, передавая значения сторов параметрами.
+import type {
+	TunnelListItem,
+	SystemTunnel,
+	ExternalTunnel,
+	SingboxTunnel,
+	Subscription,
+	SingboxTraffic,
+} from '$lib/types';
+import type {
+	AwgTunnelSortKey,
+	SingboxTunnelSortKey,
+	SubscriptionSortKey,
+} from '$lib/stores/tunnelTableSort';
+import {
+	applyDirection,
+	compareBool,
+	compareDelayLike,
+	compareNullableNumber,
+	compareString,
+} from '$lib/utils/tunnelTableSort';
+import type {
+	SubscriptionActiveCardVM,
+	SubscriptionsTrafficStats,
+	SingboxTunnelListStats,
+} from '$lib/components/subscriptions/subscriptionVMs';
+import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
+
+type TrafficMap = Map<string, SingboxTraffic>;
+type DelayHistoryMap = Map<string, number[]>;
+
+// --- статусные хелперы карточек/таблиц ---
+
+export function tunnelStatusBucket(status: string): 'running' | 'broken' | 'starting' | 'stopped' | 'disabled' | 'other' {
+	switch (status) {
+		case 'running':
+			return 'running';
+		case 'broken':
+			return 'broken';
+		case 'starting':
+		case 'needs_stop':
+		case 'stopping':
+			return 'starting';
+		case 'needs_start':
+		case 'stopped':
+		case 'not_created':
+			return 'stopped';
+		case 'disabled':
+			return 'disabled';
+		default:
+			return 'other';
+	}
+}
+
+export function isManagedTunnelOn(tunnel: TunnelListItem): boolean {
+	return ['running', 'starting', 'broken'].includes(tunnel.status);
+}
+
+export function managedRouteMeta(tunnel: TunnelListItem): string {
+	const iface = tunnel.resolvedIspInterface || tunnel.ispInterface || '';
+	const label = tunnel.resolvedIspInterfaceLabel || tunnel.ispInterfaceLabel || '';
+	if (label && iface) return label === iface ? label : `${label} (${iface})`;
+	if (label) return label;
+	if (iface) return iface;
+	return 'Маршрут не установлен';
+}
+
+export function systemStatusVariant(tunnel: SystemTunnel): 'success' | 'muted' {
+	return tunnel.status === 'up' ? 'success' : 'muted';
+}
+
+export function systemStatusLabel(tunnel: SystemTunnel): string {
+	if (tunnel.status !== 'up') return 'Выключен';
+	return tunnel.peer?.online ? 'Активен' : 'Без handshake';
+}
+
+export function externalStatusVariant(tunnel: ExternalTunnel): 'success' | 'muted' {
+	return tunnel.lastHandshake ? 'success' : 'muted';
+}
+
+export function externalStatusLabel(tunnel: ExternalTunnel): string {
+	return tunnel.lastHandshake ? 'Подключён' : 'Неактивен';
+}
+
+export function matchQuery(values: Array<string | null | undefined>, query: string): boolean {
+	const q = query.trim().toLowerCase();
+	if (!q) return true;
+	return values.some((value) => String(value ?? '').toLowerCase().includes(q));
+}
+
+export function awgStatusRank(tunnel: TunnelListItem): number {
+	switch (tunnelStatusBucket(tunnel.status)) {
+		case 'running':
+			return 0;
+		case 'starting':
+			return 1;
+		case 'broken':
+			return 2;
+		case 'stopped':
+			return 3;
+		case 'disabled':
+			return 4;
+		default:
+			return 5;
+	}
+}
+
+// --- сортировка/фильтрация списков вкладки AWG ---
+
+export function sortFilterAwgList(
+	list: TunnelListItem[],
+	rawQuery: string,
+	sortBy: AwgTunnelSortKey | null,
+	asc: boolean,
+): TunnelListItem[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = list.filter((tunnel) =>
+		matchQuery(
+			[
+				tunnel.name,
+				tunnel.interfaceName,
+				tunnel.id,
+				tunnel.ndmsName,
+				tunnel.address,
+				tunnel.endpoint,
+				tunnel.backend,
+				tunnel.awgVersion,
+			],
+			query,
+		),
+	);
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		switch (sortBy) {
+			case 'name':
+				return applyDirection(compareString(a.name, b.name), asc);
+			case 'status':
+				return applyDirection(compareNullableNumber(awgStatusRank(a), awgStatusRank(b), false), asc);
+			case 'endpoint':
+				return applyDirection(compareString(a.endpoint, b.endpoint), asc);
+			case 'traffic':
+				return applyDirection(
+					compareNullableNumber((a.rxBytes ?? 0) + (a.txBytes ?? 0), (b.rxBytes ?? 0) + (b.txBytes ?? 0), false),
+					asc,
+				);
+			case 'handshake':
+				return applyDirection(
+					compareNullableNumber(
+						a.lastHandshake ? new Date(a.lastHandshake).getTime() : null,
+						b.lastHandshake ? new Date(b.lastHandshake).getTime() : null,
+					),
+					asc,
+				);
+		}
+	});
+}
+
+export function sortFilterSystemList(
+	list: SystemTunnel[],
+	rawQuery: string,
+	sortBy: AwgTunnelSortKey | null,
+	asc: boolean,
+): SystemTunnel[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = list.filter((tunnel) =>
+		matchQuery(
+			[
+				tunnel.description,
+				tunnel.interfaceName,
+				tunnel.id,
+				tunnel.address,
+				tunnel.peer?.endpoint,
+				tunnel.peer?.via,
+			],
+			query,
+		),
+	);
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		switch (sortBy) {
+			case 'name':
+				return applyDirection(compareString(a.description || a.id, b.description || b.id), asc);
+			case 'status':
+				return applyDirection(compareBool(a.status === 'up', b.status === 'up'), asc);
+			case 'endpoint':
+				return applyDirection(compareString(a.peer?.endpoint, b.peer?.endpoint), asc);
+			case 'traffic':
+				return applyDirection(
+					compareNullableNumber(
+						(a.peer?.rxBytes ?? 0) + (a.peer?.txBytes ?? 0),
+						(b.peer?.rxBytes ?? 0) + (b.peer?.txBytes ?? 0),
+						false,
+					),
+					asc,
+				);
+			case 'handshake':
+				return applyDirection(
+					compareNullableNumber(
+						a.peer?.lastHandshake ? new Date(a.peer.lastHandshake).getTime() : null,
+						b.peer?.lastHandshake ? new Date(b.peer.lastHandshake).getTime() : null,
+					),
+					asc,
+				);
+		}
+	});
+}
+
+export function sortFilterExternalList(
+	list: ExternalTunnel[],
+	rawQuery: string,
+	sortBy: AwgTunnelSortKey | null,
+	asc: boolean,
+): ExternalTunnel[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = list.filter((tunnel) =>
+		matchQuery([tunnel.interfaceName, tunnel.endpoint, tunnel.publicKey, tunnel.isAWG ? 'awg' : 'wg'], query),
+	);
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		switch (sortBy) {
+			case 'name':
+				return applyDirection(compareString(a.interfaceName, b.interfaceName), asc);
+			case 'status':
+				return applyDirection(compareBool(!!a.lastHandshake, !!b.lastHandshake), asc);
+			case 'endpoint':
+				return applyDirection(compareString(a.endpoint, b.endpoint), asc);
+			case 'traffic':
+				return applyDirection(compareNullableNumber(a.rxBytes + a.txBytes, b.rxBytes + b.txBytes, false), asc);
+			case 'handshake':
+				return applyDirection(
+					compareNullableNumber(
+						a.lastHandshake ? new Date(a.lastHandshake).getTime() : null,
+						b.lastHandshake ? new Date(b.lastHandshake).getTime() : null,
+					),
+					asc,
+				);
+		}
+	});
+}
+
+// --- сортировка/фильтрация sing-box туннелей ---
+
+export function buildSingboxDelayMap(
+	list: SingboxTunnel[],
+	delayHistory: DelayHistoryMap,
+): Map<string, number | null> {
+	const map = new Map<string, number | null>();
+	for (const tunnel of list) {
+		const history = delayHistory.get(tunnel.tag) ?? [];
+		const latest = history.length > 0 ? history[history.length - 1] : null;
+		map.set(tunnel.tag, latest && latest > 0 ? latest : null);
+	}
+	return map;
+}
+
+export function sortFilterSingboxTunnels(
+	list: SingboxTunnel[],
+	rawQuery: string,
+	sortBy: SingboxTunnelSortKey | null,
+	asc: boolean,
+	delayValues: Map<string, number | null>,
+	traffic: TrafficMap,
+): SingboxTunnel[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = list.filter((tunnel) =>
+		matchQuery(
+			[
+				tunnel.tag,
+				tunnel.protocol,
+				tunnel.server,
+				tunnel.proxyInterface,
+				tunnel.kernelInterface,
+				tunnel.transport,
+				tunnel.security,
+			],
+			query,
+		),
+	);
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		switch (sortBy) {
+			case 'delay':
+				return compareDelayLike(delayValues.get(a.tag), delayValues.get(b.tag), asc);
+			case 'ping':
+				return compareDelayLike(delayValues.get(a.tag), delayValues.get(b.tag), asc);
+			case 'name':
+				return applyDirection(compareString(a.tag, b.tag), asc);
+			case 'protocol':
+				return applyDirection(compareString(a.protocol, b.protocol), asc);
+			case 'server':
+				return applyDirection(compareString(`${a.server}:${a.port}`, `${b.server}:${b.port}`), asc);
+			case 'running':
+				return applyDirection(compareBool(a.running, b.running), asc);
+			case 'traffic':
+				return applyDirection(
+					compareNullableNumber(
+						(traffic.get(a.tag)?.download ?? 0) + (traffic.get(a.tag)?.upload ?? 0),
+						(traffic.get(b.tag)?.download ?? 0) + (traffic.get(b.tag)?.upload ?? 0),
+						false,
+					),
+					asc,
+				);
+		}
+	});
+}
+
+// --- сортировка/фильтрация подписок ---
+
+export function subscriptionTrafficBytes(traffic: TrafficMap, activeTag: string | null): number {
+	if (!activeTag) return 0;
+	const tr = traffic.get(activeTag);
+	return (tr?.download ?? 0) + (tr?.upload ?? 0);
+}
+
+export function subscriptionDelayValue(delayHistory: DelayHistoryMap, activeTag: string | null): number | null {
+	if (!activeTag) return null;
+	const history = delayHistory.get(activeTag) ?? [];
+	const latest = history.length > 0 ? history[history.length - 1] : null;
+	return latest && latest > 0 ? latest : null;
+}
+
+export function sortFilterSubscriptionsActiveCards(
+	cards: SubscriptionActiveCardVM[],
+	rawQuery: string,
+	sortBy: SubscriptionSortKey | null,
+	asc: boolean,
+	traffic: TrafficMap,
+	delayHistory: DelayHistoryMap,
+): SubscriptionActiveCardVM[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = cards.filter(({ subscription, activeMember }) =>
+		matchQuery(
+			[
+				subscription.label,
+				subscription.url,
+				subscription.inboundTag,
+				subscription.selectorTag,
+				activeMember.tag,
+				activeMember.label,
+				activeMember.server,
+				`Proxy${subscription.proxyIndex}`,
+				`t2s${subscription.proxyIndex}`,
+			],
+			query,
+		),
+	);
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		switch (sortBy) {
+			case 'delay':
+				return compareDelayLike(subscriptionDelayValue(delayHistory, a.activeMember.tag), subscriptionDelayValue(delayHistory, b.activeMember.tag), asc);
+			case 'ping':
+				return compareDelayLike(subscriptionDelayValue(delayHistory, a.activeMember.tag), subscriptionDelayValue(delayHistory, b.activeMember.tag), asc);
+			case 'label':
+				return applyDirection(compareString(a.subscription.label, b.subscription.label), asc);
+			case 'mode':
+				return applyDirection(compareString(a.subscription.mode, b.subscription.mode), asc);
+			case 'active':
+				return applyDirection(compareString(a.activeMember.label || a.activeMember.tag, b.activeMember.label || b.activeMember.tag), asc);
+			case 'traffic':
+				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic, a.activeMember.tag), subscriptionTrafficBytes(traffic, b.activeMember.tag), false), asc);
+			case 'updated':
+				return applyDirection(compareNullableNumber(
+					a.subscription.lastFetched ? new Date(a.subscription.lastFetched).getTime() : null,
+					b.subscription.lastFetched ? new Date(b.subscription.lastFetched).getTime() : null,
+				), asc);
+		}
+	});
+}
+
+export function sortFilterSubscriptionsListRows(
+	rows: Subscription[],
+	rawQuery: string,
+	sortBy: SubscriptionSortKey | null,
+	asc: boolean,
+	liveActives: Record<string, string>,
+	traffic: TrafficMap,
+	delayHistory: DelayHistoryMap,
+): Subscription[] {
+	const query = rawQuery.trim().toLowerCase();
+	const filtered = rows.filter((subscription) => {
+		const activeTag = liveActives[subscription.id] || null;
+		const member = subscription.members?.find((m) => m.tag === activeTag) ?? null;
+		return matchQuery(
+			[
+				subscription.label,
+				subscription.url,
+				subscription.inboundTag,
+				subscription.selectorTag,
+				member?.tag,
+				member?.label,
+				member?.server,
+				`Proxy${subscription.proxyIndex}`,
+				`t2s${subscription.proxyIndex}`,
+			],
+			query,
+		);
+	});
+	if (!sortBy) return filtered;
+	return [...filtered].sort((a, b) => {
+		const activeA = liveActives[a.id] || resolveSubscriptionMemberTag(a, null);
+		const activeB = liveActives[b.id] || resolveSubscriptionMemberTag(b, null);
+		const memberA = a.members?.find((m) => m.tag === activeA) ?? null;
+		const memberB = b.members?.find((m) => m.tag === activeB) ?? null;
+		switch (sortBy) {
+			case 'delay':
+				return compareDelayLike(subscriptionDelayValue(delayHistory, activeA), subscriptionDelayValue(delayHistory, activeB), asc);
+			case 'ping':
+				return compareDelayLike(subscriptionDelayValue(delayHistory, activeA), subscriptionDelayValue(delayHistory, activeB), asc);
+			case 'label':
+				return applyDirection(compareString(a.label, b.label), asc);
+			case 'mode':
+				return applyDirection(compareString(a.mode, b.mode), asc);
+			case 'active':
+				return applyDirection(compareString(memberA?.label || memberA?.tag, memberB?.label || memberB?.tag), asc);
+			case 'traffic':
+				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic, activeA), subscriptionTrafficBytes(traffic, activeB), false), asc);
+			case 'updated':
+				return applyDirection(compareNullableNumber(
+					a.lastFetched ? new Date(a.lastFetched).getTime() : null,
+					b.lastFetched ? new Date(b.lastFetched).getTime() : null,
+				), asc);
+		}
+	});
+}
+
+// --- сводные статистики ---
+
+export function computeAwgSummaryPeak(
+	awgList: TunnelListItem[],
+	visibleSystemList: SystemTunnel[],
+	latestRate: (id: string) => { rx: number; tx: number },
+): { rate: number; name: string } {
+	let rate = 0;
+	let name = '—';
+
+	for (const tunnel of awgList) {
+		if (!isManagedTunnelOn(tunnel)) continue;
+		const latest = latestRate(tunnel.id);
+		const combined = latest.rx + latest.tx;
+		if (combined > rate) {
+			rate = combined;
+			name = tunnel.name;
+		}
+	}
+
+	for (const tunnel of visibleSystemList) {
+		if (tunnel.status !== 'up') continue;
+		const latest = latestRate(tunnel.id);
+		const combined = latest.rx + latest.tx;
+		if (combined > rate) {
+			rate = combined;
+			name = tunnel.description || tunnel.interfaceName;
+		}
+	}
+
+	return { rate, name };
+}
+
+export function computeAwgTrafficLeader(
+	awgList: TunnelListItem[],
+	visibleSystemList: SystemTunnel[],
+	externalList: ExternalTunnel[],
+): { bytes: number; name: string } {
+	let bytes = 0;
+	let name = '—';
+
+	for (const tunnel of awgList) {
+		const total = (tunnel.rxBytes ?? 0) + (tunnel.txBytes ?? 0);
+		if (total > bytes) {
+			bytes = total;
+			name = tunnel.name;
+		}
+	}
+
+	for (const tunnel of visibleSystemList) {
+		const total = (tunnel.peer?.rxBytes ?? 0) + (tunnel.peer?.txBytes ?? 0);
+		if (total > bytes) {
+			bytes = total;
+			name = tunnel.description || tunnel.interfaceName;
+		}
+	}
+
+	for (const tunnel of externalList) {
+		const total = tunnel.rxBytes + tunnel.txBytes;
+		if (total > bytes) {
+			bytes = total;
+			name = tunnel.interfaceName;
+		}
+	}
+
+	return { bytes, name };
+}
+
+export function computeSingboxTunnelListStats(
+	list: SingboxTunnel[],
+	traffic: TrafficMap,
+	delayHistory: DelayHistoryMap,
+): SingboxTunnelListStats {
+	let running = 0;
+	let down = 0;
+	let up = 0;
+	let delaySum = 0;
+	let delayN = 0;
+	let leaderBytes = 0;
+	let leaderName = '—';
+	for (const t of list) {
+		if (t.running === true) running++;
+		const tr = traffic.get(t.tag);
+		if (tr) {
+			const tunnelDown = tr.download ?? 0;
+			const tunnelUp = tr.upload ?? 0;
+			const total = tunnelDown + tunnelUp;
+			down += tunnelDown;
+			up += tunnelUp;
+			if (total > leaderBytes) {
+				leaderBytes = total;
+				leaderName = t.tag;
+			}
+		}
+		const h = delayHistory.get(t.tag) ?? [];
+		const last = h.length > 0 ? h[h.length - 1] : 0;
+		if (typeof last === 'number' && last > 0) {
+			delaySum += last;
+			delayN++;
+		}
+	}
+	return {
+		count: list.length,
+		running,
+		stopped: list.length - running,
+		down,
+		up,
+		avgDelayMs: delayN > 0 ? Math.round(delaySum / delayN) : null,
+		leaderBytes,
+		leaderName,
+	};
+}
+
+export function computeSubscriptionsTrafficStats(
+	subscriptionsList: Subscription[],
+	activeCards: SubscriptionActiveCardVM[],
+	listRows: Subscription[],
+	liveActives: Record<string, string>,
+	traffic: TrafficMap,
+	delayHistory: DelayHistoryMap,
+): SubscriptionsTrafficStats {
+	let down = 0;
+	let up = 0;
+	let delaySum = 0;
+	let delaySamples = 0;
+	let leaderBytes = 0;
+	let leaderName = '—';
+
+	function ingestMember(tag: string, label: string, sampleDelay = false): void {
+		const tr = traffic.get(tag);
+		const memberDown = tr?.download ?? 0;
+		const memberUp = tr?.upload ?? 0;
+		const memberTotal = memberDown + memberUp;
+		down += memberDown;
+		up += memberUp;
+		if (memberTotal > leaderBytes) {
+			leaderBytes = memberTotal;
+			leaderName = label || tag;
+		}
+
+		if (sampleDelay) {
+			const history = delayHistory.get(tag) ?? [];
+			const lastDelay = history.length > 0 ? history[history.length - 1] : 0;
+			if (typeof lastDelay === 'number' && lastDelay > 0) {
+				delaySum += lastDelay;
+				delaySamples += 1;
+			}
+		}
+	}
+
+	for (const card of activeCards) {
+		ingestMember(
+			card.activeMember.tag,
+			card.subscription.label || card.activeMember.label || card.activeMember.tag,
+			true,
+		);
+	}
+	for (const sub of listRows) {
+		const tag = resolveSubscriptionMemberTag(sub, liveActives[sub.id] || null);
+		if (!tag) continue;
+		ingestMember(tag, sub.label || tag);
+	}
+	const totalTraffic = down + up;
+	return {
+		count: subscriptionsList.length,
+		activeCount: activeCards.length,
+		inactiveCount: listRows.length,
+		down,
+		up,
+		avgDelayMs: delaySamples > 0 ? Math.round(delaySum / delaySamples) : null,
+		delaySamples,
+		leaderBytes,
+		leaderName,
+		leaderSharePct: totalTraffic > 0 ? Math.round((leaderBytes / totalTraffic) * 100) : 0,
+	};
+}

--- a/frontend/src/lib/components/tunnels/tunnelPageSelectors.ts
+++ b/frontend/src/lib/components/tunnels/tunnelPageSelectors.ts
@@ -32,6 +32,13 @@ import { resolveSubscriptionMemberTag } from '$lib/utils/subscriptionMember';
 type TrafficMap = Map<string, SingboxTraffic>;
 type DelayHistoryMap = Map<string, number[]>;
 
+// Последний положительный замер задержки; пустая история и нулевые/отрицательные
+// значения (проба не удалась) считаются отсутствием данных.
+function latestPositiveDelay(history: number[]): number | null {
+	const latest = history.length > 0 ? history[history.length - 1] : null;
+	return latest && latest > 0 ? latest : null;
+}
+
 // --- статусные хелперы карточек/таблиц ---
 
 export function tunnelStatusBucket(status: string): 'running' | 'broken' | 'starting' | 'stopped' | 'disabled' | 'other' {
@@ -249,9 +256,7 @@ export function buildSingboxDelayMap(
 ): Map<string, number | null> {
 	const map = new Map<string, number | null>();
 	for (const tunnel of list) {
-		const history = delayHistory.get(tunnel.tag) ?? [];
-		const latest = history.length > 0 ? history[history.length - 1] : null;
-		map.set(tunnel.tag, latest && latest > 0 ? latest : null);
+		map.set(tunnel.tag, latestPositiveDelay(delayHistory.get(tunnel.tag) ?? []));
 	}
 	return map;
 }
@@ -261,8 +266,8 @@ export function sortFilterSingboxTunnels(
 	rawQuery: string,
 	sortBy: SingboxTunnelSortKey | null,
 	asc: boolean,
-	delayValues: Map<string, number | null>,
-	traffic: TrafficMap,
+	getDelayValues: () => Map<string, number | null>,
+	getTraffic: () => TrafficMap,
 ): SingboxTunnel[] {
 	const query = rawQuery.trim().toLowerCase();
 	const filtered = list.filter((tunnel) =>
@@ -280,12 +285,16 @@ export function sortFilterSingboxTunnels(
 		),
 	);
 	if (!sortBy) return filtered;
+	// Карты читаются лениво — только когда активная сортировка их требует,
+	// иначе каждый poll трафика/задержек инвалидировал бы отсортированный
+	// список даже без сортировки по этим колонкам.
+	const delayValues = sortBy === 'delay' || sortBy === 'ping' ? getDelayValues() : null;
+	const traffic = sortBy === 'traffic' ? getTraffic() : null;
 	return [...filtered].sort((a, b) => {
 		switch (sortBy) {
 			case 'delay':
-				return compareDelayLike(delayValues.get(a.tag), delayValues.get(b.tag), asc);
 			case 'ping':
-				return compareDelayLike(delayValues.get(a.tag), delayValues.get(b.tag), asc);
+				return compareDelayLike(delayValues!.get(a.tag), delayValues!.get(b.tag), asc);
 			case 'name':
 				return applyDirection(compareString(a.tag, b.tag), asc);
 			case 'protocol':
@@ -297,8 +306,8 @@ export function sortFilterSingboxTunnels(
 			case 'traffic':
 				return applyDirection(
 					compareNullableNumber(
-						(traffic.get(a.tag)?.download ?? 0) + (traffic.get(a.tag)?.upload ?? 0),
-						(traffic.get(b.tag)?.download ?? 0) + (traffic.get(b.tag)?.upload ?? 0),
+						(traffic!.get(a.tag)?.download ?? 0) + (traffic!.get(a.tag)?.upload ?? 0),
+						(traffic!.get(b.tag)?.download ?? 0) + (traffic!.get(b.tag)?.upload ?? 0),
 						false,
 					),
 					asc,
@@ -317,9 +326,7 @@ export function subscriptionTrafficBytes(traffic: TrafficMap, activeTag: string 
 
 export function subscriptionDelayValue(delayHistory: DelayHistoryMap, activeTag: string | null): number | null {
 	if (!activeTag) return null;
-	const history = delayHistory.get(activeTag) ?? [];
-	const latest = history.length > 0 ? history[history.length - 1] : null;
-	return latest && latest > 0 ? latest : null;
+	return latestPositiveDelay(delayHistory.get(activeTag) ?? []);
 }
 
 export function sortFilterSubscriptionsActiveCards(
@@ -327,8 +334,8 @@ export function sortFilterSubscriptionsActiveCards(
 	rawQuery: string,
 	sortBy: SubscriptionSortKey | null,
 	asc: boolean,
-	traffic: TrafficMap,
-	delayHistory: DelayHistoryMap,
+	getTraffic: () => TrafficMap,
+	getDelayHistory: () => DelayHistoryMap,
 ): SubscriptionActiveCardVM[] {
 	const query = rawQuery.trim().toLowerCase();
 	const filtered = cards.filter(({ subscription, activeMember }) =>
@@ -348,12 +355,13 @@ export function sortFilterSubscriptionsActiveCards(
 		),
 	);
 	if (!sortBy) return filtered;
+	const delayHistory = sortBy === 'delay' || sortBy === 'ping' ? getDelayHistory() : null;
+	const traffic = sortBy === 'traffic' ? getTraffic() : null;
 	return [...filtered].sort((a, b) => {
 		switch (sortBy) {
 			case 'delay':
-				return compareDelayLike(subscriptionDelayValue(delayHistory, a.activeMember.tag), subscriptionDelayValue(delayHistory, b.activeMember.tag), asc);
 			case 'ping':
-				return compareDelayLike(subscriptionDelayValue(delayHistory, a.activeMember.tag), subscriptionDelayValue(delayHistory, b.activeMember.tag), asc);
+				return compareDelayLike(subscriptionDelayValue(delayHistory!, a.activeMember.tag), subscriptionDelayValue(delayHistory!, b.activeMember.tag), asc);
 			case 'label':
 				return applyDirection(compareString(a.subscription.label, b.subscription.label), asc);
 			case 'mode':
@@ -361,7 +369,7 @@ export function sortFilterSubscriptionsActiveCards(
 			case 'active':
 				return applyDirection(compareString(a.activeMember.label || a.activeMember.tag, b.activeMember.label || b.activeMember.tag), asc);
 			case 'traffic':
-				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic, a.activeMember.tag), subscriptionTrafficBytes(traffic, b.activeMember.tag), false), asc);
+				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic!, a.activeMember.tag), subscriptionTrafficBytes(traffic!, b.activeMember.tag), false), asc);
 			case 'updated':
 				return applyDirection(compareNullableNumber(
 					a.subscription.lastFetched ? new Date(a.subscription.lastFetched).getTime() : null,
@@ -377,8 +385,8 @@ export function sortFilterSubscriptionsListRows(
 	sortBy: SubscriptionSortKey | null,
 	asc: boolean,
 	liveActives: Record<string, string>,
-	traffic: TrafficMap,
-	delayHistory: DelayHistoryMap,
+	getTraffic: () => TrafficMap,
+	getDelayHistory: () => DelayHistoryMap,
 ): Subscription[] {
 	const query = rawQuery.trim().toLowerCase();
 	const filtered = rows.filter((subscription) => {
@@ -400,6 +408,8 @@ export function sortFilterSubscriptionsListRows(
 		);
 	});
 	if (!sortBy) return filtered;
+	const delayHistory = sortBy === 'delay' || sortBy === 'ping' ? getDelayHistory() : null;
+	const traffic = sortBy === 'traffic' ? getTraffic() : null;
 	return [...filtered].sort((a, b) => {
 		const activeA = liveActives[a.id] || resolveSubscriptionMemberTag(a, null);
 		const activeB = liveActives[b.id] || resolveSubscriptionMemberTag(b, null);
@@ -407,9 +417,8 @@ export function sortFilterSubscriptionsListRows(
 		const memberB = b.members?.find((m) => m.tag === activeB) ?? null;
 		switch (sortBy) {
 			case 'delay':
-				return compareDelayLike(subscriptionDelayValue(delayHistory, activeA), subscriptionDelayValue(delayHistory, activeB), asc);
 			case 'ping':
-				return compareDelayLike(subscriptionDelayValue(delayHistory, activeA), subscriptionDelayValue(delayHistory, activeB), asc);
+				return compareDelayLike(subscriptionDelayValue(delayHistory!, activeA), subscriptionDelayValue(delayHistory!, activeB), asc);
 			case 'label':
 				return applyDirection(compareString(a.label, b.label), asc);
 			case 'mode':
@@ -417,7 +426,7 @@ export function sortFilterSubscriptionsListRows(
 			case 'active':
 				return applyDirection(compareString(memberA?.label || memberA?.tag, memberB?.label || memberB?.tag), asc);
 			case 'traffic':
-				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic, activeA), subscriptionTrafficBytes(traffic, activeB), false), asc);
+				return applyDirection(compareNullableNumber(subscriptionTrafficBytes(traffic!, activeA), subscriptionTrafficBytes(traffic!, activeB), false), asc);
 			case 'updated':
 				return applyDirection(compareNullableNumber(
 					a.lastFetched ? new Date(a.lastFetched).getTime() : null,
@@ -521,9 +530,8 @@ export function computeSingboxTunnelListStats(
 				leaderName = t.tag;
 			}
 		}
-		const h = delayHistory.get(t.tag) ?? [];
-		const last = h.length > 0 ? h[h.length - 1] : 0;
-		if (typeof last === 'number' && last > 0) {
+		const last = latestPositiveDelay(delayHistory.get(t.tag) ?? []);
+		if (last !== null) {
 			delaySum += last;
 			delayN++;
 		}
@@ -568,9 +576,8 @@ export function computeSubscriptionsTrafficStats(
 		}
 
 		if (sampleDelay) {
-			const history = delayHistory.get(tag) ?? [];
-			const lastDelay = history.length > 0 ? history[history.length - 1] : 0;
-			if (typeof lastDelay === 'number' && lastDelay > 0) {
+			const lastDelay = latestPositiveDelay(delayHistory.get(tag) ?? []);
+			if (lastDelay !== null) {
 				delaySum += lastDelay;
 				delaySamples += 1;
 			}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2236,31 +2236,6 @@
 {/if}
 
 <style>
-	/* Комбинированная сводка дашборда (issue #353): липкий блок «тулбар +
-	   сводка» под AppHeader — тот же паттерн, что sticky-header в
-	   TunnelEditHeader.svelte. */
-
-
-	/* На мобильном тулбар складывается в несколько рядов — прилипший блок
-	   съедал бы половину вьюпорта, поэтому ниже 760px он статичен. */
-	@media (max-width: 760px) {
-	}
-
-	/* Обёртка карточки в сплошном/теговом дашборде: карточка + футер
-	   (грип ручного порядка + чипы тегов). */
-
-
-
-
-
-
-	/* Ручной порядок включён, но dnd заблокирован (поиск/фильтр/загрузка
-	   данных): грип виден, но неактивен — не исчезает молча. */
-
-	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
-	   Движок вертикальный, поэтому на время активного drag сетка
-	   схлопывается в одну колонку — индексы вставки и индикатор
-	   становятся однозначными на любой плотности. ── */
 
 	/* Ghost-токен drag-переупорядочивания: бейдж вида + имя. */
 	.drag-ghost-token {
@@ -2298,21 +2273,6 @@
 		min-width: 0;
 	}
 
-	/* Во время drag строки компактные — слот источника и раскрытый
-	   drop-скелетон ужимаются до высоты ряда, а не исходной карточки
-	   (--drop-height меряется на pointerdown по полной карточке). */
-
-
-
-
-
-
-
-
-
-
-
-
 	.dashboard-drag-ghost {
 		position: fixed;
 		z-index: 10000;
@@ -2325,56 +2285,6 @@
 		user-select: none;
 		cursor: grabbing;
 	}
-
-	/* Toolbar (count + actions row above the tunnel grid) */
-
-
-
-
-
-
-	/* Empty-state ghost terminal — page-specific */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-	/* Backend selector — chip-like toggles for nativewg/kernel */
-
-
-
-
-
-
-	/* Drag-over / importing overlays */
-
-
-	/* Empty-state kind picker — three clickable cards opening the wizard
-	   on the matching step 2. Mirrors the wizard's step-1 visual so the
-	   transition into the modal feels continuous. */
-	@media (min-width: 600px) {
-	}
-	:global(.empty-kind-icon) { color: var(--color-primary, #3b82f6); }
-
-	/* "About AmneziaWG / Sing-box" info card — page-specific */
-
-
-
-
-
-
-
-
 
 	/* "Kernel module unavailable" full-screen overlay — page-specific */
 	.unsupported-overlay {
@@ -2454,8 +2364,6 @@
 		color: #fff;
 		border-color: var(--color-accent);
 	}
-
-
 
 	@media (max-width: 760px) {
 	}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -7,9 +7,6 @@
 	import { notifications } from '$lib/stores/notifications';
 	import { api } from '$lib/api/client';
 	import {
-		TunnelCard,
-		ExternalTunnelCard,
-		SystemTunnelCard,
 		TunnelListTrafficCell,
 		TunnelPingButton,
 		TunnelTitleRow,
@@ -20,7 +17,6 @@
 	import { TunnelListActions } from '$lib/components/ui';
 	import { PageContainer, PageHeader, LoadingSpinner, EmptyState, WelcomeBanner } from '$lib/components/layout';
 	import {
-		StoreStatusBadge,
 		TrafficSparkline,
 		Badge,
 		Tabs,
@@ -32,14 +28,10 @@
 		TableSortHeader,
 	} from '$lib/components/ui';
 	import { singboxDelayHistory, singboxStatus, singboxTraffic, singboxTunnels } from '$lib/stores/singbox';
-	import { SingboxInstallBanner, SingboxTunnelCard } from '$lib/components/singbox';
 	import { feedTraffic, getTrafficRates, getTrafficSparklineSeries, subscribeTraffic } from '$lib/stores/traffic';
 	import { usageLevel } from '$lib/stores/settings';
 	import { isSectionVisible, isTunnelDashboardAvailable } from '$lib/types/usageLevel';
 	import { subscriptionsStore } from '$lib/stores/subscriptions';
-	import SubscriptionCard from '$lib/components/subscriptions/SubscriptionCard.svelte';
-	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
-	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
 	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
 	import SingboxTunnelsTabSection from '$lib/components/singbox/SingboxTunnelsTabSection.svelte';
 	import AwgTunnelsTabSection from '$lib/components/tunnels/AwgTunnelsTabSection.svelte';
@@ -90,12 +82,8 @@
 		type TunnelRenderMode,
 	} from '$lib/constants/singboxLayout';
 	import { isMockDevMode as getIsMockDevMode } from '$lib/env';
-	import { Eye, EyeOff, GripVertical, Server, Upload, LayoutGrid, Link, Globe, TriangleAlert } from 'lucide-svelte';
-	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
+	import { Eye, EyeOff, Server, Upload, LayoutGrid, Link, Globe, TriangleAlert } from 'lucide-svelte';
 	import { formatRunningSub, pluralForm, SUBSCRIPTION_WORDS, TUNNEL_WORDS } from '$lib/utils/pluralize';
-	import DashboardToolbar from '$lib/components/tunnels/DashboardToolbar.svelte';
-	import DashboardSummary from '$lib/components/tunnels/DashboardSummary.svelte';
-	import TunnelTagChips from '$lib/components/tunnels/TunnelTagChips.svelte';
 	import TunnelSectionHeader from '$lib/components/tunnels/TunnelSectionHeader.svelte';
 	import {
 		tunnelDashboardLayout,
@@ -109,7 +97,7 @@
 		tunnelDashboardTags,
 	} from '$lib/stores/tunnelDashboardPrefs';
 	import { applyManualOrder, mergeManualOrder, reorder } from '$lib/utils/tunnelDashboardOrder';
-	import { filterItemsByTag, getItemTags, groupFlatItemsByTag } from '$lib/utils/tunnelDashboardTags';
+	import { filterItemsByTag, groupFlatItemsByTag } from '$lib/utils/tunnelDashboardTags';
 	import { createReorderDrag } from '$lib/components/sb-router/reorderDrag.svelte';
 	import { buildFlatDashboardItems, type TunnelDashboardFlatItem } from '$lib/utils/tunnelDashboardFlat';
 	import {
@@ -120,13 +108,6 @@
 		type SingboxTunnelSortKey,
 		type SubscriptionSortKey,
 	} from '$lib/stores/tunnelTableSort';
-	import {
-		applyDirection,
-		compareBool,
-		compareDelayLike,
-		compareNullableNumber,
-		compareString,
-	} from '$lib/utils/tunnelTableSort';
 
 	type TunnelTab = 'awg' | 'singbox' | 'subscriptions';
 	type AwgTunnelViewMode = 'cards' | 'compact' | 'list';
@@ -1073,8 +1054,8 @@
 			effectiveSingboxTunnelsSearchQuery,
 			$singboxTunnelTableSort.sortBy,
 			$singboxTunnelTableSort.sortAsc,
-			singboxTunnelDelayValue,
-			$singboxTraffic,
+			() => singboxTunnelDelayValue,
+			() => $singboxTraffic,
 		),
 	);
 
@@ -1084,8 +1065,8 @@
 			effectiveSubscriptionsSearchQuery,
 			$singboxSubscriptionTableSort.sortBy,
 			$singboxSubscriptionTableSort.sortAsc,
-			$singboxTraffic,
-			$singboxDelayHistory,
+			() => $singboxTraffic,
+			() => $singboxDelayHistory,
 		),
 	);
 
@@ -1096,8 +1077,8 @@
 			$singboxSubscriptionTableSort.sortBy,
 			$singboxSubscriptionTableSort.sortAsc,
 			liveActives,
-			$singboxTraffic,
-			$singboxDelayHistory,
+			() => $singboxTraffic,
+			() => $singboxDelayHistory,
 		),
 	);
 
@@ -1439,7 +1420,6 @@
 	// Live-контекст flat-дашборда (см. dashboardFlatContext.ts).
 	const dashboardFlatCtx: DashboardFlatContext = {
 		get DASHBOARD_KIND_LABELS() { return DASHBOARD_KIND_LABELS; },
-		get dashboardOn() { return dashboardOn; },
 		get dashboardDndEnabled() { return dashboardDndEnabled; },
 		get dashboardFilterEmpty() { return dashboardFilterEmpty; },
 		get dashboardFlatCardMode() { return dashboardFlatCardMode; },
@@ -1457,9 +1437,7 @@
 		get effectiveSingboxSubscriptionsRenderMode() { return effectiveSingboxSubscriptionsRenderMode; },
 		get showSingboxListOption() { return showSingboxListOption; },
 		get showSingboxSections() { return showSingboxSections; },
-		get loading() { return loading; },
 		get exporting() { return exporting; },
-		get adoptingInterface() { return adoptingInterface; },
 		get awgAutoConnectivityNonce() { return awgAutoConnectivityNonce; },
 		get singboxAutoDelayCheckNonce() { return singboxAutoDelayCheckNonce; },
 		get deleteLoading() { return deleteLoading; },
@@ -1467,19 +1445,13 @@
 		get liveActives() { return liveActives; },
 		get flatDrag() { return flatDrag; },
 		get flatRowEls() { return flatRowEls; },
-		get adoptDialogOpen() { return adoptDialogOpen; },
-		set adoptDialogOpen(v) { adoptDialogOpen = v; },
-		get adoptError() { return adoptError; },
-		set adoptError(v) { adoptError = v; },
-		get adoptLoading() { return adoptLoading; },
-		set adoptLoading(v) { adoptLoading = v; },
 		get dashboardSearchQuery() { return dashboardSearchQuery; },
 		set dashboardSearchQuery(v) { dashboardSearchQuery = v; },
 		get dashboardTagFilter() { return dashboardTagFilter; },
 		set dashboardTagFilter(v) { dashboardTagFilter = v; },
 		get flatGridEl() { return flatGridEl; },
 		set flatGridEl(v) { flatGridEl = v; },
-		handleAdopt, handleAdoptClick, handleExportAll, handleGripKeydown, handleGripPointerDown, handleToggleOnOff, markAsServer, openAwgDiagnostics, openDetail, openSingboxDetail, openWizard, requestDelete, requestSubscriptionDelete,
+		handleAdoptClick, handleExportAll, handleGripKeydown, handleGripPointerDown, handleToggleOnOff, markAsServer, openAwgDiagnostics, openDetail, openSingboxDetail, openWizard, requestDelete, requestSubscriptionDelete,
 	};
 
 	// Live-контекст модалок страницы (см. tunnelPageModalsContext.ts).
@@ -1519,10 +1491,6 @@
 		handleAdopt, handleDelete, confirmSubscriptionDelete, closeDetail, closeSingboxDetail, closeAwgDiagnostics, closeConnectivitySettings,
 	};
 </script>
-
-{#snippet createIcon()}
-	<CreateIcon />
-{/snippet}
 
 <svelte:head>
 	<title>Туннели - AWG Manager</title>
@@ -1800,8 +1768,5 @@
 		background: var(--color-accent);
 		color: #fff;
 		border-color: var(--color-accent);
-	}
-
-	@media (max-width: 760px) {
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -51,6 +51,8 @@
 	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
 	import SingboxTunnelsTabSection from '$lib/components/singbox/SingboxTunnelsTabSection.svelte';
 	import AwgTunnelsTabSection from '$lib/components/tunnels/AwgTunnelsTabSection.svelte';
+	import DashboardFlatSection from '$lib/components/tunnels/DashboardFlatSection.svelte';
+	import type { DashboardFlatContext } from '$lib/components/tunnels/dashboardFlatContext';
 	import type { AwgTabContext } from '$lib/components/tunnels/awgTabContext';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
@@ -1904,108 +1906,56 @@
 		set fileInput(v) { fileInput = v; },
 		endpointHost, endpointPort, endpointVisible, toggleEndpointVisible, externalStatusLabel, externalStatusVariant, systemStatusLabel, systemStatusVariant, isManagedTunnelOn, managedRouteMeta, showManagedPing, latestRate, sparklineSeries, handleAdoptClick, handleAwgSortChange, handleDragLeave, handleDragOver, handleDrop, handleFileSelect, openAwgDiagnostics, openConnectivitySettings, openDetail, requestDelete, markAsServer, handleToggleOnOff, checkPing, handleExportAll,
 	};
+
+	// Live-контекст flat-дашборда (см. dashboardFlatContext.ts).
+	const dashboardFlatCtx: DashboardFlatContext = {
+		get DASHBOARD_KIND_LABELS() { return DASHBOARD_KIND_LABELS; },
+		get dashboardOn() { return dashboardOn; },
+		get dashboardDndEnabled() { return dashboardDndEnabled; },
+		get dashboardFilterEmpty() { return dashboardFilterEmpty; },
+		get dashboardFlatCardMode() { return dashboardFlatCardMode; },
+		get dashboardFlatLayout() { return dashboardFlatLayout; },
+		get dashboardGridClass() { return dashboardGridClass; },
+		get dashboardGroupByTags() { return dashboardGroupByTags; },
+		get dashboardRenderItems() { return dashboardRenderItems; },
+		get dashboardSummaryStats() { return dashboardSummaryStats; },
+		get dashboardTagGroups() { return dashboardTagGroups; },
+		get effectiveAwgCardViewMode() { return effectiveAwgCardViewMode; },
+		get effectiveAwgRenderMode() { return effectiveAwgRenderMode; },
+		get effectiveSingboxTunnelsEffectiveLayout() { return effectiveSingboxTunnelsEffectiveLayout; },
+		get effectiveSingboxTunnelsRenderMode() { return effectiveSingboxTunnelsRenderMode; },
+		get effectiveSingboxSubscriptionsEffectiveLayout() { return effectiveSingboxSubscriptionsEffectiveLayout; },
+		get effectiveSingboxSubscriptionsRenderMode() { return effectiveSingboxSubscriptionsRenderMode; },
+		get showSingboxListOption() { return showSingboxListOption; },
+		get showSingboxSections() { return showSingboxSections; },
+		get loading() { return loading; },
+		get exporting() { return exporting; },
+		get adoptingInterface() { return adoptingInterface; },
+		get awgAutoConnectivityNonce() { return awgAutoConnectivityNonce; },
+		get singboxAutoDelayCheckNonce() { return singboxAutoDelayCheckNonce; },
+		get deleteLoading() { return deleteLoading; },
+		get toggleLoading() { return toggleLoading; },
+		get liveActives() { return liveActives; },
+		get flatDrag() { return flatDrag; },
+		get flatRowEls() { return flatRowEls; },
+		get adoptDialogOpen() { return adoptDialogOpen; },
+		set adoptDialogOpen(v) { adoptDialogOpen = v; },
+		get adoptError() { return adoptError; },
+		set adoptError(v) { adoptError = v; },
+		get adoptLoading() { return adoptLoading; },
+		set adoptLoading(v) { adoptLoading = v; },
+		get dashboardSearchQuery() { return dashboardSearchQuery; },
+		set dashboardSearchQuery(v) { dashboardSearchQuery = v; },
+		get dashboardTagFilter() { return dashboardTagFilter; },
+		set dashboardTagFilter(v) { dashboardTagFilter = v; },
+		get flatGridEl() { return flatGridEl; },
+		set flatGridEl(v) { flatGridEl = v; },
+		handleAdopt, handleAdoptClick, handleExportAll, handleGripKeydown, handleGripPointerDown, handleToggleOnOff, markAsServer, openAwgDiagnostics, openDetail, openSingboxDetail, openWizard, requestDelete, requestSubscriptionDelete,
+	};
 </script>
 
 {#snippet createIcon()}
 	<CreateIcon />
-{/snippet}
-
-{#snippet dashboardFlatCard(item: TunnelDashboardFlatItem, suppressAutoCheck: boolean = false)}
-	{#if item.kind === 'awg-managed'}
-		<TunnelCard
-			tunnel={item.tunnel}
-			view={effectiveAwgRenderMode === 'list-card' ? 'list' : effectiveAwgCardViewMode}
-			toggleLoading={toggleLoading[item.tunnel.id] ?? false}
-			deleteLoading={deleteLoading[item.tunnel.id] ?? false}
-			autoConnectivityNonce={suppressAutoCheck ? 0 : awgAutoConnectivityNonce}
-			autoConnectivityDelayMs={item.index * 180}
-			onToggleOnOff={() => handleToggleOnOff(item.tunnel.id)}
-			ondelete={() => requestDelete(item.tunnel.id)}
-			ondetail={(id) => openDetail(id)}
-		/>
-	{:else if item.kind === 'awg-system'}
-		<SystemTunnelCard
-			tunnel={item.tunnel}
-			view={effectiveAwgRenderMode === 'list-card' ? 'list' : effectiveAwgCardViewMode}
-			onMarkServer={markAsServer}
-			ondetail={(id) => openDetail(id)}
-			ontest={(id, name) => openAwgDiagnostics(id, name, 'system')}
-		/>
-	{:else if item.kind === 'awg-external'}
-		<ExternalTunnelCard
-			tunnel={item.tunnel}
-			view={effectiveAwgRenderMode === 'list-card' ? 'list' : effectiveAwgCardViewMode}
-			onadopt={(name) => handleAdoptClick(name)}
-		/>
-	{:else if item.kind === 'singbox'}
-		<SingboxTunnelCard
-			tunnel={item.tunnel}
-			layout={effectiveSingboxTunnelsRenderMode === 'list-card' ? 'list' : effectiveSingboxTunnelsEffectiveLayout}
-			renderMode={effectiveSingboxTunnelsRenderMode}
-			autoDelayCheckNonce={suppressAutoCheck ? 0 : singboxAutoDelayCheckNonce}
-			autoDelayCheckDelayMs={item.index * 180}
-			ondetail={(tag) => openSingboxDetail(tag)}
-		/>
-	{:else if item.kind === 'sub-active'}
-		<SubscriptionActiveCard
-			subscription={item.card.subscription}
-			activeMember={item.card.activeMember}
-			autoDelayCheckNonce={suppressAutoCheck ? 0 : singboxAutoDelayCheckNonce}
-			autoDelayCheckDelayMs={item.index * 180}
-			layout={effectiveSingboxSubscriptionsEffectiveLayout}
-			renderMode={effectiveSingboxSubscriptionsRenderMode}
-			ondetail={(tag) => openSingboxDetail(tag)}
-		/>
-	{:else if item.kind === 'sub-stopped'}
-		<SubscriptionCard
-			subscription={item.subscription}
-			liveActiveMember={liveActives[item.subscription.id] || null}
-			layout={effectiveSingboxSubscriptionsEffectiveLayout}
-			renderMode={effectiveSingboxSubscriptionsRenderMode}
-			ondelete={requestSubscriptionDelete}
-			ondetail={(tag) => openSingboxDetail(tag)}
-		/>
-	{/if}
-{/snippet}
-
-{#snippet dashboardItemFooter(item: TunnelDashboardFlatItem, dragIndex: number | null, dragDisabled: boolean = false)}
-	{@const itemTags = getItemTags($tunnelDashboardTags, item.key)}
-	<!-- Футер рендерится только когда в нём есть содержимое: грип ручного
-	     порядка и/или чипы тегов. Без тегов и вне тегового вида ряд с одиноким
-	     «+» под каждой карточкой не показывается; редактирование тегов живёт в
-	     группировке «Теги», в сплошном виде чипы readonly (клик = фильтр). -->
-	{#if dragIndex !== null || itemTags.length > 0 || dashboardGroupByTags}
-		<div class="dashboard-item-footer">
-			{#if dragIndex !== null}
-				<button
-					type="button"
-					class="dashboard-item-grip"
-					class:is-busy={flatDrag.busy}
-					disabled={dragDisabled}
-					title={dragDisabled
-						? 'Перетаскивание недоступно при поиске и фильтре'
-						: 'Перетащить для изменения порядка'}
-					aria-label="Перетащить «{item.name}»"
-					onpointerdown={dragDisabled || flatDrag.busy
-						? undefined
-						: (e) => handleGripPointerDown(dragIndex, e)}
-					onkeydown={dragDisabled ? undefined : (e) => handleGripKeydown(dragIndex, e)}
-				>
-					<GripVertical size={14} strokeWidth={2} aria-hidden="true" />
-				</button>
-			{/if}
-			{#if itemTags.length > 0 || dashboardGroupByTags}
-				<TunnelTagChips
-					tags={itemTags}
-					readonly={!dashboardGroupByTags}
-					onAdd={(raw) => tunnelDashboardTags.addTag(item.key, raw)}
-					onRemove={(tag) => tunnelDashboardTags.removeTag(item.key, tag)}
-					onSelect={(tag) => (dashboardTagFilter = tag)}
-					activeTag={dashboardTagFilter}
-				/>
-			{/if}
-		</div>
-	{/if}
 {/snippet}
 
 <svelte:head>
@@ -2026,135 +1976,7 @@
 		/>
 	{:else}
 		{#if dashboardOn}
-			{#if showSingboxSections}
-				<SingboxInstallBanner />
-			{/if}
-			<div class="dashboard-sticky">
-				<div class="tunnels-toolbar">
-					<div class="toolbar-actions">
-						<DashboardToolbar
-							searchQuery={dashboardSearchQuery}
-							onSearchChange={(value) => (dashboardSearchQuery = value)}
-							layout={$tunnelDashboardLayout}
-							onLayoutChange={(layout) => tunnelDashboardLayout.setLayout(layout)}
-							viewMode={$tunnelDashboardView}
-							onViewModeChange={tunnelDashboardView.setViewMode}
-							showViewToggle={showSingboxListOption}
-							showListOption={showSingboxListOption}
-							orderMode={$tunnelDashboardOrderMode}
-							onOrderModeChange={tunnelDashboardOrderMode.setMode}
-							showOrderControl={dashboardFlatLayout}
-							groupMode={$tunnelDashboardGroupMode}
-							onGroupModeChange={tunnelDashboardGroupMode.setMode}
-							showGroupControl={!dashboardFlatLayout}
-							activeTagFilter={dashboardTagFilter}
-							onClearTagFilter={() => (dashboardTagFilter = null)}
-							showSingboxCreate={showSingboxSections}
-							onCreateAwg={() => goto('/tunnels/new')}
-							onCreateSingboxSingle={() => openWizard('single')}
-							onCreateSingboxGroup={() => openWizard('inline')}
-							onCreateSingboxSubscription={() => openWizard('url')}
-							{createIcon}
-						>
-							{#snippet actions()}
-								<StoreStatusBadge store={tunnels} />
-								<Button variant="secondary" size="md" onclick={handleExportAll} disabled={exporting} iconBefore={exportIcon}>
-									Экспорт
-								</Button>
-							{/snippet}
-						</DashboardToolbar>
-					</div>
-				</div>
-				<DashboardSummary stats={dashboardSummaryStats} />
-			</div>
-			{#if dashboardFlatCardMode}
-				<div
-					bind:this={flatGridEl}
-					class={dashboardGridClass}
-					class:dashboard-grid--reordering={flatDrag.active}
-					style={dashboardDndEnabled ? flatDrag.cardsMotionStyle() : undefined}
-				>
-					{#each dashboardRenderItems as item, i (item.key)}
-						<div
-							class="dashboard-flat-item"
-							class:drag-source-exiting={flatDrag.isDragSource(i)}
-							class:drag-source-collapsed={flatDrag.sourceCollapsed(i)}
-							style={flatDrag.isDragSource(i) ? flatDrag.dropIndicatorStyle() : undefined}
-							bind:this={flatRowEls[i]}
-						>
-							{#if flatDrag.showsDropBefore(i)}
-								<div
-									class="drop-indicator"
-									class:expanded={flatDrag.dropBeforeExpanded(i)}
-									class:collapsing={flatDrag.dropBeforeCollapsing(i)}
-									style={flatDrag.dropIndicatorStyle()}
-								></div>
-							{/if}
-							{#if flatDrag.active}
-								<!-- Во время drag карточки (с графиками) заменяются
-								     компактными рядами фиксированной высоты: без двух
-								     полных релэйаутов страницы, и длинный список влезает
-								     на экран. Ключи те же — ключи снапшота. -->
-								<div class="dashboard-reorder-row">
-									<span class="dashboard-kind-badge">{DASHBOARD_KIND_LABELS[item.kind]}</span>
-									<span class="dashboard-reorder-name">{item.name}</span>
-								</div>
-							{:else}
-								{@render dashboardFlatCard(item)}
-								{@render dashboardItemFooter(
-									item,
-									$tunnelDashboardOrderMode === 'manual' ? i : null,
-									!dashboardDndEnabled,
-								)}
-							{/if}
-						</div>
-					{/each}
-					{#if flatDrag.showsDropAtEnd()}
-						<div
-							class="drop-indicator drop-indicator-end"
-							class:expanded={flatDrag.dropEndExpanded()}
-							class:collapsing={flatDrag.dropEndCollapsing()}
-							style={flatDrag.dropIndicatorStyle()}
-						></div>
-					{/if}
-				</div>
-			{:else if dashboardGroupByTags}
-				{#each dashboardTagGroups as group (group.tag ?? ' untagged')}
-					<TunnelSectionHeader
-						title={group.tag ?? 'Без тегов'}
-						count={group.items.length}
-						countLabel={pluralForm(group.items.length, TUNNEL_WORDS)}
-					/>
-					<div class={dashboardGridClass}>
-						{#each group.items as entry (entry.item.key)}
-							<div class="dashboard-flat-item">
-								{@render dashboardFlatCard(entry.item, !entry.autoCheck)}
-								{@render dashboardItemFooter(entry.item, null)}
-							</div>
-						{/each}
-					</div>
-				{/each}
-			{/if}
-			{#if dashboardFilterEmpty}
-				<EmptyState
-					title="Ничего не найдено"
-					description={dashboardTagFilter !== null
-						? `Нет туннелей с тегом «${dashboardTagFilter}»${dashboardSearchQuery.trim() !== '' ? ' по этому запросу' : ''}.`
-						: 'По запросу не нашлось ни одного туннеля.'}
-				>
-					{#snippet action()}
-						{#if dashboardTagFilter !== null}
-							<Button variant="secondary" size="md" onclick={() => (dashboardTagFilter = null)}>
-								Сбросить фильтр
-							</Button>
-						{:else}
-							<Button variant="secondary" size="md" onclick={() => (dashboardSearchQuery = '')}>
-								Очистить поиск
-							</Button>
-						{/if}
-					{/snippet}
-				</EmptyState>
-			{/if}
+			<DashboardFlatSection ctx={dashboardFlatCtx} />
 		{:else}
 			<Tabs
 				tabs={tunnelTabs}
@@ -2417,97 +2239,30 @@
 	/* Комбинированная сводка дашборда (issue #353): липкий блок «тулбар +
 	   сводка» под AppHeader — тот же паттерн, что sticky-header в
 	   TunnelEditHeader.svelte. */
-	.dashboard-sticky {
-		position: sticky;
-		top: 56px;
-		z-index: var(--z-sticky-secondary);
-		background: var(--color-bg-primary);
-		padding-bottom: 0.75rem;
-		border-bottom: 1px solid var(--color-border);
-		margin-bottom: 1rem;
-	}
 
-	.dashboard-sticky .tunnels-toolbar {
-		margin-bottom: 0.75rem;
-	}
 
 	/* На мобильном тулбар складывается в несколько рядов — прилипший блок
 	   съедал бы половину вьюпорта, поэтому ниже 760px он статичен. */
 	@media (max-width: 760px) {
-		.dashboard-sticky {
-			position: static;
-		}
 	}
 
 	/* Обёртка карточки в сплошном/теговом дашборде: карточка + футер
 	   (грип ручного порядка + чипы тегов). */
-	.dashboard-flat-item {
-		position: relative;
-		display: flex;
-		flex-direction: column;
-		gap: 0.375rem;
-		min-width: 0;
-	}
 
-	.dashboard-item-footer {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		min-width: 0;
-		margin-top: auto;
-	}
 
-	.dashboard-item-grip {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		flex: 0 0 auto;
-		background: transparent;
-		border: none;
-		padding: 0.125rem;
-		color: var(--color-text-muted);
-		opacity: 0.55;
-		cursor: grab;
-		touch-action: none;
-		border-radius: 4px;
-	}
 
-	.dashboard-item-grip:hover {
-		color: var(--color-text-primary);
-		opacity: 1;
-	}
 
-	.dashboard-item-grip:active {
-		cursor: grabbing;
-	}
 
-	.dashboard-item-grip.is-busy {
-		cursor: wait;
-		opacity: 0.3;
-		pointer-events: none;
-	}
 
 	/* Ручной порядок включён, но dnd заблокирован (поиск/фильтр/загрузка
 	   данных): грип виден, но неактивен — не исчезает молча. */
-	.dashboard-item-grip:disabled {
-		opacity: 0.3;
-		cursor: not-allowed;
-	}
 
 	/* ── D7: drag-reorder (общее pointer-ядро sb-router/reorderDrag).
 	   Движок вертикальный, поэтому на время активного drag сетка
 	   схлопывается в одну колонку — индексы вставки и индикатор
 	   становятся однозначными на любой плотности. ── */
-	.tunnel-grid.dashboard-grid--reordering {
-		--reorder-row-height: 40px;
-		display: flex;
-		flex-direction: column;
-		gap: var(--card-gap, 6px);
-		user-select: none;
-	}
 
-	/* Компактный ряд на время drag и ghost-токен: бейдж вида + имя. */
-	.dashboard-reorder-row,
+	/* Ghost-токен drag-переупорядочивания: бейдж вида + имя. */
 	.drag-ghost-token {
 		display: flex;
 		align-items: center;
@@ -2546,114 +2301,17 @@
 	/* Во время drag строки компактные — слот источника и раскрытый
 	   drop-скелетон ужимаются до высоты ряда, а не исходной карточки
 	   (--drop-height меряется на pointerdown по полной карточке). */
-	.dashboard-grid--reordering .dashboard-flat-item.drag-source-exiting:not(.drag-source-collapsed) {
-		height: var(--reorder-row-height, 40px);
-	}
 
-	.dashboard-grid--reordering .drop-indicator.expanded:not(.collapsing) {
-		height: var(--reorder-row-height, 40px);
-	}
 
-	.dashboard-flat-item.drag-source-exiting {
-		overflow: hidden;
-		height: var(--drop-height);
-		opacity: 1;
-		transition:
-			height var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			opacity var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			margin var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
-	}
 
-	.dashboard-flat-item.drag-source-exiting.drag-source-collapsed {
-		height: 0;
-		max-height: 0;
-		opacity: 0;
-		margin-bottom: calc(-1 * var(--card-gap, 6px));
-	}
 
-	.drop-indicator {
-		box-sizing: border-box;
-		overflow: hidden;
-		border: 1px solid transparent;
-		border-radius: 999px;
-		background: var(--color-accent);
-		box-shadow: 0 0 10px color-mix(in srgb, var(--color-accent) 45%, transparent);
-		opacity: 1;
-		pointer-events: none;
-		transition:
-			height var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			margin var(--drop-slot-motion-ms, 360ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			border-radius calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			background calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			box-shadow calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			border-color calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			opacity calc(var(--drop-slot-motion-ms, 360ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
-	}
 
-	.drop-indicator:not(.expanded):not(.collapsing) {
-		position: absolute;
-		top: -1px;
-		left: 0;
-		right: 0;
-		height: 2px;
-		margin: 0;
-		z-index: 2;
-	}
 
-	.drop-indicator.expanded:not(.collapsing) {
-		position: static;
-		top: auto;
-		height: var(--drop-height);
-		margin: 0 0 var(--card-gap, 6px);
-		border-radius: var(--radius-sm, 6px);
-		background: color-mix(in srgb, var(--color-accent) 6%, transparent);
-		border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
-		border-style: dashed;
-		box-shadow: none;
-	}
 
-	.drop-indicator.collapsing {
-		margin: 0 !important;
-		opacity: 0;
-		border-color: transparent;
-		background: transparent;
-		box-shadow: none;
-	}
 
-	.drop-indicator.collapsing.expanded {
-		position: static;
-		height: 0 !important;
-	}
 
-	.drop-indicator.collapsing:not(.expanded) {
-		position: absolute;
-		top: -1px;
-		left: 0;
-		right: 0;
-		height: 2px !important;
-		z-index: 2;
-		transition:
-			opacity var(--drop-line-collapse-ms, 240ms) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			box-shadow calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			background calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95)),
-			border-color calc(var(--drop-line-collapse-ms, 240ms) * 0.85) var(--slot-ease, cubic-bezier(0.45, 0.05, 0.55, 0.95));
-	}
 
-	.drop-indicator-end:not(.expanded):not(.collapsing) {
-		position: relative;
-		top: auto;
-		height: 2px;
-		margin: -1px 0 0;
-	}
 
-	.drop-indicator-end.collapsing:not(.expanded) {
-		position: relative;
-		top: auto;
-		left: auto;
-		right: auto;
-		height: 2px !important;
-		margin: -1px 0 0 !important;
-	}
 
 	.dashboard-drag-ghost {
 		position: fixed;
@@ -2669,304 +2327,53 @@
 	}
 
 	/* Toolbar (count + actions row above the tunnel grid) */
-	.tunnels-toolbar {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		margin-bottom: 1rem;
-	}
 
-	.tunnel-count {
-		font-size: 0.8125rem;
-		color: var(--color-text-muted);
-	}
 
-	.count-group {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
 
-	.toolbar-actions {
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
 
-	.toolbar-actions :global(.btn.size-md) {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		box-sizing: border-box;
-		height: 32px;
-		min-height: 32px;
-		max-height: 32px;
-		padding-block: 0;
-	}
 
-	.toolbar-actions :global(.btn.variant-primary:hover:not(:disabled):not(.is-disabled)) {
-		background: transparent;
-		color: var(--color-accent);
-		border-color: var(--color-accent);
-		filter: none;
-	}
 
 	/* Empty-state ghost terminal — page-specific */
-	.ghost-terminal {
-		margin: 3rem 0;
-		border: 2px dashed var(--color-border);
-		border-radius: var(--radius);
-		padding: 2rem 2rem 1.5rem;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 1.5rem;
-		transition: border-color var(--t-fast) ease, background var(--t-fast) ease;
-	}
 
-	.ghost-terminal.drag-over {
-		border-color: var(--color-accent);
-		border-style: solid;
-		background: var(--color-accent-tint);
-	}
 
-	.term-status {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.25rem;
-		font-family: var(--font-mono);
-	}
 
-	.term-prompt {
-		font-size: 0.8125rem;
-		color: var(--color-text-muted);
-	}
 
-	.term-info {
-		font-size: 0.75rem;
-		color: var(--color-text-muted);
-		opacity: 0.7;
-	}
 
-	.term-action-group {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 1.5rem;
-	}
 
-	.term-drop-hint {
-		display: flex;
-		align-items: center;
-		gap: 0.625rem;
-		color: var(--color-accent);
-		font-size: 1.0625rem;
-		font-weight: 500;
-	}
 
-	.term-drop-hint :global(svg) {
-		flex-shrink: 0;
-		opacity: 0.8;
-	}
 
-	.term-commands {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.125rem;
-		font-family: var(--font-mono);
-	}
 
-	.term-found {
-		font-size: 0.8125rem;
-		color: var(--color-accent);
-		margin-bottom: 0.375rem;
-	}
 
-	.term-cmd {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		background: none;
-		border: none;
-		color: var(--color-text-secondary);
-		font-family: inherit;
-		font-size: 0.875rem;
-		padding: 0.375rem 0.5rem;
-		border-radius: var(--radius-sm);
-		cursor: pointer;
-		transition: color var(--t-fast) ease, background var(--t-fast) ease;
-		text-decoration: none;
-	}
 
-	.term-cmd:hover {
-		color: var(--color-text-primary);
-		background: var(--color-bg-hover);
-	}
 
-	.term-cmd-primary {
-		color: var(--color-accent);
-	}
 
-	.term-cmd-primary:hover {
-		color: var(--color-accent-hover);
-	}
 
-	.term-arrow {
-		color: var(--color-text-muted);
-	}
 
 	/* Backend selector — chip-like toggles for nativewg/kernel */
-	.term-backend-selector {
-		display: flex;
-		gap: 8px;
-	}
 
-	.term-backend-btn {
-		font-family: var(--font-mono);
-		font-size: 0.8125rem;
-		padding: 0.375rem 1rem;
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-sm);
-		background: transparent;
-		color: var(--color-text-muted);
-		cursor: pointer;
-		transition: border-color var(--t-fast) ease, color var(--t-fast) ease, background var(--t-fast) ease;
-	}
 
-	.term-backend-btn:hover:not(.disabled) {
-		border-color: var(--color-accent);
-		color: var(--color-text-secondary);
-	}
 
-	.term-backend-btn.selected {
-		border-color: var(--color-accent);
-		color: var(--color-accent);
-		background: var(--color-accent-tint);
-	}
 
-	.term-backend-btn.disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
 
-	.term-backend-hint {
-		margin: 8px 0 0;
-		font-family: var(--font-mono);
-		font-size: 0.75rem;
-		line-height: 1.4;
-		color: var(--color-text-muted);
-	}
 
 	/* Drag-over / importing overlays */
-	.drop-overlay {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 2rem 0;
-		color: var(--color-accent);
-	}
 
-	.drop-text {
-		font-size: 1.0625rem;
-		font-weight: 500;
-	}
 
 	/* Empty-state kind picker — three clickable cards opening the wizard
 	   on the matching step 2. Mirrors the wizard's step-1 visual so the
 	   transition into the modal feels continuous. */
-	.empty-kinds {
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: 0.7rem;
-		margin-top: 0.5rem;
-	}
 	@media (min-width: 600px) {
-		.empty-kinds { grid-template-columns: 1fr 1fr 1fr; }
-	}
-	.empty-kind-card {
-		display: flex;
-		flex-direction: column;
-		gap: 0.45rem;
-		padding: 1.1rem 1.2rem;
-		background: var(--color-bg-primary);
-		border: 1px solid var(--color-border);
-		border-radius: 8px;
-		text-align: left;
-		cursor: pointer;
-		font: inherit;
-		color: var(--color-text-primary);
-		transition: border-color 120ms, transform 120ms, background 120ms;
-	}
-	.empty-kind-card:hover {
-		border-color: var(--color-primary, #3b82f6);
-		background: rgba(59, 130, 246, 0.04);
-		transform: translateY(-1px);
-	}
-	.empty-kind-card:focus-visible {
-		outline: 2px solid var(--color-primary, #3b82f6);
-		outline-offset: 2px;
 	}
 	:global(.empty-kind-icon) { color: var(--color-primary, #3b82f6); }
-	.empty-kind-title { font-weight: 600; font-size: 0.95rem; }
-	.empty-kind-desc { color: var(--color-text-muted); font-size: 0.8rem; line-height: 1.4; }
 
 	/* "About AmneziaWG / Sing-box" info card — page-specific */
-	.info-card {
-		border-left: 3px solid var(--color-accent);
-		background: var(--color-bg-secondary);
-		border-radius: 0 var(--radius) var(--radius) 0;
-		padding: 1.25rem 1.5rem;
-		margin-top: 1.5rem;
-	}
 
-	.info-title {
-		font-size: 1rem;
-		font-weight: 600;
-		margin-bottom: 0.75rem;
-	}
 
-	.info-text {
-		font-size: 0.8125rem;
-		color: var(--color-text-secondary);
-		line-height: 1.6;
-		margin: 0;
-	}
 
-	.info-section-desc {
-		font-size: 0.85rem;
-		color: var(--color-text-muted);
-		margin: 0 0 0.75rem 0;
-	}
 
-	.info-versions {
-		display: flex;
-		flex-direction: column;
-		gap: 0.625rem;
-		margin: 0.75rem 0;
-	}
 
-	.info-version {
-		display: flex;
-		gap: 0.75rem;
-		align-items: baseline;
-	}
 
-	.info-version-desc {
-		font-size: 0.8125rem;
-		color: var(--color-text-secondary);
-		line-height: 1.5;
-	}
 
-	.info-kernel {
-		margin-top: 0.75rem;
-		padding-top: 0.75rem;
-		border-top: 1px solid var(--color-border);
-	}
 
 
 	/* "Kernel module unavailable" full-screen overlay — page-specific */
@@ -3048,68 +2455,8 @@
 		border-color: var(--color-accent);
 	}
 
-	.external-section {
-		margin-top: 2rem;
-		padding-top: 1.5rem;
-		border-top: 1px solid var(--border);
-	}
-	.singbox-sub-inactive-section {
-		margin-top: 0;
-		padding-top: 0;
-		border-top: none;
-	}
-	.section-title {
-		font-size: 1rem;
-		font-weight: 600;
-		color: var(--text-secondary);
-		margin-bottom: 1rem;
-	}
 
-	.subscription-empty {
-		padding: 3rem 1.5rem;
-		text-align: center;
-		border: 1px dashed var(--color-border);
-		border-radius: 6px;
-		margin-top: 0.5rem;
-	}
-	.subscription-empty-title {
-		color: var(--color-text-primary);
-		font-size: 1.1rem;
-		font-weight: 600;
-		margin-bottom: 0.4rem;
-	}
-	.subscription-empty-desc {
-		color: var(--color-text-muted);
-		font-size: 0.88rem;
-		margin-bottom: 1.2rem;
-	}
 
 	@media (max-width: 760px) {
-		.tunnels-toolbar {
-			flex-direction: column;
-			align-items: stretch;
-			gap: 0.75rem;
-		}
-
-		.toolbar-actions {
-			display: grid;
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-			align-items: stretch;
-			gap: 0.5rem;
-			width: 100%;
-		}
-
-		.toolbar-actions :global(.toolbar-view-row) {
-			grid-column: 1 / -1;
-		}
-
-		.toolbar-actions > :global(.btn) {
-			width: 100%;
-			min-height: 32px;
-		}
-
-		.toolbar-actions > :global(.btn:only-of-type) {
-			grid-column: 1 / -1;
-		}
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -9,10 +9,7 @@
 	import {
 		TunnelCard,
 		ExternalTunnelCard,
-		AdoptTunnelDialog,
 		SystemTunnelCard,
-		TunnelReferencedModal,
-		ConnectivitySettingsModal,
 		TunnelListTrafficCell,
 		TunnelPingButton,
 		TunnelTitleRow,
@@ -21,14 +18,10 @@
 		DefaultRouteBadge,
 	} from '$lib/components/tunnels';
 	import { TunnelListActions } from '$lib/components/ui';
-	import TunnelDiagnosticsModal from '$lib/components/testing/TunnelDiagnosticsModal.svelte';
 	import { PageContainer, PageHeader, LoadingSpinner, EmptyState, WelcomeBanner } from '$lib/components/layout';
 	import {
-		Modal,
 		StoreStatusBadge,
-		TrafficChartModal,
 		TrafficSparkline,
-		Button,
 		Badge,
 		Tabs,
 		Toggle,
@@ -45,14 +38,15 @@
 	import { isSectionVisible, isTunnelDashboardAvailable } from '$lib/types/usageLevel';
 	import { subscriptionsStore } from '$lib/stores/subscriptions';
 	import SubscriptionCard from '$lib/components/subscriptions/SubscriptionCard.svelte';
-	import AddTunnelWizard from '$lib/components/subscriptions/AddTunnelWizard.svelte';
 	import SubscriptionActiveCard from '$lib/components/subscriptions/SubscriptionActiveCard.svelte';
 	import SubscriptionGroupsSection from '$lib/components/subscriptions/SubscriptionGroupsSection.svelte';
 	import SubscriptionsTabSection from '$lib/components/subscriptions/SubscriptionsTabSection.svelte';
 	import SingboxTunnelsTabSection from '$lib/components/singbox/SingboxTunnelsTabSection.svelte';
 	import AwgTunnelsTabSection from '$lib/components/tunnels/AwgTunnelsTabSection.svelte';
 	import DashboardFlatSection from '$lib/components/tunnels/DashboardFlatSection.svelte';
+	import TunnelPageModals from '$lib/components/tunnels/TunnelPageModals.svelte';
 	import type { DashboardFlatContext } from '$lib/components/tunnels/dashboardFlatContext';
+	import type { TunnelPageModalsContext } from '$lib/components/tunnels/tunnelPageModalsContext';
 	import type { AwgTabContext } from '$lib/components/tunnels/awgTabContext';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
@@ -77,7 +71,7 @@
 		type TunnelRenderMode,
 	} from '$lib/constants/singboxLayout';
 	import { isMockDevMode as getIsMockDevMode } from '$lib/env';
-	import { Download, Eye, EyeOff, GripVertical, Server, Upload, LayoutGrid, Link, Globe, TriangleAlert } from 'lucide-svelte';
+	import { Eye, EyeOff, GripVertical, Server, Upload, LayoutGrid, Link, Globe, TriangleAlert } from 'lucide-svelte';
 	import CreateIcon from '$lib/components/ui/icons/CreateIcon.svelte';
 	import { formatRunningSub, pluralForm, SUBSCRIPTION_WORDS, TUNNEL_WORDS } from '$lib/utils/pluralize';
 	import DashboardToolbar from '$lib/components/tunnels/DashboardToolbar.svelte';
@@ -1952,6 +1946,43 @@
 		set flatGridEl(v) { flatGridEl = v; },
 		handleAdopt, handleAdoptClick, handleExportAll, handleGripKeydown, handleGripPointerDown, handleToggleOnOff, markAsServer, openAwgDiagnostics, openDetail, openSingboxDetail, openWizard, requestDelete, requestSubscriptionDelete,
 	};
+
+	// Live-контекст модалок страницы (см. tunnelPageModalsContext.ts).
+	const pageModalsCtx: TunnelPageModalsContext = {
+		get awgList() { return awgList; },
+		get systemList() { return systemList; },
+		get singboxTunnelsList() { return singboxTunnelsList; },
+		get subscriptionsActiveCards() { return subscriptionsActiveCards; },
+		get subscriptionsListRows() { return subscriptionsListRows; },
+		get liveActives() { return liveActives; },
+		get pendingSubscriptionLabel() { return pendingSubscriptionLabel; },
+		get adoptDialogOpen() { return adoptDialogOpen; },
+		set adoptDialogOpen(v) { adoptDialogOpen = v; },
+		get adoptError() { return adoptError; },
+		set adoptError(v) { adoptError = v; },
+		get adoptLoading() { return adoptLoading; },
+		set adoptLoading(v) { adoptLoading = v; },
+		get adoptingInterface() { return adoptingInterface; },
+		get deleteConfirmId() { return deleteConfirmId; },
+		set deleteConfirmId(v) { deleteConfirmId = v; },
+		get referencedDetails() { return referencedDetails; },
+		set referencedDetails(v) { referencedDetails = v; },
+		get referencedTunnelName() { return referencedTunnelName; },
+		set referencedTunnelName(v) { referencedTunnelName = v; },
+		get createModalOpen() { return createModalOpen; },
+		set createModalOpen(v) { createModalOpen = v; },
+		get wizardPreselect() { return wizardPreselect; },
+		get pendingSubscriptionDelete() { return pendingSubscriptionDelete; },
+		set pendingSubscriptionDelete(v) { pendingSubscriptionDelete = v; },
+		get deletingSubscription() { return deletingSubscription; },
+		get detailId() { return detailId; },
+		get singboxDetailTag() { return singboxDetailTag; },
+		get awgDiagnosticsTarget() { return awgDiagnosticsTarget; },
+		get connectivitySettingsTunnel() { return connectivitySettingsTunnel; },
+		get connectivitySettingsOpen() { return connectivitySettingsOpen; },
+		set connectivitySettingsOpen(v) { connectivitySettingsOpen = v; },
+		handleAdopt, handleDelete, confirmSubscriptionDelete, closeDetail, closeSingboxDetail, closeAwgDiagnostics, closeConnectivitySettings,
+	};
 </script>
 
 {#snippet createIcon()}
@@ -2082,136 +2113,7 @@
 	</div>
 {/if}
 
-<AdoptTunnelDialog
-	interfaceName={adoptingInterface}
-	bind:open={adoptDialogOpen}
-	bind:error={adoptError}
-	bind:loading={adoptLoading}
-	onclose={() => adoptDialogOpen = false}
-	onadopt={handleAdopt}
-/>
-
-{#if deleteConfirmId}
-	{@const tunnelName = awgList.find(t => t.id === deleteConfirmId)?.name ?? deleteConfirmId}
-	<Modal
-		open={true}
-		title="Удалить туннель"
-		size="sm"
-		onclose={() => deleteConfirmId = null}
-	>
-		<p class="confirm-text">Удалить туннель <strong>{tunnelName}</strong>?</p>
-		{#snippet actions()}
-			<Button variant="secondary" size="md" onclick={() => deleteConfirmId = null}>Отмена</Button>
-			<Button variant="danger" size="md" onclick={() => handleDelete(deleteConfirmId!)}>Удалить</Button>
-		{/snippet}
-	</Modal>
-{/if}
-
-<TunnelReferencedModal
-	open={referencedDetails !== null}
-	details={referencedDetails}
-	tunnelName={referencedTunnelName}
-	onclose={() => { referencedDetails = null; referencedTunnelName = ''; }}
-/>
-
-<AddTunnelWizard bind:open={createModalOpen} preselect={wizardPreselect} />
-
-<Modal
-	open={pendingSubscriptionDelete !== null}
-	title="Удалить подписку?"
-	size="md"
-	onclose={() => {
-		if (deletingSubscription) return;
-		pendingSubscriptionDelete = null;
-	}}
->
-	<p>
-		Подписка <strong>{pendingSubscriptionLabel}</strong> будет удалена
-		вместе с её sing-box outbound'ами и NDMS Proxy-интерфейсом.
-	</p>
-	{#snippet actions()}
-		<Button
-			variant="ghost"
-			disabled={deletingSubscription}
-			onclick={() => (pendingSubscriptionDelete = null)}
-		>
-			Отмена
-		</Button>
-		<Button
-			variant="danger"
-			disabled={deletingSubscription}
-			loading={deletingSubscription}
-			onclick={confirmSubscriptionDelete}
-		>
-			{deletingSubscription ? 'Удаляем...' : 'Удалить'}
-		</Button>
-	{/snippet}
-</Modal>
-
-{#if detailId}
-	{@const managed = awgList.find((x) => x.id === detailId)}
-	{@const sys = systemList.find((x) => x.id === detailId)}
-	{#if managed || sys}
-		<TrafficChartModal
-			open={true}
-			tunnelId={detailId}
-			tunnelName={managed?.name ?? sys?.description ?? detailId}
-			ifaceName={managed?.interfaceName ?? sys?.interfaceName ?? ''}
-			onclose={closeDetail}
-		/>
-	{/if}
-{/if}
-
-{#if singboxDetailTag}
-	{@const sb = singboxTunnelsList.find((x) => x.tag === singboxDetailTag)}
-	{@const subActiveCard = subscriptionsActiveCards.find((c) => c.activeMember.tag === singboxDetailTag)}
-	{@const subListRow = subscriptionsListRows.find(
-		(s) => resolveSubscriptionMemberTag(s, liveActives[s.id] || null) === singboxDetailTag,
-	)}
-	{@const detailName =
-		subActiveCard?.subscription.label
-		?? subListRow?.label
-		?? sb?.tag
-		?? singboxDetailTag}
-	{@const detailIface =
-		subActiveCard
-			? (subActiveCard.subscription.proxyIndex >= 0 ? `Proxy${subActiveCard.subscription.proxyIndex}` : '')
-			: (subListRow
-				? (subListRow.proxyIndex >= 0 ? `Proxy${subListRow.proxyIndex}` : '')
-				: (sb?.proxyInterface ?? ''))}
-	<TrafficChartModal
-		open={true}
-		tunnelId={singboxDetailTag}
-		tunnelName={detailName}
-		ifaceName={detailIface}
-		onclose={closeSingboxDetail}
-	/>
-{/if}
-
-{#if awgDiagnosticsTarget}
-	<TunnelDiagnosticsModal
-		open={true}
-		kind={awgDiagnosticsTarget.kind}
-		targetId={awgDiagnosticsTarget.id}
-		displayName={awgDiagnosticsTarget.name}
-		subjectLabel="туннель"
-		onclose={closeAwgDiagnostics}
-	/>
-{/if}
-
-{#if connectivitySettingsTunnel}
-	<ConnectivitySettingsModal
-		bind:open={connectivitySettingsOpen}
-		tunnelId={connectivitySettingsTunnel.id}
-		tunnelAddress={connectivitySettingsTunnel.address}
-		onclose={closeConnectivitySettings}
-		onSaved={closeConnectivitySettings}
-	/>
-{/if}
-
-{#snippet exportIcon()}
-	<Download size={14} strokeWidth={2} aria-hidden="true" />
-{/snippet}
+<TunnelPageModals ctx={pageModalsCtx} />
 
 {#if showUnsupportedBlock}
 	<div class="unsupported-overlay">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -47,6 +47,25 @@
 	import TunnelPageModals from '$lib/components/tunnels/TunnelPageModals.svelte';
 	import type { DashboardFlatContext } from '$lib/components/tunnels/dashboardFlatContext';
 	import type { TunnelPageModalsContext } from '$lib/components/tunnels/tunnelPageModalsContext';
+	import {
+		buildSingboxDelayMap,
+		computeAwgSummaryPeak,
+		computeAwgTrafficLeader,
+		computeSingboxTunnelListStats,
+		computeSubscriptionsTrafficStats,
+		externalStatusLabel,
+		externalStatusVariant,
+		isManagedTunnelOn,
+		managedRouteMeta,
+		sortFilterAwgList,
+		sortFilterExternalList,
+		sortFilterSingboxTunnels,
+		sortFilterSubscriptionsActiveCards,
+		sortFilterSubscriptionsListRows,
+		sortFilterSystemList,
+		systemStatusLabel,
+		systemStatusVariant,
+	} from '$lib/components/tunnels/tunnelPageSelectors';
 	import type { AwgTabContext } from '$lib/components/tunnels/awgTabContext';
 	import type { ExternalTunnel, Subscription, SubscriptionMember, SystemTunnel, TunnelListItem } from '$lib/types';
 	import { formatBitRate, formatBytes, formatDuration, formatRelativeTime, secondsSince } from '$lib/utils/format';
@@ -103,7 +122,6 @@
 	} from '$lib/stores/tunnelTableSort';
 	import {
 		applyDirection,
-		ariaSort,
 		compareBool,
 		compareDelayLike,
 		compareNullableNumber,
@@ -119,9 +137,7 @@
 		if (layout === 'dense' || layout === 'cards') return 'dense';
 		return 'compact';
 	}
-	type ConnectivityCell = { connected: boolean; latency: number | null } | undefined;
 	type EndpointScope = 'managed' | 'system' | 'external';
-	type TunnelSortOption = { value: string; label: string };
 
 	const AWG_TUNNEL_VIEW_STORAGE_KEY = 'awg_tunnel_view_mode';
 	const SINGBOX_TUNNELS_LAYOUT_STORAGE_KEY = 'singbox_tunnels_layout_mode';
@@ -398,47 +414,7 @@
 
 	const singboxTunnelListStats = $derived.by(() => {
 		void trafficTick;
-		const list = singboxTunnelsList;
-		let running = 0;
-		let down = 0;
-		let up = 0;
-		let delaySum = 0;
-		let delayN = 0;
-		let leaderBytes = 0;
-		let leaderName = '—';
-		const trMap = $singboxTraffic;
-		const histMap = $singboxDelayHistory;
-		for (const t of list) {
-			if (t.running === true) running++;
-			const tr = trMap.get(t.tag);
-			if (tr) {
-				const tunnelDown = tr.download ?? 0;
-				const tunnelUp = tr.upload ?? 0;
-				const total = tunnelDown + tunnelUp;
-				down += tunnelDown;
-				up += tunnelUp;
-				if (total > leaderBytes) {
-					leaderBytes = total;
-					leaderName = t.tag;
-				}
-			}
-			const h = histMap.get(t.tag) ?? [];
-			const last = h.length > 0 ? h[h.length - 1] : 0;
-			if (typeof last === 'number' && last > 0) {
-				delaySum += last;
-				delayN++;
-			}
-		}
-		return {
-			count: list.length,
-			running,
-			stopped: list.length - running,
-			down,
-			up,
-			avgDelayMs: delayN > 0 ? Math.round(delaySum / delayN) : null,
-			leaderBytes,
-			leaderName,
-		};
+		return computeSingboxTunnelListStats(singboxTunnelsList, $singboxTraffic, $singboxDelayHistory);
 	});
 
 	let subscriptionsState = $derived($subscriptionsStore);
@@ -560,62 +536,14 @@
 
 	const singboxSubscriptionsTrafficStats = $derived.by(() => {
 		void trafficTick;
-		let down = 0;
-		let up = 0;
-		let delaySum = 0;
-		let delaySamples = 0;
-		let leaderBytes = 0;
-		let leaderName = '—';
-		const map = $singboxTraffic;
-		const delayMap = $singboxDelayHistory;
-
-		function ingestMember(tag: string, label: string, sampleDelay = false): void {
-			const tr = map.get(tag);
-			const memberDown = tr?.download ?? 0;
-			const memberUp = tr?.upload ?? 0;
-			const memberTotal = memberDown + memberUp;
-			down += memberDown;
-			up += memberUp;
-			if (memberTotal > leaderBytes) {
-				leaderBytes = memberTotal;
-				leaderName = label || tag;
-			}
-
-			if (sampleDelay) {
-				const delayHistory = delayMap.get(tag) ?? [];
-				const lastDelay = delayHistory.length > 0 ? delayHistory[delayHistory.length - 1] : 0;
-				if (typeof lastDelay === 'number' && lastDelay > 0) {
-					delaySum += lastDelay;
-					delaySamples += 1;
-				}
-			}
-		}
-
-		for (const card of subscriptionsActiveCards) {
-			ingestMember(
-				card.activeMember.tag,
-				card.subscription.label || card.activeMember.label || card.activeMember.tag,
-				true,
-			);
-		}
-		for (const sub of subscriptionsListRows) {
-			const tag = resolveSubscriptionMemberTag(sub, liveActives[sub.id] || null);
-			if (!tag) continue;
-			ingestMember(tag, sub.label || tag);
-		}
-		const totalTraffic = down + up;
-		return {
-			count: subscriptionsList.length,
-			activeCount: subscriptionsActiveCards.length,
-			inactiveCount: subscriptionsListRows.length,
-			down,
-			up,
-			avgDelayMs: delaySamples > 0 ? Math.round(delaySum / delaySamples) : null,
-			delaySamples,
-			leaderBytes,
-			leaderName,
-			leaderSharePct: totalTraffic > 0 ? Math.round((leaderBytes / totalTraffic) * 100) : 0,
-		};
+		return computeSubscriptionsTrafficStats(
+			subscriptionsList,
+			subscriptionsActiveCards,
+			subscriptionsListRows,
+			liveActives,
+			$singboxTraffic,
+			$singboxDelayHistory,
+		);
 	});
 
 	// Tabs
@@ -1069,62 +997,11 @@
 		),
 	);
 
-	function tunnelStatusBucket(status: string): 'running' | 'broken' | 'starting' | 'stopped' | 'disabled' | 'other' {
-		switch (status) {
-			case 'running':
-				return 'running';
-			case 'broken':
-				return 'broken';
-			case 'starting':
-			case 'needs_stop':
-			case 'stopping':
-				return 'starting';
-			case 'needs_start':
-			case 'stopped':
-			case 'not_created':
-				return 'stopped';
-			case 'disabled':
-				return 'disabled';
-			default:
-				return 'other';
-		}
-	}
-
-	function isManagedTunnelOn(tunnel: TunnelListItem): boolean {
-		return ['running', 'starting', 'broken'].includes(tunnel.status);
-	}
-
 	function showManagedPing(
 		tunnel: TunnelListItem,
 		connectivity: { connected: boolean; latency: number | null } | undefined,
 	): boolean {
 		return awgListShowsPingButton(tunnel, connectivity);
-	}
-
-	function managedRouteMeta(tunnel: TunnelListItem): string {
-		const iface = tunnel.resolvedIspInterface || tunnel.ispInterface || '';
-		const label = tunnel.resolvedIspInterfaceLabel || tunnel.ispInterfaceLabel || '';
-		if (label && iface) return label === iface ? label : `${label} (${iface})`;
-		if (label) return label;
-		if (iface) return iface;
-		return 'Маршрут не установлен';
-	}
-
-	function systemStatusVariant(tunnel: SystemTunnel): 'success' | 'muted' {
-		return tunnel.status === 'up' ? 'success' : 'muted';
-	}
-
-	function systemStatusLabel(tunnel: SystemTunnel): string {
-		if (tunnel.status !== 'up') return 'Выключен';
-		return tunnel.peer?.online ? 'Активен' : 'Без handshake';
-	}
-
-	function externalStatusVariant(tunnel: ExternalTunnel): 'success' | 'muted' {
-		return tunnel.lastHandshake ? 'success' : 'muted';
-	}
-
-	function externalStatusLabel(tunnel: ExternalTunnel): string {
-		return tunnel.lastHandshake ? 'Подключён' : 'Неактивен';
 	}
 
 	function latestRate(id: string): { rx: number; tx: number } {
@@ -1148,32 +1025,7 @@
 		externalList.filter((t) => !!t.lastHandshake).length,
 	);
 
-	let awgSummaryPeak = $derived.by(() => {
-		let rate = 0;
-		let name = '—';
-
-		for (const tunnel of awgList) {
-			if (!isManagedTunnelOn(tunnel)) continue;
-			const latest = latestRate(tunnel.id);
-			const combined = latest.rx + latest.tx;
-			if (combined > rate) {
-				rate = combined;
-				name = tunnel.name;
-			}
-		}
-
-		for (const tunnel of visibleSystemList) {
-			if (tunnel.status !== 'up') continue;
-			const latest = latestRate(tunnel.id);
-			const combined = latest.rx + latest.tx;
-			if (combined > rate) {
-				rate = combined;
-				name = tunnel.description || tunnel.interfaceName;
-			}
-		}
-
-		return { rate, name };
-	});
+	let awgSummaryPeak = $derived(computeAwgSummaryPeak(awgList, visibleSystemList, latestRate));
 
 	let awgSummaryRx = $derived(
 		awgList.reduce((sum, tunnel) => sum + (tunnel.rxBytes ?? 0), 0) +
@@ -1187,64 +1039,7 @@
 		externalList.reduce((sum, tunnel) => sum + tunnel.txBytes, 0),
 	);
 
-	let awgTrafficLeader = $derived.by(() => {
-		let bytes = 0;
-		let name = '—';
-
-		for (const tunnel of awgList) {
-			const total = (tunnel.rxBytes ?? 0) + (tunnel.txBytes ?? 0);
-			if (total > bytes) {
-				bytes = total;
-				name = tunnel.name;
-			}
-		}
-
-		for (const tunnel of visibleSystemList) {
-			const total = (tunnel.peer?.rxBytes ?? 0) + (tunnel.peer?.txBytes ?? 0);
-			if (total > bytes) {
-				bytes = total;
-				name = tunnel.description || tunnel.interfaceName;
-			}
-		}
-
-		for (const tunnel of externalList) {
-			const total = tunnel.rxBytes + tunnel.txBytes;
-			if (total > bytes) {
-				bytes = total;
-				name = tunnel.interfaceName;
-			}
-		}
-
-		return { bytes, name };
-	});
-
-	const awgSortOptions: TunnelSortOption[] = [
-		{ value: 'name', label: 'По имени' },
-		{ value: 'status', label: 'По статусу' },
-		{ value: 'endpoint', label: 'По endpoint' },
-		{ value: 'traffic', label: 'По трафику' },
-		{ value: 'handshake', label: 'По handshake' },
-	];
-
-	const singboxTunnelSortOptions: TunnelSortOption[] = [
-		{ value: 'delay', label: 'По delay' },
-		{ value: 'name', label: 'По имени' },
-		{ value: 'protocol', label: 'По протоколу' },
-		{ value: 'server', label: 'По серверу' },
-		{ value: 'running', label: 'По процессу' },
-		{ value: 'traffic', label: 'По трафику' },
-		{ value: 'ping', label: 'По ping' },
-	];
-
-	const subscriptionSortOptions: TunnelSortOption[] = [
-		{ value: 'delay', label: 'По delay' },
-		{ value: 'label', label: 'По имени' },
-		{ value: 'mode', label: 'По режиму' },
-		{ value: 'active', label: 'По активному серверу' },
-		{ value: 'traffic', label: 'По трафику' },
-		{ value: 'updated', label: 'По обновлению' },
-		{ value: 'ping', label: 'По ping' },
-	];
+	let awgTrafficLeader = $derived(computeAwgTrafficLeader(awgList, visibleSystemList, externalList));
 
 	function handleAwgSortChange(key: AwgTunnelSortKey): void {
 		awgTunnelTableSort.toggleSort(key);
@@ -1258,313 +1053,53 @@
 		singboxSubscriptionTableSort.toggleSort(key);
 	}
 
-	function matchQuery(values: Array<string | null | undefined>, query: string): boolean {
-		const q = query.trim().toLowerCase();
-		if (!q) return true;
-		return values.some((value) => String(value ?? '').toLowerCase().includes(q));
-	}
+	let sortedFilteredAwgList = $derived(
+		sortFilterAwgList(awgList, effectiveAwgSearchQuery, $awgTunnelTableSort.sortBy, $awgTunnelTableSort.sortAsc),
+	);
 
-	function awgStatusRank(tunnel: TunnelListItem): number {
-		switch (tunnelStatusBucket(tunnel.status)) {
-			case 'running':
-				return 0;
-			case 'starting':
-				return 1;
-			case 'broken':
-				return 2;
-			case 'stopped':
-				return 3;
-			case 'disabled':
-				return 4;
-			default:
-				return 5;
-		}
-	}
+	let sortedFilteredSystemList = $derived(
+		sortFilterSystemList(visibleSystemList, effectiveAwgSearchQuery, $awgTunnelTableSort.sortBy, $awgTunnelTableSort.sortAsc),
+	);
 
-	let sortedFilteredAwgList = $derived.by(() => {
-		const query = effectiveAwgSearchQuery.trim().toLowerCase();
-		const filtered = awgList.filter((tunnel) =>
-			matchQuery(
-				[
-					tunnel.name,
-					tunnel.interfaceName,
-					tunnel.id,
-					tunnel.ndmsName,
-					tunnel.address,
-					tunnel.endpoint,
-					tunnel.backend,
-					tunnel.awgVersion,
-				],
-				query,
-			),
-		);
-		const sortBy = $awgTunnelTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $awgTunnelTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			switch (sortBy) {
-				case 'name':
-					return applyDirection(compareString(a.name, b.name), asc);
-				case 'status':
-					return applyDirection(compareNullableNumber(awgStatusRank(a), awgStatusRank(b), false), asc);
-				case 'endpoint':
-					return applyDirection(compareString(a.endpoint, b.endpoint), asc);
-				case 'traffic':
-					return applyDirection(
-						compareNullableNumber((a.rxBytes ?? 0) + (a.txBytes ?? 0), (b.rxBytes ?? 0) + (b.txBytes ?? 0), false),
-						asc,
-					);
-				case 'handshake':
-					return applyDirection(
-						compareNullableNumber(
-							a.lastHandshake ? new Date(a.lastHandshake).getTime() : null,
-							b.lastHandshake ? new Date(b.lastHandshake).getTime() : null,
-						),
-						asc,
-					);
-			}
-		});
-	});
+	let sortedFilteredExternalList = $derived(
+		sortFilterExternalList(externalList, effectiveAwgSearchQuery, $awgTunnelTableSort.sortBy, $awgTunnelTableSort.sortAsc),
+	);
 
-	let sortedFilteredSystemList = $derived.by(() => {
-		const query = effectiveAwgSearchQuery.trim().toLowerCase();
-		const filtered = visibleSystemList.filter((tunnel) =>
-			matchQuery(
-				[
-					tunnel.description,
-					tunnel.interfaceName,
-					tunnel.id,
-					tunnel.address,
-					tunnel.peer?.endpoint,
-					tunnel.peer?.via,
-				],
-				query,
-			),
-		);
-		const sortBy = $awgTunnelTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $awgTunnelTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			switch (sortBy) {
-				case 'name':
-					return applyDirection(compareString(a.description || a.id, b.description || b.id), asc);
-				case 'status':
-					return applyDirection(compareBool(a.status === 'up', b.status === 'up'), asc);
-				case 'endpoint':
-					return applyDirection(compareString(a.peer?.endpoint, b.peer?.endpoint), asc);
-				case 'traffic':
-					return applyDirection(
-						compareNullableNumber(
-							(a.peer?.rxBytes ?? 0) + (a.peer?.txBytes ?? 0),
-							(b.peer?.rxBytes ?? 0) + (b.peer?.txBytes ?? 0),
-							false,
-						),
-						asc,
-					);
-				case 'handshake':
-					return applyDirection(
-						compareNullableNumber(
-							a.peer?.lastHandshake ? new Date(a.peer.lastHandshake).getTime() : null,
-							b.peer?.lastHandshake ? new Date(b.peer.lastHandshake).getTime() : null,
-						),
-						asc,
-					);
-			}
-		});
-	});
+	let singboxTunnelDelayValue = $derived(buildSingboxDelayMap(singboxTunnelsList, $singboxDelayHistory));
 
-	let sortedFilteredExternalList = $derived.by(() => {
-		const query = effectiveAwgSearchQuery.trim().toLowerCase();
-		const filtered = externalList.filter((tunnel) =>
-			matchQuery([tunnel.interfaceName, tunnel.endpoint, tunnel.publicKey, tunnel.isAWG ? 'awg' : 'wg'], query),
-		);
-		const sortBy = $awgTunnelTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $awgTunnelTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			switch (sortBy) {
-				case 'name':
-					return applyDirection(compareString(a.interfaceName, b.interfaceName), asc);
-				case 'status':
-					return applyDirection(compareBool(!!a.lastHandshake, !!b.lastHandshake), asc);
-				case 'endpoint':
-					return applyDirection(compareString(a.endpoint, b.endpoint), asc);
-				case 'traffic':
-					return applyDirection(compareNullableNumber(a.rxBytes + a.txBytes, b.rxBytes + b.txBytes, false), asc);
-				case 'handshake':
-					return applyDirection(
-						compareNullableNumber(
-							a.lastHandshake ? new Date(a.lastHandshake).getTime() : null,
-							b.lastHandshake ? new Date(b.lastHandshake).getTime() : null,
-						),
-						asc,
-					);
-			}
-		});
-	});
+	let sortedFilteredSingboxTunnels = $derived(
+		sortFilterSingboxTunnels(
+			singboxTunnelsList,
+			effectiveSingboxTunnelsSearchQuery,
+			$singboxTunnelTableSort.sortBy,
+			$singboxTunnelTableSort.sortAsc,
+			singboxTunnelDelayValue,
+			$singboxTraffic,
+		),
+	);
 
-	let singboxTunnelDelayValue = $derived.by(() => {
-		const map = new Map<string, number | null>();
-		for (const tunnel of singboxTunnelsList) {
-			const history = $singboxDelayHistory.get(tunnel.tag) ?? [];
-			const latest = history.length > 0 ? history[history.length - 1] : null;
-			map.set(tunnel.tag, latest && latest > 0 ? latest : null);
-		}
-		return map;
-	});
+	let sortedFilteredSubscriptionsActiveCards = $derived(
+		sortFilterSubscriptionsActiveCards(
+			subscriptionsActiveCards,
+			effectiveSubscriptionsSearchQuery,
+			$singboxSubscriptionTableSort.sortBy,
+			$singboxSubscriptionTableSort.sortAsc,
+			$singboxTraffic,
+			$singboxDelayHistory,
+		),
+	);
 
-	let sortedFilteredSingboxTunnels = $derived.by(() => {
-		const query = effectiveSingboxTunnelsSearchQuery.trim().toLowerCase();
-		const filtered = singboxTunnelsList.filter((tunnel) =>
-			matchQuery(
-				[
-					tunnel.tag,
-					tunnel.protocol,
-					tunnel.server,
-					tunnel.proxyInterface,
-					tunnel.kernelInterface,
-					tunnel.transport,
-					tunnel.security,
-				],
-				query,
-			),
-		);
-		const sortBy = $singboxTunnelTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $singboxTunnelTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			switch (sortBy) {
-				case 'delay':
-					return compareDelayLike(singboxTunnelDelayValue.get(a.tag), singboxTunnelDelayValue.get(b.tag), asc);
-				case 'ping':
-					return compareDelayLike(singboxTunnelDelayValue.get(a.tag), singboxTunnelDelayValue.get(b.tag), asc);
-				case 'name':
-					return applyDirection(compareString(a.tag, b.tag), asc);
-				case 'protocol':
-					return applyDirection(compareString(a.protocol, b.protocol), asc);
-				case 'server':
-					return applyDirection(compareString(`${a.server}:${a.port}`, `${b.server}:${b.port}`), asc);
-				case 'running':
-					return applyDirection(compareBool(a.running, b.running), asc);
-				case 'traffic':
-					return applyDirection(
-						compareNullableNumber(
-							($singboxTraffic.get(a.tag)?.download ?? 0) + ($singboxTraffic.get(a.tag)?.upload ?? 0),
-							($singboxTraffic.get(b.tag)?.download ?? 0) + ($singboxTraffic.get(b.tag)?.upload ?? 0),
-							false,
-						),
-						asc,
-					);
-			}
-		});
-	});
-
-	function subscriptionTrafficBytes(subscription: Subscription, activeTag: string | null): number {
-		if (!activeTag) return 0;
-		const traffic = $singboxTraffic.get(activeTag);
-		return (traffic?.download ?? 0) + (traffic?.upload ?? 0);
-	}
-
-	function subscriptionDelayValue(subscription: Subscription, activeTag: string | null): number | null {
-		if (!activeTag) return null;
-		const history = $singboxDelayHistory.get(activeTag) ?? [];
-		const latest = history.length > 0 ? history[history.length - 1] : null;
-		return latest && latest > 0 ? latest : null;
-	}
-
-	let sortedFilteredSubscriptionsActiveCards = $derived.by(() => {
-		const query = effectiveSubscriptionsSearchQuery.trim().toLowerCase();
-		const filtered = subscriptionsActiveCards.filter(({ subscription, activeMember }) =>
-			matchQuery(
-				[
-					subscription.label,
-					subscription.url,
-					subscription.inboundTag,
-					subscription.selectorTag,
-					activeMember.tag,
-					activeMember.label,
-					activeMember.server,
-					`Proxy${subscription.proxyIndex}`,
-					`t2s${subscription.proxyIndex}`,
-				],
-				query,
-			),
-		);
-		const sortBy = $singboxSubscriptionTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $singboxSubscriptionTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			switch (sortBy) {
-				case 'delay':
-					return compareDelayLike(subscriptionDelayValue(a.subscription, a.activeMember.tag), subscriptionDelayValue(b.subscription, b.activeMember.tag), asc);
-				case 'ping':
-					return compareDelayLike(subscriptionDelayValue(a.subscription, a.activeMember.tag), subscriptionDelayValue(b.subscription, b.activeMember.tag), asc);
-				case 'label':
-					return applyDirection(compareString(a.subscription.label, b.subscription.label), asc);
-				case 'mode':
-					return applyDirection(compareString(a.subscription.mode, b.subscription.mode), asc);
-				case 'active':
-					return applyDirection(compareString(a.activeMember.label || a.activeMember.tag, b.activeMember.label || b.activeMember.tag), asc);
-				case 'traffic':
-					return applyDirection(compareNullableNumber(subscriptionTrafficBytes(a.subscription, a.activeMember.tag), subscriptionTrafficBytes(b.subscription, b.activeMember.tag), false), asc);
-				case 'updated':
-					return applyDirection(compareNullableNumber(
-						a.subscription.lastFetched ? new Date(a.subscription.lastFetched).getTime() : null,
-						b.subscription.lastFetched ? new Date(b.subscription.lastFetched).getTime() : null,
-					), asc);
-			}
-		});
-	});
-
-	let sortedFilteredSubscriptionsListRows = $derived.by(() => {
-		const query = effectiveSubscriptionsSearchQuery.trim().toLowerCase();
-		const filtered = subscriptionsListRows.filter((subscription) => {
-			const activeTag = liveActives[subscription.id] || null;
-			const member = subscription.members?.find((m) => m.tag === activeTag) ?? null;
-			return matchQuery(
-				[
-					subscription.label,
-					subscription.url,
-					subscription.inboundTag,
-					subscription.selectorTag,
-					member?.tag,
-					member?.label,
-					member?.server,
-					`Proxy${subscription.proxyIndex}`,
-					`t2s${subscription.proxyIndex}`,
-				],
-				query,
-			);
-		});
-		const sortBy = $singboxSubscriptionTableSort.sortBy;
-		if (!sortBy) return filtered;
-		const asc = $singboxSubscriptionTableSort.sortAsc;
-		return [...filtered].sort((a, b) => {
-			const activeA = liveActives[a.id] || resolveSubscriptionMemberTag(a, null);
-			const activeB = liveActives[b.id] || resolveSubscriptionMemberTag(b, null);
-			const memberA = a.members?.find((m) => m.tag === activeA) ?? null;
-			const memberB = b.members?.find((m) => m.tag === activeB) ?? null;
-			switch (sortBy) {
-				case 'delay':
-					return compareDelayLike(subscriptionDelayValue(a, activeA), subscriptionDelayValue(b, activeB), asc);
-				case 'ping':
-					return compareDelayLike(subscriptionDelayValue(a, activeA), subscriptionDelayValue(b, activeB), asc);
-				case 'label':
-					return applyDirection(compareString(a.label, b.label), asc);
-				case 'mode':
-					return applyDirection(compareString(a.mode, b.mode), asc);
-				case 'active':
-					return applyDirection(compareString(memberA?.label || memberA?.tag, memberB?.label || memberB?.tag), asc);
-				case 'traffic':
-					return applyDirection(compareNullableNumber(subscriptionTrafficBytes(a, activeA), subscriptionTrafficBytes(b, activeB), false), asc);
-				case 'updated':
-					return applyDirection(compareNullableNumber(
-						a.lastFetched ? new Date(a.lastFetched).getTime() : null,
-						b.lastFetched ? new Date(b.lastFetched).getTime() : null,
-					), asc);
-			}
-		});
-	});
+	let sortedFilteredSubscriptionsListRows = $derived(
+		sortFilterSubscriptionsListRows(
+			subscriptionsListRows,
+			effectiveSubscriptionsSearchQuery,
+			$singboxSubscriptionTableSort.sortBy,
+			$singboxSubscriptionTableSort.sortAsc,
+			liveActives,
+			$singboxTraffic,
+			$singboxDelayHistory,
+		),
+	);
 
 	let awgSourceRowCount = $derived(awgList.length + visibleSystemList.length + externalList.length);
 	let singboxTunnelsSourceRowCount = $derived(singboxTunnelsList.length);


### PR DESCRIPTION
## Что сделано

Завершение декомпозиции `routes/+page.svelte` (класс 2, продолжение #502/#504). Страница: **2660 → 1807 строк**. Четыре коммита:

### 1. Flat-режим дашборда → `DashboardFlatSection.svelte` (`cdf895b8`)
Дословный перенос true-ветки `{#if dashboardOn}` (~560 строк разметки + 29 CSS-правил): снипеты карточек всех видов, тулбар, сетка, группировка по тегам, drag-reorder строки. Состояние — live-контекстом `dashboardFlatContext.ts` (геттеры поверх `$state`/`$derived`, сеттеры для мутируемых полей, `bind:this` через сеттер). Ghost-слой drag остался в странице (fixed-позиционирование).

### 2. Чистка по ревью (`6aac20cf`)
Осиротевшие CSS-комментарии, пустые `@media`, дубликат `:global(.empty-kind-icon)` после чистки неиспользуемых селекторов.

### 3. Модалки → `TunnelPageModals.svelte` (`b167bce3`)
Дословный перенос блока модалок (~126 строк): AdoptTunnelDialog, подтверждения удаления туннеля/подписки, TunnelReferencedModal, AddTunnelWizard, TrafficChartModal (AWG и sing-box), TunnelDiagnosticsModal, ConnectivitySettingsModal. Контекст — `tunnelPageModalsContext.ts`. Попутно: мёртвый снипет `exportIcon`, мёртвый импорт `AdoptTunnelDialog` в DashboardFlatSection, неиспользуемые импорты страницы.

### 4. Селекторы списков → `tunnelPageSelectors.ts` (`59cbc101`)
Сортировка/фильтрация шести списков, карта задержек, статусные хелперы и три сводные статистики — чистыми функциями (значения сторов параметрами, в странице тонкие `$derived`-обёртки). Единственное смысловое изменение: `subscriptionTrafficBytes`/`subscriptionDelayValue` принимают карты вместо неиспользуемого параметра `subscription`. Попутно мёртвый код: три `*SortOptions`, типы `TunnelSortOption`/`ConnectivityCell`, импорт `ariaSort`. **+20 vitest-тестов** на селекторы.

## Верификация (каждый коммит)

- svelte-check `0 errors / 0 warnings`, eslint 0, vitest **1363** (1343 + 20 новых), build OK
- **8/8 скриншот-кадров пиксельно идентичны** пре-рефакторной базе (детерминированный мок `MOCK_DETERMINISTIC=1`, замороженное время, заблокированный SSE): desktop dark/light, mobile, list-режим, вкладки sing-box/подписки, дашборд sections/flat
- DOM-smoke интеракций: flat-дашборд (поиск 27→0→27 через ctx-сеттеры, empty-state reset), модалки 9/9 (`?detail=`/`?sbDetail=`/delete-confirm: открытие, содержимое, закрытие), сортировка таблицы AWG (asc/desc по клику)

## Ограничения

Скриншоты покрывают отрендеренные состояния; неотрендеренные ветки (drag-состояния, error-ветки) защищены типами svelte-check и кросс-проверкой «потерянных» CSS-классов (LOST: none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg