### PR TITLE
Серверы: полные настройки для перенесённых системных серверов

### DIFF
--- a/frontend/src/lib/components/servers/ServerCard.svelte
+++ b/frontend/src/lib/components/servers/ServerCard.svelte
@@ -266,18 +266,22 @@
 	}
 
 	function openConf(peer: ManagedPeer) {
+		// Клиент, созданный через AWG Manager, имеет сохранённые ключи —
+		// показываем готовый .conf (и для перенесённых серверов тоже).
+		const raw = managedPeerMap.get(peer.publicKey);
+		if (raw?.confAvailable) {
+			confPubkey = peer.publicKey;
+			confPeerName = peer.description || 'peer';
+			confModalOpen = true;
+			return;
+		}
 		if (isMarked) {
+			// Ключей нет (клиент создан в веб-интерфейсе Keenetic) — генератор
+			// собирает .conf по вручную введённому приватному ключу.
 			void openConfGenerator(peer.publicKey);
 			return;
 		}
-		const raw = managedPeerMap.get(peer.publicKey);
-		if (!raw?.confAvailable) {
-			notifications.warning('Конфиг недоступен — клиент создан вне AWG Manager или через KeenDNS');
-			return;
-		}
-		confPubkey = peer.publicKey;
-		confPeerName = peer.description || 'peer';
-		confModalOpen = true;
+		notifications.warning('Конфиг недоступен — клиент создан вне AWG Manager или через KeenDNS');
 	}
 
 	async function openConfGenerator(publicKey: string) {
@@ -306,7 +310,9 @@
 	);
 
 	$effect(() => {
-		if (!isBuiltIn) {
+		// WAN IP нужен подсказке endpoint-настройки — она видна и встроенному,
+		// и перенесённому системному серверу.
+		if (!isBuiltIn && !isMarked) {
 			builtinWanIP = '';
 			loadingBuiltinWanIP = false;
 			builtinWanIPLoadedFor = '';
@@ -386,7 +392,9 @@
 		<Stat value={`UDP :${server.listenPort}`} label="Listen" />
 	</StatStrip>
 
-	{#if isBuiltIn}
+	<!-- Панель настроек доступна и перенесённым системным серверам: бэкенд
+	     (NAT/политика/endpoint/пиры) принимает их наравне со встроенным. -->
+	{#if isBuiltIn || isMarked}
 		<ServerSettingsPanel persistKey="awgm:servers:settingsCollapsed">
 			<div class="setting-row setting-row-toggle">
 				<div class="setting-copy">
@@ -461,7 +469,7 @@
 					showSearch={(server.peers ?? []).length > 0}
 					hideSortOnDesktop
 				/>
-				{#if isBuiltIn}
+				{#if isBuiltIn || isMarked}
 					<Button variant="secondary" size="sm" onclick={() => (addPeerOpen = true)} iconBefore={addPeerIcon}>
 						Добавить клиента
 					</Button>
@@ -476,8 +484,8 @@
 				peers={sortedPeers}
 				{getPeerStats}
 				showPeerDownload={isBuiltIn || isMarked}
-				showPeerActions={isBuiltIn}
-				showPeerToggle={isBuiltIn}
+				showPeerActions={isBuiltIn || isMarked}
+				showPeerToggle={isBuiltIn || isMarked}
 				onTogglePeer={handleTogglePeer}
 				{isPeerToggling}
 				onOpenConf={openConf}


### PR DESCRIPTION
## Проблема

Системный WireGuard-интерфейс, перенесённый на страницу «Серверы» кнопкой «В серверы» со вкладки туннелей, показывал только статистику и read-only список клиентов — без настроек, которые есть у встроенного «Wireguard VPN Server».

## Что сделано

Оказалось, что бэкенд уже всё умеет: эндпоинты NAT/политики/endpoint и управления пирами (`requireListedServer`) принимают перенесённые серверы наравне со встроенным, и `enrichServerDTO` уже наполняет для них `natMode`/`policy`/`endpoint`/`*Known`. Вся дыра была во фронтовом гейте `isBuiltIn` в `ServerCard.svelte` — он и снят:

- Панель «Настройки доступа» — **NAT**, **Маршрутизация через sing-box**, **Политика доступа**, **Endpoint клиентов** — теперь рендерится и для перенесённых серверов (`isBuiltIn || isMarked`). WAN IP для подсказки endpoint грузится и для них.
- **«Добавить клиента»** и полные действия по пирам (вкл/выкл, редактирование, удаление) доступны перенесённым серверам.
- Скачивание конфига: клиент с сохранёнными ключами (создан через AWG Manager) получает готовый `.conf` и на перенесённом сервере; для клиентов из веб-интерфейса Keenetic остаётся генератор по вручную введённому ключу.
- «Вернуть в туннели» и бейдж «Системный» — без изменений.

Изменения только во фронте (`ServerCard.svelte`, +21/−13); новых эндпоинтов и изменений бэкенда нет.

## Проверка

- svelte-check 0/0, eslint чисто, vitest 1368 passed, build ок.
- Визуально на mock-стеке (mock содержит перенесённый сервер Wireguard9): панель настроек, добавление клиента и полные действия по пирам рендерятся; у встроенного сервера ничего не изменилось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_