### PR TITLE
feat(logging): этапы A+B+C — конец спама connectivity check и полная видимость действий в журнале

### DIFF
--- a/cmd/awg-manager/boot.go
+++ b/cmd/awg-manager/boot.go
@@ -63,6 +63,12 @@ func populateWANModel(ctx context.Context, queries *ndmsquery.Queries, model *wa
 func (a *app) startBootSequence() {
 	// Boot vs restart detection
 	a.uptime = getUptime()
+	tunnelCount := 0
+	if list, err := a.awgStore.List(); err == nil {
+		tunnelCount = len(list)
+	}
+	a.bootLog.Info("startup", "",
+		fmt.Sprintf("awg-manager %s started (uptime %ds, tunnels in config: %d)", version, int(a.uptime), tunnelCount))
 	const bootDetectionMax = 300 // 5 minutes
 	isBoot := (a.uptime > 0 && a.uptime < bootDetectionMax) || a.forceBoot
 	if isBoot {

--- a/cmd/awg-manager/wiring_core.go
+++ b/cmd/awg-manager/wiring_core.go
@@ -53,6 +53,11 @@ func (a *app) setupCore() {
 
 	// Logging service (created early — injected into tunnel service, pingcheck, dnsroute, operator, state, firewall, nwg)
 	a.loggingService = logging.NewService(a.settingsStore)
+	// События восстановления хранилищ (карантин битых файлов, откат к .bak)
+	// произошли до появления журнала — выгружаем отложенный буфер.
+	for _, n := range storage.DrainNotices() {
+		a.loggingService.AppLog(logging.LevelWarn, logging.GroupSystem, logging.SubStorage, n.Action, n.Target, n.Message)
+	}
 	a.deferOnExit(a.loggingService.Stop)
 
 	// bootLog: UI-visible scoped logger for all bootstrap diagnostics. Replaces

--- a/cmd/awg-manager/wiring_core.go
+++ b/cmd/awg-manager/wiring_core.go
@@ -53,11 +53,13 @@ func (a *app) setupCore() {
 
 	// Logging service (created early — injected into tunnel service, pingcheck, dnsroute, operator, state, firewall, nwg)
 	a.loggingService = logging.NewService(a.settingsStore)
-	// События восстановления хранилищ (карантин битых файлов, откат к .bak)
-	// произошли до появления журнала — выгружаем отложенный буфер.
-	for _, n := range storage.DrainNotices() {
+	// События восстановления хранилищ (карантин битых файлов, откат к .bak):
+	// живой sink — большинство хранилищ грузятся лениво позже этой точки,
+	// разовый дрейн терял бы их события. Заодно выгружается накопленное
+	// до связывания (настройки грузятся раньше журнала).
+	storage.SetNoticeSink(func(n storage.Notice) {
 		a.loggingService.AppLog(logging.LevelWarn, logging.GroupSystem, logging.SubStorage, n.Action, n.Target, n.Message)
-	}
+	})
 	a.deferOnExit(a.loggingService.Stop)
 
 	// bootLog: UI-visible scoped logger for all bootstrap diagnostics. Replaces

--- a/cmd/awg-manager/wiring_routing.go
+++ b/cmd/awg-manager/wiring_routing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/connectivity"
 	"github.com/hoaxisr/awg-manager/internal/dnsroute"
 	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/managed"
 	"github.com/hoaxisr/awg-manager/internal/monitoring"
 	ndmsevents "github.com/hoaxisr/awg-manager/internal/ndms/events"
@@ -92,6 +94,7 @@ func (a *app) setupOrchestrator() {
 		}
 		return nil
 	})
+	a.dnsFailover.SetLogger(dnsFailoverJournal{log: logging.NewScopedLogger(a.loggingService, logging.GroupRouting, logging.SubDnsRoute)})
 	a.dnsRouteService.SetHydraRoute(a.hydraService)
 	a.dnsRouteService.SetFailoverManager(a.dnsFailover)
 	a.dnsFailover.SetAffectedListsLookup(a.dnsRouteService.LookupAffectedLists)
@@ -223,4 +226,17 @@ func (a *app) setupEventWiring() {
 	connMonitor.Start()
 	a.deferOnExit(connMonitor.Stop)
 
+}
+
+// dnsFailoverJournal адаптирует журнал приложения к минимальному
+// Logger-интерфейсу failover-менеджера (до сих пор он подключался только
+// в тестах — срабатывания failover в проде не оставляли следа).
+type dnsFailoverJournal struct{ log *logging.ScopedLogger }
+
+func (j dnsFailoverJournal) Warnf(format string, args ...interface{}) {
+	j.log.Warn("failover", "", fmt.Sprintf(format, args...))
+}
+
+func (j dnsFailoverJournal) Infof(format string, args ...interface{}) {
+	j.log.Info("failover", "", fmt.Sprintf(format, args...))
 }

--- a/cmd/awg-manager/wiring_server.go
+++ b/cmd/awg-manager/wiring_server.go
@@ -349,6 +349,7 @@ func (a *app) setupRouter() {
 		a.singboxOp.ConfigDir(),
 		selectiveAdapter,
 		selectiveBuilder,
+		a.loggingService,
 	))
 	selectiveCDNRefresh := selective.StartCDNRefreshLoop(
 		selective.CDNRefreshInterval,
@@ -436,7 +437,7 @@ func (a *app) setupRouter() {
 	a.srv.SetSingboxConfigHandler(api.NewSingboxConfigHandler(a.sbOrch.ConfigDir))
 	// Эксперт-редактор конфигурации: обзор слотов config.d + draft-пайплайн
 	// пользовательского слота 90-user.json (единственный слот без продюсера).
-	a.srv.SetSingboxConfigEditorHandler(api.NewSingboxConfigEditorHandler(a.sbOrch))
+	a.srv.SetSingboxConfigEditorHandler(api.NewSingboxConfigEditorHandler(a.sbOrch, a.loggingService))
 	// Зеркало inbound'ов merged-конфига: per-slot чтение config.d с атрибуцией
 	// источника (подписка/группа/туннель/device-proxy/QoS/движок). Резолверы
 	// nil-safe — при частичном bootstrap источник деградирует до слота.
@@ -500,7 +501,7 @@ func (a *app) setupListen() {
 	if err := dnsRewriteSvc.Resync(); err != nil {
 		a.bootLog.Warn("dnsrewrite-resync", "", err.Error())
 	}
-	a.srv.SetDNSRewritesHandler(api.NewDNSRewritesHandler(dnsRewriteSvc))
+	a.srv.SetDNSRewritesHandler(api.NewDNSRewritesHandler(dnsRewriteSvc, a.loggingService))
 
 	// Boot status: 0 = booting, 1 = done. Used by /api/system/info.
 	a.srv.SetBootStatusFunc(func() bool { return atomic.LoadInt32(&a.bootDone) == 0 })

--- a/cmd/awg-manager/wiring_singbox.go
+++ b/cmd/awg-manager/wiring_singbox.go
@@ -196,7 +196,7 @@ func (a *app) setupSingbox() {
 		a.eventBus,
 	)
 	a.singboxHandler = api.NewSingboxHandler(a.singboxOp, a.eventBus, delayChecker, a.testService, a.loggingService)
-	singboxMigrator := singbox.NewMigrator(a.singboxOp, a.settingsStore)
+	singboxMigrator := singbox.NewMigrator(a.singboxOp, a.settingsStore, a.loggingService)
 	a.singboxHandler.SetNDMSProxyMigrator(singboxMigrator, a.settingsStore)
 	a.clashProxy = api.NewClashProxy(a.singboxOp)
 	a.singboxConnsHandler = api.NewSingboxConnectionsHandler(a.ndmsQueries.Hotspot)

--- a/cmd/awg-manager/wiring_tunnels.go
+++ b/cmd/awg-manager/wiring_tunnels.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/dnsroute"
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/hydraroute"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	ndmscommand "github.com/hoaxisr/awg-manager/internal/ndms/command"
 	"github.com/hoaxisr/awg-manager/internal/pingcheck"
 	"github.com/hoaxisr/awg-manager/internal/presets"
@@ -203,6 +204,7 @@ func (a *app) setupServices() {
 	// existing sessions.
 	a.keeneticClient = auth.NewKeeneticClient()
 	a.sessionStore = auth.NewSessionStore(a.settingsStore.GetSessionTTL)
+	a.sessionStore.SetLogger(logging.NewScopedLogger(a.loggingService, logging.GroupSystem, logging.SubAuth))
 	a.deferOnExit(a.sessionStore.Stop)
 
 	a.operator.SetAppLogger(a.loggingService)

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -19,6 +19,9 @@ export interface LogEntryEvent {
 	target: string;
 	message: string;
 	bucket: 'app' | 'singbox';
+	/** Повтор, свёрнутый в существующую запись: счётчик и время последнего. */
+	repeats?: number;
+	lastSeen?: string;
 }
 
 export interface SystemBootingEvent {

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -593,8 +593,10 @@ const api_LANSegmentsListResponse: v.GenericSchema = v.looseObject({
 const api_LogEntryDTO: v.GenericSchema = v.looseObject({
 	action: v.optional(v.nullable(v.string())),
 	group: v.optional(v.nullable(v.string())),
+	lastSeen: v.optional(v.nullable(v.string())),
 	level: v.optional(v.nullable(v.string())),
 	message: v.optional(v.nullable(v.string())),
+	repeats: v.optional(v.nullable(v.number())),
 	sanitized: v.optional(v.nullable(v.boolean())),
 	subgroup: v.optional(v.nullable(v.string())),
 	target: v.optional(v.nullable(v.string())),

--- a/frontend/src/lib/components/diagnostics/LogRow.svelte
+++ b/frontend/src/lib/components/diagnostics/LogRow.svelte
@@ -57,6 +57,14 @@
 
   const subgroupFamily = $derived(familyOf(log.subgroup));
 
+  // Схлопнутые повторы: бейдж «×N» = всего появлений записи; тултип —
+  // время последнего повтора (timestamp строки — первое появление).
+  const repeatTitle = $derived(
+    log.lastSeen
+      ? `Повторялось, последний раз: ${formatDateTimeWithOffset(log.lastSeen, routerOffset ?? undefined)}`
+      : 'Повторяющаяся запись',
+  );
+
   // Sing-box stderr lines (and any other ANSI-emitting source) may carry
   // raw colour escapes. Strip at the render boundary — sing-box has no
   // config-level switch to suppress colour, and its CLI --disable-color
@@ -148,6 +156,9 @@
   <span class="target">{log.target}</span>
   <span class="arrow">→</span>
   <span class="message" class:truncate={!isExpanded}>{cleanMessage}</span>
+  {#if (log.repeats ?? 0) > 0}
+    <span class="repeat-badge" title={repeatTitle}>×{(log.repeats ?? 0) + 1}</span>
+  {/if}
 </div>
 
 <style>
@@ -188,6 +199,18 @@
 
   .row.level-error { border-left-color: var(--color-error); }
   .row.level-warn { border-left-color: var(--color-warning); }
+
+  .repeat-badge {
+    flex: 0 0 auto;
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 0 5px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-secondary);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
 
   .time {
     color: var(--color-text-muted);

--- a/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
+++ b/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
@@ -48,6 +48,7 @@
     'client-route': 'Per-client routes',
     'singbox-router': 'Sing-box router',
     selective: 'Селективный ipset',
+    subscription: 'Подписки',
     deviceproxy: 'Device proxy',
     hrneo: 'HrNeo',
     catalog: 'Каталог',
@@ -69,6 +70,11 @@
     profiling: 'Profiling HTTP',
     rci: 'RCI',
     ndms: 'NDMS',
+    storage: 'Хранилище',
+    monitoring: 'Мониторинг',
+    orchestrator: 'Оркестратор',
+    kmod: 'Модуль ядра',
+    http: 'HTTP-сервер',
   };
 
   export interface BufferBadge {

--- a/frontend/src/lib/components/diagnostics/subgroup-palette.ts
+++ b/frontend/src/lib/components/diagnostics/subgroup-palette.ts
@@ -15,12 +15,16 @@ export const SUBGROUP_FAMILY: Record<string, SubgroupFamily> = {
   'client-route': 'routing',
   'singbox-router': 'routing',
   'hrneo': 'routing',
+  'subscription': 'routing',
+  'selective': 'routing',
   // lifecycle
   'lifecycle': 'lifecycle',
   'ops': 'lifecycle',
   'state': 'lifecycle',
   'boot': 'lifecycle',
   'cleanup': 'lifecycle',
+  'orchestrator': 'lifecycle',
+  'kmod': 'lifecycle',
   // network
   'connectivity': 'network',
   'pingcheck': 'network',
@@ -28,6 +32,7 @@ export const SUBGROUP_FAMILY: Record<string, SubgroupFamily> = {
   'wan': 'network',
   'connections': 'network',
   'traffic': 'network',
+  'monitoring': 'network',
   // policy
   'access-policy': 'policy',
   'firewall': 'policy',
@@ -35,6 +40,8 @@ export const SUBGROUP_FAMILY: Record<string, SubgroupFamily> = {
   // system
   'rci': 'system',
   'ndms': 'system',
+  'storage': 'system',
+  'http': 'system',
   'settings': 'system',
   'auth': 'system',
   'update': 'system',

--- a/frontend/src/lib/stores/logs.test.ts
+++ b/frontend/src/lib/stores/logs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { appLogEntries } from './logs';
+import type { LogEntryEvent } from '$lib/api/events';
+import type { LogEntry } from '$lib/types';
+
+function ev(over: Partial<LogEntryEvent> = {}): LogEntryEvent {
+	return {
+		timestamp: '2026-01-01T10:00:00Z',
+		level: 'warn',
+		group: 'tunnel',
+		subgroup: 'test',
+		action: 'http-check',
+		target: 'awg10',
+		message: 'Connectivity check failed: timeout',
+		bucket: 'app',
+		...over,
+	};
+}
+
+describe('logs store: схлопнутые повторы', () => {
+	beforeEach(() => appLogEntries.clear());
+
+	it('append с repeats обновляет существующую строку вместо новой', () => {
+		appLogEntries.append(ev());
+		appLogEntries.append(ev({ repeats: 1, lastSeen: '2026-01-01T10:00:30Z' }));
+
+		const entries = get(appLogEntries);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].repeats).toBe(1);
+		expect(entries[0].lastSeen).toBe('2026-01-01T10:00:30Z');
+		expect(get(appLogEntries.total)).toBe(1);
+	});
+
+	it('append с repeats без базовой строки вставляет её как обычную', () => {
+		appLogEntries.append(ev({ repeats: 3, lastSeen: '2026-01-01T10:02:00Z' }));
+		const entries = get(appLogEntries);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].repeats).toBe(3);
+	});
+
+	it('append без repeats добавляет новую строку как раньше', () => {
+		appLogEntries.append(ev());
+		appLogEntries.append(ev({ message: 'другое сообщение' }));
+		expect(get(appLogEntries)).toHaveLength(2);
+	});
+
+	it('appendMany освежает счётчик у существующей строки при бОльшем repeats', () => {
+		appLogEntries.append(ev());
+		const rest: LogEntry[] = [
+			{
+				timestamp: '2026-01-01T10:00:00Z',
+				level: 'warn',
+				group: 'tunnel',
+				subgroup: 'test',
+				action: 'http-check',
+				target: 'awg10',
+				message: 'Connectivity check failed: timeout',
+				repeats: 5,
+				lastSeen: '2026-01-01T10:04:00Z',
+			},
+		];
+		appLogEntries.appendMany(rest);
+		const entries = get(appLogEntries);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].repeats).toBe(5);
+		expect(entries[0].lastSeen).toBe('2026-01-01T10:04:00Z');
+	});
+
+	it('appendMany не откатывает счётчик при меньшем repeats', () => {
+		appLogEntries.append(ev({ repeats: 4, lastSeen: '2026-01-01T10:03:00Z' }));
+		appLogEntries.appendMany([
+			{
+				timestamp: '2026-01-01T10:00:00Z',
+				level: 'warn',
+				group: 'tunnel',
+				subgroup: 'test',
+				action: 'http-check',
+				target: 'awg10',
+				message: 'Connectivity check failed: timeout',
+				repeats: 2,
+			} as LogEntry,
+		]);
+		const entries = get(appLogEntries);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].repeats).toBe(4);
+	});
+});

--- a/frontend/src/lib/stores/logs.test.ts
+++ b/frontend/src/lib/stores/logs.test.ts
@@ -79,7 +79,7 @@ describe('logs store: схлопнутые повторы', () => {
 				target: 'awg10',
 				message: 'Connectivity check failed: timeout',
 				repeats: 2,
-			} as LogEntry,
+			},
 		]);
 		const entries = get(appLogEntries);
 		expect(entries).toHaveLength(1);

--- a/frontend/src/lib/stores/logs.ts
+++ b/frontend/src/lib/stores/logs.ts
@@ -5,6 +5,10 @@ import type { LogEntryEvent } from '$lib/api/events';
 export type LogBucket = 'app' | 'singbox';
 
 const MAX_ENTRIES = 5000;
+// Кап скана при upsert повтора — зеркало backend coalesceScanLimit:
+// повторы почти всегда матчатся в свежих строках, полный проход по 5000
+// строк на каждое SSE-событие — лишняя работа на UI-потоке.
+const REPEAT_SCAN_LIMIT = 300;
 
 function keyOf(e: LogEntry): string {
   return `${e.timestamp}|${e.level}|${e.group}|${e.subgroup}|${e.action}|${e.target}|${e.message}`;
@@ -45,16 +49,30 @@ function createLogStore(bucket: LogBucket) {
         const key = keyOf(logEntry);
         let found = false;
         update((entries) => {
-          const idx = entries.findIndex((e) => keyOf(e) === key);
-          if (idx === -1) return entries;
-          found = true;
-          const next = entries.slice();
-          next[idx] = { ...next[idx], repeats: entry.repeats, lastSeen: entry.lastSeen };
-          return next;
+          const limit = Math.min(entries.length, REPEAT_SCAN_LIMIT);
+          for (let i = 0; i < limit; i++) {
+            if (keyOf(entries[i]) !== key) continue;
+            found = true;
+            const next = entries.slice();
+            next[i] = { ...next[i], repeats: entry.repeats, lastSeen: entry.lastSeen };
+            return next;
+          }
+          return entries;
         });
-        // Первое появление могло не попасть в клиентский буфер (страница
-        // открыта позже) — тогда повтор вставляется как обычная строка.
         if (found) return;
+        // Первое появление не попало в клиентский буфер (страница открыта
+        // позже): вставляем строку по её timestamp (первое появление может
+        // быть давним — в голове списка она ломала бы порядок), total не
+        // трогаем — на сервере повтор не создал новой записи.
+        update((entries) => {
+          const ts2 = new Date(logEntry.timestamp).getTime();
+          const pos = entries.findIndex((e) => new Date(e.timestamp).getTime() <= ts2);
+          const at = pos === -1 ? entries.length : pos;
+          const updated = [...entries.slice(0, at), logEntry, ...entries.slice(at)];
+          if (updated.length > MAX_ENTRIES) updated.length = MAX_ENTRIES;
+          return updated;
+        });
+        return;
       }
       update((entries) => {
         const updated = [logEntry, ...entries];

--- a/frontend/src/lib/stores/logs.ts
+++ b/frontend/src/lib/stores/logs.ts
@@ -32,14 +32,30 @@ function createLogStore(bucket: LogBucket) {
     loaded: { subscribe: loaded.subscribe },
     lastSeenTs: { subscribe: lastSeenTs.subscribe },
     stats: { subscribe: stats.subscribe },
-    /** SSE-driven head append (newest at front). */
+    /** SSE-driven head append (newest at front). Повтор (repeats > 0)
+     * обновляет существующую строку по составному ключу вместо новой. */
     append(entry: LogEntryEvent) {
       const logEntry: LogEntry = {
         ...entry,
         subgroup: entry.subgroup ?? '',
       };
-      const ts = new Date(entry.timestamp).getTime();
+      const ts = new Date(entry.lastSeen ?? entry.timestamp).getTime();
       lastSeenTs.update((cur) => (ts > cur ? ts : cur));
+      if ((entry.repeats ?? 0) > 0) {
+        const key = keyOf(logEntry);
+        let found = false;
+        update((entries) => {
+          const idx = entries.findIndex((e) => keyOf(e) === key);
+          if (idx === -1) return entries;
+          found = true;
+          const next = entries.slice();
+          next[idx] = { ...next[idx], repeats: entry.repeats, lastSeen: entry.lastSeen };
+          return next;
+        });
+        // Первое появление могло не попасть в клиентский буфер (страница
+        // открыта позже) — тогда повтор вставляется как обычная строка.
+        if (found) return;
+      }
       update((entries) => {
         const updated = [logEntry, ...entries];
         if (updated.length > MAX_ENTRIES) updated.length = MAX_ENTRIES;
@@ -47,14 +63,23 @@ function createLogStore(bucket: LogBucket) {
       });
       logsTotal.update((n) => n + 1);
     },
-    /** Catch-up merge after SSE reconnect — keeps entries newest-first, dedups by composite key. */
+    /** Catch-up merge after SSE reconnect — keeps entries newest-first, dedups by composite key.
+     * Дубликат с бОльшим repeats освежает счётчик существующей строки. */
     appendMany(arr: LogEntry[]) {
       update((entries) => {
-        const seen = new Set(entries.map(keyOf));
+        const byKey = new Map(entries.map((e, i) => [keyOf(e), i]));
         const newOnes: LogEntry[] = [];
+        let refreshed: LogEntry[] | null = null;
         for (const e of arr) {
-          if (!seen.has(keyOf(e))) newOnes.push(e);
+          const idx = byKey.get(keyOf(e));
+          if (idx === undefined) {
+            newOnes.push(e);
+          } else if ((e.repeats ?? 0) > ((refreshed ?? entries)[idx].repeats ?? 0)) {
+            refreshed = refreshed ?? entries.slice();
+            refreshed[idx] = { ...refreshed[idx], repeats: e.repeats, lastSeen: e.lastSeen };
+          }
         }
+        if (refreshed) entries = refreshed;
         if (newOnes.length === 0) return entries;
         const newestTs = newOnes.reduce((m, e) => Math.max(m, new Date(e.timestamp).getTime()), 0);
         if (newestTs > 0) lastSeenTs.update((cur) => (newestTs > cur ? newestTs : cur));

--- a/frontend/src/lib/types/diagnostics.ts
+++ b/frontend/src/lib/types/diagnostics.ts
@@ -12,6 +12,10 @@ export interface LogEntry {
 	message: string;
 	/** true when target/message were sanitized by backend before delivery. */
 	sanitized?: boolean;
+	/** Схлопнутые повторы: сколько идентичных записей свёрнуто в эту (0/нет = уникальна). */
+	repeats?: number;
+	/** Время последнего повтора (timestamp — первое появление). */
+	lastSeen?: string;
 }
 
 export interface LogsResponse {

--- a/internal/accesspolicy/impl.go
+++ b/internal/accesspolicy/impl.go
@@ -289,7 +289,7 @@ func (s *ServiceImpl) SetDescription(ctx context.Context, name, description stri
 		return err
 	}
 
-	s.appLog.Full("set-description", name, fmt.Sprintf("Policy %s description updated", name))
+	s.appLog.Info("set-description", name, fmt.Sprintf("Policy %s description updated", name))
 	return nil
 }
 
@@ -311,7 +311,7 @@ func (s *ServiceImpl) SetStandalone(ctx context.Context, name string, enabled bo
 	if enabled {
 		state = "enabled"
 	}
-	s.appLog.Full("set-standalone", name, fmt.Sprintf("Policy %s standalone %s", name, state))
+	s.appLog.Info("set-standalone", name, fmt.Sprintf("Policy %s standalone %s", name, state))
 	return nil
 }
 
@@ -491,7 +491,7 @@ func (s *ServiceImpl) SetInterfaceUp(ctx context.Context, ndmsName string, up bo
 				return lerr
 			}
 			s.refreshInterfaceAfterLifecycle(ndmsName)
-			s.appLog.Full("set-interface", ndmsName, fmt.Sprintf("Managed tunnel %s set %s via lifecycle", id, action))
+			s.appLog.Info("set-interface", ndmsName, fmt.Sprintf("Managed tunnel %s set %s via lifecycle", id, action))
 			return nil
 		}
 	}
@@ -506,7 +506,7 @@ func (s *ServiceImpl) SetInterfaceUp(ctx context.Context, ndmsName string, up bo
 		s.appLog.Warn("set-interface", ndmsName, fmt.Sprintf("Failed to set %s: %v", action, err))
 		return err
 	}
-	s.appLog.Full("set-interface", ndmsName, fmt.Sprintf("Interface %s set %s", ndmsName, action))
+	s.appLog.Info("set-interface", ndmsName, fmt.Sprintf("Interface %s set %s", ndmsName, action))
 	return nil
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -238,7 +238,11 @@ func (h *AuthHandler) finishFailedLogin(w http.ResponseWriter, login, clientIP s
 // actually checked (see finishFailedLogin) for the throttle and applies the
 // constant anti-brute-force delay before the handler returns its status.
 func (h *AuthHandler) registerFailure(clientIP string) {
-	h.throttle.Fail(clientIP)
+	if h.throttle.Fail(clientIP) {
+		// Момент срабатывания анти-брутфорса — основной сигнал атаки
+		// подбором; отдельные неудачные попытки уже логируются выше.
+		h.log.Warn("login-throttle", clientIP, "login blocked after repeated failures (anti-bruteforce)")
+	}
 	if h.failureDelay > 0 {
 		time.Sleep(h.failureDelay)
 	}

--- a/internal/api/dns_rewrites.go
+++ b/internal/api/dns_rewrites.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/singbox/dnsrewrite"
 )
@@ -53,10 +55,16 @@ type DNSRewritesService interface {
 
 type DNSRewritesHandler struct {
 	svc DNSRewritesService
+	log *logging.ScopedLogger
 }
 
-func NewDNSRewritesHandler(svc DNSRewritesService) *DNSRewritesHandler {
-	return &DNSRewritesHandler{svc: svc}
+// NewDNSRewritesHandler constructs the handler.
+// appLogger may be nil — the scoped logger is nil-safe.
+func NewDNSRewritesHandler(svc DNSRewritesService, appLogger logging.AppLogger) *DNSRewritesHandler {
+	return &DNSRewritesHandler{
+		svc: svc,
+		log: logging.NewScopedLogger(appLogger, logging.GroupRouting, logging.SubSingboxRouter),
+	}
 }
 
 // List returns all DNS rewrites in priority order.
@@ -113,6 +121,7 @@ func (h *DNSRewritesHandler) Add(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, err.Error())
 		return
 	}
+	h.log.Info("dns-rewrite-add", rw.Pattern, "DNS rewrite added: "+rw.Pattern)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -146,6 +155,7 @@ func (h *DNSRewritesHandler) Update(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, err.Error())
 		return
 	}
+	h.log.Info("dns-rewrite-update", req.Rewrite.Pattern, "DNS rewrite updated: "+req.Rewrite.Pattern)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -178,6 +188,7 @@ func (h *DNSRewritesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, err.Error())
 		return
 	}
+	h.log.Info("dns-rewrite-delete", strconv.Itoa(req.Index), "DNS rewrite deleted at index "+strconv.Itoa(req.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -211,5 +222,7 @@ func (h *DNSRewritesHandler) Move(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, err.Error())
 		return
 	}
+	h.log.Info("dns-rewrite-move", strconv.Itoa(req.From),
+		"DNS rewrite moved from index "+strconv.Itoa(req.From)+" to "+strconv.Itoa(req.To))
 	response.Success(w, map[string]bool{"ok": true})
 }

--- a/internal/api/dns_rewrites.go
+++ b/internal/api/dns_rewrites.go
@@ -114,10 +114,12 @@ func (h *DNSRewritesHandler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 	var rw dnsrewrite.DNSRewrite
 	if err := decodeBody(r, &rw); err != nil {
+		h.log.Warn("dns-rewrite-add", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
 	if err := h.svc.Add(rw); err != nil {
+		h.log.Warn("dns-rewrite-add", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
@@ -148,10 +150,12 @@ func (h *DNSRewritesHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Rewrite dnsrewrite.DNSRewrite `json:"rewrite"`
 	}
 	if err := decodeBody(r, &req); err != nil {
+		h.log.Warn("dns-rewrite-update", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
 	if err := h.svc.Update(req.Index, req.Rewrite); err != nil {
+		h.log.Warn("dns-rewrite-update", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
@@ -181,10 +185,12 @@ func (h *DNSRewritesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		Index int `json:"index"`
 	}
 	if err := decodeBody(r, &req); err != nil {
+		h.log.Warn("dns-rewrite-delete", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
 	if err := h.svc.Delete(req.Index); err != nil {
+		h.log.Warn("dns-rewrite-delete", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
@@ -215,10 +221,12 @@ func (h *DNSRewritesHandler) Move(w http.ResponseWriter, r *http.Request) {
 		To   int `json:"to"`
 	}
 	if err := decodeBody(r, &req); err != nil {
+		h.log.Warn("dns-rewrite-move", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}
 	if err := h.svc.Move(req.From, req.To); err != nil {
+		h.log.Warn("dns-rewrite-move", "", err.Error())
 		response.BadRequest(w, err.Error())
 		return
 	}

--- a/internal/api/dnsroute.go
+++ b/internal/api/dnsroute.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/hoaxisr/awg-manager/internal/dnsroute"
@@ -444,6 +445,7 @@ func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	changed := 0
 	for _, id := range req.ListIDs {
 		list, err := h.svc.Get(r.Context(), id)
 		if err != nil {
@@ -454,6 +456,10 @@ func (h *DNSRouteHandler) BulkBackend(w http.ResponseWriter, r *http.Request) {
 			h.log.Warn("bulk-backend", id, "Failed to update backend: "+err.Error())
 			continue
 		}
+		changed++
+	}
+	if changed > 0 {
+		h.log.Info("bulk-backend", req.Backend, fmt.Sprintf("bulk backend change: %d lists → %s", changed, req.Backend))
 	}
 
 	fresh, err := h.svc.List(r.Context())

--- a/internal/api/hook.go
+++ b/internal/api/hook.go
@@ -41,6 +41,7 @@ type HookHandler struct {
 	wanModel       HookWANModel   // may be nil until SetWANModel is called
 	refreshTunnels TunnelHookInvalidator
 	log            *logging.ScopedLogger
+	wanLog         *logging.ScopedLogger
 	// selfCreateGate counts in-flight awg-manager-initiated NDMS interface
 	// creations. While > 0, ifcreated hook events suppress their automatic
 	// snapshot rebroadcast — the caller (importer / Create path) is
@@ -68,6 +69,9 @@ func NewHookHandler(svc TunnelService, orch *orchestrator.Orchestrator, appLogge
 		svc:  svc,
 		orch: orch,
 		log:  logging.NewScopedLogger(appLogger, logging.GroupSystem, logging.SubBoot),
+		// Переходы WAN — отдельная подгруппа: их ищут при разборе обрывов,
+		// не смешивая с потоком NDMS-хуков.
+		wanLog: logging.NewScopedLogger(appLogger, logging.GroupSystem, logging.SubWan),
 	}
 }
 
@@ -231,6 +235,14 @@ func (h *HookHandler) handleWANLayerEvent(e events.Event) {
 	// Sync WAN model update — must happen before the orch decides
 	// whether any WAN is up. SetUp handles hot-plug via repopulateFn.
 	h.wanModel.SetUp(kernelName, up)
+
+	if h.wanLog != nil {
+		if up {
+			h.wanLog.Info("wan-state", kernelName, "WAN interface up")
+		} else {
+			h.wanLog.Warn("wan-state", kernelName, "WAN interface down")
+		}
+	}
 
 	if h.orch == nil {
 		return

--- a/internal/api/hook.go
+++ b/internal/api/hook.go
@@ -23,7 +23,7 @@ type HookDispatcher interface {
 // HookWANModel is the narrow surface HookHandler needs from the WAN
 // model. Kept local so api/hook.go doesn't depend on *wan.Model.
 type HookWANModel interface {
-	SetUp(kernelName string, up bool)
+	SetUp(kernelName string, up bool) (changed bool)
 }
 
 // TunnelHookInvalidator is invoked on ifcreated / ifdestroyed hooks so
@@ -234,9 +234,11 @@ func (h *HookHandler) handleWANLayerEvent(e events.Event) {
 
 	// Sync WAN model update — must happen before the orch decides
 	// whether any WAN is up. SetUp handles hot-plug via repopulateFn.
-	h.wanModel.SetUp(kernelName, up)
+	changed := h.wanModel.SetUp(kernelName, up)
 
-	if h.wanLog != nil {
+	// Логируем только реальные переходы: NDMS повторяет hook-события с
+	// неизменным уровнем, и без этого фильтра каждый повтор писал бы строку.
+	if h.wanLog != nil && changed {
 		if up {
 			h.wanLog.Info("wan-state", kernelName, "WAN interface up")
 		} else {

--- a/internal/api/hook_test.go
+++ b/internal/api/hook_test.go
@@ -202,10 +202,11 @@ type fakeWANSetUp struct {
 	Up   bool
 }
 
-func (f *fakeWANModel) SetUp(name string, up bool) {
+func (f *fakeWANModel) SetUp(name string, up bool) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, fakeWANSetUp{Name: name, Up: up})
+	return true
 }
 
 func (f *fakeWANModel) Calls() []fakeWANSetUp {

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -23,6 +23,10 @@ type LogEntryDTO struct {
 	Target    string `json:"target" example:"dns"`
 	Message   string `json:"message" example:"lookup succeed for node.example.org: 203.0.113.77"`
 	Sanitized bool   `json:"sanitized" example:"false"`
+	// Схлопнутые повторы: Repeats — сколько идентичных записей свёрнуто в
+	// эту (0 = уникальна), LastSeen — время последнего повтора.
+	Repeats  int    `json:"repeats,omitempty" example:"4"`
+	LastSeen string `json:"lastSeen,omitempty" example:"2024-01-15T10:35:00Z"`
 }
 
 // LogsData mirrors frontend LogsResponse.
@@ -125,7 +129,7 @@ func logEntryDTO(entry logging.LogEntry, sanitized bool) LogEntryDTO {
 		message = logging.SanitizeLogText(message)
 	}
 
-	return LogEntryDTO{
+	dto := LogEntryDTO{
 		Timestamp: entry.Timestamp.UTC().Format(time.RFC3339Nano),
 		Level:     entry.Level,
 		Group:     entry.Group,
@@ -134,7 +138,12 @@ func logEntryDTO(entry logging.LogEntry, sanitized bool) LogEntryDTO {
 		Target:    target,
 		Message:   message,
 		Sanitized: sanitized,
+		Repeats:   entry.Repeats,
 	}
+	if entry.LastSeen != nil {
+		dto.LastSeen = entry.LastSeen.UTC().Format(time.RFC3339Nano)
+	}
+	return dto
 }
 
 func logEntryDTOs(entries []logging.LogEntry, sanitized bool) []LogEntryDTO {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -441,6 +441,33 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			h.log.Info("memory-saving", "", "Memory saving enabled")
 		}
 	}
+	if oldSettings.ConnectivityCheckURL != merged.ConnectivityCheckURL {
+		h.log.Info("connectivity-check", "", fmt.Sprintf("Connectivity check URL changed: %s -> %s", oldSettings.ConnectivityCheckURL, merged.ConnectivityCheckURL))
+	}
+	if oldSettings.Download != merged.Download {
+		h.log.Info("download-route", "", fmt.Sprintf("Download route changed: %s -> %s", formatDownloadRoute(oldSettings.Download), formatDownloadRoute(merged.Download)))
+	}
+	if oldSettings.UsageLevel != merged.UsageLevel {
+		h.log.Info("usage-level", "", fmt.Sprintf("Usage level changed: %s -> %s", oldSettings.UsageLevel, merged.UsageLevel))
+	}
+	if oldSettings.DNSRoute != merged.DNSRoute {
+		h.log.Info("dns-route-schedule", "", fmt.Sprintf("DNS route auto-refresh schedule changed: %s -> %s",
+			formatRefreshSchedule(oldSettings.DNSRoute.AutoRefreshEnabled, oldSettings.DNSRoute.RefreshMode, oldSettings.DNSRoute.RefreshIntervalHours, oldSettings.DNSRoute.RefreshDailyTime),
+			formatRefreshSchedule(merged.DNSRoute.AutoRefreshEnabled, merged.DNSRoute.RefreshMode, merged.DNSRoute.RefreshIntervalHours, merged.DNSRoute.RefreshDailyTime)))
+	}
+	if oldSettings.GeoFile != merged.GeoFile {
+		h.log.Info("geo-file-schedule", "", fmt.Sprintf("Geo file auto-refresh schedule changed: %s -> %s",
+			formatRefreshSchedule(oldSettings.GeoFile.AutoRefreshEnabled, oldSettings.GeoFile.RefreshMode, oldSettings.GeoFile.RefreshIntervalHours, oldSettings.GeoFile.RefreshDailyTime),
+			formatRefreshSchedule(merged.GeoFile.AutoRefreshEnabled, merged.GeoFile.RefreshMode, merged.GeoFile.RefreshIntervalHours, merged.GeoFile.RefreshDailyTime)))
+	}
+	if oldSettings.Logging.MaxAge != merged.Logging.MaxAge {
+		h.log.Info("logging", "", fmt.Sprintf("Log max age changed: %dh -> %dh", oldSettings.Logging.MaxAge, merged.Logging.MaxAge))
+	}
+	if oldSettings.Logging.AppMaxEntries != merged.Logging.AppMaxEntries || oldSettings.Logging.SingboxMaxEntries != merged.Logging.SingboxMaxEntries {
+		h.log.Info("logging", "", fmt.Sprintf("Log max entries changed: app %d -> %d, singbox %d -> %d",
+			oldSettings.Logging.AppMaxEntries, merged.Logging.AppMaxEntries,
+			oldSettings.Logging.SingboxMaxEntries, merged.Logging.SingboxMaxEntries))
+	}
 
 	if h.pingCheckSnapshot != nil && (toggleEnabled || toggleDisabled) {
 		h.pingCheckSnapshot()
@@ -506,6 +533,27 @@ func generateUUIDv4() (string, error) {
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// formatDownloadRoute renders a download route for the settings diff log,
+// e.g. "direct" or "vless-de (outbound)".
+func formatDownloadRoute(d storage.DownloadSettings) string {
+	if d.RouteKind == "" || d.RouteKind == d.RouteTag {
+		return d.RouteTag
+	}
+	return d.RouteTag + " (" + d.RouteKind + ")"
+}
+
+// formatRefreshSchedule renders an auto-refresh schedule (dnsRoute/geoFile)
+// for the settings diff log, e.g. "off", "every 24h" or "daily at 03:00".
+func formatRefreshSchedule(enabled bool, mode string, intervalHours int, dailyTime string) string {
+	if !enabled {
+		return "off"
+	}
+	if mode == "daily" {
+		return "daily at " + dailyTime
+	}
+	return fmt.Sprintf("every %dh", intervalHours)
 }
 
 func normalizePingCheckTarget(target string) string {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -358,6 +358,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	// Save settings BEFORE starting monitoring (so service reads new values)
 	if err := h.store.Save(&merged); err != nil {
+		h.log.Warn("settings", "", "save failed: "+err.Error())
 		response.Error(w, err.Error(), "SETTINGS_SAVE_ERROR")
 		return
 	}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -451,15 +451,16 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if oldSettings.UsageLevel != merged.UsageLevel {
 		h.log.Info("usage-level", "", fmt.Sprintf("Usage level changed: %s -> %s", oldSettings.UsageLevel, merged.UsageLevel))
 	}
-	if oldSettings.DNSRoute != merged.DNSRoute {
-		h.log.Info("dns-route-schedule", "", fmt.Sprintf("DNS route auto-refresh schedule changed: %s -> %s",
-			formatRefreshSchedule(oldSettings.DNSRoute.AutoRefreshEnabled, oldSettings.DNSRoute.RefreshMode, oldSettings.DNSRoute.RefreshIntervalHours, oldSettings.DNSRoute.RefreshDailyTime),
-			formatRefreshSchedule(merged.DNSRoute.AutoRefreshEnabled, merged.DNSRoute.RefreshMode, merged.DNSRoute.RefreshIntervalHours, merged.DNSRoute.RefreshDailyTime)))
+	// Сравниваем отрендеренные расписания, а не структуры: правка поля,
+	// не влияющего на действующее расписание (интервал при выключенном
+	// авто-обновлении), не должна давать строку «off -> off».
+	if from, to := formatRefreshSchedule(oldSettings.DNSRoute.AutoRefreshEnabled, oldSettings.DNSRoute.RefreshMode, oldSettings.DNSRoute.RefreshIntervalHours, oldSettings.DNSRoute.RefreshDailyTime),
+		formatRefreshSchedule(merged.DNSRoute.AutoRefreshEnabled, merged.DNSRoute.RefreshMode, merged.DNSRoute.RefreshIntervalHours, merged.DNSRoute.RefreshDailyTime); from != to {
+		h.log.Info("dns-route-schedule", "", fmt.Sprintf("DNS route auto-refresh schedule changed: %s -> %s", from, to))
 	}
-	if oldSettings.GeoFile != merged.GeoFile {
-		h.log.Info("geo-file-schedule", "", fmt.Sprintf("Geo file auto-refresh schedule changed: %s -> %s",
-			formatRefreshSchedule(oldSettings.GeoFile.AutoRefreshEnabled, oldSettings.GeoFile.RefreshMode, oldSettings.GeoFile.RefreshIntervalHours, oldSettings.GeoFile.RefreshDailyTime),
-			formatRefreshSchedule(merged.GeoFile.AutoRefreshEnabled, merged.GeoFile.RefreshMode, merged.GeoFile.RefreshIntervalHours, merged.GeoFile.RefreshDailyTime)))
+	if from, to := formatRefreshSchedule(oldSettings.GeoFile.AutoRefreshEnabled, oldSettings.GeoFile.RefreshMode, oldSettings.GeoFile.RefreshIntervalHours, oldSettings.GeoFile.RefreshDailyTime),
+		formatRefreshSchedule(merged.GeoFile.AutoRefreshEnabled, merged.GeoFile.RefreshMode, merged.GeoFile.RefreshIntervalHours, merged.GeoFile.RefreshDailyTime); from != to {
+		h.log.Info("geo-file-schedule", "", fmt.Sprintf("Geo file auto-refresh schedule changed: %s -> %s", from, to))
 	}
 	if oldSettings.Logging.MaxAge != merged.Logging.MaxAge {
 		h.log.Info("logging", "", fmt.Sprintf("Log max age changed: %dh -> %dh", oldSettings.Logging.MaxAge, merged.Logging.MaxAge))

--- a/internal/api/singbox_config_editor.go
+++ b/internal/api/singbox_config_editor.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
@@ -20,11 +21,16 @@ import (
 // не пишет в user-слот — единственный владелец содержимого здесь.
 type SingboxConfigEditorHandler struct {
 	orch *orchestrator.Orchestrator
+	log  *logging.ScopedLogger
 }
 
 // NewSingboxConfigEditorHandler constructs the handler.
-func NewSingboxConfigEditorHandler(orch *orchestrator.Orchestrator) *SingboxConfigEditorHandler {
-	return &SingboxConfigEditorHandler{orch: orch}
+// appLogger may be nil — the scoped logger is nil-safe.
+func NewSingboxConfigEditorHandler(orch *orchestrator.Orchestrator, appLogger logging.AppLogger) *SingboxConfigEditorHandler {
+	return &SingboxConfigEditorHandler{
+		orch: orch,
+		log:  logging.NewScopedLogger(appLogger, logging.GroupSingbox, logging.SubSBRuntime),
+	}
 }
 
 // ConfigSlotInfo describes one config.d slot for the slots browser.
@@ -281,6 +287,7 @@ func (h *SingboxConfigEditorHandler) PutUserConfig(w http.ResponseWriter, r *htt
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("user-config-save", "90-user.json", "user config draft saved")
 	response.Success(w, OkData{Ok: true})
 }
 
@@ -381,6 +388,7 @@ func (h *SingboxConfigEditorHandler) ApplyUserConfig(w http.ResponseWriter, r *h
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("user-config-apply", "90-user.json", "user config draft applied")
 	out := UserConfigApplyResponse{Ok: true}
 	_, out.Warnings = splitUserValidationDTO(res)
 	response.Success(w, out)
@@ -406,6 +414,7 @@ func (h *SingboxConfigEditorHandler) DiscardUserConfig(w http.ResponseWriter, r 
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("user-config-discard", "90-user.json", "user config draft discarded")
 	response.Success(w, OkData{Ok: true})
 }
 
@@ -437,5 +446,10 @@ func (h *SingboxConfigEditorHandler) EnableUserConfig(w http.ResponseWriter, r *
 		response.InternalError(w, err.Error())
 		return
 	}
+	state := "disabled"
+	if req.Enabled {
+		state = "enabled"
+	}
+	h.log.Info("user-config-enable", "90-user.json", "user config slot "+state)
 	response.Success(w, OkData{Ok: true})
 }

--- a/internal/api/singbox_config_editor.go
+++ b/internal/api/singbox_config_editor.go
@@ -29,7 +29,11 @@ type SingboxConfigEditorHandler struct {
 func NewSingboxConfigEditorHandler(orch *orchestrator.Orchestrator, appLogger logging.AppLogger) *SingboxConfigEditorHandler {
 	return &SingboxConfigEditorHandler{
 		orch: orch,
-		log:  logging.NewScopedLogger(appLogger, logging.GroupSingbox, logging.SubSBRuntime),
+		// Действия пользователя над конфигом — в главный app-журнал
+		// (routing/singbox-router, как и остальной CRUD конфигурации);
+		// singbox-бакет — для вывода самого процесса, там строки быстро
+		// вытесняются форвардером.
+		log: logging.NewScopedLogger(appLogger, logging.GroupRouting, logging.SubSingboxRouter),
 	}
 }
 
@@ -332,7 +336,8 @@ func (h *SingboxConfigEditorHandler) CheckUserConfig(w http.ResponseWriter, r *h
 	}
 	res, err := h.orch.CheckMerged(orchestrator.SlotUser, raw)
 	if err != nil {
-		h.log.Warn("user-config-apply", "90-user.json", "merged check failed: "+err.Error())
+		// Dry-run проверка, не применение — отдельная метка.
+		h.log.Warn("user-config-check", "90-user.json", "merged check failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}
@@ -379,10 +384,12 @@ func (h *SingboxConfigEditorHandler) ApplyUserConfig(w http.ResponseWriter, r *h
 		return
 	}
 	if err != nil {
+		h.log.Warn("user-config-apply", "90-user.json", "apply rejected by sing-box check: "+err.Error())
 		writeJSONStatus(w, http.StatusUnprocessableEntity, RouterStagingValidationError{SbCheck: stripAnsiFromErr(err)})
 		return
 	}
 	if !res.Ok() {
+		h.log.Warn("user-config-apply", "90-user.json", "apply rejected: config validation failed")
 		writeJSONStatus(w, http.StatusUnprocessableEntity, RouterStagingValidationError{Validation: validationDTOFrom(res)})
 		return
 	}

--- a/internal/api/singbox_config_editor.go
+++ b/internal/api/singbox_config_editor.go
@@ -284,6 +284,7 @@ func (h *SingboxConfigEditorHandler) PutUserConfig(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := h.orch.SaveDraft(orchestrator.SlotUser, raw); err != nil {
+		h.log.Warn("user-config-save", "90-user.json", "save draft failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}
@@ -331,6 +332,7 @@ func (h *SingboxConfigEditorHandler) CheckUserConfig(w http.ResponseWriter, r *h
 	}
 	res, err := h.orch.CheckMerged(orchestrator.SlotUser, raw)
 	if err != nil {
+		h.log.Warn("user-config-apply", "90-user.json", "merged check failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}
@@ -385,6 +387,7 @@ func (h *SingboxConfigEditorHandler) ApplyUserConfig(w http.ResponseWriter, r *h
 		return
 	}
 	if err := h.orch.SetEnabled(orchestrator.SlotUser, true); err != nil {
+		h.log.Warn("user-config-apply", "90-user.json", "enable slot failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}
@@ -411,6 +414,7 @@ func (h *SingboxConfigEditorHandler) DiscardUserConfig(w http.ResponseWriter, r 
 		return
 	}
 	if err := h.orch.DiscardDraft(orchestrator.SlotUser); err != nil {
+		h.log.Warn("user-config-discard", "90-user.json", "discard draft failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}
@@ -443,6 +447,7 @@ func (h *SingboxConfigEditorHandler) EnableUserConfig(w http.ResponseWriter, r *
 		return
 	}
 	if err := h.orch.SetEnabled(orchestrator.SlotUser, req.Enabled); err != nil {
+		h.log.Warn("user-config-enable", "90-user.json", "toggle slot failed: "+err.Error())
 		response.InternalError(w, err.Error())
 		return
 	}

--- a/internal/api/singbox_config_editor_test.go
+++ b/internal/api/singbox_config_editor_test.go
@@ -30,7 +30,7 @@ func newEditorHandler(t *testing.T) (*SingboxConfigEditorHandler, *orchestrator.
 	if err := o.Bootstrap(); err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
-	return NewSingboxConfigEditorHandler(o), o, dir
+	return NewSingboxConfigEditorHandler(o, nil), o, dir
 }
 
 func decodeEnvelope(t *testing.T, body []byte, data any) {

--- a/internal/api/singbox_fakeip_config.go
+++ b/internal/api/singbox_fakeip_config.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
@@ -117,6 +118,7 @@ func (h *SingboxFakeIPConfigHandler) AddDNSServer(w http.ResponseWriter, r *http
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-server-add", s.Tag, "fakeip DNS server added: "+s.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -150,6 +152,7 @@ func (h *SingboxFakeIPConfigHandler) UpdateDNSServer(w http.ResponseWriter, r *h
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-server-update", body.Tag, "fakeip DNS server updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -181,6 +184,7 @@ func (h *SingboxFakeIPConfigHandler) DeleteDNSServer(w http.ResponseWriter, r *h
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-server-delete", body.Tag, "fakeip DNS server deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -211,6 +215,8 @@ func (h *SingboxFakeIPConfigHandler) MoveDNSServer(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-server-move", strconv.Itoa(body.From),
+		"fakeip DNS server moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -270,6 +276,7 @@ func (h *SingboxFakeIPConfigHandler) AddDNSRule(w http.ResponseWriter, r *http.R
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-rule-add", rule.Server, "fakeip DNS rule added (server: "+rule.Server+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -303,6 +310,8 @@ func (h *SingboxFakeIPConfigHandler) UpdateDNSRule(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-rule-update", strconv.Itoa(body.Index),
+		"fakeip DNS rule updated at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -333,6 +342,8 @@ func (h *SingboxFakeIPConfigHandler) DeleteDNSRule(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-rule-delete", strconv.Itoa(body.Index),
+		"fakeip DNS rule deleted at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -363,6 +374,8 @@ func (h *SingboxFakeIPConfigHandler) MoveDNSRule(w http.ResponseWriter, r *http.
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-rule-move", strconv.Itoa(body.From),
+		"fakeip DNS rule moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -421,6 +434,8 @@ func (h *SingboxFakeIPConfigHandler) PutDNSGlobals(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-dns-globals", body.Final,
+		"fakeip DNS globals updated (final: "+body.Final+", strategy: "+body.Strategy+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -480,6 +495,7 @@ func (h *SingboxFakeIPConfigHandler) AddRule(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-rule-add", rule.Outbound, "fakeip routing rule added (outbound: "+rule.Outbound+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -513,6 +529,8 @@ func (h *SingboxFakeIPConfigHandler) UpdateRule(w http.ResponseWriter, r *http.R
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-rule-update", strconv.Itoa(body.Index),
+		"fakeip routing rule updated at index "+strconv.Itoa(body.Index)+" (outbound: "+body.Rule.Outbound+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -545,6 +563,8 @@ func (h *SingboxFakeIPConfigHandler) DeleteRule(w http.ResponseWriter, r *http.R
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-rule-delete", strconv.Itoa(body.Index),
+		"fakeip routing rule deleted at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -578,6 +598,8 @@ func (h *SingboxFakeIPConfigHandler) MoveRule(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-rule-move", strconv.Itoa(body.From),
+		"fakeip routing rule moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -611,6 +633,7 @@ func (h *SingboxFakeIPConfigHandler) SetRouteFinal(w http.ResponseWriter, r *htt
 		h.handleErr(w, "route-final", err)
 		return
 	}
+	h.log.Info("fakeip-route-final", req.Final, "fakeip route.final set to "+req.Final)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -670,6 +693,7 @@ func (h *SingboxFakeIPConfigHandler) AddRuleSet(w http.ResponseWriter, r *http.R
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-ruleset-add", rs.Tag, "fakeip ruleset added: "+rs.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -708,6 +732,7 @@ func (h *SingboxFakeIPConfigHandler) UpdateRuleSet(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-ruleset-update", body.Tag, "fakeip ruleset updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -742,6 +767,7 @@ func (h *SingboxFakeIPConfigHandler) DeleteRuleSet(w http.ResponseWriter, r *htt
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-ruleset-delete", body.Tag, "fakeip ruleset deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -801,6 +827,7 @@ func (h *SingboxFakeIPConfigHandler) AddOutbound(w http.ResponseWriter, r *http.
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-outbound-add", o.Tag, "fakeip composite outbound added: "+o.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -834,6 +861,7 @@ func (h *SingboxFakeIPConfigHandler) UpdateOutbound(w http.ResponseWriter, r *ht
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-outbound-update", body.Tag, "fakeip composite outbound updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -868,5 +896,6 @@ func (h *SingboxFakeIPConfigHandler) DeleteOutbound(w http.ResponseWriter, r *ht
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("fakeip-outbound-delete", body.Tag, "fakeip composite outbound deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -97,6 +97,7 @@ func (h *SingboxRouterHandler) Enable(w http.ResponseWriter, r *http.Request) {
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("enable", "", "Sing-box router enabled")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -120,6 +121,7 @@ func (h *SingboxRouterHandler) Disable(w http.ResponseWriter, r *http.Request) {
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("disable", "", "Sing-box router disabled")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -169,6 +171,7 @@ func (h *SingboxRouterHandler) SwitchMode(w http.ResponseWriter, r *http.Request
 	// Keep the documented OkResponse shape ({"ok":true}); 200 here means
 	// "transition accepted and started", progress/terminal state arrives via
 	// the singbox-router:transition SSE events.
+	h.log.Info("mode-switch", mode, "mode switch requested: "+mode)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -225,6 +228,7 @@ func (h *SingboxRouterHandler) PutSettings(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("settings", "", "Sing-box router settings updated")
 	response.Success(w, map[string]bool{"ok": true})
 }
 

--- a/internal/api/singbox_router_dns.go
+++ b/internal/api/singbox_router_dns.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router"
@@ -165,6 +166,7 @@ func (h *SingboxRouterHandler) AddDNSServer(w http.ResponseWriter, r *http.Reque
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-server-add", s.Tag, "DNS server added: "+s.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -198,6 +200,7 @@ func (h *SingboxRouterHandler) UpdateDNSServer(w http.ResponseWriter, r *http.Re
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-server-update", body.Tag, "DNS server updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -229,6 +232,7 @@ func (h *SingboxRouterHandler) DeleteDNSServer(w http.ResponseWriter, r *http.Re
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-server-delete", body.Tag, "DNS server deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -259,6 +263,8 @@ func (h *SingboxRouterHandler) MoveDNSServer(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-server-move", strconv.Itoa(body.From),
+		"DNS server moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -316,6 +322,7 @@ func (h *SingboxRouterHandler) AddDNSRule(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-rule-add", rule.Server, "DNS rule added (server: "+rule.Server+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -349,6 +356,7 @@ func (h *SingboxRouterHandler) UpdateDNSRule(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-rule-update", strconv.Itoa(body.Index), "DNS rule updated at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -379,6 +387,7 @@ func (h *SingboxRouterHandler) DeleteDNSRule(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-rule-delete", strconv.Itoa(body.Index), "DNS rule deleted at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -409,6 +418,8 @@ func (h *SingboxRouterHandler) MoveDNSRule(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-rule-move", strconv.Itoa(body.From),
+		"DNS rule moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -465,5 +476,6 @@ func (h *SingboxRouterHandler) PutDNSGlobals(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("dns-globals", body.Final, "DNS globals updated (final: "+body.Final+", strategy: "+body.Strategy+")")
 	response.Success(w, map[string]bool{"ok": true})
 }

--- a/internal/api/singbox_router_outbounds.go
+++ b/internal/api/singbox_router_outbounds.go
@@ -60,6 +60,7 @@ func (h *SingboxRouterHandler) AddOutbound(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("outbound-add", o.Tag, "composite outbound added: "+o.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -93,6 +94,7 @@ func (h *SingboxRouterHandler) UpdateOutbound(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("outbound-update", body.Tag, "composite outbound updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -134,6 +136,7 @@ func (h *SingboxRouterHandler) DeleteOutbound(w http.ResponseWriter, r *http.Req
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("outbound-delete", body.Tag, "composite outbound deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -190,6 +193,7 @@ func (h *SingboxRouterHandler) ApplyPreset(w http.ResponseWriter, r *http.Reques
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("preset-apply", body.ID, "preset applied: "+body.ID+" (outbound: "+body.Outbound+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 

--- a/internal/api/singbox_router_policies.go
+++ b/internal/api/singbox_router_policies.go
@@ -70,6 +70,7 @@ func (h *SingboxRouterHandler) createPolicy(w http.ResponseWriter, r *http.Reque
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("policy-create", policy.Name, "NDMS policy created: "+policy.Name)
 	response.Success(w, policy)
 }
 
@@ -136,6 +137,7 @@ func (h *SingboxRouterHandler) BindDevice(w http.ResponseWriter, r *http.Request
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("device-bind", req.MAC, "device bound to policy "+req.PolicyName)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -168,5 +170,6 @@ func (h *SingboxRouterHandler) UnbindDevice(w http.ResponseWriter, r *http.Reque
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("device-unbind", req.MAC, "device policy binding removed")
 	response.Success(w, map[string]bool{"ok": true})
 }

--- a/internal/api/singbox_router_rules.go
+++ b/internal/api/singbox_router_rules.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/response"
@@ -60,6 +61,7 @@ func (h *SingboxRouterHandler) AddRule(w http.ResponseWriter, r *http.Request) {
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("rule-add", rule.Outbound, "routing rule added (outbound: "+rule.Outbound+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -93,6 +95,8 @@ func (h *SingboxRouterHandler) UpdateRule(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("rule-update", strconv.Itoa(body.Index),
+		"routing rule updated at index "+strconv.Itoa(body.Index)+" (outbound: "+body.Rule.Outbound+")")
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -125,6 +129,7 @@ func (h *SingboxRouterHandler) DeleteRule(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("rule-delete", strconv.Itoa(body.Index), "routing rule deleted at index "+strconv.Itoa(body.Index))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -158,6 +163,8 @@ func (h *SingboxRouterHandler) MoveRule(w http.ResponseWriter, r *http.Request) 
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("rule-move", strconv.Itoa(body.From),
+		"routing rule moved from index "+strconv.Itoa(body.From)+" to "+strconv.Itoa(body.To))
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -212,6 +219,7 @@ func (h *SingboxRouterHandler) AddRuleSet(w http.ResponseWriter, r *http.Request
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("ruleset-add", rs.Tag, "ruleset added: "+rs.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -250,6 +258,7 @@ func (h *SingboxRouterHandler) UpdateRuleSet(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("ruleset-update", body.Tag, "ruleset updated: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -284,6 +293,7 @@ func (h *SingboxRouterHandler) DeleteRuleSet(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "request", err)
 		return
 	}
+	h.log.Info("ruleset-delete", body.Tag, "ruleset deleted: "+body.Tag)
 	response.Success(w, map[string]bool{"ok": true})
 }
 
@@ -390,5 +400,6 @@ func (h *SingboxRouterHandler) SetRouteFinal(w http.ResponseWriter, r *http.Requ
 		h.handleErr(w, "route-final", err)
 		return
 	}
+	h.log.Info("route-final", req.Final, "route.final set to "+req.Final)
 	response.Success(w, map[string]bool{"ok": true})
 }

--- a/internal/api/singbox_router_staging.go
+++ b/internal/api/singbox_router_staging.go
@@ -101,6 +101,7 @@ func (h *SingboxRouterHandler) PostStagingApply(w http.ResponseWriter, r *http.R
 		writeJSONStatus(w, http.StatusUnprocessableEntity, RouterStagingValidationError{Validation: validationDTOFrom(res)})
 		return
 	}
+	h.log.Info("staging-apply", "", "staging draft applied")
 	response.Success(w, OkData{Ok: true})
 }
 
@@ -124,5 +125,6 @@ func (h *SingboxRouterHandler) PostStagingDiscard(w http.ResponseWriter, r *http
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("staging-discard", "", "staging draft discarded")
 	response.Success(w, OkData{Ok: true})
 }

--- a/internal/api/singbox_router_staging.go
+++ b/internal/api/singbox_router_staging.go
@@ -94,10 +94,12 @@ func (h *SingboxRouterHandler) PostStagingApply(w http.ResponseWriter, r *http.R
 		return
 	}
 	if err != nil {
+		h.log.Warn("staging-apply", "", "apply rejected by sing-box check: "+err.Error())
 		writeJSONStatus(w, http.StatusUnprocessableEntity, RouterStagingValidationError{SbCheck: stripAnsiFromErr(err)})
 		return
 	}
 	if !res.Ok() {
+		h.log.Warn("staging-apply", "", "apply rejected: config validation failed")
 		writeJSONStatus(w, http.StatusUnprocessableEntity, RouterStagingValidationError{Validation: validationDTOFrom(res)})
 		return
 	}

--- a/internal/api/singbox_selective.go
+++ b/internal/api/singbox_selective.go
@@ -321,6 +321,7 @@ func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), installTimeout)
 	defer cancel()
 	if err := selective.InstallIPSet(ctx, nil); err != nil { // progress delivered via SSE by the builder
+		h.log.Warn("install-deps", "ipset", "installation failed: "+err.Error())
 		response.InternalError(w, "ipset installation failed: "+err.Error())
 		return
 	}
@@ -361,6 +362,7 @@ func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), installTimeout)
 	defer cancel()
 	if err := selective.InstallConntrackTools(ctx, nil); err != nil {
+		h.log.Warn("install-conntrack", "conntrack-tools", "installation failed: "+err.Error())
 		response.InternalError(w, "conntrack installation failed: "+err.Error())
 		return
 	}

--- a/internal/api/singbox_selective.go
+++ b/internal/api/singbox_selective.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
 	"github.com/hoaxisr/awg-manager/internal/singbox/heavyop"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router/selective"
@@ -129,6 +130,7 @@ type SelectiveHandler struct {
 	rebuilding atomic.Bool
 	builder    SelectiveRebuildTriggerer
 	status     SelectiveStatusProvider
+	log        *logging.ScopedLogger
 }
 
 // Настенного таймаута фоновой пересборки ipset больше нет: медленная, но
@@ -175,8 +177,15 @@ type SelectiveCancelData struct {
 
 // NewSelectiveHandler creates a new handler. configDir is the sing-box config.d
 // path used to read NDJSON matcher snapshots. status may be nil.
-func NewSelectiveHandler(settings *storage.SettingsStore, configDir string, builder SelectiveRebuildTriggerer, status SelectiveStatusProvider) *SelectiveHandler {
-	return &SelectiveHandler{settings: settings, configDir: configDir, builder: builder, status: status}
+// appLogger may be nil — the scoped logger is nil-safe.
+func NewSelectiveHandler(settings *storage.SettingsStore, configDir string, builder SelectiveRebuildTriggerer, status SelectiveStatusProvider, appLogger logging.AppLogger) *SelectiveHandler {
+	return &SelectiveHandler{
+		settings:  settings,
+		configDir: configDir,
+		builder:   builder,
+		status:    status,
+		log:       logging.NewScopedLogger(appLogger, logging.GroupRouting, logging.SubSelective),
+	}
 }
 
 // GetStatus handles GET /api/singbox/router/selective/status.
@@ -319,6 +328,7 @@ func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
 	// Try to load xt_set now that ipset is installed.
 	_ = selective.EnsureXtSetModule(ctx)
 
+	h.log.Info("install-deps", "ipset", "ipset package installed")
 	h.GetStatus(w, r)
 }
 
@@ -354,6 +364,7 @@ func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Reque
 		response.InternalError(w, "conntrack installation failed: "+err.Error())
 		return
 	}
+	h.log.Info("install-conntrack", "conntrack-tools", "conntrack-tools package installed")
 	h.GetStatus(w, r)
 }
 
@@ -470,6 +481,9 @@ func (h *SelectiveHandler) CancelRebuild(w http.ResponseWriter, r *http.Request)
 	cancelled := false
 	if c, ok := h.status.(SelectiveRebuildCanceller); ok {
 		cancelled = c.CancelRun(selective.ErrCancelledByUser)
+	}
+	if cancelled {
+		h.log.Info("rebuild-cancel", "", "ipset rebuild cancellation requested")
 	}
 	response.Success(w, SelectiveCancelData{Cancelled: cancelled})
 }

--- a/internal/api/singbox_selective_test.go
+++ b/internal/api/singbox_selective_test.go
@@ -74,7 +74,7 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 
 func TestSelectiveRebuild_Returns202AndRunsInBackground(t *testing.T) {
 	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
-	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{})
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{}, nil)
 
 	rr := postRebuild(t, h)
 	if rr.Code != http.StatusAccepted {
@@ -116,7 +116,7 @@ func TestSelectiveRebuild_409WhenHeavyOpGateHeld(t *testing.T) {
 	defer heavyop.Default.Unlock()
 
 	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
-	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{})
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{}, nil)
 
 	rr := postRebuild(t, h)
 	if rr.Code != http.StatusConflict || !strings.Contains(rr.Body.String(), "OPERATION_IN_PROGRESS") {
@@ -132,7 +132,7 @@ func TestSelectiveRebuild_409WhenHeavyOpGateHeld(t *testing.T) {
 
 func TestSelectiveRebuild_202WhenAutoRebuildInFlight(t *testing.T) {
 	b := &blockingRebuildTriggerer{started: make(chan struct{}, 1), release: make(chan struct{})}
-	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{rebuilding: true})
+	h := NewSelectiveHandler(nil, "", b, &stubSelectiveStatus{rebuilding: true}, nil)
 
 	rr := postRebuild(t, h)
 	if rr.Code != http.StatusAccepted || !strings.Contains(rr.Body.String(), `"rebuilding":true`) {
@@ -147,7 +147,7 @@ func TestSelectiveRebuild_202WhenAutoRebuildInFlight(t *testing.T) {
 }
 
 func TestSelectiveRebuild_MethodAndConfigGuards(t *testing.T) {
-	h := NewSelectiveHandler(nil, "", nil, &stubSelectiveStatus{})
+	h := NewSelectiveHandler(nil, "", nil, &stubSelectiveStatus{}, nil)
 
 	rr := httptest.NewRecorder()
 	h.Rebuild(rr, httptest.NewRequest(http.MethodGet, "/singbox/router/selective/rebuild", nil))
@@ -174,7 +174,7 @@ func postCancelRebuild(t *testing.T, h *SelectiveHandler) *httptest.ResponseReco
 // поддержки CancelRun (сторонняя заглушка) → cancelled:false без паники.
 func TestSelectiveCancelRebuild(t *testing.T) {
 	st := &stubCancellableStatus{active: true}
-	h := NewSelectiveHandler(nil, "", nil, st)
+	h := NewSelectiveHandler(nil, "", nil, st, nil)
 
 	rr := postCancelRebuild(t, h)
 	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"cancelled":true`) {
@@ -197,7 +197,7 @@ func TestSelectiveCancelRebuild(t *testing.T) {
 	}
 
 	// Статус-провайдер без SelectiveRebuildCanceller — честный no-op.
-	hPlain := NewSelectiveHandler(nil, "", nil, &stubSelectiveStatus{rebuilding: true})
+	hPlain := NewSelectiveHandler(nil, "", nil, &stubSelectiveStatus{rebuilding: true}, nil)
 	rr = postCancelRebuild(t, hPlain)
 	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"cancelled":false`) {
 		t.Fatalf("non-canceller status: code=%d body=%s", rr.Code, rr.Body.String())
@@ -206,7 +206,7 @@ func TestSelectiveCancelRebuild(t *testing.T) {
 
 func TestSelectiveGetStatus_ReportsRebuilding(t *testing.T) {
 	st := &stubSelectiveStatus{}
-	h := NewSelectiveHandler(nil, "", nil, st)
+	h := NewSelectiveHandler(nil, "", nil, st, nil)
 
 	rr := httptest.NewRecorder()
 	h.GetStatus(rr, httptest.NewRequest(http.MethodGet, "/singbox/router/selective/status", nil))

--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -175,6 +175,7 @@ func (h *SubscriptionHandler) Create(w http.ResponseWriter, r *http.Request) {
 		h.respondServiceError(w, err)
 		return
 	}
+	h.log.Info("subscription-create", sub.Label, "Subscription created: "+sub.Label)
 	response.Success(w, toSubscriptionDTO(*sub, h.ndmsProxyEnabled()))
 }
 
@@ -268,6 +269,7 @@ func (h *SubscriptionHandler) Update(w http.ResponseWriter, r *http.Request) {
 		h.respondServiceError(w, err)
 		return
 	}
+	h.log.Info("subscription-update", sub.Label, "Subscription updated: "+sub.Label)
 	response.Success(w, toSubscriptionDTO(*sub, h.ndmsProxyEnabled()))
 }
 
@@ -289,7 +291,11 @@ func (h *SubscriptionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	label := id
 	if sub, err := h.svc.Get(id); err == nil {
+		if sub.Label != "" {
+			label = sub.Label
+		}
 		tags := make([]string, 0, 1+len(sub.MemberTags))
 		if sub.SelectorTag != "" {
 			tags = append(tags, sub.SelectorTag)
@@ -308,6 +314,7 @@ func (h *SubscriptionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		response.InternalError(w, err.Error())
 		return
 	}
+	h.log.Info("subscription-delete", id, "Subscription deleted: "+label)
 	response.Success(w, struct {
 		OK bool `json:"ok"`
 	}{true})

--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -41,7 +41,9 @@ func NewSubscriptionHandler(svc *subscription.Service, presence SingboxPresenceP
 	return &SubscriptionHandler{
 		svc:      svc,
 		presence: presence,
-		log:      logging.NewScopedLogger(lg, logging.GroupSingbox, logging.SubSBRuntime),
+		// Действия пользователя над подписками — в главный app-журнал
+		// (routing/subscription), а не в изолированный singbox-бакет.
+		log: logging.NewScopedLogger(lg, logging.GroupRouting, logging.SubSubscription),
 	}
 }
 
@@ -75,8 +77,22 @@ func (h *SubscriptionHandler) ndmsProxyEnabled() bool {
 // frontend can surface a "your subscription has invalid outbound(s)"
 // banner instead of a generic 500. Other errors fall through to 500.
 func (h *SubscriptionHandler) respondServiceError(w http.ResponseWriter, action string, err error) {
-	h.log.Warn(action, "", err.Error())
+	// Ошибки клиента (4xx: валидация, фильтры, not-found) — Debug: ответ
+	// пользователь уже видит в UI, а Warn всегда видим и содержит
+	// свободный ввод (не сворачивается коалесцером). Warn — только для
+	// внутренних сбоев (default → 500).
 	var filterErr *subscription.FilterError
+	isInternal := !errors.As(err, &filterErr) &&
+		!errors.Is(err, subscription.ErrValidation) &&
+		!errors.Is(err, subscription.ErrExcludeOnInline) &&
+		!errors.Is(err, subscription.ErrAllMembersExcluded) &&
+		!errors.Is(err, subscription.ErrAllMembersFiltered) &&
+		!errors.Is(err, subscription.ErrMemberNotFound)
+	if isInternal {
+		h.log.Warn(action, "", err.Error())
+	} else {
+		h.log.Debug(action, "", err.Error())
+	}
 	switch {
 	case errors.As(err, &filterErr):
 		response.ErrorWithStatus(w, http.StatusBadRequest, err.Error(), "INVALID_FILTER")
@@ -172,7 +188,6 @@ func (h *SubscriptionHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	sub, err := h.svc.Create(r.Context(), in)
 	if err != nil {
-		h.log.Warn("subscription-create", req.Label, "failed: "+err.Error())
 		h.respondServiceError(w, "subscription-create", err)
 		return
 	}

--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -74,7 +74,8 @@ func (h *SubscriptionHandler) ndmsProxyEnabled() bool {
 // box check rejected the merged config) → 422 VALIDATION_FAILED so the
 // frontend can surface a "your subscription has invalid outbound(s)"
 // banner instead of a generic 500. Other errors fall through to 500.
-func (h *SubscriptionHandler) respondServiceError(w http.ResponseWriter, err error) {
+func (h *SubscriptionHandler) respondServiceError(w http.ResponseWriter, action string, err error) {
+	h.log.Warn(action, "", err.Error())
 	var filterErr *subscription.FilterError
 	switch {
 	case errors.As(err, &filterErr):
@@ -172,7 +173,7 @@ func (h *SubscriptionHandler) Create(w http.ResponseWriter, r *http.Request) {
 	sub, err := h.svc.Create(r.Context(), in)
 	if err != nil {
 		h.log.Warn("subscription-create", req.Label, "failed: "+err.Error())
-		h.respondServiceError(w, err)
+		h.respondServiceError(w, "subscription-create", err)
 		return
 	}
 	h.log.Info("subscription-create", sub.Label, "Subscription created: "+sub.Label)
@@ -266,7 +267,7 @@ func (h *SubscriptionHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	sub, err := h.svc.Update(id, patch)
 	if err != nil {
-		h.respondServiceError(w, err)
+		h.respondServiceError(w, "subscription-update", err)
 		return
 	}
 	h.log.Info("subscription-update", sub.Label, "Subscription updated: "+sub.Label)
@@ -341,7 +342,7 @@ func (h *SubscriptionHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	h.log.Info("subscription-refresh", id, "requested via API")
 	res, err := h.svc.Refresh(r.Context(), id)
 	if err != nil {
-		h.respondServiceError(w, err)
+		h.respondServiceError(w, "subscription-refresh", err)
 		return
 	}
 	response.Success(w, res)

--- a/internal/api/subscription_groups.go
+++ b/internal/api/subscription_groups.go
@@ -137,8 +137,10 @@ func (h *SubscriptionHandler) toSubscriptionGroupDTO(g subscription.AggregateGro
 	}
 }
 
-// respondGroupServiceError маппит ошибки Group-CRUD на HTTP-статусы.
-func (h *SubscriptionHandler) respondGroupServiceError(w http.ResponseWriter, err error) {
+// respondGroupServiceError маппит ошибки Group-CRUD на HTTP-статусы
+// и журналит сбой мутации.
+func (h *SubscriptionHandler) respondGroupServiceError(w http.ResponseWriter, action string, err error) {
+	h.log.Warn(action, "", err.Error())
 	var filterErr *subscription.FilterError
 	switch {
 	case errors.As(err, &filterErr):
@@ -218,7 +220,7 @@ func (h *SubscriptionHandler) CreateGroup(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		h.log.Warn("subscription-group-create", req.Label, "failed: "+err.Error())
-		h.respondGroupServiceError(w, err)
+		h.respondGroupServiceError(w, "subscription-group-create", err)
 		return
 	}
 	h.log.Info("subscription-group-create", g.Label, "Subscription group created: "+g.Label)
@@ -274,7 +276,7 @@ func (h *SubscriptionHandler) UpdateGroup(w http.ResponseWriter, r *http.Request
 	}
 	g, err := h.svc.UpdateGroup(r.Context(), id, patch)
 	if err != nil {
-		h.respondGroupServiceError(w, err)
+		h.respondGroupServiceError(w, "subscription-group-update", err)
 		return
 	}
 	h.log.Info("subscription-group-update", g.Label, "Subscription group updated: "+g.Label)
@@ -313,7 +315,7 @@ func (h *SubscriptionHandler) DeleteGroup(w http.ResponseWriter, r *http.Request
 		label = g.Label
 	}
 	if err := h.svc.DeleteGroup(r.Context(), req.ID); err != nil {
-		h.respondGroupServiceError(w, err)
+		h.respondGroupServiceError(w, "subscription-group-delete", err)
 		return
 	}
 	h.log.Info("subscription-group-delete", req.ID, "Subscription group deleted: "+label)

--- a/internal/api/subscription_groups.go
+++ b/internal/api/subscription_groups.go
@@ -221,6 +221,7 @@ func (h *SubscriptionHandler) CreateGroup(w http.ResponseWriter, r *http.Request
 		h.respondGroupServiceError(w, err)
 		return
 	}
+	h.log.Info("subscription-group-create", g.Label, "Subscription group created: "+g.Label)
 	response.Success(w, h.toSubscriptionGroupDTO(*g))
 }
 
@@ -276,6 +277,7 @@ func (h *SubscriptionHandler) UpdateGroup(w http.ResponseWriter, r *http.Request
 		h.respondGroupServiceError(w, err)
 		return
 	}
+	h.log.Info("subscription-group-update", g.Label, "Subscription group updated: "+g.Label)
 	response.Success(w, h.toSubscriptionGroupDTO(*g))
 }
 
@@ -306,10 +308,15 @@ func (h *SubscriptionHandler) DeleteGroup(w http.ResponseWriter, r *http.Request
 		response.ErrorWithStatus(w, http.StatusBadRequest, "id required", "MISSING_ID")
 		return
 	}
+	label := req.ID
+	if g, err := h.svc.GetGroup(req.ID); err == nil && g.Label != "" {
+		label = g.Label
+	}
 	if err := h.svc.DeleteGroup(r.Context(), req.ID); err != nil {
 		h.respondGroupServiceError(w, err)
 		return
 	}
+	h.log.Info("subscription-group-delete", req.ID, "Subscription group deleted: "+label)
 	response.Success(w, struct {
 		OK bool `json:"ok"`
 	}{true})

--- a/internal/api/subscription_groups.go
+++ b/internal/api/subscription_groups.go
@@ -140,8 +140,17 @@ func (h *SubscriptionHandler) toSubscriptionGroupDTO(g subscription.AggregateGro
 // respondGroupServiceError маппит ошибки Group-CRUD на HTTP-статусы
 // и журналит сбой мутации.
 func (h *SubscriptionHandler) respondGroupServiceError(w http.ResponseWriter, action string, err error) {
-	h.log.Warn(action, "", err.Error())
+	// См. respondServiceError: клиентские 4xx — Debug, внутренние — Warn.
 	var filterErr *subscription.FilterError
+	isInternal := !errors.As(err, &filterErr) &&
+		!errors.Is(err, subscription.ErrGroupSubscriptionNotFound) &&
+		!errors.Is(err, subscription.ErrValidation) &&
+		!errors.Is(err, subscription.ErrGroupNotFound)
+	if isInternal {
+		h.log.Warn(action, "", err.Error())
+	} else {
+		h.log.Debug(action, "", err.Error())
+	}
 	switch {
 	case errors.As(err, &filterErr):
 		response.ErrorWithStatus(w, http.StatusBadRequest, err.Error(), "INVALID_FILTER")
@@ -219,7 +228,6 @@ func (h *SubscriptionHandler) CreateGroup(w http.ResponseWriter, r *http.Request
 		Enabled:            req.Enabled,
 	})
 	if err != nil {
-		h.log.Warn("subscription-group-create", req.Label, "failed: "+err.Error())
 		h.respondGroupServiceError(w, "subscription-group-create", err)
 		return
 	}

--- a/internal/api/subscription_members.go
+++ b/internal/api/subscription_members.go
@@ -227,7 +227,7 @@ func (h *SubscriptionHandler) RejectedToInfo(w http.ResponseWriter, r *http.Requ
 		case errors.Is(err, subscription.ErrInfoItemsFull):
 			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "INFO_ITEMS_FULL")
 		default:
-			h.respondServiceError(w, err)
+			h.respondServiceError(w, "subscription-rejected-to-info", err)
 		}
 		return
 	}
@@ -259,7 +259,7 @@ func (h *SubscriptionHandler) InfoRemove(w http.ResponseWriter, r *http.Request)
 		case errors.Is(err, subscription.ErrInfoItemNotFound):
 			response.ErrorWithStatus(w, http.StatusNotFound, err.Error(), "INFO_ITEM_NOT_FOUND")
 		default:
-			h.respondServiceError(w, err)
+			h.respondServiceError(w, "subscription-info-remove", err)
 		}
 		return
 	}
@@ -306,7 +306,7 @@ func (h *SubscriptionHandler) AddMember(w http.ResponseWriter, r *http.Request) 
 		case errors.Is(err, subscription.ErrMemberDuplicate):
 			response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "MEMBER_DUPLICATE")
 		default:
-			h.respondServiceError(w, err)
+			h.respondServiceError(w, "subscription-add-member", err)
 		}
 		return
 	}
@@ -354,7 +354,7 @@ func (h *SubscriptionHandler) RemoveMember(w http.ResponseWriter, r *http.Reques
 		case errors.Is(err, subscription.ErrMemberNotFound):
 			response.ErrorWithStatus(w, http.StatusNotFound, err.Error(), "MEMBER_NOT_FOUND")
 		default:
-			h.respondServiceError(w, err)
+			h.respondServiceError(w, "subscription-remove-member", err)
 		}
 		return
 	}
@@ -401,7 +401,7 @@ func (h *SubscriptionHandler) ExcludeMembers(w http.ResponseWriter, r *http.Requ
 	}
 	sub, err := h.svc.ExcludeMembers(r.Context(), id, req.MemberTags)
 	if err != nil {
-		h.respondServiceError(w, err)
+		h.respondServiceError(w, "subscription-exclude-members", err)
 		return
 	}
 	response.Success(w, toSubscriptionDTO(*sub, h.ndmsProxyEnabled()))
@@ -440,7 +440,7 @@ func (h *SubscriptionHandler) RestoreMembers(w http.ResponseWriter, r *http.Requ
 	}
 	sub, err := h.svc.RestoreMembers(r.Context(), id, req.MemberTags)
 	if err != nil {
-		h.respondServiceError(w, err)
+		h.respondServiceError(w, "subscription-restore-members", err)
 		return
 	}
 	response.Success(w, toSubscriptionDTO(*sub, h.ndmsProxyEnabled()))

--- a/internal/api/systemtunnels.go
+++ b/internal/api/systemtunnels.go
@@ -53,15 +53,19 @@ type SystemTunnelsHandler struct {
 	settings *storage.SettingsStore
 	awgStore *storage.AWGTunnelStore
 	appLog   *logging.ScopedLogger
+	// connTracker: авто-чеки фронта повторяются при каждой навигации —
+	// в журнал идут переходы, повторы одного исхода только на debug.
+	connTracker *logging.TransitionTracker
 }
 
 // NewSystemTunnelsHandler creates a new system tunnels handler.
 func NewSystemTunnelsHandler(svc systemtunnel.Service, settings *storage.SettingsStore, awgStore *storage.AWGTunnelStore, appLogger logging.AppLogger) *SystemTunnelsHandler {
 	return &SystemTunnelsHandler{
-		svc:      svc,
-		settings: settings,
-		awgStore: awgStore,
-		appLog:   logging.NewScopedLogger(appLogger, logging.GroupSystem, logging.SubSystemTunnel),
+		svc:         svc,
+		settings:    settings,
+		awgStore:    awgStore,
+		appLog:      logging.NewScopedLogger(appLogger, logging.GroupSystem, logging.SubSystemTunnel),
+		connTracker: logging.NewTransitionTracker(),
 	}
 }
 
@@ -247,6 +251,8 @@ func (h *SystemTunnelsHandler) CheckConnectivity(w http.ResponseWriter, r *http.
 		return
 	}
 	if tunnel.Status != "up" {
+		// Сброс серии: после подъёма туннеля первый отказ снова Warn.
+		h.connTracker.Forget(name)
 		response.Success(w, testing.ConnectivityResult{
 			Connected: false,
 			Reason:    testing.ReasonTunnelNotRunning,
@@ -255,10 +261,19 @@ func (h *SystemTunnelsHandler) CheckConnectivity(w http.ResponseWriter, r *http.
 	}
 	h.appLog.Debug("connectivity-check", name, fmt.Sprintf("Starting connectivity check for system tunnel %s", name))
 	result := testing.CheckConnectivityByInterfaceURL(r.Context(), tunnel.InterfaceName, h.connectivityCheckURL())
-	if result.Connected {
-		h.appLog.Debug("connectivity-check", name, fmt.Sprintf("Connectivity check passed: latency=%dms", *result.Latency))
-	} else {
+	latency := ""
+	if result.Latency != nil {
+		latency = fmt.Sprintf(", latency=%dms", *result.Latency)
+	}
+	switch obs := h.connTracker.Observe(name, result.Connected); obs.Kind {
+	case logging.TransitionNowFailing:
 		h.appLog.Warn("connectivity-check", name, fmt.Sprintf("Connectivity check failed: reason=%s", result.Reason))
+	case logging.TransitionStillFailing:
+		h.appLog.Debug("connectivity-check", name, fmt.Sprintf("Connectivity check still failing (%d in a row): reason=%s", obs.Failures, result.Reason))
+	case logging.TransitionRecovered:
+		h.appLog.Info("connectivity-check", name, fmt.Sprintf("Connectivity restored after %d failed checks%s", obs.Failures, latency))
+	default:
+		h.appLog.Debug("connectivity-check", name, fmt.Sprintf("Connectivity check passed%s", latency))
 	}
 	response.Success(w, result)
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"sync"
 	"time"
 )
@@ -29,6 +30,10 @@ type SessionStore struct {
 	mu       sync.RWMutex
 	sessions map[string]*Session
 	stopCh   chan struct{}
+	// log — журнал приложения (system/auth); nil-safe. Истечение сессии —
+	// причина внезапного «разлогинило», без строки в журнале она выглядит
+	// как сбой.
+	log *logging.ScopedLogger
 	// ttl returns the configured session lifetime. Read LIVE on every
 	// expiry check, so a shortened TTL takes effect immediately for
 	// already-issued sessions (the server-side check is authoritative;
@@ -96,6 +101,9 @@ func (s *SessionStore) Get(token string) *Session {
 	// Check if expired (TTL read live — settings changes apply immediately)
 	if time.Since(session.LastSeen) > s.TTL() {
 		delete(s.sessions, token)
+		if s.log != nil {
+			s.log.Info("session-expired", session.Login, "session expired (inactive longer than TTL)")
+		}
 		return nil
 	}
 
@@ -141,8 +149,18 @@ func (s *SessionStore) cleanup() {
 	for token, session := range s.sessions {
 		if now.Sub(session.LastSeen) > ttl {
 			delete(s.sessions, token)
+			if s.log != nil {
+				s.log.Info("session-expired", session.Login, "session expired (inactive longer than TTL)")
+			}
 		}
 	}
+}
+
+// SetLogger подключает журнал приложения (после создания logging.Service).
+func (s *SessionStore) SetLogger(log *logging.ScopedLogger) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.log = log
 }
 
 // generateToken creates a cryptographically secure random token.

--- a/internal/auth/throttle.go
+++ b/internal/auth/throttle.go
@@ -136,7 +136,10 @@ func (t *LoginThrottle) Done(ip string) {
 
 // Fail records a failed login attempt for ip. Reaching the failure limit
 // (re-)arms the block window.
-func (t *LoginThrottle) Fail(ip string) {
+// Fail регистрирует неудачную попытку и сообщает, активировала ли именно
+// она блокировку (переход через порог) — вызывающий код логирует
+// активацию один раз, а не на каждый заблокированный запрос.
+func (t *LoginThrottle) Fail(ip string) (nowBlocked bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.sweepLocked()
@@ -150,8 +153,10 @@ func (t *LoginThrottle) Fail(ip string) {
 	e.failures++
 	e.lastSeen = now
 	if e.failures >= throttleMaxFailures {
+		nowBlocked = e.blockedUntil.Before(now) || e.blockedUntil.IsZero()
 		e.blockedUntil = now.Add(throttleBlockDuration)
 	}
+	return nowBlocked
 }
 
 // Success clears the failure counter and any block for ip (sliding reset on

--- a/internal/dnsroute/failover.go
+++ b/internal/dnsroute/failover.go
@@ -7,9 +7,9 @@ import (
 )
 
 // Logger is the minimal logger interface used by FailoverManager.
-// (Will be filled in by Task 2 — for now just a type stub.)
 type Logger interface {
 	Warnf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
 }
 
 // AffectedList describes a DNS route list affected by a tunnel state change.
@@ -142,6 +142,13 @@ func (fm *FailoverManager) MarkFailed(tunnelID string) error {
 	}
 	fm.mu.Unlock()
 
+	if fm.log != nil {
+		if err != nil {
+			fm.log.Warnf("failover: DNS lists switch off failed tunnel %s did not apply: %v", tunnelID, err)
+		} else {
+			fm.log.Warnf("failover: tunnel %s failed, DNS lists switched to backup", tunnelID)
+		}
+	}
 	fm.publishFailoverEvents(tunnelID, "switched", err)
 	return err
 }
@@ -182,6 +189,13 @@ func (fm *FailoverManager) MarkRecovered(tunnelID string) error {
 	}
 	fm.mu.Unlock()
 
+	if fm.log != nil {
+		if err != nil {
+			fm.log.Warnf("failover: DNS lists restore to recovered tunnel %s did not apply: %v", tunnelID, err)
+		} else {
+			fm.log.Infof("failover: tunnel %s recovered, DNS lists restored", tunnelID)
+		}
+	}
 	fm.publishFailoverEvents(tunnelID, "restored", err)
 	return err
 }

--- a/internal/dnsroute/failover.go
+++ b/internal/dnsroute/failover.go
@@ -142,15 +142,32 @@ func (fm *FailoverManager) MarkFailed(tunnelID string) error {
 	}
 	fm.mu.Unlock()
 
-	if fm.log != nil {
-		if err != nil {
-			fm.log.Warnf("failover: DNS lists switch off failed tunnel %s did not apply: %v", tunnelID, err)
-		} else {
-			fm.log.Warnf("failover: tunnel %s failed, DNS lists switched to backup", tunnelID)
+	// Журналим только реальный переход (не dirty-retry от чужих событий)
+	// и только когда у туннеля есть DNS-листы — иначе «переключение»
+	// не происходило и строка вводит в заблуждение.
+	if fm.log != nil && !alreadyFailed {
+		if n := fm.affectedCount(tunnelID, "switched"); n != 0 {
+			if err != nil {
+				fm.log.Warnf("failover: DNS lists switch off failed tunnel %s did not apply: %v", tunnelID, err)
+			} else if n > 0 {
+				fm.log.Warnf("failover: tunnel %s failed, %d DNS list(s) switched to backup", tunnelID, n)
+			} else {
+				fm.log.Warnf("failover: tunnel %s failed, DNS lists switched to backup", tunnelID)
+			}
 		}
 	}
 	fm.publishFailoverEvents(tunnelID, "switched", err)
 	return err
+}
+
+// affectedCount возвращает число DNS-листов, затронутых сменой состояния
+// туннеля; -1 когда lookup не подключён (журналим без числа? нет —
+// считаем «неизвестно» как «есть», чтобы не потерять событие).
+func (fm *FailoverManager) affectedCount(tunnelID, action string) int {
+	if fm.lookupAffected == nil {
+		return -1
+	}
+	return len(fm.lookupAffected(tunnelID, action))
 }
 
 // MarkRecovered removes a tunnel from the failed set and triggers reconcile.
@@ -189,11 +206,13 @@ func (fm *FailoverManager) MarkRecovered(tunnelID string) error {
 	}
 	fm.mu.Unlock()
 
-	if fm.log != nil {
-		if err != nil {
-			fm.log.Warnf("failover: DNS lists restore to recovered tunnel %s did not apply: %v", tunnelID, err)
-		} else {
-			fm.log.Infof("failover: tunnel %s recovered, DNS lists restored", tunnelID)
+	if fm.log != nil && wasFailed {
+		if n := fm.affectedCount(tunnelID, "restored"); n != 0 {
+			if err != nil {
+				fm.log.Warnf("failover: DNS lists restore to recovered tunnel %s did not apply: %v", tunnelID, err)
+			} else {
+				fm.log.Infof("failover: tunnel %s recovered, DNS lists restored", tunnelID)
+			}
 		}
 	}
 	fm.publishFailoverEvents(tunnelID, "restored", err)

--- a/internal/dnsroute/failover_test.go
+++ b/internal/dnsroute/failover_test.go
@@ -272,6 +272,8 @@ func (c *captureLogger) Warnf(format string, args ...interface{}) {
 	c.warnings = append(c.warnings, format)
 }
 
+func (c *captureLogger) Infof(format string, args ...interface{}) {}
+
 func TestFailoverManager_HandlePingCheckEvent_LogsTypeMismatch(t *testing.T) {
 	fm := NewFailoverManager(nil)
 	logger := &captureLogger{}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -50,6 +50,11 @@ type LogEntryEvent struct {
 	Target    string `json:"target"`
 	Message   string `json:"message"`
 	Bucket    string `json:"bucket"` // "app" | "singbox"
+	// Повтор, свёрнутый в существующую запись (Timestamp — её первое
+	// появление): Repeats — счётчик схлопнутых повторов, LastSeen — время
+	// последнего. Клиент обновляет строку по составному ключу вместо append.
+	Repeats  int    `json:"repeats,omitempty"`
+	LastSeen string `json:"lastSeen,omitempty"`
 }
 
 // Traffic update payload (sent by Traffic Collector).

--- a/internal/hydraroute/service.go
+++ b/internal/hydraroute/service.go
@@ -324,22 +324,22 @@ func (s *Service) WriteConfig(cfg *Config) error {
 		effectiveMaxElem = defaultMaxElem
 		s.appLog.Warn("config-normalize", "IpsetMaxElem", "invalid value <=0 normalized to 65536")
 	}
+	if err := WriteConfig(cfg); err != nil {
+		s.appLog.Warn("config-write", "", "full config write failed: "+err.Error())
+		return err
+	}
+
 	s.appLog.Info(
 		"config-write",
 		"",
 		fmt.Sprintf(
-			"full config write: geoip=%d geosite=%d ipsetMaxElem=%d policyOrder=%d",
+			"HydraRoute settings updated: geoip=%d geosite=%d ipsetMaxElem=%d policyOrder=%d",
 			len(cfg.GeoIPFiles),
 			len(cfg.GeoSiteFiles),
 			effectiveMaxElem,
 			len(cfg.PolicyOrder),
 		),
 	)
-
-	if err := WriteConfig(cfg); err != nil {
-		s.appLog.Warn("config-write", "", "full config write failed: "+err.Error())
-		return err
-	}
 
 	s.scheduleRestart("config-write")
 	return nil

--- a/internal/logbuf/buffer.go
+++ b/internal/logbuf/buffer.go
@@ -140,6 +140,29 @@ func (b *Buffer[T]) FilterPage(pred func(T) bool, limit, offset int) ([]T, int) 
 	return page, total
 }
 
+// UpdateRecent scans entries newest-first, at most scanLimit of them
+// (0 = no cap), and applies update in place to the first entry matching
+// match. Returns a copy of the updated entry. Entry order and timestamps
+// are untouched — the caller's update decides what changes.
+func (b *Buffer[T]) UpdateRecent(scanLimit int, match func(T) bool, update func(*T)) (T, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	scanned := 0
+	for i := len(b.entries) - 1; i >= 0; i-- {
+		if scanLimit > 0 && scanned >= scanLimit {
+			break
+		}
+		scanned++
+		if match(b.entries[i]) {
+			update(&b.entries[i])
+			return b.entries[i], true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
 // Clear drops all entries.
 func (b *Buffer[T]) Clear() {
 	b.mu.Lock()

--- a/internal/logbuf/buffer.go
+++ b/internal/logbuf/buffer.go
@@ -140,11 +140,13 @@ func (b *Buffer[T]) FilterPage(pred func(T) bool, limit, offset int) ([]T, int) 
 	return page, total
 }
 
-// UpdateRecent scans entries newest-first, at most scanLimit of them
+// UpsertRecent scans entries newest-first, at most scanLimit of them
 // (0 = no cap), and applies update in place to the first entry matching
-// match. Returns a copy of the updated entry. Entry order and timestamps
-// are untouched — the caller's update decides what changes.
-func (b *Buffer[T]) UpdateRecent(scanLimit int, match func(T) bool, update func(*T)) (T, bool) {
+// match; when nothing matches, appends entry (respecting MaxEntries) —
+// scan and append happen under ONE lock, so two goroutines upserting the
+// same key concurrently cannot both append. Returns the stored entry and
+// whether an existing one was updated.
+func (b *Buffer[T]) UpsertRecent(scanLimit int, match func(T) bool, update func(*T), entry T) (T, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -159,8 +161,14 @@ func (b *Buffer[T]) UpdateRecent(scanLimit int, match func(T) bool, update func(
 			return b.entries[i], true
 		}
 	}
-	var zero T
-	return zero, false
+	if b.setTimestamp != nil && b.timestampOf(entry).IsZero() {
+		b.setTimestamp(&entry, time.Now())
+	}
+	if len(b.entries) >= b.maxEntries {
+		b.entries = b.entries[len(b.entries)-b.maxEntries+1:]
+	}
+	b.entries = append(b.entries, entry)
+	return entry, false
 }
 
 // Clear drops all entries.

--- a/internal/logging/buffer.go
+++ b/internal/logging/buffer.go
@@ -75,6 +75,41 @@ func (lb *LogBuffer) GetPaginatedMulti(groups, subgroups []string, level string,
 	return lb.inner.FilterPage(matcherMulti(groups, subgroups, level, since), limit, offset)
 }
 
+// coalesceScanLimit ограничивает поиск дубликата последними записями —
+// при debug-флуде окно может содержать сотни записей, сканировать весь
+// буфер на каждую запись незачем.
+const coalesceScanLimit = 300
+
+// Coalesce сворачивает идентичный повтор в недавнюю существующую запись:
+// совпадают level/group/subgroup/action/target/message и последнее появление
+// (LastSeen, иначе Timestamp) не старше window от entry.Timestamp. У найденной
+// записи Repeats++ и LastSeen обновляется; Timestamp (первое появление) и
+// позиция в буфере не меняются. Возвращает обновлённую запись.
+func (lb *LogBuffer) Coalesce(entry LogEntry, window time.Duration) (LogEntry, bool) {
+	now := entry.Timestamp
+	if now.IsZero() {
+		now = time.Now()
+	}
+	cutoff := now.Add(-window)
+	return lb.inner.UpdateRecent(coalesceScanLimit,
+		func(e LogEntry) bool {
+			if e.Level != entry.Level || e.Group != entry.Group || e.Subgroup != entry.Subgroup ||
+				e.Action != entry.Action || e.Target != entry.Target || e.Message != entry.Message {
+				return false
+			}
+			last := e.Timestamp
+			if e.LastSeen != nil {
+				last = *e.LastSeen
+			}
+			return last.After(cutoff)
+		},
+		func(e *LogEntry) {
+			e.Repeats++
+			t := now
+			e.LastSeen = &t
+		})
+}
+
 // Clear removes all entries.
 func (lb *LogBuffer) Clear() { lb.inner.Clear() }
 

--- a/internal/logging/buffer.go
+++ b/internal/logging/buffer.go
@@ -30,9 +30,12 @@ func NewLogBuffer(bucket Bucket) *LogBuffer {
 	return &LogBuffer{
 		bucket: bucket,
 		inner: logbuf.New(logbuf.Options[LogEntry]{
-			MaxAge:       defaultMaxAge,
-			MaxEntries:   defaultMaxEntriesFor(bucket),
-			TimestampOf:  func(e LogEntry) time.Time { return e.Timestamp },
+			MaxAge:     defaultMaxAge,
+			MaxEntries: defaultMaxEntriesFor(bucket),
+			// Эффективное время записи — последний повтор: активно
+			// повторяющаяся схлопнутая запись не должна выселяться TTL-очисткой
+			// по давнему первому появлению.
+			TimestampOf:  effectiveTime,
 			SetTimestamp: func(e *LogEntry, t time.Time) { e.Timestamp = t },
 		}),
 	}
@@ -80,34 +83,41 @@ func (lb *LogBuffer) GetPaginatedMulti(groups, subgroups []string, level string,
 // буфер на каждую запись незачем.
 const coalesceScanLimit = 300
 
-// Coalesce сворачивает идентичный повтор в недавнюю существующую запись:
-// совпадают level/group/subgroup/action/target/message и последнее появление
-// (LastSeen, иначе Timestamp) не старше window от entry.Timestamp. У найденной
-// записи Repeats++ и LastSeen обновляется; Timestamp (первое появление) и
-// позиция в буфере не меняются. Возвращает обновлённую запись.
-func (lb *LogBuffer) Coalesce(entry LogEntry, window time.Duration) (LogEntry, bool) {
+// effectiveTime — время последней активности записи: LastSeen для
+// схлопнутых повторов, иначе Timestamp (первое появление).
+func effectiveTime(e LogEntry) time.Time {
+	if e.LastSeen != nil {
+		return *e.LastSeen
+	}
+	return e.Timestamp
+}
+
+// CoalesceOrAdd сворачивает идентичный повтор в недавнюю существующую
+// запись (совпадают level/group/subgroup/action/target/message, последнее
+// появление не старше window), иначе добавляет новую — атомарно, под одним
+// локом буфера: параллельные одинаковые записи не могут задвоиться. У
+// свёрнутой записи Repeats++ и LastSeen; Timestamp и позиция не меняются.
+// Возвращает сохранённую запись и признак сворачивания.
+func (lb *LogBuffer) CoalesceOrAdd(entry LogEntry, window time.Duration) (LogEntry, bool) {
 	now := entry.Timestamp
 	if now.IsZero() {
 		now = time.Now()
 	}
 	cutoff := now.Add(-window)
-	return lb.inner.UpdateRecent(coalesceScanLimit,
+	return lb.inner.UpsertRecent(coalesceScanLimit,
 		func(e LogEntry) bool {
 			if e.Level != entry.Level || e.Group != entry.Group || e.Subgroup != entry.Subgroup ||
 				e.Action != entry.Action || e.Target != entry.Target || e.Message != entry.Message {
 				return false
 			}
-			last := e.Timestamp
-			if e.LastSeen != nil {
-				last = *e.LastSeen
-			}
-			return last.After(cutoff)
+			return effectiveTime(e).After(cutoff)
 		},
 		func(e *LogEntry) {
 			e.Repeats++
 			t := now
 			e.LastSeen = &t
-		})
+		},
+		entry)
 }
 
 // Clear removes all entries.
@@ -140,7 +150,9 @@ func (lb *LogBuffer) Oldest() time.Time {
 // `since` disables the timestamp cutoff.
 func matcher(group, subgroup, level string, since time.Time) func(LogEntry) bool {
 	return func(e LogEntry) bool {
-		if !since.IsZero() && !e.Timestamp.After(since) {
+		// Отсечка по последней активности: схлопнутая запись, повторившаяся
+		// после since, попадает в catch-up и освежает счётчик у клиента.
+		if !since.IsZero() && !effectiveTime(e).After(since) {
 			return false
 		}
 		if group != "" && e.Group != group {
@@ -172,7 +184,7 @@ func matcherMulti(groups, subgroups []string, level string, since time.Time) fun
 	}
 
 	return func(e LogEntry) bool {
-		if !since.IsZero() && !e.Timestamp.After(since) {
+		if !since.IsZero() && !effectiveTime(e).After(since) {
 			return false
 		}
 		if len(groupSet) > 0 {

--- a/internal/logging/coalesce_test.go
+++ b/internal/logging/coalesce_test.go
@@ -26,7 +26,7 @@ func TestCoalesce_FoldsIdenticalRepeat(t *testing.T) {
 	base := time.Now()
 	lb.Add(testEntry("fail", base))
 
-	updated, ok := lb.Coalesce(testEntry("fail", base.Add(30*time.Second)), 5*time.Minute)
+	updated, ok := lb.CoalesceOrAdd(testEntry("fail", base.Add(30*time.Second)), 5*time.Minute)
 	if !ok {
 		t.Fatal("expected repeat to coalesce")
 	}
@@ -55,7 +55,7 @@ func TestCoalesce_LastSeenExtendsWindow(t *testing.T) {
 	// в окно от LastSeen предыдущего, хотя от Timestamp уже далеко.
 	for i := 1; i <= 3; i++ {
 		ts := base.Add(time.Duration(i) * 4 * time.Minute)
-		updated, ok := lb.Coalesce(testEntry("fail", ts), 5*time.Minute)
+		updated, ok := lb.CoalesceOrAdd(testEntry("fail", ts), 5*time.Minute)
 		if !ok {
 			t.Fatalf("repeat %d must coalesce (window extends via LastSeen)", i)
 		}
@@ -75,8 +75,11 @@ func TestCoalesce_ExpiredWindowStartsFresh(t *testing.T) {
 	base := time.Now()
 	lb.Add(testEntry("fail", base))
 
-	if _, ok := lb.Coalesce(testEntry("fail", base.Add(6*time.Minute)), 5*time.Minute); ok {
+	if _, ok := lb.CoalesceOrAdd(testEntry("fail", base.Add(6*time.Minute)), 5*time.Minute); ok {
 		t.Fatal("repeat outside window must NOT coalesce")
+	}
+	if lb.Len() != 2 {
+		t.Fatalf("expired repeat must be added as a fresh entry: Len = %d, want 2", lb.Len())
 	}
 }
 
@@ -89,17 +92,20 @@ func TestCoalesce_DifferentFieldsDoNotFold(t *testing.T) {
 
 	other := testEntry("fail", base.Add(time.Second))
 	other.Target = "awg11"
-	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+	if _, ok := lb.CoalesceOrAdd(other, 5*time.Minute); ok {
 		t.Fatal("different target must not coalesce")
 	}
 	other = testEntry("different message", base.Add(time.Second))
-	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+	if _, ok := lb.CoalesceOrAdd(other, 5*time.Minute); ok {
 		t.Fatal("different message must not coalesce")
 	}
 	other = testEntry("fail", base.Add(time.Second))
 	other.Level = "error"
-	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+	if _, ok := lb.CoalesceOrAdd(other, 5*time.Minute); ok {
 		t.Fatal("different level must not coalesce")
+	}
+	if lb.Len() != 4 {
+		t.Fatalf("non-matching entries must be added: Len = %d, want 4", lb.Len())
 	}
 }
 
@@ -112,7 +118,7 @@ func TestCoalesce_InterleavedEntriesStillFold(t *testing.T) {
 	lb.Add(testEntry("fail B", base.Add(time.Second)))
 
 	// Повтор A находит свою запись сквозь более новую B.
-	updated, ok := lb.Coalesce(testEntry("fail A", base.Add(2*time.Second)), 5*time.Minute)
+	updated, ok := lb.CoalesceOrAdd(testEntry("fail A", base.Add(2*time.Second)), 5*time.Minute)
 	if !ok || updated.Message != "fail A" || updated.Repeats != 1 {
 		t.Fatalf("interleaved repeat must coalesce into its own entry: ok=%v entry=%+v", ok, updated)
 	}

--- a/internal/logging/coalesce_test.go
+++ b/internal/logging/coalesce_test.go
@@ -3,6 +3,8 @@ package logging
 import (
 	"testing"
 	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/events"
 )
 
 func testEntry(msg string, ts time.Time) LogEntry {
@@ -143,5 +145,43 @@ func TestServiceAppLog_CoalescesRepeats(t *testing.T) {
 	_, total = s.GetLogs(BucketApp, "", "", "", time.Time{}, 10, 0)
 	if total != 2 {
 		t.Fatalf("total = %d, want 2", total)
+	}
+}
+
+// SSE-событие и REST-DTO должны выдавать побайтно одинаковую строку
+// timestamp — клиент сопоставляет повторы с загруженными строками по
+// составному ключу (см. frontend logs store keyOf).
+func TestServiceAppLog_SSETimestampMatchesRESTFormat(t *testing.T) {
+	s := NewService(&mockSettings{enabled: true, maxAge: 2, logLevel: "info", appMaxEntries: 100, sbMaxEntries: 100})
+	defer s.Stop()
+	bus := events.NewBus()
+	s.SetEventBus(bus)
+	_, ch, unsub := bus.Subscribe()
+	defer unsub()
+
+	s.AppLog(LevelWarn, GroupTunnel, SubConnectivity, "http-check", "awg10", "fail")
+	s.AppLog(LevelWarn, GroupTunnel, SubConnectivity, "http-check", "awg10", "fail") // повтор
+
+	entries, _ := s.GetLogs(BucketApp, "", "", "", time.Time{}, 1, 0)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	wantTS := entries[0].Timestamp.UTC().Format(time.RFC3339Nano)
+	wantLastSeen := entries[0].LastSeen.UTC().Format(time.RFC3339Nano)
+
+	var got []events.LogEntryEvent
+	for i := 0; i < 2; i++ {
+		select {
+		case ev := <-ch:
+			got = append(got, ev.Data.(events.LogEntryEvent))
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for log:entry event")
+		}
+	}
+	if got[0].Timestamp != wantTS || got[1].Timestamp != wantTS {
+		t.Fatalf("SSE timestamps %q/%q != REST format %q", got[0].Timestamp, got[1].Timestamp, wantTS)
+	}
+	if got[1].Repeats != 1 || got[1].LastSeen != wantLastSeen {
+		t.Fatalf("repeat event: repeats=%d lastSeen=%q, want 1/%q", got[1].Repeats, got[1].LastSeen, wantLastSeen)
 	}
 }

--- a/internal/logging/coalesce_test.go
+++ b/internal/logging/coalesce_test.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"testing"
+	"time"
+)
+
+func testEntry(msg string, ts time.Time) LogEntry {
+	return LogEntry{
+		Timestamp: ts,
+		Level:     "warn",
+		Group:     GroupTunnel,
+		Subgroup:  SubConnectivity,
+		Action:    "http-check",
+		Target:    "awg10",
+		Message:   msg,
+	}
+}
+
+func TestCoalesce_FoldsIdenticalRepeat(t *testing.T) {
+	lb := NewLogBuffer(BucketApp)
+	defer lb.Stop()
+
+	base := time.Now()
+	lb.Add(testEntry("fail", base))
+
+	updated, ok := lb.Coalesce(testEntry("fail", base.Add(30*time.Second)), 5*time.Minute)
+	if !ok {
+		t.Fatal("expected repeat to coalesce")
+	}
+	if updated.Repeats != 1 {
+		t.Fatalf("Repeats = %d, want 1", updated.Repeats)
+	}
+	if updated.LastSeen == nil || !updated.LastSeen.Equal(base.Add(30*time.Second)) {
+		t.Fatalf("LastSeen = %v, want %v", updated.LastSeen, base.Add(30*time.Second))
+	}
+	if !updated.Timestamp.Equal(base) {
+		t.Fatalf("Timestamp must stay first-seen: %v != %v", updated.Timestamp, base)
+	}
+	if lb.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", lb.Len())
+	}
+}
+
+func TestCoalesce_LastSeenExtendsWindow(t *testing.T) {
+	lb := NewLogBuffer(BucketApp)
+	defer lb.Stop()
+
+	base := time.Now()
+	lb.Add(testEntry("fail", base))
+
+	// Повторы каждые 4 минуты при окне 5 минут: каждый следующий попадает
+	// в окно от LastSeen предыдущего, хотя от Timestamp уже далеко.
+	for i := 1; i <= 3; i++ {
+		ts := base.Add(time.Duration(i) * 4 * time.Minute)
+		updated, ok := lb.Coalesce(testEntry("fail", ts), 5*time.Minute)
+		if !ok {
+			t.Fatalf("repeat %d must coalesce (window extends via LastSeen)", i)
+		}
+		if updated.Repeats != i {
+			t.Fatalf("repeat %d: Repeats = %d", i, updated.Repeats)
+		}
+	}
+	if lb.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", lb.Len())
+	}
+}
+
+func TestCoalesce_ExpiredWindowStartsFresh(t *testing.T) {
+	lb := NewLogBuffer(BucketApp)
+	defer lb.Stop()
+
+	base := time.Now()
+	lb.Add(testEntry("fail", base))
+
+	if _, ok := lb.Coalesce(testEntry("fail", base.Add(6*time.Minute)), 5*time.Minute); ok {
+		t.Fatal("repeat outside window must NOT coalesce")
+	}
+}
+
+func TestCoalesce_DifferentFieldsDoNotFold(t *testing.T) {
+	lb := NewLogBuffer(BucketApp)
+	defer lb.Stop()
+
+	base := time.Now()
+	lb.Add(testEntry("fail", base))
+
+	other := testEntry("fail", base.Add(time.Second))
+	other.Target = "awg11"
+	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+		t.Fatal("different target must not coalesce")
+	}
+	other = testEntry("different message", base.Add(time.Second))
+	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+		t.Fatal("different message must not coalesce")
+	}
+	other = testEntry("fail", base.Add(time.Second))
+	other.Level = "error"
+	if _, ok := lb.Coalesce(other, 5*time.Minute); ok {
+		t.Fatal("different level must not coalesce")
+	}
+}
+
+func TestCoalesce_InterleavedEntriesStillFold(t *testing.T) {
+	lb := NewLogBuffer(BucketApp)
+	defer lb.Stop()
+
+	base := time.Now()
+	lb.Add(testEntry("fail A", base))
+	lb.Add(testEntry("fail B", base.Add(time.Second)))
+
+	// Повтор A находит свою запись сквозь более новую B.
+	updated, ok := lb.Coalesce(testEntry("fail A", base.Add(2*time.Second)), 5*time.Minute)
+	if !ok || updated.Message != "fail A" || updated.Repeats != 1 {
+		t.Fatalf("interleaved repeat must coalesce into its own entry: ok=%v entry=%+v", ok, updated)
+	}
+	if lb.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", lb.Len())
+	}
+}
+
+func TestServiceAppLog_CoalescesRepeats(t *testing.T) {
+	s := NewService(&mockSettings{enabled: true, maxAge: 2, logLevel: "info", appMaxEntries: 100, sbMaxEntries: 100})
+	defer s.Stop()
+
+	for i := 0; i < 5; i++ {
+		s.AppLog(LevelWarn, GroupTunnel, SubConnectivity, "http-check", "awg10", "HTTP check failed: timeout")
+	}
+	entries, total := s.GetLogs(BucketApp, "", "", "", time.Time{}, 10, 0)
+	if total != 1 || len(entries) != 1 {
+		t.Fatalf("total = %d, len = %d, want 1", total, len(entries))
+	}
+	if entries[0].Repeats != 4 {
+		t.Fatalf("Repeats = %d, want 4", entries[0].Repeats)
+	}
+	if entries[0].LastSeen == nil {
+		t.Fatal("LastSeen must be set on coalesced entry")
+	}
+
+	// Другая запись не сворачивается и не мешает следующему повтору свернуться.
+	s.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "start", "awg11", "Tunnel started")
+	s.AppLog(LevelWarn, GroupTunnel, SubConnectivity, "http-check", "awg10", "HTTP check failed: timeout")
+	_, total = s.GetLogs(BucketApp, "", "", "", time.Time{}, 10, 0)
+	if total != 2 {
+		t.Fatalf("total = %d, want 2", total)
+	}
+}

--- a/internal/logging/service.go
+++ b/internal/logging/service.go
@@ -6,6 +6,12 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/events"
 )
 
+// repeatCoalesceWindow — окно схлопывания идентичных повторов: пока между
+// одинаковыми записями проходит меньше этого времени, они копятся в одной
+// строке журнала (LastSeen продлевает окно, так что непрерывный шум с любым
+// периодом короче окна остаётся одной записью).
+const repeatCoalesceWindow = 5 * time.Minute
+
 // SettingsGetter provides logging configuration.
 type SettingsGetter interface {
 	IsLoggingEnabled() bool
@@ -105,9 +111,16 @@ func (s *Service) AppLog(level Level, group, subgroup, action, target, message s
 		Target:    target,
 		Message:   message,
 	}
-	target_buf.Add(entry)
+	// Идентичный повтор в окне сворачивается в существующую запись (×N)
+	// вместо новой строки — источник рекуррентного шума (периодические
+	// проверки, зацикленные Warn) не может забить журнал.
+	if updated, ok := target_buf.Coalesce(entry, repeatCoalesceWindow); ok {
+		entry = updated
+	} else {
+		target_buf.Add(entry)
+	}
 	if s.bus != nil {
-		s.bus.Publish("log:entry", events.LogEntryEvent{
+		ev := events.LogEntryEvent{
 			Timestamp: entry.Timestamp.Format(time.RFC3339),
 			Level:     entry.Level,
 			Group:     entry.Group,
@@ -116,7 +129,12 @@ func (s *Service) AppLog(level Level, group, subgroup, action, target, message s
 			Target:    entry.Target,
 			Message:   entry.Message,
 			Bucket:    string(bucket),
-		})
+			Repeats:   entry.Repeats,
+		}
+		if entry.LastSeen != nil {
+			ev.LastSeen = entry.LastSeen.Format(time.RFC3339)
+		}
+		s.bus.Publish("log:entry", ev)
 	}
 }
 

--- a/internal/logging/service.go
+++ b/internal/logging/service.go
@@ -114,11 +114,7 @@ func (s *Service) AppLog(level Level, group, subgroup, action, target, message s
 	// Идентичный повтор в окне сворачивается в существующую запись (×N)
 	// вместо новой строки — источник рекуррентного шума (периодические
 	// проверки, зацикленные Warn) не может забить журнал.
-	if updated, ok := target_buf.Coalesce(entry, repeatCoalesceWindow); ok {
-		entry = updated
-	} else {
-		target_buf.Add(entry)
-	}
+	entry, _ = target_buf.CoalesceOrAdd(entry, repeatCoalesceWindow)
 	if s.bus != nil {
 		// Формат должен побайтно совпадать с REST-DTO (api.logEntryDTO):
 		// клиент сопоставляет SSE-повторы с загруженными строками по

--- a/internal/logging/service.go
+++ b/internal/logging/service.go
@@ -120,8 +120,11 @@ func (s *Service) AppLog(level Level, group, subgroup, action, target, message s
 		target_buf.Add(entry)
 	}
 	if s.bus != nil {
+		// Формат должен побайтно совпадать с REST-DTO (api.logEntryDTO):
+		// клиент сопоставляет SSE-повторы с загруженными строками по
+		// составному ключу, включающему timestamp как строку.
 		ev := events.LogEntryEvent{
-			Timestamp: entry.Timestamp.Format(time.RFC3339),
+			Timestamp: entry.Timestamp.UTC().Format(time.RFC3339Nano),
 			Level:     entry.Level,
 			Group:     entry.Group,
 			Subgroup:  entry.Subgroup,
@@ -132,7 +135,7 @@ func (s *Service) AppLog(level Level, group, subgroup, action, target, message s
 			Repeats:   entry.Repeats,
 		}
 		if entry.LastSeen != nil {
-			ev.LastSeen = entry.LastSeen.Format(time.RFC3339)
+			ev.LastSeen = entry.LastSeen.UTC().Format(time.RFC3339Nano)
 		}
 		s.bus.Publish("log:entry", ev)
 	}

--- a/internal/logging/service_test.go
+++ b/internal/logging/service_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -165,7 +166,7 @@ func TestService_GetLogsPagination(t *testing.T) {
 	defer svc.Stop()
 
 	for i := 0; i < 10; i++ {
-		svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "create", "t", "msg")
+		svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "create", "t", fmt.Sprintf("msg %d", i))
 	}
 
 	// First page
@@ -362,8 +363,8 @@ func TestService_StatsReportsBucketState(t *testing.T) {
 	svc := NewService(settings)
 	defer svc.Stop()
 
-	svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", "msg")
-	svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", "msg")
+	svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", "msg 1")
+	svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", "msg 2")
 
 	stats := svc.Stats(BucketApp)
 	if stats.Bucket != BucketApp {
@@ -395,7 +396,7 @@ func TestService_ApplySettingsRetargetsCaps(t *testing.T) {
 	defer svc.Stop()
 
 	for i := 0; i < 50; i++ {
-		svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", "msg")
+		svc.AppLog(LevelInfo, GroupTunnel, SubLifecycle, "x", "t", fmt.Sprintf("msg %d", i))
 	}
 
 	// Shrink to 10.

--- a/internal/logging/transitions.go
+++ b/internal/logging/transitions.go
@@ -1,0 +1,81 @@
+package logging
+
+import "sync"
+
+// TransitionKind классифицирует одно наблюдение повторяющейся бинарной
+// проверки (connectivity, ping и т.п.): значимы переходы состояния, а не
+// каждое измерение. Логика уровней у вызывающего кода: NowFailing → Warn,
+// Recovered → Info, StillOK/StillFailing/FirstOK → Debug.
+type TransitionKind int
+
+const (
+	// TransitionFirstOK — первый успешный результат для цели.
+	TransitionFirstOK TransitionKind = iota
+	// TransitionStillOK — успех после успеха, ничего не изменилось.
+	TransitionStillOK
+	// TransitionNowFailing — переход в отказ (или первый результат — отказ).
+	TransitionNowFailing
+	// TransitionStillFailing — повторный отказ подряд.
+	TransitionStillFailing
+	// TransitionRecovered — успех после серии отказов.
+	TransitionRecovered
+)
+
+// TransitionResult — классификация наблюдения. Failures — длина текущей
+// серии отказов: для NowFailing/StillFailing — включая это наблюдение,
+// для Recovered — сколько отказов было до восстановления.
+type TransitionResult struct {
+	Kind     TransitionKind
+	Failures int
+}
+
+type transitionState struct {
+	ok       bool
+	failures int
+}
+
+// TransitionTracker хранит последний исход по каждой цели и классифицирует
+// новые наблюдения. Потокобезопасен.
+type TransitionTracker struct {
+	mu   sync.Mutex
+	last map[string]transitionState
+}
+
+func NewTransitionTracker() *TransitionTracker {
+	return &TransitionTracker{last: make(map[string]transitionState)}
+}
+
+// Observe регистрирует результат очередной проверки цели и возвращает его
+// классификацию относительно предыдущего состояния.
+func (t *TransitionTracker) Observe(target string, ok bool) TransitionResult {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev, known := t.last[target]
+	switch {
+	case ok && !known:
+		t.last[target] = transitionState{ok: true}
+		return TransitionResult{Kind: TransitionFirstOK}
+	case ok && prev.ok:
+		return TransitionResult{Kind: TransitionStillOK}
+	case ok: // fail → ok
+		t.last[target] = transitionState{ok: true}
+		return TransitionResult{Kind: TransitionRecovered, Failures: prev.failures}
+	case !known || prev.ok: // (первый результат | ok) → fail
+		t.last[target] = transitionState{ok: false, failures: 1}
+		return TransitionResult{Kind: TransitionNowFailing, Failures: 1}
+	default: // fail → fail
+		prev.failures++
+		t.last[target] = prev
+		return TransitionResult{Kind: TransitionStillFailing, Failures: prev.failures}
+	}
+}
+
+// Forget сбрасывает состояние цели: следующий результат будет считаться
+// первым (используется при остановке/удалении туннеля, чтобы после запуска
+// отказ снова дал Warn, а не «повтор»).
+func (t *TransitionTracker) Forget(target string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.last, target)
+}

--- a/internal/logging/transitions.go
+++ b/internal/logging/transitions.go
@@ -79,3 +79,17 @@ func (t *TransitionTracker) Forget(target string) {
 	defer t.mu.Unlock()
 	delete(t.last, target)
 }
+
+// Retain оставляет только перечисленные цели — остальные забываются.
+// Используется циклами, наблюдающими изменяющееся множество объектов
+// (мониторинг туннелей): удалённый объект не должен продолжать серию
+// после пересоздания.
+func (t *TransitionTracker) Retain(keep map[string]bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for target := range t.last {
+		if !keep[target] {
+			delete(t.last, target)
+		}
+	}
+}

--- a/internal/logging/transitions_test.go
+++ b/internal/logging/transitions_test.go
@@ -1,0 +1,65 @@
+package logging
+
+import "testing"
+
+func TestTransitionTracker_Sequence(t *testing.T) {
+	tr := NewTransitionTracker()
+
+	steps := []struct {
+		ok           bool
+		wantKind     TransitionKind
+		wantFailures int
+	}{
+		{true, TransitionFirstOK, 0},
+		{true, TransitionStillOK, 0},
+		{false, TransitionNowFailing, 1},
+		{false, TransitionStillFailing, 2},
+		{false, TransitionStillFailing, 3},
+		{true, TransitionRecovered, 3},
+		{true, TransitionStillOK, 0},
+		{false, TransitionNowFailing, 1},
+		{true, TransitionRecovered, 1},
+	}
+	for i, st := range steps {
+		got := tr.Observe("t1", st.ok)
+		if got.Kind != st.wantKind || got.Failures != st.wantFailures {
+			t.Fatalf("step %d: got {%v %d}, want {%v %d}", i, got.Kind, got.Failures, st.wantKind, st.wantFailures)
+		}
+	}
+}
+
+func TestTransitionTracker_FirstResultIsFail(t *testing.T) {
+	tr := NewTransitionTracker()
+	got := tr.Observe("t1", false)
+	if got.Kind != TransitionNowFailing || got.Failures != 1 {
+		t.Fatalf("first fail: got {%v %d}, want {NowFailing 1}", got.Kind, got.Failures)
+	}
+}
+
+func TestTransitionTracker_TargetsIndependent(t *testing.T) {
+	tr := NewTransitionTracker()
+	tr.Observe("a", false)
+	got := tr.Observe("b", false)
+	if got.Kind != TransitionNowFailing || got.Failures != 1 {
+		t.Fatalf("target b must be independent: got {%v %d}", got.Kind, got.Failures)
+	}
+	if got := tr.Observe("a", false); got.Failures != 2 {
+		t.Fatalf("target a streak: got %d, want 2", got.Failures)
+	}
+}
+
+func TestTransitionTracker_Forget(t *testing.T) {
+	tr := NewTransitionTracker()
+	tr.Observe("t1", false)
+	tr.Observe("t1", false)
+	tr.Forget("t1")
+	// После сброса отказ — снова «новый» (Warn), а не продолжение серии.
+	if got := tr.Observe("t1", false); got.Kind != TransitionNowFailing || got.Failures != 1 {
+		t.Fatalf("after Forget: got {%v %d}, want {NowFailing 1}", got.Kind, got.Failures)
+	}
+	tr.Forget("t1")
+	// И успех после сброса — FirstOK, а не Recovered.
+	if got := tr.Observe("t1", true); got.Kind != TransitionFirstOK {
+		t.Fatalf("after Forget: got %v, want FirstOK", got.Kind)
+	}
+}

--- a/internal/logging/types.go
+++ b/internal/logging/types.go
@@ -75,6 +75,7 @@ const (
 	SubKmod           = "kmod"         // awg_proxy kernel module load/add/remove
 	SubStorage        = "storage"      // tunnel store + settings persistence
 	SubHTTP           = "http"         // HTTP server lifecycle and listener events
+	SubMonitoring     = "monitoring"   // matrix probe transitions (ok→fail / restore)
 
 	// Singbox bucket subgroups
 	SubSBInbound  = "inbound"
@@ -123,7 +124,7 @@ var KnownSubgroups = map[string][]string{
 	GroupSystem: {
 		SubBoot, SubAuth, SubSettings, SubUpdate, SubWan, SubSystemTunnel,
 		SubCleanup, SubDnsCheck, SubConnections, SubTraffic, SubDiagnostics,
-		SubProfiling, SubRCI, SubNDMS, SubStorage,
+		SubProfiling, SubRCI, SubNDMS, SubStorage, SubMonitoring,
 	},
 	GroupSingbox: {
 		SubSBProcess, SubSBInbound, SubSBOutbound, SubSBDNS, SubSBRouter, SubSBRuntime,

--- a/internal/logging/types.go
+++ b/internal/logging/types.go
@@ -131,12 +131,18 @@ var KnownSubgroups = map[string][]string{
 }
 
 // LogEntry represents a single log entry.
+//
+// Идентичные повторы схлопываются в одну запись (см. LogBuffer.Coalesce):
+// Timestamp — первое появление, Repeats — сколько повторов свёрнуто
+// (0 = запись уникальна), LastSeen — время последнего повтора.
 type LogEntry struct {
-	Timestamp time.Time `json:"timestamp"`
-	Level     string    `json:"level"`
-	Group     string    `json:"group"`
-	Subgroup  string    `json:"subgroup,omitempty"`
-	Action    string    `json:"action"`
-	Target    string    `json:"target"`
-	Message   string    `json:"message"`
+	Timestamp time.Time  `json:"timestamp"`
+	Level     string     `json:"level"`
+	Group     string     `json:"group"`
+	Subgroup  string     `json:"subgroup,omitempty"`
+	Action    string     `json:"action"`
+	Target    string     `json:"target"`
+	Message   string     `json:"message"`
+	Repeats   int        `json:"repeats,omitempty"`
+	LastSeen  *time.Time `json:"lastSeen,omitempty"`
 }

--- a/internal/managed/service_peers.go
+++ b/internal/managed/service_peers.go
@@ -145,7 +145,7 @@ func (s *Service) UpdatePeer(ctx context.Context, id, pubkey string, req UpdateP
 	}
 
 	s.log.Info("peer updated", "interface", iface, "pubkey", pubkey[:8]+"...")
-	s.appLog.Full("update-peer", req.Description, fmt.Sprintf("Peer %s updated", req.Description))
+	s.appLog.Info("update-peer", req.Description, fmt.Sprintf("Peer %s updated", req.Description))
 	return nil
 }
 
@@ -225,7 +225,7 @@ func (s *Service) TogglePeer(ctx context.Context, id, pubkey string, enabled boo
 	if enabled {
 		state = "enabled"
 	}
-	s.appLog.Full("toggle-peer", peerName, fmt.Sprintf("Peer %s %s", peerName, state))
+	s.appLog.Info("toggle-peer", peerName, fmt.Sprintf("Peer %s %s", peerName, state))
 	return nil
 }
 

--- a/internal/managed/service_server.go
+++ b/internal/managed/service_server.go
@@ -224,6 +224,7 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateServerRequest
 	}
 
 	s.log.Info("managed server updated", "interface", server.InterfaceName, "address", req.Address, "port", req.ListenPort)
+	s.appLog.Info("update", server.InterfaceName, fmt.Sprintf("Managed server updated on %s", server.InterfaceName))
 	return nil
 }
 
@@ -707,5 +708,10 @@ func (s *Service) SetLANSegments(ctx context.Context, id string, segments []stri
 		return fmt.Errorf("save to storage: %w", err)
 	}
 	s.log.Info("managed server LAN segments changed", "interface", server.InterfaceName, "segments", segments)
+	segs := strings.Join(segments, ", ")
+	if segs == "" {
+		segs = "none"
+	}
+	s.appLog.Info("lan-segments", server.InterfaceName, "LAN segments changed: "+segs)
 	return nil
 }

--- a/internal/monitoring/scheduler.go
+++ b/internal/monitoring/scheduler.go
@@ -258,6 +258,12 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 
 	cells := make([]Cell, 0, len(targets)*len(tunnels))
 	var cellsMu sync.Mutex
+	// Наблюдаемые в этом проходе туннели: серии переходов живут только у
+	// них — туннель с disabled/handshake-методом или без self-цели
+	// забывается (после включения проверки первый отказ снова даст Warn,
+	// а не «повтор»; та же семантика, что у connectivity-трекера).
+	probed := make(map[string]bool, len(tunnels))
+	var probedMu sync.Mutex
 
 	sem := make(chan struct{}, s.workerLimit)
 	var wg sync.WaitGroup
@@ -285,6 +291,9 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 				latency, ok := s.runProbeCell(ctx, t, tn, self)
 				now := time.Now()
 
+				probedMu.Lock()
+				probed[tn.ID] = true
+				probedMu.Unlock()
 				s.logProbeTransition(tn, t, ok)
 
 				sample := Sample{TS: now, OK: ok}
@@ -331,9 +340,7 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 		keepIDs[t.ID] = true
 	}
 	s.history.PruneTunnels(keepIDs)
-	// Удалённый/остановленный туннель не должен продолжать серию после
-	// пересоздания — его следующий отказ снова даст Warn, а не «повтор».
-	s.transitions.Retain(keepIDs)
+	s.transitions.Retain(probed)
 
 	if s.deps.Bus != nil {
 		s.deps.Bus.Publish("monitoring:matrix-update", snap)

--- a/internal/monitoring/scheduler.go
+++ b/internal/monitoring/scheduler.go
@@ -131,6 +131,10 @@ type Scheduler struct {
 	probeTimeout time.Duration
 	workerLimit  int
 	history      *History
+	// transitions классифицирует self-пробы по туннелям: в журнал попадают
+	// только переходы ok→fail (Warn) и восстановления (Info) — сами пробы
+	// каждые 60 секунд журнал не трогают.
+	transitions *logging.TransitionTracker
 
 	mu       sync.RWMutex
 	lastSnap Snapshot
@@ -147,6 +151,7 @@ func NewScheduler(deps SchedulerDeps, history *History) *Scheduler {
 		probeTimeout: 5 * time.Second,
 		workerLimit:  10,
 		history:      history,
+		transitions:  logging.NewTransitionTracker(),
 		stopCh:       make(chan struct{}),
 	}
 }
@@ -280,6 +285,8 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 				latency, ok := s.runProbeCell(ctx, t, tn, self)
 				now := time.Now()
 
+				s.logProbeTransition(tn, t, ok)
+
 				sample := Sample{TS: now, OK: ok}
 				if ok {
 					l := latency
@@ -324,9 +331,34 @@ func (s *Scheduler) RunOnce(ctx context.Context) {
 		keepIDs[t.ID] = true
 	}
 	s.history.PruneTunnels(keepIDs)
+	// Удалённый/остановленный туннель не должен продолжать серию после
+	// пересоздания — его следующий отказ снова даст Warn, а не «повтор».
+	s.transitions.Retain(keepIDs)
 
 	if s.deps.Bus != nil {
 		s.deps.Bus.Publish("monitoring:matrix-update", snap)
+	}
+}
+
+// logProbeTransition пишет в журнал только смену состояния self-пробы:
+// недостижимость — Warn, восстановление — Info с длиной серии. Пробы
+// выполняются раз в минуту на туннель; стабильное состояние журнал
+// не трогает.
+func (s *Scheduler) logProbeTransition(tn Tunnel, t Target, ok bool) {
+	if s.deps.Log == nil {
+		return
+	}
+	name := tn.Name
+	if name == "" {
+		name = tn.ID
+	}
+	switch obs := s.transitions.Observe(tn.ID, ok); obs.Kind {
+	case logging.TransitionNowFailing:
+		s.deps.Log.AppLog(logging.LevelWarn, logging.GroupSystem, logging.SubMonitoring,
+			"probe", name, fmt.Sprintf("monitoring probe unreachable: %s", t.Host))
+	case logging.TransitionRecovered:
+		s.deps.Log.AppLog(logging.LevelInfo, logging.GroupSystem, logging.SubMonitoring,
+			"probe", name, fmt.Sprintf("monitoring probe reachable again (%s) after %d failed cycles", t.Host, obs.Failures))
 	}
 }
 

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1602,12 +1602,21 @@ definitions:
       group:
         example: singbox
         type: string
+      lastSeen:
+        example: "2024-01-15T10:35:00Z"
+        type: string
       level:
         example: info
         type: string
       message:
         example: 'lookup succeed for node.example.org: 203.0.113.77'
         type: string
+      repeats:
+        description: |-
+          Схлопнутые повторы: Repeats — сколько идентичных записей свёрнуто в
+          эту (0 = уникальна), LastSeen — время последнего повтора.
+        example: 4
+        type: integer
       sanitized:
         example: false
         type: boolean

--- a/internal/singbox/migrate_ndms_proxy.go
+++ b/internal/singbox/migrate_ndms_proxy.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/hoaxisr/awg-manager/internal/logging"
+
 	"github.com/hoaxisr/awg-manager/internal/sys/ndmsinfo"
 )
 
@@ -23,14 +25,23 @@ type Migrator struct {
 	op       *Operator
 	settings SettingsToggler
 	log      *slog.Logger
+	// appLog — журнал приложения (system/ndms): ошибки создания/удаления
+	// ProxyN при переключении режима видны пользователю, а не только в
+	// stderr (nil-safe).
+	appLog *logging.ScopedLogger
 }
 
-func NewMigrator(op *Operator, settings SettingsToggler) *Migrator {
+func NewMigrator(op *Operator, settings SettingsToggler, appLogger logging.AppLogger) *Migrator {
 	log := op.log
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Migrator{op: op, settings: settings, log: log}
+	return &Migrator{
+		op:       op,
+		settings: settings,
+		log:      log,
+		appLog:   logging.NewScopedLogger(appLogger, logging.GroupSystem, logging.SubNDMS),
+	}
 }
 
 // MigrateOff выключает создание ProxyN. Sequence:
@@ -65,6 +76,7 @@ func (m *Migrator) MigrateOff(ctx context.Context) error {
 			if rerr := m.op.proxyMgr.RemoveProxy(ctx, idx); rerr != nil {
 				m.log.Warn("MigrateOff: RemoveProxy failed",
 					"tag", t.Tag, "iface", t.ProxyInterface, "err", rerr)
+				m.appLog.Warn("ndms-proxy-migrate", t.Tag, fmt.Sprintf("remove %s failed: %v", t.ProxyInterface, rerr))
 			}
 		}
 	}
@@ -76,6 +88,7 @@ func (m *Migrator) MigrateOff(ctx context.Context) error {
 		if rerr := m.op.proxyMgr.RemoveProxy(ctx, sp.Index); rerr != nil {
 			m.log.Warn("MigrateOff: RemoveProxy (subscription) failed",
 				"label", sp.Label, "idx", sp.Index, "err", rerr)
+			m.appLog.Warn("ndms-proxy-migrate", sp.Label, fmt.Sprintf("remove Proxy%d failed: %v", sp.Index, rerr))
 		}
 	}
 
@@ -108,6 +121,7 @@ func (m *Migrator) MigrateOn(ctx context.Context) error {
 		// Tunnels() заполнит ProxyInterface "Proxy<slot>" из listen_port.
 		if serr := m.op.proxyMgr.SyncProxies(ctx, cfg.Tunnels()); serr != nil {
 			m.log.Warn("MigrateOn: SyncProxies failed", "err", serr)
+			m.appLog.Warn("ndms-proxy-migrate", "", "proxy sync failed: "+serr.Error())
 		}
 	}
 
@@ -119,12 +133,14 @@ func (m *Migrator) MigrateOn(ctx context.Context) error {
 	if m.op.subProxySync != nil {
 		if serr := m.op.subProxySync(ctx); serr != nil {
 			m.log.Warn("MigrateOn: subscription proxy sync failed", "err", serr)
+			m.appLog.Warn("ndms-proxy-migrate", "", "subscription proxy sync failed: "+serr.Error())
 		}
 	} else {
 		for _, sp := range m.op.subscriptionProxies() {
 			if eerr := m.op.proxyMgr.EnsureProxy(ctx, sp.Index, sp.Port, sp.Label); eerr != nil {
 				m.log.Warn("MigrateOn: EnsureProxy (subscription) failed",
 					"label", sp.Label, "idx", sp.Index, "err", eerr)
+				m.appLog.Warn("ndms-proxy-migrate", sp.Label, fmt.Sprintf("ensure Proxy%d failed: %v", sp.Index, eerr))
 			}
 		}
 	}

--- a/internal/singbox/operator_process.go
+++ b/internal/singbox/operator_process.go
@@ -640,6 +640,11 @@ func (o *Operator) autoRestartIfCrashed(ctx context.Context, waitClash bool) (re
 		}
 		return false, true, nil
 	}
+	if o.runtimeLogger != nil {
+		// Явное подтверждение восстановления: падение видно по Warn выше,
+		// но без этой строки успешный исход авто-рестарта был невидим.
+		o.runtimeLogger.Info("auto-restart", "", "process restored")
+	}
 	return true, false, nil
 }
 

--- a/internal/singbox/router/fakeip_reconcile.go
+++ b/internal/singbox/router/fakeip_reconcile.go
@@ -104,6 +104,11 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 						Network: poolNet4, Mask: poolMask4, Interface: ndmsName, Comment: fakeIPPoolRouteComment,
 					}); e != nil {
 						s.appLog.Warn("fakeip-reconcile", iface, "re-add pool route v4: "+e.Error())
+					} else {
+						// Успешный drift-heal: маршрут пула пропадал (утечка
+						// трафика мимо туннеля) и был восстановлен — событие,
+						// а не рутинная проверка.
+						s.appLog.Info("fakeip-reconcile", iface, "pool route v4 was absent, re-added (drift-heal)")
 					}
 					// v6 re-add is gated on the SAME v4-absence signal: routes are added
 					// together at Enable, so v4-present ⇒ v6-present is a sound v1
@@ -114,6 +119,8 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 							V6: true, Network: st.Inet6Range, Interface: ndmsName,
 						}); e != nil {
 							s.appLog.Warn("fakeip-reconcile", iface, "re-add pool route v6: "+e.Error())
+						} else {
+							s.appLog.Info("fakeip-reconcile", iface, "pool route v6 was absent, re-added (drift-heal)")
 						}
 					}
 				}
@@ -142,6 +149,8 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 				if pfx, perr := netip.ParsePrefix(c); perr == nil && !fakeIPPoolRoutePresent(iface, pfx.Masked()) {
 					if e := s.addCIDRRoute(ctx, ndmsName, c, false); e != nil {
 						s.appLog.Warn("fakeip-reconcile", iface, "re-add cidr route "+c+": "+e.Error())
+					} else {
+						s.appLog.Info("fakeip-reconcile", iface, "cidr route "+c+" was absent, re-added (drift-heal)")
 					}
 				}
 			}
@@ -154,6 +163,8 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 				if pfx, perr := netip.ParsePrefix(c); perr == nil && !fakeIPPoolRoute6Present(iface, pfx.Masked()) {
 					if e := s.addCIDRRoute(ctx, ndmsName, c, true); e != nil {
 						s.appLog.Warn("fakeip-reconcile", iface, "re-add cidr route v6 "+c+": "+e.Error())
+					} else {
+						s.appLog.Info("fakeip-reconcile", iface, "cidr route v6 "+c+" was absent, re-added (drift-heal)")
 					}
 				}
 			}

--- a/internal/singbox/router/ruleset_materializer.go
+++ b/internal/singbox/router/ruleset_materializer.go
@@ -337,14 +337,18 @@ func (m ruleSetMaterializer) gcArtifacts(referenced map[string]struct{}) {
 	if m.configDir == "" {
 		return
 	}
-	m.gcArtifactDir(filepath.Join(m.configDir, "rule-sets", "inline"), referenced)
-	m.gcArtifactDir(filepath.Join(m.configDir, "rule-sets", "dat"), referenced)
+	removed := m.gcArtifactDir(filepath.Join(m.configDir, "rule-sets", "inline"), referenced)
+	removed += m.gcArtifactDir(filepath.Join(m.configDir, "rule-sets", "dat"), referenced)
+	// Пофайловые строки — debug; сводка уборки видна на info.
+	if removed > 0 && m.log != nil {
+		m.log.Info("gc", "", fmt.Sprintf("removed %d orphaned rule-set artifact(s)", removed))
+	}
 }
 
-func (m ruleSetMaterializer) gcArtifactDir(dir string, referenced map[string]struct{}) {
+func (m ruleSetMaterializer) gcArtifactDir(dir string, referenced map[string]struct{}) (removed int) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return // dir absent — nothing to sweep
+		return 0 // dir absent — nothing to sweep
 	}
 	for _, entry := range entries {
 		if !entry.Type().IsRegular() {
@@ -365,10 +369,12 @@ func (m ruleSetMaterializer) gcArtifactDir(dir string, referenced map[string]str
 			}
 			continue
 		}
+		removed++
 		if m.log != nil {
 			m.log.Debug("gc", base, "removed orphaned rule-set artifact "+path)
 		}
 	}
+	return removed
 }
 
 // ruleSetArtifactBase maps an artifact filename to the base name compared

--- a/internal/singbox/router/service_selective.go
+++ b/internal/singbox/router/service_selective.go
@@ -132,9 +132,15 @@ func (s *ServiceImpl) triggerSelectiveRebuild(_ context.Context) {
 		return
 	}
 	go func() {
+		// Пересборка на MIPS может занимать минуты и меняет поведение
+		// bypass — старт и завершение видны в журнале, детали и счётчики
+		// живут в selective-панели (SSE-статус билдера).
+		s.appLog.Info("selective-rebuild", "", "ipset rebuild started")
 		if err := s.deps.SelectiveBuilder.Rebuild(context.Background()); err != nil {
 			s.appLog.Warn("selective-rebuild", "", fmt.Sprintf("ipset rebuild failed: %v", err))
+			return
 		}
+		s.appLog.Info("selective-rebuild", "", "ipset rebuild complete")
 	}()
 }
 

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -612,7 +612,10 @@ func (s *Service) refreshLockedOpts(ctx context.Context, id string, forceInlineR
 	// подробная строка выше живёт в sing-box бакете, а пользователь смотрит
 	// главный журнал. Без изменений не дублируем — иначе плановые тики
 	// снова превращаются в шум.
-	if s.appLog != nil && (res.Added > 0 || res.Updated > 0 || res.Orphaned > 0) {
+	// Updated = len(diff.Existing) — все члены, пережившие fetch: он >0 на
+	// каждом успешном обновлении непустой подписки. Реальные изменения —
+	// только Added/Orphaned; иначе плановые тики снова спамят журнал.
+	if s.appLog != nil && (res.Added > 0 || res.Orphaned > 0) {
 		label := sub.Label
 		if label == "" {
 			label = id

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -608,6 +608,18 @@ func (s *Service) refreshLockedOpts(ctx context.Context, id string, forceInlineR
 		return nil, err
 	}
 	s.logInfo("subscription-refresh", id, fmt.Sprintf("done added=%d updated=%d orphaned=%d skipped_dup=%d skipped_vmess=%d skipped_other=%d parse_errors=%d", res.Added, res.Updated, res.Orphaned, res.SkippedDuplicate, res.SkippedVmess, res.SkippedOther, len(res.ParseErrors)))
+	// Итог с изменениями зеркалится в app-журнал (routing/subscription):
+	// подробная строка выше живёт в sing-box бакете, а пользователь смотрит
+	// главный журнал. Без изменений не дублируем — иначе плановые тики
+	// снова превращаются в шум.
+	if s.appLog != nil && (res.Added > 0 || res.Updated > 0 || res.Orphaned > 0) {
+		label := sub.Label
+		if label == "" {
+			label = id
+		}
+		s.appLog.Info("refresh", label,
+			fmt.Sprintf("Subscription refreshed: +%d new, %d updated, %d removed", res.Added, res.Updated, res.Orphaned))
+	}
 	return res, nil
 }
 

--- a/internal/storage/atomic.go
+++ b/internal/storage/atomic.go
@@ -79,7 +79,9 @@ func QuarantineCorrupt(path string, parseErr error) {
 	quarantine := path + ".corrupt"
 	if err := os.Rename(path, quarantine); err != nil {
 		fmt.Fprintf(os.Stderr, "storage: %s is corrupt (%v); quarantine failed: %v\n", path, parseErr, err)
+		recordNotice("quarantine", path, fmt.Sprintf("state file corrupt (%v); quarantine failed: %v", parseErr, err))
 		return
 	}
 	fmt.Fprintf(os.Stderr, "storage: %s is corrupt (%v); moved to %s, continuing with defaults\n", path, parseErr, quarantine)
+	recordNotice("quarantine", path, fmt.Sprintf("state file corrupt (%v); moved to %s, continuing with defaults — recover manually if needed", parseErr, quarantine))
 }

--- a/internal/storage/notices.go
+++ b/internal/storage/notices.go
@@ -14,23 +14,43 @@ type Notice struct {
 	Message string
 }
 
+// maxPendingNotices ограничивает довайринговый буфер: при систематическом
+// сбое (например, карантин не срабатывает на read-only ФС и Load повторяется
+// каждый тик) буфер не должен расти безгранично.
+const maxPendingNotices = 64
+
 var (
 	noticesMu      sync.Mutex
 	pendingNotices []Notice
+	noticeSink     func(Notice)
 )
 
 func recordNotice(action, target, message string) {
+	n := Notice{Action: action, Target: target, Message: message}
 	noticesMu.Lock()
-	defer noticesMu.Unlock()
-	pendingNotices = append(pendingNotices, Notice{Action: action, Target: target, Message: message})
+	sink := noticeSink
+	if sink == nil {
+		if len(pendingNotices) < maxPendingNotices {
+			pendingNotices = append(pendingNotices, n)
+		}
+		noticesMu.Unlock()
+		return
+	}
+	noticesMu.Unlock()
+	sink(n)
 }
 
-// DrainNotices возвращает накопленные события восстановления и очищает
-// буфер. Вызывается один раз после создания logging.Service.
-func DrainNotices() []Notice {
+// SetNoticeSink подключает живой приёмник (журнал приложения) и выгружает
+// в него всё накопленное до подключения. Большинство хранилищ грузятся
+// лениво ПОСЛЕ создания logging.Service — без живого sink их события
+// восстановления терялись бы навсегда.
+func SetNoticeSink(sink func(Notice)) {
 	noticesMu.Lock()
-	defer noticesMu.Unlock()
-	out := pendingNotices
+	noticeSink = sink
+	buffered := pendingNotices
 	pendingNotices = nil
-	return out
+	noticesMu.Unlock()
+	for _, n := range buffered {
+		sink(n)
+	}
 }

--- a/internal/storage/notices.go
+++ b/internal/storage/notices.go
@@ -1,0 +1,36 @@
+package storage
+
+import "sync"
+
+// Хранилища создаются раньше журнала (logging.Service сам зависит от
+// настроек), поэтому события восстановления после повреждённых файлов
+// (карантин, откат к .bak) записываются в отложенный буфер и выгружаются
+// в журнал при связывании приложения (cmd/awg-manager/wiring). До выгрузки
+// каждое событие дублируется в stderr — если демон падает до подключения
+// журнала, след остаётся хотя бы там.
+type Notice struct {
+	Action  string
+	Target  string
+	Message string
+}
+
+var (
+	noticesMu      sync.Mutex
+	pendingNotices []Notice
+)
+
+func recordNotice(action, target, message string) {
+	noticesMu.Lock()
+	defer noticesMu.Unlock()
+	pendingNotices = append(pendingNotices, Notice{Action: action, Target: target, Message: message})
+}
+
+// DrainNotices возвращает накопленные события восстановления и очищает
+// буфер. Вызывается один раз после создания logging.Service.
+func DrainNotices() []Notice {
+	noticesMu.Lock()
+	defer noticesMu.Unlock()
+	out := pendingNotices
+	pendingNotices = nil
+	return out
+}

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -79,6 +79,7 @@ func (s *SettingsStore) Load() (*Settings, error) {
 			return nil, fmt.Errorf("parse %s (quarantined to %s, backup also corrupt: %v): %w", s.path, quarantine, bakErr, err)
 		}
 		fmt.Fprintf(os.Stderr, "settings: %s was corrupt (%v), quarantined to %s, restored from backup\n", s.path, err, quarantine)
+		recordNotice("backup-restore", s.path, fmt.Sprintf("settings file corrupt (%v), quarantined to %s, RESTORED FROM BACKUP — recent settings changes may be lost", err, quarantine))
 		restoredFromBackup = true
 	}
 

--- a/internal/testing/connectivity.go
+++ b/internal/testing/connectivity.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/httpprobe"
 	"github.com/hoaxisr/awg-manager/internal/icmpprobe"
+	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/sys/exec"
 )
@@ -16,6 +17,9 @@ import (
 func (s *Service) CheckConnectivity(ctx context.Context, tunnelID string) (*ConnectivityResult, error) {
 	if err := s.CheckTunnelRunning(tunnelID); err != nil {
 		s.appLog.Debug("connectivity-check", tunnelID, "Tunnel not running")
+		// Сброс серии: после перезапуска туннеля первый отказ снова
+		// логируется как Warn, а не как «повтор».
+		s.connTracker.Forget(tunnelID)
 		return &ConnectivityResult{Connected: false, Reason: ReasonTunnelNotRunning}, nil
 	}
 
@@ -27,16 +31,47 @@ func (s *Service) CheckConnectivity(ctx context.Context, tunnelID string) (*Conn
 
 	s.appLog.Full("connectivity-check", tunnelID, fmt.Sprintf("Starting connectivity check with method: %s", method))
 
+	var result *ConnectivityResult
+	var err error
 	switch method {
 	case "ping":
-		return s.checkPing(ctx, tunnelID, stored)
+		result, err = s.checkPing(ctx, tunnelID, stored)
 	case "handshake":
-		return s.checkHandshake(tunnelID)
+		result, err = s.checkHandshake(tunnelID)
 	case "disabled":
 		s.appLog.Debug("connectivity-check", tunnelID, "Check disabled, returning OK")
 		return &ConnectivityResult{Connected: true, Reason: "check disabled"}, nil
 	default:
-		return s.checkHTTP(ctx, tunnelID)
+		result, err = s.checkHTTP(ctx, tunnelID)
+	}
+	if err == nil && result != nil {
+		s.logConnectivityOutcome(method, tunnelID, result)
+	}
+	return result, err
+}
+
+// logConnectivityOutcome логирует исход проверки по переходной модели:
+// повторяющиеся периодические проверки (авто-чеки фронта) не спамят журнал —
+// Warn пишется на переходе в отказ, Info на восстановлении с длиной серии,
+// повторы того же исхода видны только на debug.
+func (s *Service) logConnectivityOutcome(method, tunnelID string, res *ConnectivityResult) {
+	action := method + "-check"
+	if method == "http" {
+		action = "http-check"
+	}
+	latency := ""
+	if res.Latency != nil {
+		latency = fmt.Sprintf(", latency=%dms", *res.Latency)
+	}
+	switch obs := s.connTracker.Observe(tunnelID, res.Connected); obs.Kind {
+	case logging.TransitionNowFailing:
+		s.appLog.Warn(action, tunnelID, fmt.Sprintf("Connectivity check failed: %s", res.Reason))
+	case logging.TransitionStillFailing:
+		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check still failing (%d in a row): %s", obs.Failures, res.Reason))
+	case logging.TransitionRecovered:
+		s.appLog.Info(action, tunnelID, fmt.Sprintf("Connectivity restored after %d failed checks%s", obs.Failures, latency))
+	default: // FirstOK / StillOK
+		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check ok%s", latency))
 	}
 }
 
@@ -54,7 +89,6 @@ func (s *Service) checkHTTP(ctx context.Context, tunnelID string) (*Connectivity
 	res, err := httpprobe.ByInterface(ctx, iface, checkURL, nil)
 	if err != nil {
 		errDetail := err.Error()
-		s.appLog.Warn("http-check", tunnelID, fmt.Sprintf("HTTP check failed: %s", errDetail))
 		return &ConnectivityResult{Connected: false, Reason: ReasonConnectionFailed + ": " + errDetail}, nil
 	}
 
@@ -62,12 +96,10 @@ func (s *Service) checkHTTP(ctx context.Context, tunnelID string) (*Connectivity
 
 	latencyMs := res.LatencyMs
 	if httpprobe.SuccessCode(res.HTTPCode) {
-		s.appLog.Debug("http-check", tunnelID, fmt.Sprintf("HTTP check successful: code=%d, latency=%dms", res.HTTPCode, latencyMs))
 		return &ConnectivityResult{Connected: true, Latency: &latencyMs}, nil
 	}
 
-	s.appLog.Warn("http-check", tunnelID, fmt.Sprintf("HTTP check returned unexpected code: %d", res.HTTPCode))
-	return &ConnectivityResult{Connected: false, Reason: ReasonUnexpectedResponse, HTTPCode: &res.HTTPCode}, nil
+	return &ConnectivityResult{Connected: false, Reason: fmt.Sprintf("%s: code=%d", ReasonUnexpectedResponse, res.HTTPCode), HTTPCode: &res.HTTPCode}, nil
 }
 
 // checkPing performs connectivity check using ICMP ping through the tunnel interface.
@@ -82,7 +114,6 @@ func (s *Service) checkPing(ctx context.Context, tunnelID string, stored *storag
 		target = autoDetectGateway(stored)
 	}
 	if target == "" {
-		s.appLog.Warn("ping-check", tunnelID, "No ping target configured for tunnel "+tunnelID)
 		return &ConnectivityResult{Connected: false, Reason: "no ping target configured"}, nil
 	}
 
@@ -94,11 +125,9 @@ func (s *Service) checkPing(ctx context.Context, tunnelID string, stored *storag
 
 	res, err := icmpprobe.ByInterface(pingCtx, iface, target, nil)
 	if err != nil {
-		s.appLog.Warn("ping-check", tunnelID, fmt.Sprintf("Ping failed: target=%s: %v", target, err))
 		return &ConnectivityResult{Connected: false, Reason: "ping failed: " + target + " - " + err.Error()}, nil
 	}
 
-	s.appLog.Debug("ping-check", tunnelID, fmt.Sprintf("Ping successful: target=%s, latency=%dms", target, res.LatencyMs))
 	return &ConnectivityResult{Connected: true, Latency: intPtr(res.LatencyMs)}, nil
 }
 
@@ -148,7 +177,7 @@ func (s *Service) checkHandshake(tunnelID string) (*ConnectivityResult, error) {
 	defer cancel()
 	result, err := exec.Run(ctx, "/opt/sbin/awg", "show", iface)
 	if err != nil {
-		s.appLog.Warn("handshake-check", tunnelID, fmt.Sprintf("Cannot read WG state: %v, stdout=%s, stderr=%s", err, result.Stdout, result.Stderr))
+		s.appLog.Debug("handshake-check", tunnelID, fmt.Sprintf("Cannot read WG state: %v, stdout=%s, stderr=%s", err, result.Stdout, result.Stderr))
 		return &ConnectivityResult{Connected: false, Reason: "cannot read WG state"}, nil
 	}
 
@@ -161,26 +190,22 @@ func (s *Service) checkHandshake(tunnelID string) (*ConnectivityResult, error) {
 		}
 		hs := strings.TrimSpace(strings.TrimPrefix(line, "latest handshake:"))
 		if hs == "(none)" || hs == "" {
-			s.appLog.Warn("handshake-check", tunnelID, "No handshake found")
 			return &ConnectivityResult{Connected: false, Reason: "no handshake"}, nil
 		}
 		if strings.Contains(hs, "hour") || strings.Contains(hs, "day") {
-			s.appLog.Warn("handshake-check", tunnelID, fmt.Sprintf("Handshake stale: %s", hs))
 			return &ConnectivityResult{Connected: false, Reason: "handshake stale: " + hs}, nil
 		}
 		if strings.Contains(hs, "minute") {
 			var mins int
 			fmt.Sscanf(hs, "%d minute", &mins)
 			if mins >= 3 {
-				s.appLog.Warn("handshake-check", tunnelID, fmt.Sprintf("Handshake stale: %s (%d min)", hs, mins))
 				return &ConnectivityResult{Connected: false, Reason: "handshake stale: " + hs}, nil
 			}
 		}
-		s.appLog.Info("handshake-check", tunnelID, fmt.Sprintf("Handshake recent: %s", hs))
+		s.appLog.Debug("handshake-check", tunnelID, fmt.Sprintf("Handshake recent: %s", hs))
 		return &ConnectivityResult{Connected: true}, nil
 	}
 
-	s.appLog.Warn("handshake-check", tunnelID, "No handshake info found in awg show output")
 	return &ConnectivityResult{Connected: false, Reason: "no handshake info"}, nil
 }
 

--- a/internal/testing/connectivity.go
+++ b/internal/testing/connectivity.go
@@ -58,23 +58,22 @@ func (s *Service) CheckConnectivity(ctx context.Context, tunnelID string) (*Conn
 // Warn пишется на переходе в отказ, Info на восстановлении с длиной серии,
 // повторы того же исхода видны только на debug.
 func (s *Service) logConnectivityOutcome(method, tunnelID string, res *ConnectivityResult) {
-	action := method + "-check"
-	if method == "http" {
-		action = "http-check"
-	}
+	// Единая метка: method приходит из хранимого конфига и не whitelisted —
+	// производная метка вида "<произвольное>-check" дробила бы фильтрацию.
+	const action = "connectivity-check"
 	latency := ""
 	if res.Latency != nil {
 		latency = fmt.Sprintf(", latency=%dms", *res.Latency)
 	}
 	switch obs := s.connTracker.Observe(tunnelID, res.Connected); obs.Kind {
 	case logging.TransitionNowFailing:
-		s.appLog.Warn(action, tunnelID, fmt.Sprintf("Connectivity check failed: %s", res.Reason))
+		s.appLog.Warn(action, tunnelID, fmt.Sprintf("Connectivity check (%s) failed: %s", method, res.Reason))
 	case logging.TransitionStillFailing:
-		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check still failing (%d in a row): %s", obs.Failures, res.Reason))
+		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check (%s) still failing (%d in a row): %s", method, obs.Failures, res.Reason))
 	case logging.TransitionRecovered:
 		s.appLog.Info(action, tunnelID, fmt.Sprintf("Connectivity restored after %d failed checks%s", obs.Failures, latency))
 	default: // FirstOK / StillOK
-		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check ok%s", latency))
+		s.appLog.Debug(action, tunnelID, fmt.Sprintf("Connectivity check (%s) ok%s", method, latency))
 	}
 }
 

--- a/internal/testing/connectivity.go
+++ b/internal/testing/connectivity.go
@@ -40,6 +40,9 @@ func (s *Service) CheckConnectivity(ctx context.Context, tunnelID string) (*Conn
 		result, err = s.checkHandshake(tunnelID)
 	case "disabled":
 		s.appLog.Debug("connectivity-check", tunnelID, "Check disabled, returning OK")
+		// Выключенная проверка не наблюдается трекером — сбрасываем серию,
+		// чтобы после включения первый отказ снова дал Warn, а не «повтор».
+		s.connTracker.Forget(tunnelID)
 		return &ConnectivityResult{Connected: true, Reason: "check disabled"}, nil
 	default:
 		result, err = s.checkHTTP(ctx, tunnelID)

--- a/internal/testing/service.go
+++ b/internal/testing/service.go
@@ -27,13 +27,18 @@ type Service struct {
 	awgStore *storage.AWGTunnelStore
 	settings *storage.SettingsStore
 	appLog   *logging.ScopedLogger
+	// connTracker классифицирует исходы connectivity-проверок по туннелям:
+	// в журнал попадают переходы (Warn на отказ, Info на восстановление),
+	// повторы одного и того же исхода — только Debug.
+	connTracker *logging.TransitionTracker
 }
 
 // NewService creates a new testing service.
 func NewService(awgStore *storage.AWGTunnelStore, appLogger logging.AppLogger) *Service {
 	return &Service{
-		awgStore: awgStore,
-		appLog:   logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubTest),
+		awgStore:    awgStore,
+		appLog:      logging.NewScopedLogger(appLogger, logging.GroupTunnel, logging.SubTest),
+		connTracker: logging.NewTransitionTracker(),
 	}
 }
 

--- a/internal/tunnel/wan/model.go
+++ b/internal/tunnel/wan/model.go
@@ -69,12 +69,16 @@ func (m *Model) SetRepopulateFn(fn func()) {
 // Called by hook handler on ipv4 state change.
 // If the interface is unknown and the model has been populated, triggers
 // a full re-populate from NDMS to discover newly configured WANs.
-func (m *Model) SetUp(name string, up bool) {
+// SetUp обновляет up-состояние интерфейса и сообщает, изменилось ли оно
+// фактически (NDMS может повторять hook-события с тем же уровнем —
+// вызывающий код логирует только реальные переходы).
+func (m *Model) SetUp(name string, up bool) (changed bool) {
 	m.mu.Lock()
 	if iface, ok := m.interfaces[name]; ok {
+		changed = iface.Up != up
 		iface.Up = up
 		m.mu.Unlock()
-		return
+		return changed
 	}
 	populated := m.populated
 	m.mu.Unlock()
@@ -85,10 +89,12 @@ func (m *Model) SetUp(name string, up bool) {
 		// Apply hook state after repopulate (NDMS snapshot may lag behind hook)
 		m.mu.Lock()
 		if iface, ok := m.interfaces[name]; ok {
+			changed = iface.Up != up
 			iface.Up = up
 		}
 		m.mu.Unlock()
 	}
+	return changed
 }
 
 // IsUp returns true if the named interface is up.

--- a/internal/tunnel/wan/model.go
+++ b/internal/tunnel/wan/model.go
@@ -89,7 +89,10 @@ func (m *Model) SetUp(name string, up bool) (changed bool) {
 		// Apply hook state after repopulate (NDMS snapshot may lag behind hook)
 		m.mu.Lock()
 		if iface, ok := m.interfaces[name]; ok {
-			changed = iface.Up != up
+			// Интерфейс был неизвестен модели до этого hook'а — его первое
+			// появление само по себе переход, даже если свежий NDMS-снапшот
+			// уже отражает up-состояние.
+			changed = true
 			iface.Up = up
 		}
 		m.mu.Unlock()


### PR DESCRIPTION
## Проблема

Главный журнал спамится connectivity-check'ами (Warn видимы всегда, авто-чеки повторяются при каждой навигации), а о реальных действиях программы журнал молчит — от применения конфига sing-box до восстановления настроек из бэкапа.

## Этап A — конец спама

- **Коалесцер повторов** (`89991231`): идентичная запись в окне 5 минут от последнего появления копится счётчиком в одной строке **×N** (бейдж в UI, окно продлевается от последнего повтора). Сквозь весь тракт: logbuf → Coalesce → SSE → REST/swagger → клиентский стор (upsert по ключу) → LogRow. Управа на неотключаемые повторяющиеся Warn.
- **Переходное connectivity-логирование** (`57272666`): `logging.TransitionTracker` — Warn только на переходе в отказ, Info на восстановлении с длиной серии, повторы — Debug. AWG (http/ping/handshake) + system-туннели.
- **Фиксы ревью** (`3c2db2ed`): SSE-timestamp приведён к формату REST (UTC RFC3339Nano; иначе upsert по ключу не находил REST-строки — паритет запинован тестом через шину); disabled-метод сбрасывает серию.

## Этап B — значимые события (`b35d96ef` + фикс ревью `921f29e8`)

Стартовая строка с версией и числом туннелей; Info «process restored» после авто-рестарта sing-box; итог обновления подписки с изменениями в app-журнал; переходы WAN up/down — **по ревью**: `Model.SetUp` возвращает факт изменения, лог пишется только на реальном переходе (NDMS повторяет хуки с тем же уровнем).

## Этап C — полная видимость (по двум аудитам покрытия)

**C1 — автономные события** (`98a7c1f1`): восстановление хранилищ после повреждения (карантин/.bak) через отложенный буфер `storage.DrainNotices` → Warn при связывании; переходы self-проб мониторинг-матрицы (ok→fail Warn / восстановление Info, edge-triggered, подгруппа `monitoring`); DNS-failover — продовый логгер не был подключён вовсе, теперь переключение/восстановление листов в `routing/dns-route`; активация анти-брутфорс блокировки логина (один раз на переход порога); успешный FakeIP drift-heal (закрытое окно утечки); ошибки NDMS Proxy migrate из slog в журнал; старт/финиш пересборки selective ipset; истечение сессии; сводка GC артефактов rule-set'ов.

**C2 — sing-box роутер и редактор** (`7ae99716`): ~50 целиком немых мутаций получили success-Info — enable/disable/режим/настройки роутера, **экспертный редактор 90-user.json** (применение сырого конфига — самое значимое нелогируемое действие), staging apply/discard, CRUD правил/rule-set'ов/outbound'ов/DNS/политик + пресеты, DNS-rewrites, весь FakeIP-конфиг, установка selective-зависимостей.

**C3 — хвост CRUD** (`0975d4a9`): подписки и сводные группы create/update/delete; managed update/LAN-сегменты + peer-операции Full→Info; access-policy Full→Info; HydraRoute settings; расширенный diff настроек (URL чека, download route, usage level, расписания, лимиты журнала); сводка bulk-смены бэкенда DNS-листов.

Всё новое — edge-triggered или по действию пользователя; спама не создаёт, коалесцер этапа A подстраховывает.

## Верификация

- Go: gofmt, vet, `go test ./...`, `-race` (logging/logbuf/monitoring/dnsroute/auth/api/singbox/storage), кросс MIPS softfloat + ARM64
- Новые тесты: коалесцер 7 (вкл. паритет SSE/REST), TransitionTracker 4, стор логов 5 vitest
- Frontend: svelte-check 0/0, eslint 0, vitest 1368, build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg