### PR TITLE
feat(logs): логи sing-box на вкладке TProxy, Журнал — только действия приложения

### DIFF
--- a/frontend/src/lib/components/diagnostics/LogsTerminal.svelte
+++ b/frontend/src/lib/components/diagnostics/LogsTerminal.svelte
@@ -22,11 +22,22 @@
   // lockBucket: фиксирует журнал на один bucket (напр. FakeIP-чип «Журнал» —
   // только 'singbox') и прячет переключатель app/singbox в тулбаре. Не задан —
   // прежнее поведение (переключаемый, как на странице Диагностики).
-  let { lockBucket }: { lockBucket?: LogBucket } = $props();
+  // storagePrefix: пространство localStorage-ключей инстанса. Терминалы на
+  // разных страницах (Диагностика, FakeIP, TProxy) обязаны хранить фильтры
+  // раздельно, иначе они перетекают между страницами через общие ключи.
+  let { lockBucket, storagePrefix = 'awgm.diagnostics' }: {
+    lockBucket?: LogBucket;
+    storagePrefix?: string;
+  } = $props();
 
-  const STORAGE_KEY = 'awgm.diagnostics.logsFilter';
-  const BUCKET_KEY = 'awgm.diagnostics.logsBucket';
-  const FULL_TIMESTAMP_KEY = 'awgm.diagnostics.logsFullTimestamp';
+  // Пропы фиксированы на всё время жизни инстанса — захват начальных значений
+  // намеренный.
+  // svelte-ignore state_referenced_locally
+  const STORAGE_KEY = `${storagePrefix}.logsFilter`;
+  // svelte-ignore state_referenced_locally
+  const BUCKET_KEY = `${storagePrefix}.logsBucket`;
+  // svelte-ignore state_referenced_locally
+  const FULL_TIMESTAMP_KEY = `${storagePrefix}.logsFullTimestamp`;
   const PAGE_SIZE = 200;
   type LogsQueryParams = {
     bucket: 'app' | 'singbox';
@@ -107,9 +118,22 @@
     localStorage.setItem(FULL_TIMESTAMP_KEY, v ? '1' : '0');
   }
 
-  let filter = $state<LogsFilter>(loadFilter());
+  // Сохранённый фильтр всегда согласован с сохранённым bucket'ом (setBucket
+  // сбрасывает группы). Если журнал зафиксирован на другом bucket'е —
+  // групповые фильтры чужие (наборы групп не пересекаются), сбрасываем их.
+  function initialFilter(): LogsFilter {
+    const f = loadFilter();
+    if (!lockBucket || loadBucket() === lockBucket) return f;
+    saveBucket(lockBucket);
+    const next = { ...f, groups: [], subgroups: [] };
+    saveFilter(next);
+    return next;
+  }
+
   // lockBucket — фиксированный проп (не меняется в рантайме): захват начального
   // значения — намеренный.
+  // svelte-ignore state_referenced_locally
+  let filter = $state<LogsFilter>(initialFilter());
   // svelte-ignore state_referenced_locally
   let bucket = $state<LogBucket>(lockBucket ?? loadBucket());
   let showFullTimestamp = $state(loadFullTimestamp());

--- a/frontend/src/lib/components/diagnostics/LogsTerminal.svelte
+++ b/frontend/src/lib/components/diagnostics/LogsTerminal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
   import { TriangleAlert } from 'lucide-svelte';
-  import { appLogEntries, singboxLogEntries, logStoreFor, type LogBucket, type LogStore } from '$lib/stores/logs';
+  import { logStoreFor, type LogBucket, type LogStore } from '$lib/stores/logs';
   import { LoadingSpinner, EmptyState } from '$lib/components/layout';
   import { Button } from '$lib/components/ui';
   import { api } from '$lib/api/client';
@@ -14,19 +14,19 @@
   import { diagnosticsSanitized, toggleDiagnosticsSanitized } from '$lib/stores/diagnosticsPrivacy';
   import { sanitizeLogEntry } from '$lib/utils/log-privacy';
   import LogRow from './LogRow.svelte';
