### PR TITLE
sb-router: каталог SagerNet geosite — все наборы репозитория в один клик

### DIFF
--- a/frontend/src/lib/api/clientSbRouter.ts
+++ b/frontend/src/lib/api/clientSbRouter.ts
@@ -3,6 +3,7 @@ import type {
 	RouterPolicy,
 	RouterStagingStatusResponse,
 	SelectiveStatus,
+	SingboxGeositesData,
 	SingboxProxiesListResponse,
 	SingboxProxiesSelectRequest,
 	SingboxProxiesTestRequest,
@@ -145,6 +146,12 @@ export class SbRouterClient extends SingboxClient {
 
 	async singboxRouterListProxies(): Promise<SingboxProxiesListResponse> {
 		return this.request<SingboxProxiesListResponse>('/singbox/router/proxies/list');
+	}
+
+	async singboxRouterListGeosites(refresh = false): Promise<SingboxGeositesData> {
+		return this.request<SingboxGeositesData>(
+			`/singbox/router/geosites/list${refresh ? '?refresh=1' : ''}`,
+		);
 	}
 
 	async singboxRouterSelectProxy(req: SingboxProxiesSelectRequest): Promise<void> {

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1270,6 +1270,7 @@ const api_SingboxGeositesData: v.GenericSchema = v.looseObject({
 	baseUrl: v.optional(v.nullable(v.string())),
 	fetchedAt: v.optional(v.nullable(v.string())),
 	names: v.optional(v.nullable(v.array(v.string()))),
+	stale: v.optional(v.nullable(v.boolean())),
 });
 
 const api_SingboxInboundEntry: v.GenericSchema = v.looseObject({

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1266,6 +1266,12 @@ const api_SingboxDomainResolverDTO: v.GenericSchema = v.looseObject({
 	strategy: v.optional(v.nullable(v.string())),
 });
 
+const api_SingboxGeositesData: v.GenericSchema = v.looseObject({
+	baseUrl: v.optional(v.nullable(v.string())),
+	fetchedAt: v.optional(v.nullable(v.string())),
+	names: v.optional(v.nullable(v.array(v.string()))),
+});
+
 const api_SingboxInboundEntry: v.GenericSchema = v.looseObject({
 	idle: v.optional(v.nullable(v.boolean())),
 	idleReason: v.optional(v.nullable(v.string())),
@@ -2297,6 +2303,9 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /singbox/router/dns/rewrites/list": v.lazy(() => api_SingboxDNSRewritesListResponse),
 	"GET /singbox/router/dns/rules/list": v.lazy(() => api_SingboxDNSRulesListResponse),
 	"GET /singbox/router/dns/servers/list": v.lazy(() => api_SingboxDNSServersListResponse),
+	"GET /singbox/router/geosites/list": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxGeositesData))),
+})]),
 	"GET /singbox/router/ingress-eligible-interfaces": v.lazy(() => api_SingboxRouterWANInterfacesListResponse),
 	"GET /singbox/router/outbounds/list": v.lazy(() => api_SingboxRouterOutboundsListResponse),
 	"GET /singbox/router/policies": v.lazy(() => api_SingboxRouterPoliciesListResponse),

--- a/frontend/src/lib/components/sb-router/ExpertPanel.svelte
+++ b/frontend/src/lib/components/sb-router/ExpertPanel.svelte
@@ -1016,6 +1016,10 @@
   .rs-head-actions {
     display: flex;
     align-items: center;
+    /* Три кнопки не влезают в шапку панели на узких телефонах — перенос
+       вместо молчаливого обрезания overflow:hidden родителя. */
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
   }
   .panel-cap {

--- a/frontend/src/lib/components/sb-router/ExpertPanel.svelte
+++ b/frontend/src/lib/components/sb-router/ExpertPanel.svelte
@@ -45,7 +45,8 @@
   import RoutingTable from './RoutingTable.svelte';
   import RuleSetsTable from './RuleSetsTable.svelte';
   import SbRouterRuleSetCatalogModal from './SbRouterRuleSetCatalogModal.svelte';
-  import { applyCatalogPresetsAsRuleSets } from './rulesetCatalogActions';
+  import SbRouterGeositeCatalogModal from './SbRouterGeositeCatalogModal.svelte';
+  import { addGeositeRuleSets, applyCatalogPresetsAsRuleSets } from './rulesetCatalogActions';
   import OutboundsCompact from './OutboundsCompact.svelte';
   import DnsServersCompact from './DnsServersCompact.svelte';
   import DeviceProxyCompact from './DeviceProxyCompact.svelte';
@@ -235,6 +236,8 @@
   let rsAddOpen = $state(false);
   let rsCatalogOpen = $state(false);
   let rsCatalogBusy = $state(false);
+  let geositeCatalogOpen = $state(false);
+  let geositeCatalogBusy = $state(false);
   let outboundEditTag = $state<string | null>(null);
   let outboundAddOpen = $state(false);
   let dnsServerEditTag = $state<string | null>(null);
@@ -570,6 +573,34 @@
     }
   }
 
+  async function handleGeositeCatalogConfirm(names: string[], baseUrl: string) {
+    if (geositeCatalogBusy || names.length === 0) return;
+    geositeCatalogBusy = true;
+    try {
+      const result = await addGeositeRuleSets(names, baseUrl, $storeRuleSets);
+      await singboxRouterStore.loadAll();
+
+      if (result.added.length > 0) {
+        notifications.success(
+          `Добавлено ${pluralize(result.added.length, SET_WORDS)} из каталога SagerNet`,
+        );
+      } else if (result.failures.length === 0) {
+        notifications.info('Выбранные наборы уже есть в конфиге');
+      }
+
+      if (result.failures.length > 0) {
+        const msg = result.failures.map((f) => `${f.tag}: ${f.error}`).join('; ');
+        notifications.error(`Не удалось добавить: ${msg}`);
+      } else {
+        geositeCatalogOpen = false;
+      }
+    } catch (e) {
+      notifications.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      geositeCatalogBusy = false;
+    }
+  }
+
   // Outbound handlers
   async function handleOutboundAddSave(o: SingboxRouterOutbound) {
     await api.singboxRouterAddOutbound(o);
@@ -692,6 +723,14 @@
                 <LayoutGrid size={14} aria-hidden="true" />
               {/snippet}
               Каталог
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onclick={() => (geositeCatalogOpen = true)}
+              title="Все geosite-наборы из репозитория SagerNet/sing-geosite"
+            >
+              SagerNet
             </Button>
             <Button variant="primary" size="sm" onclick={() => (rsAddOpen = true)}>+ Набор</Button>
           </div>
@@ -840,6 +879,16 @@
     if (!rsCatalogBusy) rsCatalogOpen = false;
   }}
   onconfirm={handleRsCatalogConfirm}
+/>
+
+<SbRouterGeositeCatalogModal
+  open={geositeCatalogOpen}
+  existingRuleSetTags={$storeRuleSets.map((rs) => rs.tag)}
+  submitting={geositeCatalogBusy}
+  onclose={() => {
+    if (!geositeCatalogBusy) geositeCatalogOpen = false;
+  }}
+  onconfirm={handleGeositeCatalogConfirm}
 />
 
 <!-- RuleSetAddModal: add -->

--- a/frontend/src/lib/components/sb-router/SbRouterGeositeCatalogModal.svelte
+++ b/frontend/src/lib/components/sb-router/SbRouterGeositeCatalogModal.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
 	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
 	import { Badge, Button, Modal } from '$lib/components/ui';
 	import { RefreshCw } from 'lucide-svelte';
 	import type { SingboxGeositesData } from '$lib/types';
@@ -44,9 +45,20 @@
 		loading = true;
 		loadError = '';
 		try {
-			catalog = await api.singboxRouterListGeosites(refresh);
+			const fresh = await api.singboxRouterListGeosites(refresh);
+			catalog = fresh;
+			if (refresh && fresh.stale) {
+				// Бэкенд не смог обновиться и отдал сохранённую копию.
+				notifications.warning('GitHub недоступен — показан сохранённый список');
+			}
 		} catch (e) {
-			loadError = e instanceof Error ? e.message : String(e);
+			const msg = e instanceof Error ? e.message : String(e);
+			if (catalog) {
+				// Неудачное обновление не должно прятать уже загруженный список.
+				notifications.error(`Не удалось обновить список: ${msg}`);
+			} else {
+				loadError = msg;
+			}
 		} finally {
 			loading = false;
 		}
@@ -58,10 +70,20 @@
 
 	$effect(() => {
 		if (!open) {
-			// Выбор и поиск не переживают закрытие; загруженный список — да.
+			// Выбор, поиск и ошибка не переживают закрытие (повторное открытие
+			// снова пробует загрузку); загруженный список — да.
 			selected = new Set();
 			query = '';
+			loadError = '';
 		}
+	});
+
+	$effect(() => {
+		// Успешно добавленные (частичный сбой оставляет модалку открытой)
+		// выбывают из выбора: иначе счётчик врёт, а повторный confirm
+		// рапортует «уже есть в конфиге» про только что добавленные.
+		const remaining = [...selected].filter((n) => !existingTagSet.has(`geosite-${n}`));
+		if (remaining.length !== selected.size) selected = new Set(remaining);
 	});
 
 	function isAdded(name: string): boolean {
@@ -113,7 +135,7 @@
 		{:else if filtered.length === 0}
 			<div class="state">Ничего не найдено по «{query}».</div>
 		{:else}
-			<div class="list" role="listbox" aria-multiselectable="true">
+			<div class="list">
 				{#each rendered as name (name)}
 					{@const added = isAdded(name)}
 					<button
@@ -121,8 +143,7 @@
 						class="row"
 						class:selected={selected.has(name)}
 						class:added
-						role="option"
-						aria-selected={selected.has(name)}
+						aria-pressed={selected.has(name)}
 						disabled={added}
 						onclick={() => toggle(name)}
 					>

--- a/frontend/src/lib/components/sb-router/SbRouterGeositeCatalogModal.svelte
+++ b/frontend/src/lib/components/sb-router/SbRouterGeositeCatalogModal.svelte
@@ -1,0 +1,264 @@
+<!--
+  Каталог SagerNet sing-geosite: полный список geosite-наборов из ветки
+  rule-set (~1.5 тыс.) с поиском и добавлением remote rule-set'ов в один
+  клик. Дополнение к курируемому каталогу пресетов, не замена: здесь нет
+  описаний и иконок, зато есть всё, что публикует SagerNet.
+-->
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import { Badge, Button, Modal } from '$lib/components/ui';
+	import { RefreshCw } from 'lucide-svelte';
+	import type { SingboxGeositesData } from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		existingRuleSetTags: string[];
+		submitting?: boolean;
+		onclose: () => void;
+		onconfirm: (names: string[], baseUrl: string) => void;
+	}
+
+	let { open = false, existingRuleSetTags, submitting = false, onclose, onconfirm }: Props = $props();
+
+	// Больше строк за раз рендерить незачем: поиск сужает список быстрее,
+	// чем его можно проскроллить.
+	const RENDER_CAP = 300;
+
+	let catalog = $state<SingboxGeositesData | null>(null);
+	let loading = $state(false);
+	let loadError = $state('');
+	let query = $state('');
+	let selected = $state(new Set<string>());
+
+	const existingTagSet = $derived(new Set(existingRuleSetTags));
+
+	const filtered = $derived.by(() => {
+		const names = catalog?.names ?? [];
+		const q = query.trim().toLowerCase();
+		if (!q) return names;
+		return names.filter((n) => n.toLowerCase().includes(q));
+	});
+	const rendered = $derived(filtered.slice(0, RENDER_CAP));
+
+	async function load(refresh = false): Promise<void> {
+		loading = true;
+		loadError = '';
+		try {
+			catalog = await api.singboxRouterListGeosites(refresh);
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (open && !catalog && !loading && !loadError) void load();
+	});
+
+	$effect(() => {
+		if (!open) {
+			// Выбор и поиск не переживают закрытие; загруженный список — да.
+			selected = new Set();
+			query = '';
+		}
+	});
+
+	function isAdded(name: string): boolean {
+		return existingTagSet.has(`geosite-${name}`);
+	}
+
+	function toggle(name: string): void {
+		if (isAdded(name)) return;
+		const next = new Set(selected);
+		if (next.has(name)) next.delete(name);
+		else next.add(name);
+		selected = next;
+	}
+
+	function confirm(): void {
+		if (submitting || selected.size === 0 || !catalog) return;
+		onconfirm([...selected], catalog.baseUrl);
+	}
+</script>
+
+<Modal {open} title="Каталог SagerNet geosite" size="lg" bodyLayout="fill" {onclose}>
+	<div class="geosite-body">
+		<div class="toolbar">
+			<input
+				type="search"
+				class="search"
+				placeholder="Поиск по {catalog?.names.length ?? 0} наборам…"
+				bind:value={query}
+				disabled={loading || !!loadError}
+			/>
+			<Button
+				variant="ghost"
+				size="sm"
+				onclick={() => void load(true)}
+				disabled={loading}
+				title="Обновить список с GitHub"
+			>
+				<RefreshCw size={14} aria-hidden="true" />
+			</Button>
+		</div>
+
+		{#if loading}
+			<div class="state">Загружаем список наборов с GitHub…</div>
+		{:else if loadError}
+			<div class="state state-error">
+				<div>{loadError}</div>
+				<Button variant="secondary" size="sm" onclick={() => void load()}>Повторить</Button>
+			</div>
+		{:else if filtered.length === 0}
+			<div class="state">Ничего не найдено по «{query}».</div>
+		{:else}
+			<div class="list" role="listbox" aria-multiselectable="true">
+				{#each rendered as name (name)}
+					{@const added = isAdded(name)}
+					<button
+						type="button"
+						class="row"
+						class:selected={selected.has(name)}
+						class:added
+						role="option"
+						aria-selected={selected.has(name)}
+						disabled={added}
+						onclick={() => toggle(name)}
+					>
+						<span class="row-name">{name}</span>
+						{#if added}
+							<Badge variant="default" size="sm">добавлено</Badge>
+						{:else if selected.has(name)}
+							<span class="row-check" aria-hidden="true">✓</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+			{#if filtered.length > RENDER_CAP}
+				<div class="cap-hint">
+					Показаны первые {RENDER_CAP} из {filtered.length} — уточните запрос.
+				</div>
+			{/if}
+		{/if}
+
+		<p class="hint">
+			Набор добавляется как remote rule-set <code>geosite-&lt;имя&gt;</code> (скачивает sing-box,
+			обновление раз в 24 ч). Правило маршрутизации к нему создаётся отдельно.
+		</p>
+	</div>
+
+	{#snippet actions()}
+		<Button variant="secondary" onclick={onclose} disabled={submitting}>Отмена</Button>
+		<Button
+			variant="primary"
+			onclick={confirm}
+			disabled={submitting || selected.size === 0}
+			loading={submitting}
+		>
+			Добавить наборы{selected.size > 0 ? ` (${selected.size})` : ''}
+		</Button>
+	{/snippet}
+</Modal>
+
+<style>
+	.geosite-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		min-height: 0;
+		height: 100%;
+		padding: 0.25rem 0;
+	}
+	.toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.search {
+		flex: 1;
+		min-width: 0;
+		padding: 0.45rem 0.7rem;
+		background: var(--color-bg-tertiary, var(--bg-tertiary));
+		border: 1px solid var(--color-border, var(--border));
+		border-radius: var(--radius-sm, 8px);
+		color: var(--text-primary);
+		font-size: 0.875rem;
+	}
+	.list {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		border: 1px solid var(--color-border, var(--border));
+		border-radius: var(--radius-sm, 8px);
+	}
+	.row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.4rem 0.75rem;
+		background: transparent;
+		border: 0;
+		border-bottom: 1px solid color-mix(in srgb, var(--color-border, var(--border)) 55%, transparent);
+		color: var(--text-primary);
+		cursor: pointer;
+		text-align: left;
+	}
+	.row:last-child {
+		border-bottom: 0;
+	}
+	@media (hover: hover) {
+		.row:hover:not(:disabled) {
+			background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
+		}
+	}
+	.row.selected {
+		background: color-mix(in srgb, var(--color-accent, var(--accent)) 12%, transparent);
+	}
+	.row.added {
+		cursor: default;
+		color: var(--text-muted);
+	}
+	.row-name {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.row-check {
+		color: var(--color-accent, var(--accent));
+		font-weight: 700;
+		flex-shrink: 0;
+	}
+	.state {
+		padding: 1.5rem 0.5rem;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.state-error {
+		color: var(--color-error, #e06a5a);
+		overflow-wrap: anywhere;
+	}
+	.cap-hint {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+	.hint {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		line-height: 1.4;
+	}
+	.hint code {
+		font-family: var(--font-mono);
+	}
+</style>

--- a/frontend/src/lib/components/sb-router/rulesetCatalogActions.test.ts
+++ b/frontend/src/lib/components/sb-router/rulesetCatalogActions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  addGeositeRuleSets,
   applyCatalogPresetsAsRuleSets,
   fullyAddedPresetNames,
 } from './rulesetCatalogActions';
@@ -121,5 +122,47 @@ describe('applyCatalogPresetsAsRuleSets', () => {
 
     expect(result.failures).toEqual([{ tag: 'geosite-netflix', error: 'boom' }]);
     expect(result.added).toEqual(['geosite-youtube']);
+  });
+});
+
+describe('addGeositeRuleSets', () => {
+  beforeEach(() => {
+    vi.mocked(api.singboxRouterAddRuleSet).mockReset();
+    vi.mocked(api.singboxRouterAddRuleSet).mockResolvedValue(undefined);
+  });
+
+  const BASE = 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/';
+
+  it('строит тег geosite-<имя> и URL <baseUrl>geosite-<имя>.srs', async () => {
+    const result = await addGeositeRuleSets(['xiaomi@cn'], BASE, []);
+
+    expect(api.singboxRouterAddRuleSet).toHaveBeenCalledWith({
+      tag: 'geosite-xiaomi@cn',
+      type: 'remote',
+      format: 'binary',
+      url: `${BASE}geosite-xiaomi@cn.srs`,
+      update_interval: '24h',
+    });
+    expect(result.added).toEqual(['geosite-xiaomi@cn']);
+  });
+
+  it('пропускает уже существующие теги без вызова API', async () => {
+    const existing: SingboxRouterRuleSet[] = [{ tag: 'geosite-youtube', type: 'remote' }];
+    const result = await addGeositeRuleSets(['youtube', 'netflix'], BASE, existing);
+
+    expect(api.singboxRouterAddRuleSet).toHaveBeenCalledTimes(1);
+    expect(result.skipped).toEqual(['geosite-youtube']);
+    expect(result.added).toEqual(['geosite-netflix']);
+  });
+
+  it('собирает сбои, не прерывая пакет', async () => {
+    vi.mocked(api.singboxRouterAddRuleSet)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await addGeositeRuleSets(['a', 'b'], BASE, []);
+
+    expect(result.failures).toEqual([{ tag: 'geosite-a', error: 'boom' }]);
+    expect(result.added).toEqual(['geosite-b']);
   });
 });

--- a/frontend/src/lib/components/sb-router/rulesetCatalogActions.ts
+++ b/frontend/src/lib/components/sb-router/rulesetCatalogActions.ts
@@ -49,29 +49,61 @@ export async function applyCatalogPresetsAsRuleSets(
       emptyPresets.push(preset.id);
       continue;
     }
-    for (const ref of refs) {
-      if (existingTags.has(ref.tag)) {
-        skipped.push(ref.tag);
-        continue;
-      }
-      try {
-        await addFn({
-          tag: ref.tag,
-          type: 'remote',
-          format: 'binary',
-          url: ref.url,
-          update_interval: '24h',
-        });
-        existingTags.add(ref.tag);
-        added.push(ref.tag);
-      } catch (e) {
-        failures.push({
-          tag: ref.tag,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    }
+    await addRemoteRuleSetRefs(refs, existingTags, addFn, { added, skipped, failures });
   }
 
   return { added, skipped, failures, emptyPresets };
+}
+
+/** Add remote rule-sets from SagerNet geosite catalog names (no routing rules).
+ *  Тег строится как `geosite-<name>`, URL — `<baseUrl>geosite-<name>.srs`. */
+export async function addGeositeRuleSets(
+  names: string[],
+  baseUrl: string,
+  existingRuleSets: SingboxRouterRuleSet[],
+  addRuleSetFn?: AddRuleSetFn,
+): Promise<ApplyRuleSetsFromCatalogResult> {
+  const addFn: AddRuleSetFn = addRuleSetFn ?? ((rs) => api.singboxRouterAddRuleSet(rs));
+  const existingTags = new Set(existingRuleSets.map((rs) => rs.tag));
+  const added: string[] = [];
+  const skipped: string[] = [];
+  const failures: Array<{ tag: string; error: string }> = [];
+
+  const refs = names.map((name) => ({
+    tag: `geosite-${name}`,
+    url: `${baseUrl}geosite-${name}.srs`,
+  }));
+  await addRemoteRuleSetRefs(refs, existingTags, addFn, { added, skipped, failures });
+
+  return { added, skipped, failures, emptyPresets: [] };
+}
+
+async function addRemoteRuleSetRefs(
+  refs: Array<{ tag: string; url: string }>,
+  existingTags: Set<string>,
+  addFn: AddRuleSetFn,
+  out: { added: string[]; skipped: string[]; failures: Array<{ tag: string; error: string }> },
+): Promise<void> {
+  for (const ref of refs) {
+    if (existingTags.has(ref.tag)) {
+      out.skipped.push(ref.tag);
+      continue;
+    }
+    try {
+      await addFn({
+        tag: ref.tag,
+        type: 'remote',
+        format: 'binary',
+        url: ref.url,
+        update_interval: '24h',
+      });
+      existingTags.add(ref.tag);
+      out.added.push(ref.tag);
+    } catch (e) {
+      out.failures.push({
+        tag: ref.tag,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
 }

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -323,6 +323,15 @@ export interface SingboxProxiesListResponse {
 	groups: SingboxProxyGroup[];
 }
 
+/** GET /singbox/router/geosites/list — каталог SagerNet sing-geosite. */
+export interface SingboxGeositesData {
+	/** Имена без префикса geosite- и суффикса .srs. */
+	names: string[];
+	/** baseUrl + "geosite-" + name + ".srs" — готовый URL rule-set'а. */
+	baseUrl: string;
+	fetchedAt: string;
+}
+
 export interface SingboxProxiesSelectRequest {
 	group: string;
 	member: string;

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -330,6 +330,8 @@ export interface SingboxGeositesData {
 	/** baseUrl + "geosite-" + name + ".srs" — готовый URL rule-set'а. */
 	baseUrl: string;
 	fetchedAt: string;
+	/** Обновление не удалось — отдана сохранённая копия. */
+	stale?: boolean;
 }
 
 export interface SingboxProxiesSelectRequest {

--- a/internal/api/singbox_geosites.go
+++ b/internal/api/singbox_geosites.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/downloader"
+	"github.com/hoaxisr/awg-manager/internal/response"
+)
+
+// Каталог SagerNet sing-geosite: полный список geosite-наборов из ветки
+// rule-set (~1.5 тыс. имён) для добавления remote rule-set'ов в один клик —
+// дополнение к курируемому каталогу пресетов, не замена. Список берётся из
+// GitHub tree API через маршрут загрузок пользователя (GitHub может быть
+// доступен только через туннель) и кэшируется в памяти: лимит анонимного
+// GitHub API — 60 запросов/час с IP, а список меняется редко.
+
+const (
+	geositeTreeAPIURL = "https://api.github.com/repos/SagerNet/sing-geosite/git/trees/rule-set"
+	// GeositeRawURLBase — база raw-ссылок на .srs; отдаётся фронту, чтобы
+	// URL добавляемых rule-set'ов строились в одном месте.
+	geositeRawURLBase = "https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/"
+
+	geositeCacheTTL     = 24 * time.Hour
+	geositeFetchTimeout = 45 * time.Second
+	// geositeMaxResponse ограничивает чтение ответа tree API: ~1.5 тыс.
+	// записей занимают ~500 КБ, 20 МБ — щедрый потолок против мусорного
+	// ответа промежуточного прокси.
+	geositeMaxResponse = 20 << 20
+)
+
+// SingboxGeositesData is the payload for GET /singbox/router/geosites/list.
+type SingboxGeositesData struct {
+	// Names — имена наборов без префикса geosite- и суффикса .srs
+	// (например "youtube", "category-ads-all", "xiaomi@cn").
+	Names []string `json:"names"`
+	// BaseURL + "geosite-" + name + ".srs" — готовый URL для rule-set.
+	BaseURL   string `json:"baseUrl" example:"https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/"`
+	FetchedAt string `json:"fetchedAt" example:"2026-07-12T10:00:00Z"`
+}
+
+// SingboxGeositesHandler serves the SagerNet geosite catalog.
+type SingboxGeositesHandler struct {
+	downloadSvc *downloader.Service
+	treeURL     string
+
+	mu        sync.Mutex
+	names     []string
+	fetchedAt time.Time
+}
+
+func NewSingboxGeositesHandler(downloadSvc *downloader.Service) *SingboxGeositesHandler {
+	if downloadSvc == nil {
+		downloadSvc = downloader.NewService(downloader.Deps{})
+	}
+	return &SingboxGeositesHandler{downloadSvc: downloadSvc, treeURL: geositeTreeAPIURL}
+}
+
+// List handles GET /api/singbox/router/geosites/list.
+//
+//	@Summary		List SagerNet sing-geosite catalog
+//	@Description	Full list of geosite rule-set names from the SagerNet/sing-geosite rule-set branch, cached for 24h. Pass refresh=1 to force a re-fetch.
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			refresh	query		int	false	"1 = force refresh"
+//	@Success		200		{object}	OkResponse{data=SingboxGeositesData}
+//	@Failure		502		{object}	APIErrorEnvelope	"listing fetch failed"
+//	@Router			/singbox/router/geosites/list [get]
+func (h *SingboxGeositesHandler) List(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	force := r.URL.Query().Get("refresh") == "1"
+	names, fetchedAt, err := h.get(r, force)
+	if err != nil {
+		response.ErrorWithStatus(w, http.StatusBadGateway,
+			"не удалось получить список geosite с GitHub: "+err.Error(), "GEOSITE_FETCH_FAILED")
+		return
+	}
+	response.Success(w, SingboxGeositesData{
+		Names:     names,
+		BaseURL:   geositeRawURLBase,
+		FetchedAt: fetchedAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// get возвращает кэшированный список или обновляет его. Фетч идёт под
+// мьютексом: конкурентные открытия каталога ждут один общий запрос вместо
+// расходования анонимного rate-limit GitHub.
+func (h *SingboxGeositesHandler) get(r *http.Request, force bool) ([]string, time.Time, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !force && h.names != nil && time.Since(h.fetchedAt) < geositeCacheTTL {
+		return h.names, h.fetchedAt, nil
+	}
+	names, err := h.fetch(r)
+	if err != nil {
+		if h.names != nil {
+			// Протухший кэш полезнее ошибки: GitHub мог стать недоступен,
+			// а список меняется редко.
+			return h.names, h.fetchedAt, nil
+		}
+		return nil, time.Time{}, err
+	}
+	h.names = names
+	h.fetchedAt = time.Now()
+	return h.names, h.fetchedAt, nil
+}
+
+func (h *SingboxGeositesHandler) fetch(r *http.Request) ([]string, error) {
+	// Отвязка от клиентского контекста: обрыв соединения (пользователь
+	// закрыл модалку) не должен ронять фетч, за которым в очереди под
+	// мьютексом могут ждать другие запросы.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), geositeFetchTimeout)
+	defer cancel()
+
+	lease, err := h.downloadSvc.ResolveClient(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolve download client: %w", err)
+	}
+	defer lease.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.treeURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "awg-manager")
+
+	resp, err := lease.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body := io.LimitReader(resp.Body, geositeMaxResponse)
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(body, 300))
+		return nil, fmt.Errorf("github tree api: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var tree struct {
+		Truncated bool `json:"truncated"`
+		Tree      []struct {
+			Path string `json:"path"`
+		} `json:"tree"`
+	}
+	if err := json.NewDecoder(body).Decode(&tree); err != nil {
+		return nil, fmt.Errorf("decode tree listing: %w", err)
+	}
+
+	names := make([]string, 0, len(tree.Tree))
+	for _, entry := range tree.Tree {
+		name, ok := strings.CutPrefix(entry.Path, "geosite-")
+		if !ok {
+			continue
+		}
+		name, ok = strings.CutSuffix(name, ".srs")
+		if !ok || name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("listing came back empty (truncated=%v, entries=%d)", tree.Truncated, len(tree.Tree))
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/internal/api/singbox_geosites.go
+++ b/internal/api/singbox_geosites.go
@@ -36,6 +36,16 @@ const (
 	geositeMaxResponse = 20 << 20
 )
 
+const (
+	// geositeFailCooldown — пауза между попытками после неудачного фетча:
+	// без неё каждый запрос при протухшем кэше и недоступном GitHub жёг бы
+	// анонимный rate-limit (60/час) и висел бы до geositeFetchTimeout.
+	geositeFailCooldown = time.Minute
+	// geositeAttemptDebounce гасит дубли refresh=1 (двойной клик, два
+	// открытых каталога): попытка только что была — её результат и отдаём.
+	geositeAttemptDebounce = 5 * time.Second
+)
+
 // SingboxGeositesData is the payload for GET /singbox/router/geosites/list.
 type SingboxGeositesData struct {
 	// Names — имена наборов без префикса geosite- и суффикса .srs
@@ -44,6 +54,9 @@ type SingboxGeositesData struct {
 	// BaseURL + "geosite-" + name + ".srs" — готовый URL для rule-set.
 	BaseURL   string `json:"baseUrl" example:"https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/"`
 	FetchedAt string `json:"fetchedAt" example:"2026-07-12T10:00:00Z"`
+	// Stale — список отдан из кэша, потому что обновление не удалось
+	// (GitHub недоступен). Фронт показывает предупреждение при refresh=1.
+	Stale bool `json:"stale,omitempty"`
 }
 
 // SingboxGeositesHandler serves the SagerNet geosite catalog.
@@ -51,9 +64,14 @@ type SingboxGeositesHandler struct {
 	downloadSvc *downloader.Service
 	treeURL     string
 
-	mu        sync.Mutex
-	names     []string
-	fetchedAt time.Time
+	mu          sync.Mutex
+	names       []string
+	fetchedAt   time.Time
+	lastAttempt time.Time
+	lastErr     string
+	// inflight != nil — фетч уже идёт; закрывается по завершении. Ожидают
+	// его только запросы без кэша, остальные отдают stale немедленно.
+	inflight chan struct{}
 }
 
 func NewSingboxGeositesHandler(downloadSvc *downloader.Service) *SingboxGeositesHandler {
@@ -80,40 +98,90 @@ func (h *SingboxGeositesHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	force := r.URL.Query().Get("refresh") == "1"
-	names, fetchedAt, err := h.get(r, force)
+	names, fetchedAt, stale, err := h.get(r, force)
 	if err != nil {
 		response.ErrorWithStatus(w, http.StatusBadGateway,
-			"не удалось получить список geosite с GitHub: "+err.Error(), "GEOSITE_FETCH_FAILED")
+			"не удалось получить список geosite: "+err.Error(), "GEOSITE_FETCH_FAILED")
 		return
 	}
 	response.Success(w, SingboxGeositesData{
 		Names:     names,
 		BaseURL:   geositeRawURLBase,
 		FetchedAt: fetchedAt.UTC().Format(time.RFC3339),
+		Stale:     stale,
 	})
 }
 
-// get возвращает кэшированный список или обновляет его. Фетч идёт под
-// мьютексом: конкурентные открытия каталога ждут один общий запрос вместо
-// расходования анонимного rate-limit GitHub.
-func (h *SingboxGeositesHandler) get(r *http.Request, force bool) ([]string, time.Time, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if !force && h.names != nil && time.Since(h.fetchedAt) < geositeCacheTTL {
-		return h.names, h.fetchedAt, nil
-	}
-	names, err := h.fetch(r)
-	if err != nil {
-		if h.names != nil {
-			// Протухший кэш полезнее ошибки: GitHub мог стать недоступен,
-			// а список меняется редко.
-			return h.names, h.fetchedAt, nil
+// get возвращает кэшированный список или обновляет его. Фетч выполняется
+// ВНЕ мьютекса (зависший GitHub не должен блокировать warm-cache чтения) и
+// дедуплицируется каналом inflight: конкурентные промахи ждут один общий
+// запрос вместо расходования анонимного rate-limit GitHub; запросы с живым
+// кэшем во время чужого фетча немедленно получают stale-копию.
+func (h *SingboxGeositesHandler) get(r *http.Request, force bool) (names []string, fetchedAt time.Time, stale bool, err error) {
+	for {
+		h.mu.Lock()
+		fresh := h.names != nil && time.Since(h.fetchedAt) < geositeCacheTTL
+		if fresh && !force {
+			names, fetchedAt = h.names, h.fetchedAt
+			h.mu.Unlock()
+			return names, fetchedAt, false, nil
 		}
-		return nil, time.Time{}, err
+		// Дебаунс: попытка (удачная или нет) была только что — отдаём её
+		// результат, не плодя фетчи на двойной клик по «Обновить».
+		if time.Since(h.lastAttempt) < geositeAttemptDebounce {
+			return h.finishLocked()
+		}
+		// Пауза после неудачи: не жжём rate-limit на каждый запрос, пока
+		// GitHub лежит. Явный refresh=1 паузу пробивает.
+		if !force && h.lastErr != "" && time.Since(h.lastAttempt) < geositeFailCooldown {
+			return h.finishLocked()
+		}
+		if h.inflight != nil {
+			ch := h.inflight
+			if h.names != nil {
+				// stale-while-revalidate: чужой фетч уже идёт — не ждём его.
+				names, fetchedAt = h.names, h.fetchedAt
+				h.mu.Unlock()
+				return names, fetchedAt, true, nil
+			}
+			h.mu.Unlock()
+			<-ch
+			continue
+		}
+		ch := make(chan struct{})
+		h.inflight = ch
+		h.mu.Unlock()
+
+		fetched, ferr := h.fetch(r)
+
+		h.mu.Lock()
+		h.inflight = nil
+		close(ch)
+		h.lastAttempt = time.Now()
+		if ferr != nil {
+			h.lastErr = ferr.Error()
+		} else {
+			h.lastErr = ""
+			h.names = fetched
+			h.fetchedAt = time.Now()
+		}
+		return h.finishLocked()
 	}
-	h.names = names
-	h.fetchedAt = time.Now()
-	return h.names, h.fetchedAt, nil
+}
+
+// finishLocked формирует ответ из текущего состояния кэша и отпускает
+// мьютекс: свежий/протухший список — успех (stale по наличию lastErr),
+// пустой кэш — последняя ошибка фетча.
+func (h *SingboxGeositesHandler) finishLocked() ([]string, time.Time, bool, error) {
+	defer h.mu.Unlock()
+	if h.names != nil {
+		return h.names, h.fetchedAt, h.lastErr != "", nil
+	}
+	err := h.lastErr
+	if err == "" {
+		err = "список ещё не загружен"
+	}
+	return nil, time.Time{}, false, fmt.Errorf("%s", err)
 }
 
 func (h *SingboxGeositesHandler) fetch(r *http.Request) ([]string, error) {
@@ -135,6 +203,7 @@ func (h *SingboxGeositesHandler) fetch(r *http.Request) ([]string, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "awg-manager")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
 	resp, err := lease.Client.Do(req)
 	if err != nil {
@@ -156,6 +225,11 @@ func (h *SingboxGeositesHandler) fetch(r *http.Request) ([]string, error) {
 	}
 	if err := json.NewDecoder(body).Decode(&tree); err != nil {
 		return nil, fmt.Errorf("decode tree listing: %w", err)
+	}
+	if tree.Truncated {
+		// Частичный листинг хуже ошибки: он закэшируется на сутки, и
+		// пользователь молча не увидит часть каталога.
+		return nil, fmt.Errorf("github tree api: listing truncated (%d entries)", len(tree.Tree))
 	}
 
 	names := make([]string, 0, len(tree.Tree))

--- a/internal/api/singbox_geosites_test.go
+++ b/internal/api/singbox_geosites_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func geositeTreeJSON(paths ...string) string {
+func geositeTreeJSON(truncated bool, paths ...string) string {
 	type entry struct {
 		Path string `json:"path"`
 	}
@@ -17,7 +17,7 @@ func geositeTreeJSON(paths ...string) string {
 	for _, p := range paths {
 		entries = append(entries, entry{Path: p})
 	}
-	b, _ := json.Marshal(map[string]any{"truncated": false, "tree": entries})
+	b, _ := json.Marshal(map[string]any{"truncated": truncated, "tree": entries})
 	return string(b)
 }
 
@@ -32,6 +32,14 @@ func newGeositesTestHandler(t *testing.T, upstream http.HandlerFunc) (*SingboxGe
 	h := NewSingboxGeositesHandler(nil)
 	h.treeURL = srv.URL
 	return h, &calls
+}
+
+// rewindGeositeAttempt отматывает дебаунс/кулдаун, чтобы тест мог сразу
+// провоцировать следующий фетч.
+func rewindGeositeAttempt(h *SingboxGeositesHandler, back time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastAttempt = h.lastAttempt.Add(-back)
 }
 
 func geositesList(t *testing.T, h *SingboxGeositesHandler, url string) (*httptest.ResponseRecorder, SingboxGeositesData) {
@@ -54,7 +62,7 @@ func geositesList(t *testing.T, h *SingboxGeositesHandler, url string) (*httptes
 // посторонние файлы отбрасываются, порядок — сортированный.
 func TestGeositesList_ParsesAndSorts(t *testing.T) {
 	h, calls := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(geositeTreeJSON(
+		_, _ = w.Write([]byte(geositeTreeJSON(false,
 			"geosite-youtube.srs",
 			"geosite-category-ads-all.srs",
 			"README.md",
@@ -80,70 +88,103 @@ func TestGeositesList_ParsesAndSorts(t *testing.T) {
 	if data.BaseURL == "" || data.FetchedAt == "" {
 		t.Errorf("baseUrl/fetchedAt must be set, got %+v", data)
 	}
+	if data.Stale {
+		t.Error("fresh fetch must not be stale")
+	}
 	if calls.Load() != 1 {
 		t.Errorf("expected 1 upstream call, got %d", calls.Load())
 	}
 
 	// Повторный запрос — из кэша, без нового обращения к GitHub.
-	rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
-	if rec2.Code != http.StatusOK {
+	if rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec2.Code != http.StatusOK {
 		t.Fatalf("cached status %d", rec2.Code)
 	}
 	if calls.Load() != 1 {
 		t.Errorf("cached call must not hit upstream, got %d calls", calls.Load())
 	}
 
-	// refresh=1 форсирует перезапрос.
-	rec3, _ := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
-	if rec3.Code != http.StatusOK {
-		t.Fatalf("refresh status %d", rec3.Code)
+	// refresh=1 сразу после удачного фетча гасится дебаунсом…
+	if rec3, _ := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1"); rec3.Code != http.StatusOK {
+		t.Fatalf("debounced refresh status %d", rec3.Code)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("debounced refresh must not hit upstream, got %d calls", calls.Load())
+	}
+
+	// …а после паузы — форсирует перезапрос.
+	rewindGeositeAttempt(h, geositeAttemptDebounce+time.Second)
+	if rec4, _ := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1"); rec4.Code != http.StatusOK {
+		t.Fatalf("refresh status %d", rec4.Code)
 	}
 	if calls.Load() != 2 {
 		t.Errorf("refresh must hit upstream, got %d calls", calls.Load())
 	}
 }
 
-// Сбой апстрима без кэша — 502; с кэшем — отдаётся протухший список.
+// Сбой апстрима без кэша — 502; с кэшем — протухший список со stale=true.
+// Кулдаун после неудачи не пускает следующий запрос к апстриму.
 func TestGeositesList_UpstreamFailure(t *testing.T) {
 	fail := true
-	h, _ := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+	h, calls := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
 		if fail {
 			w.WriteHeader(http.StatusForbidden)
 			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
 			return
 		}
-		_, _ = w.Write([]byte(geositeTreeJSON("geosite-google.srs")))
+		_, _ = w.Write([]byte(geositeTreeJSON(false, "geosite-google.srs")))
 	})
 
 	rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("no-cache failure: status %d, want 502", rec.Code)
 	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected 1 upstream call, got %d", calls.Load())
+	}
 
-	// Наполняем кэш, затем ломаем апстрим и форсируем refresh — кэш выживает.
+	// Кулдаун: немедленный повтор не жжёт rate-limit, ошибка отдаётся из кэша.
+	if rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec2.Code != http.StatusBadGateway {
+		t.Fatalf("cooldown failure: status %d, want 502", rec2.Code)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("cooldown must not hit upstream, got %d calls", calls.Load())
+	}
+
+	// Наполняем кэш (после паузы), затем ломаем апстрим и форсируем refresh —
+	// кэш выживает и помечается stale.
 	fail = false
-	if rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec2.Code != http.StatusOK {
-		t.Fatalf("prime cache: status %d", rec2.Code)
+	rewindGeositeAttempt(h, geositeFailCooldown+time.Second)
+	if rec3, data := geositesList(t, h, "/api/singbox/router/geosites/list"); rec3.Code != http.StatusOK || data.Stale {
+		t.Fatalf("prime cache: status %d stale %v", rec3.Code, data.Stale)
 	}
 	fail = true
-	rec3, data := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
-	if rec3.Code != http.StatusOK {
-		t.Fatalf("stale-cache fallback: status %d, want 200", rec3.Code)
+	rewindGeositeAttempt(h, geositeAttemptDebounce+time.Second)
+	rec4, data := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
+	if rec4.Code != http.StatusOK {
+		t.Fatalf("stale-cache fallback: status %d, want 200", rec4.Code)
 	}
 	if len(data.Names) != 1 || data.Names[0] != "google" {
 		t.Errorf("stale names = %v", data.Names)
 	}
+	if !data.Stale {
+		t.Error("failed refresh must mark the payload stale")
+	}
 }
 
-// Пустой листинг (например, HTML от перехватывающего прокси распарсился в
-// ноль записей) — ошибка, а не пустой кэш.
-func TestGeositesList_EmptyListingIsError(t *testing.T) {
+// Пустой листинг и truncated-листинг — ошибка, а не пустой/частичный кэш.
+func TestGeositesList_BadListingsAreErrors(t *testing.T) {
+	payload := geositeTreeJSON(false, "README.md")
 	h, _ := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(geositeTreeJSON("README.md")))
+		_, _ = w.Write([]byte(payload))
 	})
-	rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
-	if rec.Code != http.StatusBadGateway {
+	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusBadGateway {
 		t.Fatalf("empty listing: status %d, want 502", rec.Code)
+	}
+
+	payload = geositeTreeJSON(true, "geosite-google.srs")
+	rewindGeositeAttempt(h, geositeFailCooldown+time.Second)
+	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusBadGateway {
+		t.Fatalf("truncated listing: status %d, want 502", rec.Code)
 	}
 }
 
@@ -159,13 +200,14 @@ func TestGeositesList_MethodNotAllowed(t *testing.T) {
 // TTL: протухший кэш обновляется без refresh=1.
 func TestGeositesList_TTLExpiry(t *testing.T) {
 	h, calls := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(geositeTreeJSON("geosite-google.srs")))
+		_, _ = w.Write([]byte(geositeTreeJSON(false, "geosite-google.srs")))
 	})
 	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusOK {
 		t.Fatal("prime")
 	}
 	h.mu.Lock()
 	h.fetchedAt = time.Now().Add(-geositeCacheTTL - time.Minute)
+	h.lastAttempt = time.Now().Add(-geositeCacheTTL - time.Minute)
 	h.mu.Unlock()
 	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusOK {
 		t.Fatal("post-ttl")
@@ -173,4 +215,66 @@ func TestGeositesList_TTLExpiry(t *testing.T) {
 	if calls.Load() != 2 {
 		t.Errorf("expired cache must re-fetch, got %d calls", calls.Load())
 	}
+}
+
+// Warm-cache чтение не блокируется чужим долгим фетчем: пока refresh висит
+// в апстриме, обычный запрос немедленно получает stale-копию.
+func TestGeositesList_StaleWhileRevalidate(t *testing.T) {
+	release := make(chan struct{})
+	slow := false
+	h, _ := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		if slow {
+			<-release
+		}
+		_, _ = w.Write([]byte(geositeTreeJSON(false, "geosite-google.srs")))
+	})
+	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusOK {
+		t.Fatal("prime")
+	}
+
+	slow = true
+	// Протухший кэш: обычный запрос не пройдёт по fresh-пути и упрётся в
+	// inflight-развилку — ровно её и проверяем.
+	h.mu.Lock()
+	h.fetchedAt = time.Now().Add(-geositeCacheTTL - time.Minute)
+	h.mu.Unlock()
+	rewindGeositeAttempt(h, geositeAttemptDebounce+time.Second)
+	refreshDone := make(chan struct{})
+	go func() {
+		defer close(refreshDone)
+		_, _ = geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
+	}()
+
+	// Дожидаемся, пока refresh займёт inflight-слот.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		h.mu.Lock()
+		busy := h.inflight != nil
+		h.mu.Unlock()
+		if busy {
+			break
+		}
+		if time.Now().After(deadline) {
+			close(release)
+			t.Fatal("refresh never started")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	done := make(chan SingboxGeositesData, 1)
+	go func() {
+		_, data := geositesList(t, h, "/api/singbox/router/geosites/list")
+		done <- data
+	}()
+	select {
+	case data := <-done:
+		if len(data.Names) != 1 || !data.Stale {
+			t.Errorf("expected stale cached copy, got %+v", data)
+		}
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("warm-cache read blocked behind the in-flight fetch")
+	}
+	close(release)
+	<-refreshDone
 }

--- a/internal/api/singbox_geosites_test.go
+++ b/internal/api/singbox_geosites_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func geositeTreeJSON(paths ...string) string {
+	type entry struct {
+		Path string `json:"path"`
+	}
+	entries := make([]entry, 0, len(paths))
+	for _, p := range paths {
+		entries = append(entries, entry{Path: p})
+	}
+	b, _ := json.Marshal(map[string]any{"truncated": false, "tree": entries})
+	return string(b)
+}
+
+func newGeositesTestHandler(t *testing.T, upstream http.HandlerFunc) (*SingboxGeositesHandler, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		upstream(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	h := NewSingboxGeositesHandler(nil)
+	h.treeURL = srv.URL
+	return h, &calls
+}
+
+func geositesList(t *testing.T, h *SingboxGeositesHandler, url string) (*httptest.ResponseRecorder, SingboxGeositesData) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	var envelope struct {
+		Success bool                `json:"success"`
+		Data    SingboxGeositesData `json:"data"`
+	}
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+	}
+	return rec, envelope.Data
+}
+
+// Парсинг листинга: geosite-*.srs → имена без префикса/суффикса,
+// посторонние файлы отбрасываются, порядок — сортированный.
+func TestGeositesList_ParsesAndSorts(t *testing.T) {
+	h, calls := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(geositeTreeJSON(
+			"geosite-youtube.srs",
+			"geosite-category-ads-all.srs",
+			"README.md",
+			"geoip-cn.srs",
+			"geosite-xiaomi@cn.srs",
+			"geosite-.srs",
+		)))
+	})
+
+	rec, data := geositesList(t, h, "/api/singbox/router/geosites/list")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	want := []string{"category-ads-all", "xiaomi@cn", "youtube"}
+	if len(data.Names) != len(want) {
+		t.Fatalf("names = %v, want %v", data.Names, want)
+	}
+	for i, n := range want {
+		if data.Names[i] != n {
+			t.Fatalf("names = %v, want %v", data.Names, want)
+		}
+	}
+	if data.BaseURL == "" || data.FetchedAt == "" {
+		t.Errorf("baseUrl/fetchedAt must be set, got %+v", data)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected 1 upstream call, got %d", calls.Load())
+	}
+
+	// Повторный запрос — из кэша, без нового обращения к GitHub.
+	rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("cached status %d", rec2.Code)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("cached call must not hit upstream, got %d calls", calls.Load())
+	}
+
+	// refresh=1 форсирует перезапрос.
+	rec3, _ := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("refresh status %d", rec3.Code)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("refresh must hit upstream, got %d calls", calls.Load())
+	}
+}
+
+// Сбой апстрима без кэша — 502; с кэшем — отдаётся протухший список.
+func TestGeositesList_UpstreamFailure(t *testing.T) {
+	fail := true
+	h, _ := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		if fail {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+			return
+		}
+		_, _ = w.Write([]byte(geositeTreeJSON("geosite-google.srs")))
+	})
+
+	rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("no-cache failure: status %d, want 502", rec.Code)
+	}
+
+	// Наполняем кэш, затем ломаем апстрим и форсируем refresh — кэш выживает.
+	fail = false
+	if rec2, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec2.Code != http.StatusOK {
+		t.Fatalf("prime cache: status %d", rec2.Code)
+	}
+	fail = true
+	rec3, data := geositesList(t, h, "/api/singbox/router/geosites/list?refresh=1")
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("stale-cache fallback: status %d, want 200", rec3.Code)
+	}
+	if len(data.Names) != 1 || data.Names[0] != "google" {
+		t.Errorf("stale names = %v", data.Names)
+	}
+}
+
+// Пустой листинг (например, HTML от перехватывающего прокси распарсился в
+// ноль записей) — ошибка, а не пустой кэш.
+func TestGeositesList_EmptyListingIsError(t *testing.T) {
+	h, _ := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(geositeTreeJSON("README.md")))
+	})
+	rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("empty listing: status %d, want 502", rec.Code)
+	}
+}
+
+func TestGeositesList_MethodNotAllowed(t *testing.T) {
+	h := NewSingboxGeositesHandler(nil)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodPost, "/api/singbox/router/geosites/list", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status %d, want 405", rec.Code)
+	}
+}
+
+// TTL: протухший кэш обновляется без refresh=1.
+func TestGeositesList_TTLExpiry(t *testing.T) {
+	h, calls := newGeositesTestHandler(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(geositeTreeJSON("geosite-google.srs")))
+	})
+	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusOK {
+		t.Fatal("prime")
+	}
+	h.mu.Lock()
+	h.fetchedAt = time.Now().Add(-geositeCacheTTL - time.Minute)
+	h.mu.Unlock()
+	if rec, _ := geositesList(t, h, "/api/singbox/router/geosites/list"); rec.Code != http.StatusOK {
+		t.Fatal("post-ttl")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expired cache must re-fetch, got %d calls", calls.Load())
+	}
+}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -3401,6 +3401,23 @@ definitions:
         example: ipv4_only
         type: string
     type: object
+  api.SingboxGeositesData:
+    properties:
+      baseUrl:
+        description: BaseURL + "geosite-" + name + ".srs" — готовый URL для rule-set.
+        example: https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/
+        type: string
+      fetchedAt:
+        example: "2026-07-12T10:00:00Z"
+        type: string
+      names:
+        description: |-
+          Names — имена наборов без префикса geosite- и суффикса .srs
+          (например "youtube", "category-ads-all", "xiaomi@cn").
+        items:
+          type: string
+        type: array
+    type: object
   api.SingboxInboundEntry:
     properties:
       idle:
@@ -12248,6 +12265,36 @@ paths:
       security:
       - CookieAuth: []
       summary: Enable singbox-router
+      tags:
+      - singbox-router
+  /singbox/router/geosites/list:
+    get:
+      description: Full list of geosite rule-set names from the SagerNet/sing-geosite
+        rule-set branch, cached for 24h. Pass refresh=1 to force a re-fetch.
+      parameters:
+      - description: 1 = force refresh
+        in: query
+        name: refresh
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.OkResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SingboxGeositesData'
+              type: object
+        "502":
+          description: listing fetch failed
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: List SagerNet sing-geosite catalog
       tags:
       - singbox-router
   /singbox/router/ingress-eligible-interfaces:

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -3417,6 +3417,11 @@ definitions:
         items:
           type: string
         type: array
+      stale:
+        description: |-
+          Stale — список отдан из кэша, потому что обновление не удалось
+          (GitHub недоступен). Фронт показывает предупреждение при refresh=1.
+        type: boolean
     type: object
   api.SingboxInboundEntry:
     properties:

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -742,6 +742,10 @@ func (s *Server) registerSingboxRoutes(mux *http.ServeMux, h *routeHandlers) {
 		mux.HandleFunc("/api/singbox/router/rulesets/delete", h.guarded(rh.DeleteRuleSet))
 		mux.HandleFunc("/api/singbox/router/rulesets/dat-url", h.guarded(rh.DatRuleSetURL))
 		mux.HandleFunc("/api/singbox/router/rulesets/dat-srs", rh.DatRuleSetSRS)
+		// Каталог SagerNet geosite — дополнение к каталогу пресетов:
+		// хендлер создаётся здесь один раз, кэш живёт в нём.
+		geositesHandler := api.NewSingboxGeositesHandler(s.downloadSvc)
+		mux.HandleFunc("/api/singbox/router/geosites/list", h.guarded(geositesHandler.List))
 		mux.HandleFunc("/api/singbox/router/outbounds/list", h.guarded(rh.ListOutbounds))
 		mux.HandleFunc("/api/singbox/router/outbounds/add", h.guarded(rh.AddOutbound))
 		mux.HandleFunc("/api/singbox/router/outbounds/update", h.guarded(rh.UpdateOutbound))


### PR DESCRIPTION
## Что это

Дополнение к курируемому каталогу пресетов (не замена): поисковый каталог **всех** geosite-наборов из репозитория SagerNet/sing-geosite (ветка `rule-set`, ~1.5 тыс. имён) с добавлением remote rule-set'ов в один клик.

## Бэкенд

- `GET /api/singbox/router/geosites/list` (новый хендлер `SingboxGeositesHandler`): список имён из GitHub tree API (`git/trees/rule-set`), фильтр `geosite-*.srs`, сортировка.
- Фетч идёт через `downloader.ResolveClient` — т.е. через настроенный пользователем **маршрут загрузок** (GitHub может быть доступен только через туннель).
- Кэш в памяти на 24 ч (анонимный rate-limit GitHub — 60 req/h с IP), `?refresh=1` форсирует; при сбое апстрима отдаётся протухший кэш вместо ошибки; пустой листинг — ошибка, а не пустой кэш. Фетч отвязан от клиентского контекста и сериализован мьютексом.
- Swagger + `gen:api` перегенерированы (конверт `OkResponse{data=...}`).

## Фронт

- Кнопка **«SagerNet»** рядом с «Каталог» в панели Rule-sets эксперт-панели → модалка `SbRouterGeositeCatalogModal`: поиск (рендер первых 300 совпадений с подсказкой), бейджи «добавлено» у уже существующих тегов, мультивыбор, кнопка обновления списка, обработка загрузки/ошибки с «Повторить».
- Добавление — ровно тем же контрактом, что у каталога пресетов: remote rule-set `geosite-<имя>` с URL SagerNet `.srs`, `format: binary`, `update_interval: 24h` (скачивает сам sing-box). Общий цикл добавления выделен в `addRemoteRuleSetRefs` и переиспользуется пресетным `applyCatalogPresetsAsRuleSets`.
- Правило маршрутизации к набору создаётся отдельно — как и в существующем каталоге (подсказка об этом есть в модалке).

## Тесты и проверка

- Go: httptest-тесты хендлера — парсинг/сортировка листинга, кэш и refresh, протухший кэш при сбое апстрима, пустой листинг как ошибка, TTL, 405. Полный `go test ./...`, vet, MIPS cross — зелёные.
- Фронт: svelte-check 0/0, eslint, vitest 1370, build.
- Визуально на mock-стеке (интерсепт списка из 41 имени): поиск, выбор, «добавлено»-бейджи.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_