-  import LogsToolbar, { ALL_LEVELS } from './LogsToolbar.svelte';
+  import LogsToolbar, { ALL_LEVELS, SINGBOX_GROUPS } from './LogsToolbar.svelte';
   import LogsContextMenu from './LogsContextMenu.svelte';
   import type { LogsFilter } from './LogsToolbar.svelte';
   import type { LogEntry } from '$lib/types';
 
-  // lockBucket: фиксирует журнал на один bucket (напр. FakeIP-чип «Журнал» —
-  // только 'singbox') и прячет переключатель app/singbox в тулбаре. Не задан —
-  // прежнее поведение (переключаемый, как на странице Диагностики).
+  // lockBucket: bucket инстанса. Каждый терминал в приложении показывает ровно
+  // одну корзину (Журнал — 'app'; FakeIP и TProxy — 'singbox'), переключателя
+  // app/singbox больше нет.
   // storagePrefix: пространство localStorage-ключей инстанса. Терминалы на
   // разных страницах (Диагностика, FakeIP, TProxy) обязаны хранить фильтры
   // раздельно, иначе они перетекают между страницами через общие ключи.
   let { lockBucket, storagePrefix = 'awgm.diagnostics' }: {
-    lockBucket?: LogBucket;
+    lockBucket: LogBucket;
     storagePrefix?: string;
   } = $props();
 
@@ -34,8 +34,6 @@
   // намеренный.
   // svelte-ignore state_referenced_locally
   const STORAGE_KEY = `${storagePrefix}.logsFilter`;
-  // svelte-ignore state_referenced_locally
-  const BUCKET_KEY = `${storagePrefix}.logsBucket`;
   // svelte-ignore state_referenced_locally
   const FULL_TIMESTAMP_KEY = `${storagePrefix}.logsFullTimestamp`;
   const PAGE_SIZE = 200;
@@ -94,18 +92,11 @@
 
   function saveFilter(f: LogsFilter) {
     if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(f));
-  }
-
-  function loadBucket(): LogBucket {
-    if (typeof localStorage === 'undefined') return 'app';
-    const raw = localStorage.getItem(BUCKET_KEY);
-    return raw === 'singbox' ? 'singbox' : 'app';
-  }
-
-  function saveBucket(b: LogBucket) {
-    if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(BUCKET_KEY, b);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(f));
+    } catch {
+      /* quota / private mode — фильтр живёт в памяти */
+    }
   }
 
   function loadFullTimestamp(): boolean {
@@ -115,27 +106,34 @@
 
   function saveFullTimestamp(v: boolean) {
     if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(FULL_TIMESTAMP_KEY, v ? '1' : '0');
+    try {
+      localStorage.setItem(FULL_TIMESTAMP_KEY, v ? '1' : '0');
+    } catch {
+      /* quota / private mode — настройка живёт в памяти */
+    }
   }
 
-  // Сохранённый фильтр всегда согласован с сохранённым bucket'ом (setBucket
-  // сбрасывает группы). Если журнал зафиксирован на другом bucket'е —
-  // групповые фильтры чужие (наборы групп не пересекаются), сбрасываем их.
+  // Санация сохранённого фильтра: раньше терминалы делили один localStorage-ключ
+  // (FakeIP-журнал писал в него singbox-подгруппы, не трогая маркер bucket'а),
+  // поэтому в groups могут лежать группы чужого bucket'а. Наборы имён не
+  // пересекаются — фильтруем по принадлежности к SINGBOX_GROUPS, а не доверяем
+  // маркеру. Санация чистая (без записи): исправленный фильтр сохранится при
+  // первом же applyFilter.
   function initialFilter(): LogsFilter {
     const f = loadFilter();
-    if (!lockBucket || loadBucket() === lockBucket) return f;
-    saveBucket(lockBucket);
-    const next = { ...f, groups: [], subgroups: [] };
-    saveFilter(next);
-    return next;
+    const singbox = new Set<string>(SINGBOX_GROUPS);
+    const groups = f.groups.filter((g) =>
+      lockBucket === 'singbox' ? singbox.has(g) : !singbox.has(g),
+    );
+    if (groups.length === f.groups.length) return f;
+    return { ...f, groups, subgroups: [] };
   }
 
   // lockBucket — фиксированный проп (не меняется в рантайме): захват начального
   // значения — намеренный.
   // svelte-ignore state_referenced_locally
   let filter = $state<LogsFilter>(initialFilter());
-  // svelte-ignore state_referenced_locally
-  let bucket = $state<LogBucket>(lockBucket ?? loadBucket());
+  const bucket = $derived(lockBucket);
   let showFullTimestamp = $state(loadFullTimestamp());
   let paused = $state(false);
   /** User clicked Pause — do not auto-resume when scrolled back to the top. */
@@ -218,16 +216,11 @@
     };
   }
 
-  async function loadBucketFresh(b: LogBucket) {
-    const store = logStoreFor(b);
+  async function loadBucketFresh() {
+    const store = logStoreFor(bucket);
     pageOffset = 0;
     try {
-      const query = b === bucket
-        ? buildLogQuery(PAGE_SIZE, 0)
-        : (b === 'singbox'
-          ? { bucket: b, groups: ['singbox'], subgroups: [], limit: PAGE_SIZE, offset: 0 }
-          : { bucket: b, groups: [], subgroups: [], limit: PAGE_SIZE, offset: 0 });
-      const resp = await api.getLogs(query);
+      const resp = await api.getLogs(buildLogQuery(PAGE_SIZE, 0));
       store.setEntries(resp.logs);
       store.setTotal(resp.total);
       store.setEnabled(resp.enabled);
@@ -292,7 +285,7 @@
     if (filterLoadWarning) {
       notifications.warning('Не удалось прочитать сохранённые фильтры журнала, применены значения по умолчанию');
     }
-    await loadBucketFresh(bucket);
+    await loadBucketFresh();
     await refreshSubgroups();
     setTimeout(() => (initialFetchDone = true), 100);
     window.addEventListener('keydown', handleKeydown);
@@ -394,23 +387,7 @@
     saveFilter(f);
     // Group changed → refresh subgroup catalog; subgroup change keeps catalog.
     await refreshSubgroups();
-    await loadBucketFresh(bucket);
-  }
-
-  async function setBucket(b: LogBucket) {
-    if (lockBucket) return; // bucket зафиксирован — переключение запрещено
-    if (b === bucket) return;
-    manualPause = false;
-    paused = false;
-    bufferCount = 0;
-    manualFrozenLogs = null;
-    bucket = b;
-    saveBucket(b);
-    // Reset filters on bucket switch — group sets are disjoint per bucket.
-    filter = { ...filter, groups: [], subgroups: [] };
-    saveFilter(filter);
-    await loadBucketFresh(b);
-    await refreshSubgroups();
+    await loadBucketFresh();
   }
 
   const filteredLogs = $derived.by(() => {
@@ -461,7 +438,7 @@
     }
     saveFilter(filter);
     await refreshSubgroups();
-    await loadBucketFresh(bucket);
+    await loadBucketFresh();
   }
 
   function handleClickLevel(level: string) {
@@ -480,7 +457,7 @@
     paused = false;
     bufferCount = 0;
     manualFrozenLogs = null;
-    await loadBucketFresh(bucket);
+    await loadBucketFresh();
   }
 
   function formatLine(log: LogEntry, routerOffset: number): string {
@@ -680,8 +657,6 @@
       bind:filter
       onFilterChange={applyFilter}
       {bucket}
-      bucketLocked={!!lockBucket}
-      onBucketChange={setBucket}
       {paused}
       {bufferCount}
       onTogglePause={togglePause}

--- a/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
+++ b/frontend/src/lib/components/diagnostics/LogsToolbar.svelte
@@ -95,9 +95,6 @@
     filter: LogsFilter;
     onFilterChange: (filter: LogsFilter) => void;
     bucket: LogBucket;
-    onBucketChange: (bucket: LogBucket) => void;
-    /** Если true — bucket зафиксирован, переключатель app/singbox скрыт. */
-    bucketLocked?: boolean;
     paused: boolean;
     bufferCount: number;
     onTogglePause: () => void;
@@ -124,8 +121,6 @@
     filter = $bindable(),
     onFilterChange,
     bucket,
-    onBucketChange,
-    bucketLocked = false,
     paused,
     bufferCount,
     onTogglePause,
@@ -251,32 +246,6 @@
 
 <div class="toolbar">
   <div class="row row-bucket">
-    {#if !bucketLocked}
-      <span class="bucket-label">Источник</span>
-      <span class="chip-row" role="group" aria-label="Источник логов">
-        <button
-          type="button"
-          class="chip"
-          class:chip-active={bucket === 'app'}
-          aria-pressed={bucket === 'app'}
-          onclick={() => onBucketChange('app')}
-        >
-          Приложение
-        </button>
-        <button
-          type="button"
-          class="chip"
-          class:chip-active={bucket === 'singbox'}
-          aria-pressed={bucket === 'singbox'}
-          onclick={() => onBucketChange('singbox')}
-        >
-          Sing-box
-        </button>
-      </span>
-
-      <span class="divider" aria-hidden="true"></span>
-    {/if}
-
     <span class="live-cell">
       {#if paused}
         <Badge variant="warning" size="sm">PAUSED</Badge>
@@ -507,7 +476,6 @@
     padding: 0.125rem 0.5rem;
   }
 
-  .bucket-label,
   .sub-label {
     color: var(--color-text-muted);
     font-weight: 600;

--- a/frontend/src/lib/components/fakeip/FakeIPTab.svelte
+++ b/frontend/src/lib/components/fakeip/FakeIPTab.svelte
@@ -258,7 +258,7 @@
 				блок: при остановленном движке / clash-down — заглушка.
 			-->
 			{#if engineState === 'live'}
-				<LogsTerminal lockBucket="singbox" />
+				<LogsTerminal lockBucket="singbox" storagePrefix="awgm.fakeip" />
 			{:else if engineState === 'clash-down'}
 				<section class="chip-stub">
 					<h2 class="chip-stub-title">{activeChip.label}</h2>

--- a/frontend/src/lib/components/fakeip/FakeIPTab.svelte
+++ b/frontend/src/lib/components/fakeip/FakeIPTab.svelte
@@ -254,26 +254,11 @@
 				«Журнал»-чип по мокапу page-log = sing-box-bucket общего лог-вью
 				приложения. Переиспользуем diagnostics LogsTerminal с lockBucket="singbox"
 				(level-фильтр / subgroup-чипы inbound/outbound/dns/router/runtime / поиск /
-				пауза / очистить — всё внутри; переключатель app/singbox скрыт). Живой
-				блок: при остановленном движке / clash-down — заглушка.
+				пауза / очистить — всё внутри). Журнал — серверный кольцевой буфер,
+				поэтому показывается при ЛЮБОМ состоянии движка: логи падения нужны
+				именно тогда, когда движок мёртв.
 			-->
-			{#if engineState === 'live'}
-				<LogsTerminal lockBucket="singbox" storagePrefix="awgm.fakeip" />
-			{:else if engineState === 'clash-down'}
-				<section class="chip-stub">
-					<h2 class="chip-stub-title">{activeChip.label}</h2>
-					<p class="chip-stub-note chip-stub-error">
-						Clash-runtime недоступен — живой журнал sing-box временно не работает.
-					</p>
-				</section>
-			{:else}
-				<section class="chip-stub">
-					<h2 class="chip-stub-title">{activeChip.label}</h2>
-					<p class="chip-stub-note chip-stub-empty">
-						Движок остановлен — живой журнал sing-box недоступен.
-					</p>
-				</section>
-			{/if}
+			<LogsTerminal lockBucket="singbox" storagePrefix="awgm.fakeip" />
 		{:else}
 			<section class="chip-stub">
 				<h2 class="chip-stub-title">{activeChip.label}</h2>

--- a/frontend/src/lib/components/sb-router/PageShell.svelte
+++ b/frontend/src/lib/components/sb-router/PageShell.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
   import { onMount } from "svelte";
-  import { FileJson, FilePen, Search, Settings } from "lucide-svelte";
+  import { FileJson, FilePen, ScrollText, Search, Settings } from "lucide-svelte";
   import { mode, setMode, type RouterMode } from "./modeStore";
   import { bindLiveConnectionsStore } from "./liveConnectionsStore";
   import { openDrawer } from "./drawerStore";
@@ -22,11 +22,13 @@
     onOpenJson?: () => void;
     /** Открыть редактор конфигурации config.d (эксперт; рендерится только если задан). */
     onOpenConfigEditor?: () => void;
+    /** Открыть логи sing-box (кнопка в шапке рендерится только если задан). */
+    onOpenLogs?: () => void;
     /** Дочерний контент страницы. */
     children: Snippet;
   }
 
-  let { subtitle, onOpenInspector, onOpenJson, onOpenConfigEditor, children }: Props = $props();
+  let { subtitle, onOpenInspector, onOpenJson, onOpenConfigEditor, onOpenLogs, children }: Props = $props();
   let currentMode = $derived($mode);
 
   onMount(() => {
@@ -93,6 +95,18 @@
           >
             <span class="action-icon"><FilePen size={16} /></span>
             <span class="action-text">Редактор</span>
+          </button>
+        {/if}
+        {#if onOpenLogs}
+          <button
+            type="button"
+            class="icon-btn"
+            onclick={onOpenLogs}
+            aria-label="Логи sing-box"
+            title="Логи sing-box"
+          >
+            <span class="action-icon"><ScrollText size={16} /></span>
+            <span class="action-text">Логи</span>
           </button>
         {/if}
       </div>

--- a/frontend/src/lib/components/sb-router/PageShell.svelte
+++ b/frontend/src/lib/components/sb-router/PageShell.svelte
@@ -22,13 +22,15 @@
     onOpenJson?: () => void;
     /** Открыть редактор конфигурации config.d (эксперт; рендерится только если задан). */
     onOpenConfigEditor?: () => void;
-    /** Открыть логи sing-box (кнопка в шапке рендерится только если задан). */
+    /** Открыть/закрыть логи sing-box (кнопка в шапке рендерится только если задан). */
     onOpenLogs?: () => void;
+    /** Лог-вью сейчас открыт — кнопка «Логи» подсвечивается как активная. */
+    logsActive?: boolean;
     /** Дочерний контент страницы. */
     children: Snippet;
   }
 
-  let { subtitle, onOpenInspector, onOpenJson, onOpenConfigEditor, onOpenLogs, children }: Props = $props();
+  let { subtitle, onOpenInspector, onOpenJson, onOpenConfigEditor, onOpenLogs, logsActive = false, children }: Props = $props();
   let currentMode = $derived($mode);
 
   onMount(() => {
@@ -101,9 +103,11 @@
           <button
             type="button"
             class="icon-btn"
+            class:icon-btn-active={logsActive}
             onclick={onOpenLogs}
-            aria-label="Логи sing-box"
-            title="Логи sing-box"
+            aria-pressed={logsActive}
+            aria-label={logsActive ? 'Закрыть логи sing-box' : 'Логи sing-box'}
+            title={logsActive ? 'Закрыть логи sing-box' : 'Логи sing-box'}
           >
             <span class="action-icon"><ScrollText size={16} /></span>
             <span class="action-text">Логи</span>
@@ -224,6 +228,11 @@
   .icon-btn:hover {
     color: var(--color-text-primary, var(--text-primary));
     background: var(--color-bg-hover, var(--bg-tertiary));
+  }
+  .icon-btn-active,
+  .icon-btn-active:hover {
+    color: var(--color-text-primary, var(--text-primary));
+    border-color: var(--accent);
   }
 
   .header-actions {

--- a/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
+++ b/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
@@ -69,10 +69,12 @@
   }
 
   onMount(() => {
-    // Не восстанавливаем визард (?add=1) и sub=connections после ухода на другие вкладки routing.
+    // Не восстанавливаем визард (?add=1) и sub=connections после ухода на другие
+    // вкладки routing. sub=logs — намеренное исключение: лог-вью должен переживать
+    // F5 и открываться по прямой ссылке.
     resetSingboxOverlayState();
     const sub = $page.url.searchParams.get('sub');
-    if (!sub) {
+    if (!sub || sub === 'logs') {
       void singboxRouterStore.loadAll();
       return;
     }
@@ -134,9 +136,17 @@
     void goto(`${url.pathname}${url.search}`, { keepFocus: true, noScroll: true });
   }
 
-  function openLogsSub() {
+  // Toggle, как у чипа соединений: повторный клик закрывает вид, а не наслаивает
+  // одинаковые записи в истории. tab=singbox фиксируем явно — window.location мог
+  // ещё не получить его от асинхронного goto тулбара вкладок.
+  function toggleLogsSub() {
     const url = new URL(window.location.href);
-    url.searchParams.set('sub', 'logs');
+    if (activeSingboxSub === 'logs') {
+      url.searchParams.delete('sub');
+    } else {
+      url.searchParams.set('tab', 'singbox');
+      url.searchParams.set('sub', 'logs');
+    }
     void goto(`${url.pathname}${url.search}`, { keepFocus: true, noScroll: true });
   }
 </script>
@@ -145,7 +155,8 @@
   onOpenInspector={() => (inspectorOpen = true)}
   onOpenJson={() => (jsonOpen = true)}
   onOpenConfigEditor={$sbMode === 'expert' ? () => (configEditorOpen = true) : undefined}
-  onOpenLogs={openLogsSub}
+  onOpenLogs={toggleLogsSub}
+  logsActive={activeSingboxSub === 'logs'}
 >
   <StagingBanner />
   {#if inSubView}

--- a/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
+++ b/frontend/src/lib/components/sb-router/SingboxRouterRedesignPage.svelte
@@ -7,6 +7,7 @@
   import { singboxRouter as singboxRouterStore } from '$lib/stores/singboxRouter';
   import { StagingBanner, RouteInspector, JsonConfigDrawer, ConfigSlotsDrawer } from '$lib/components/singbox-routing';
   import { ConnectionsSubTab } from '$lib/components/routing/singboxRouter';
+  import { LogsTerminal } from '$lib/components/diagnostics';
   import {
     PageShell,
     RulesPanel,
@@ -59,7 +60,7 @@
   const singboxInitialized = singboxRouterStore.initialized;
   let singboxRulesCount = $derived($singboxRulesStore.length);
 
-  const SUB_VIEWS = new Set(['connections']);
+  const SUB_VIEWS = new Set(['connections', 'logs']);
   const LEGACY_SUBS = new Set(['deviceproxy', 'rules', 'rulesets', 'outbounds', 'dns', 'engine']);
 
   function resetSingboxOverlayState() {
@@ -102,10 +103,10 @@
     void singboxRouterStore.loadAll();
   });
 
-  // Явный переход в sub=connections — закрыть визард/trace, но sub оставить.
+  // Явный переход в sub-вид (connections/logs) — закрыть визард/trace, но sub оставить.
   $effect(() => {
     const sub = activeSingboxSub;
-    if (sub === 'connections') {
+    if (sub && SUB_VIEWS.has(sub)) {
       resetSingboxOverlayState();
     }
   });
@@ -125,11 +126,17 @@
     prevMode = current;
   });
 
-  let inSubView = $derived(activeSingboxSub === 'connections');
+  let inSubView = $derived(!!activeSingboxSub && SUB_VIEWS.has(activeSingboxSub));
 
   function clearSub() {
     const url = new URL(window.location.href);
     url.searchParams.delete('sub');
+    void goto(`${url.pathname}${url.search}`, { keepFocus: true, noScroll: true });
+  }
+
+  function openLogsSub() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('sub', 'logs');
     void goto(`${url.pathname}${url.search}`, { keepFocus: true, noScroll: true });
   }
 </script>
@@ -138,6 +145,7 @@
   onOpenInspector={() => (inspectorOpen = true)}
   onOpenJson={() => (jsonOpen = true)}
   onOpenConfigEditor={$sbMode === 'expert' ? () => (configEditorOpen = true) : undefined}
+  onOpenLogs={openLogsSub}
 >
   <StagingBanner />
   {#if inSubView}
@@ -147,6 +155,10 @@
   {/if}
   {#if activeSingboxSub === 'connections'}
     <ConnectionsSubTab />
+  {:else if activeSingboxSub === 'logs'}
+    <!-- Логи sing-box (bucket singbox: stdout движка + process/runtime-события).
+         Действия над конфигурацией остаются в Инструменты → Журнал (bucket app). -->
+    <LogsTerminal lockBucket="singbox" storagePrefix="awgm.sb-router" />
   {:else if $sbMode === 'beginner'}
     {#if $addWizardOpen}
       <AddWizardPanel />

--- a/frontend/src/routes/dev/primitives/+page.svelte
+++ b/frontend/src/routes/dev/primitives/+page.svelte
@@ -455,7 +455,6 @@
         bind:filter={toolbarFilter}
         onFilterChange={(f) => console.log('filter', f)}
         bucket="app"
-        onBucketChange={(b) => console.log('bucket', b)}
         paused={toolbarPaused}
         bufferCount={0}
         onTogglePause={() => toolbarPaused = !toolbarPaused}

--- a/frontend/src/routes/diagnostics/+page.svelte
+++ b/frontend/src/routes/diagnostics/+page.svelte
@@ -182,7 +182,9 @@
 	/>
 
 	{#if activeTab === 'logs'}
-		<LogsTerminal />
+		<!-- Журнал — только действия приложения; логи sing-box смотрятся на своих
+		     вкладках (Sing-box: TProxy → «Логи», Sing-box: FakeIP → «Журнал»). -->
+		<LogsTerminal lockBucket="app" />
 	{:else if activeTab === 'monitoring'}
 		<MonitoringTab />
 	{:else if activeTab === 'connections'}


### PR DESCRIPTION
## Что сделано

Разделение журналов по месту использования: логи самого sing-box смотрятся на вкладке **Sing-box: TProxy**, а действия приложения над конфигурацией — в **Инструменты → Журнал**.

### Sing-box: TProxy — новый sub-вид «Логи»
- В шапке страницы (рядом с Инспектором/Конфигом/Редактором) появилась кнопка **«Логи»** — работает в обоих режимах (Простой/Эксперт).
- Клик открывает встроенный вид `?sub=logs` (по образцу sub-вида `connections`) с кнопкой «← Назад».
- Внутри — тот же `LogsTerminal`, зафиксированный на bucket `singbox` (прецедент — вкладка FakeIP): чипы Входящие/Исходящие/DNS/Маршрутизация/Runtime/Процесс, уровни, поиск, пауза, копирование/скачивание/очистка, живой SSE-поток.

### Инструменты → Журнал — только приложение
- Терминал зафиксирован на bucket `app` (`lockBucket="app"`): переключатель «Приложение | Sing-box» убран, остаются только действия приложения (туннели, маршрутизация, серверы, система).
- Backend не менялся: обе корзины и SSE-раздача работают как раньше.

### LogsTerminal: изоляция localStorage между инстансами
- Новый проп `storagePrefix` — каждый инстанс хранит фильтры/настройки в своих ключах (`awgm.diagnostics.*` — Журнал, `awgm.fakeip.*` — FakeIP, `awgm.sb-router.*` — TProxy) вместо общих, из-за которых фильтры перетекали между страницами.
- Если журнал зафиксирован на bucket, отличный от сохранённого (например, у пользователя в Журнале был выбран Sing-box), чужие групповые фильтры сбрасываются, а не молча показывают пустой список.

## Проверки
- `svelte-check` 0 errors / 0 warnings, `eslint` чисто, `vitest` 1373 passed, `npm run build` ok.
- Визуальный smoke-тест на mock-стеке (Playwright): кнопка «Логи» → sub-вид с sing-box-терминалом без переключателя источника; Журнал в Инструментах — только группы приложения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg)_