### PR TITLE
fix(nwg): IPv6 endpoint для NativeWG — заглушка при create + wg set по kernel-имени на ASC-прошивках

### DIFF
--- a/internal/api/tunnels_crud.go
+++ b/internal/api/tunnels_crud.go
@@ -360,7 +360,6 @@ func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	req.CreatedAt = existing.CreatedAt
 	req.Type = existing.Type
 	req.Enabled = existing.Enabled
-	req.ResolvedEndpointIP = existing.ResolvedEndpointIP
 	req.ActiveWAN = existing.ActiveWAN
 	req.Backend = existing.Backend
 	req.NWGIndex = existing.NWGIndex
@@ -369,6 +368,13 @@ func (h *TunnelsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	mergeInterfaceWhitelist(&req, existing)
 	mergePeerWhitelist(&req, existing)
+	// Кэш резолва валиден только для endpoint'а, под которым был получен:
+	// перенос через смену endpoint'а подставлял бы DNS-фолбэкам адрес
+	// ПРЕЖНЕГО имени. Сравнение — после mergePeerWhitelist (partial-update
+	// без Peer наследует endpoint из existing).
+	if req.Peer.Endpoint == existing.Peer.Endpoint {
+		req.ResolvedEndpointIP = existing.ResolvedEndpointIP
+	}
 	if !req.DefaultRouteSet {
 		req.DefaultRoute = existing.DefaultRoute
 		req.DefaultRouteSet = existing.DefaultRouteSet

--- a/internal/orchestrator/decide.go
+++ b/internal/orchestrator/decide.go
@@ -57,6 +57,15 @@ func decideBoot(state *State) []Action {
 				// without our kmod proxy → conf=running but no handshake).
 				actions = append(actions, Action{Type: ActionReconcileNativeWG, Tunnel: t.ID})
 				actions = appendPostStartActions(actions, t)
+			} else if t.EndpointV6 {
+				// На ASC-прошивке NDMS сам поднимает интерфейс из своего
+				// конфига, и для v4 это самодостаточно (boot ничего не
+				// делает намеренно). Для v6 конфиг NDMS несёт заглушку
+				// 127.0.0.1:1 — реальный endpoint жил только в ядре и после
+				// ребута роутера потерян. Полный Start возвращает его
+				// (wg set) и заново регистрирует endpoint-страж.
+				actions = append(actions, Action{Type: ActionStartNativeWG, Tunnel: t.ID})
+				actions = appendPostStartActions(actions, t)
 			}
 		}
 	}

--- a/internal/orchestrator/decide.go
+++ b/internal/orchestrator/decide.go
@@ -57,13 +57,16 @@ func decideBoot(state *State) []Action {
 				// without our kmod proxy → conf=running but no handshake).
 				actions = append(actions, Action{Type: ActionReconcileNativeWG, Tunnel: t.ID})
 				actions = appendPostStartActions(actions, t)
-			} else if t.EndpointV6 {
+			} else if t.EndpointMayV6 {
 				// На ASC-прошивке NDMS сам поднимает интерфейс из своего
-				// конфига, и для v4 это самодостаточно (boot ничего не
-				// делает намеренно). Для v6 конфиг NDMS несёт заглушку
-				// 127.0.0.1:1 — реальный endpoint жил только в ядре и после
-				// ребута роутера потерян. Полный Start возвращает его
-				// (wg set) и заново регистрирует endpoint-страж.
+				// конфига, и для v4-литерала это самодостаточно (boot ничего
+				// не делает намеренно). Для v6-литерала и hostname'а (мог
+				// резолвиться в v6 — например DDNS только с AAAA) конфиг
+				// NDMS может нести заглушку 127.0.0.1:1 — реальный endpoint
+				// жил только в ядре и после ребута роутера потерян. Полный
+				// Start возвращает его (wg set) и заново регистрирует
+				// endpoint-страж; для hostname→v4 Start безвреден — тот же
+				// resync, что decideReconnect делает для работающих.
 				actions = append(actions, Action{Type: ActionStartNativeWG, Tunnel: t.ID})
 				actions = appendPostStartActions(actions, t)
 			}

--- a/internal/orchestrator/decide_test.go
+++ b/internal/orchestrator/decide_test.go
@@ -53,6 +53,29 @@ func TestDecide_Boot_SkipsNativeWGWithASC(t *testing.T) {
 // ASC + v6-endpoint: после ребута роутера NDMS поднимает интерфейс из своего
 // конфига с заглушкой 127.0.0.1:1 — реальный endpoint жил только в ядре.
 // Boot обязан сделать полный Start (wg set + регистрация endpoint-стража).
+// Связка stored→state: EndpointMayV6 обязан вычисляться из endpoint'а
+// хранилища так, чтобы boot чинил и hostname, и v6-формы (включая
+// IPv4-mapped), но не трогал v4-литералы. Пиннит выбор
+// nwg.EndpointMayResolveIPv6 (а не EndpointHostIsIPv6) в state.go.
+func TestTunnelStateFromStored_EndpointMayV6(t *testing.T) {
+	cases := map[string]bool{
+		"vpn.example.com:51820":  true,
+		"[2a02::1]:51820":        true,
+		"[::ffff:1.2.3.4]:51820": true,
+		"1.2.3.4:51820":          false,
+	}
+	for ep, want := range cases {
+		st := tunnelStateFromStored(&storage.AWGTunnel{
+			ID:      "awg20",
+			Backend: "nativewg",
+			Peer:    storage.AWGPeer{Endpoint: ep},
+		})
+		if st.EndpointMayV6 != want {
+			t.Errorf("EndpointMayV6 for %q = %v, want %v", ep, st.EndpointMayV6, want)
+		}
+	}
+}
+
 func TestDecide_Boot_StartsNativeWGWithASCAndV6Endpoint(t *testing.T) {
 	s := newState()
 	s.supportsASC = true

--- a/internal/orchestrator/decide_test.go
+++ b/internal/orchestrator/decide_test.go
@@ -56,8 +56,8 @@ func TestDecide_Boot_SkipsNativeWGWithASC(t *testing.T) {
 func TestDecide_Boot_StartsNativeWGWithASCAndV6Endpoint(t *testing.T) {
 	s := newState()
 	s.supportsASC = true
-	s.tunnels["awg0"] = &tunnelState{ID: "awg0", Backend: "nativewg", Enabled: true, NWGIndex: 0, EndpointV6: true}
-	s.tunnels["awg1"] = &tunnelState{ID: "awg1", Backend: "nativewg", Enabled: false, NWGIndex: 1, EndpointV6: true}
+	s.tunnels["awg0"] = &tunnelState{ID: "awg0", Backend: "nativewg", Enabled: true, NWGIndex: 0, EndpointMayV6: true}
+	s.tunnels["awg1"] = &tunnelState{ID: "awg1", Backend: "nativewg", Enabled: false, NWGIndex: 1, EndpointMayV6: true}
 
 	actions := decide(Event{Type: EventBoot}, &s)
 

--- a/internal/orchestrator/decide_test.go
+++ b/internal/orchestrator/decide_test.go
@@ -50,6 +50,27 @@ func TestDecide_Boot_SkipsNativeWGWithASC(t *testing.T) {
 	}
 }
 
+// ASC + v6-endpoint: после ребута роутера NDMS поднимает интерфейс из своего
+// конфига с заглушкой 127.0.0.1:1 — реальный endpoint жил только в ядре.
+// Boot обязан сделать полный Start (wg set + регистрация endpoint-стража).
+func TestDecide_Boot_StartsNativeWGWithASCAndV6Endpoint(t *testing.T) {
+	s := newState()
+	s.supportsASC = true
+	s.tunnels["awg0"] = &tunnelState{ID: "awg0", Backend: "nativewg", Enabled: true, NWGIndex: 0, EndpointV6: true}
+	s.tunnels["awg1"] = &tunnelState{ID: "awg1", Backend: "nativewg", Enabled: false, NWGIndex: 1, EndpointV6: true}
+
+	actions := decide(Event{Type: EventBoot}, &s)
+
+	starts := filterActions(actions, ActionStartNativeWG)
+	if len(starts) != 1 {
+		t.Fatalf("expected 1 StartNativeWG for enabled ASC+v6 tunnel, got %d", len(starts))
+	}
+	if starts[0].Tunnel != "awg0" {
+		t.Errorf("StartNativeWG for wrong tunnel: %q", starts[0].Tunnel)
+	}
+	assertNoActionForTunnel(t, actions, "awg1", ActionStartNativeWG)
+}
+
 func TestDecide_Boot_IncludesMonitoring(t *testing.T) {
 	s := newState()
 	s.tunnels["awg0"] = &tunnelState{

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -20,10 +20,11 @@ type tunnelState struct {
 	NWGIndex     int
 	PingCheck    *storage.TunnelPingCheck
 	ISPInterface string
-	// EndpointV6: peer endpoint — IPv6-литерал. Для nativewg на ASC-прошивке
-	// это значит, что реальный endpoint живёт только в ядре (wg set), а конфиг
-	// NDMS несёт заглушку — после ребута нужен полный Start (decideBoot).
-	EndpointV6 bool
+	// EndpointMayV6: peer endpoint — IPv6-литерал или hostname (может
+	// резолвиться в v6). Для nativewg на ASC-прошивке это значит, что реальный
+	// endpoint может жить только в ядре (wg set), а конфиг NDMS — нести
+	// заглушку: после ребута нужен полный Start (decideBoot).
+	EndpointMayV6 bool
 
 	// quiescentUntil: while now < this, a conf=disabled edge for this tunnel
 	// is treated as transient NDMS settling (do not stop). Set on (re)start.
@@ -95,15 +96,15 @@ func (s *State) ensureTunnel(tunnelID string, store *storage.AWGTunnelStore) boo
 // tunnelStateFromStored creates a tunnelState from stored data.
 func tunnelStateFromStored(t *storage.AWGTunnel) *tunnelState {
 	return &tunnelState{
-		ID:           t.ID,
-		Name:         t.Name,
-		Backend:      t.Backend,
-		Enabled:      t.Enabled,
-		NWGIndex:     t.NWGIndex,
-		PingCheck:    t.PingCheck,
-		ISPInterface: t.ISPInterface,
-		ActiveWAN:    t.ActiveWAN,
-		EndpointV6:   nwg.EndpointHostIsIPv6(t.Peer.Endpoint),
+		ID:            t.ID,
+		Name:          t.Name,
+		Backend:       t.Backend,
+		Enabled:       t.Enabled,
+		NWGIndex:      t.NWGIndex,
+		PingCheck:     t.PingCheck,
+		ISPInterface:  t.ISPInterface,
+		ActiveWAN:     t.ActiveWAN,
+		EndpointMayV6: nwg.EndpointMayResolveIPv6(t.Peer.Endpoint),
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -20,6 +20,10 @@ type tunnelState struct {
 	NWGIndex     int
 	PingCheck    *storage.TunnelPingCheck
 	ISPInterface string
+	// EndpointV6: peer endpoint — IPv6-литерал. Для nativewg на ASC-прошивке
+	// это значит, что реальный endpoint живёт только в ядре (wg set), а конфиг
+	// NDMS несёт заглушку — после ребута нужен полный Start (decideBoot).
+	EndpointV6 bool
 
 	// quiescentUntil: while now < this, a conf=disabled edge for this tunnel
 	// is treated as transient NDMS settling (do not stop). Set on (re)start.
@@ -99,6 +103,7 @@ func tunnelStateFromStored(t *storage.AWGTunnel) *tunnelState {
 		PingCheck:    t.PingCheck,
 		ISPInterface: t.ISPInterface,
 		ActiveWAN:    t.ActiveWAN,
+		EndpointV6:   nwg.EndpointHostIsIPv6(t.Peer.Endpoint),
 	}
 }
 

--- a/internal/tunnel/config/config.go
+++ b/internal/tunnel/config/config.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -216,6 +217,15 @@ func Parse(content string) (*storage.AWGTunnel, error) {
 	if tunnel.Peer.Endpoint == "" {
 		return nil, ErrMissingEndpoint
 	}
+	// Нормализация формата: канонизирует небракетированный IPv6-с-портом
+	// (встречается в выгрузках некоторых провайдеров) и отсекает мусорные
+	// формы (без порта, нечисловой порт) с внятной ошибкой на импорте —
+	// вместо загадочного отказа NDMS/резолвера при старте.
+	normalized, err := NormalizeEndpoint(tunnel.Peer.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Endpoint %q in [Peer]: %w", tunnel.Peer.Endpoint, err)
+	}
+	tunnel.Peer.Endpoint = normalized
 
 	if len(tunnel.Peer.AllowedIPs) == 0 {
 		tunnel.Peer.AllowedIPs = DefaultAllowedIPs()
@@ -314,4 +324,33 @@ func parsePeerField(tunnel *storage.AWGTunnel, key, value string) {
 			peer.PersistentKeepalive = v
 		}
 	}
+}
+
+// NormalizeEndpoint приводит endpoint к канонической форме "host:port"
+// (IPv6 — "[addr]:port"). Небракетированный IPv6-с-портом бракетируется;
+// порт обязан быть числом 1-65535.
+func NormalizeEndpoint(endpoint string) (string, error) {
+	addr := strings.TrimSpace(endpoint)
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		if !validEndpointPort(port) {
+			return "", fmt.Errorf("port %q must be a number 1-65535", port)
+		}
+		if strings.Contains(host, ":") {
+			return net.JoinHostPort(host, port), nil
+		}
+		return host + ":" + port, nil
+	}
+	// Небракетированный IPv6:port — сплит по последнему двоеточию.
+	if i := strings.LastIndex(addr, ":"); i > 0 {
+		host, port := addr[:i], addr[i+1:]
+		if ip := net.ParseIP(host); ip != nil && strings.Contains(host, ":") && validEndpointPort(port) {
+			return net.JoinHostPort(host, port), nil
+		}
+	}
+	return "", errors.New("expected host:port")
+}
+
+func validEndpointPort(p string) bool {
+	n, err := strconv.Atoi(p)
+	return err == nil && n >= 1 && n <= 65535
 }

--- a/internal/tunnel/nwg/endpoint_guard.go
+++ b/internal/tunnel/nwg/endpoint_guard.go
@@ -3,6 +3,8 @@ package nwg
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -14,6 +16,9 @@ import (
 // ping-check'ом. Событийной интеграции, покрывающей все эти случаи, нет —
 // страж СХОДИТСЯ к желаемому состоянию опросом: каждые guardInterval
 // сверяет `wg show <iface> endpoints` с ожидаемым и возвращает endpoint.
+// Для hostname-endpoint'ов (DDNS) ожидаемый адрес перерезолвливается на
+// каждом проходе — смена адреса за именем доезжает до ядра за один
+// интервал; при недоступном DNS страж работает по последнему известному.
 //
 // Реестр живёт в памяти демона и наполняется в startNative; после рестарта
 // awgm его восстанавливает Start (EventReconnect для работающих
@@ -28,7 +33,8 @@ var guardInterval = 20 * time.Second
 type guardEntry struct {
 	iface    string // kernel-имя (nwgN)
 	pubkey   string
-	endpoint string // каноническая форма [v6]:port
+	endpoint string // последний известный резолв, каноническая форма host:port
+	spec     string // endpoint из конфига (hostname:port или литерал) — для перерезолва DDNS
 	name     string // NDMS-имя для логов
 }
 
@@ -49,10 +55,26 @@ func (o *OperatorNativeWG) guardUnregister(id string) {
 }
 
 func (o *OperatorNativeWG) guardHas(id string) bool {
+	_, ok := o.guardGet(id)
+	return ok
+}
+
+func (o *OperatorNativeWG) guardGet(id string) (guardEntry, bool) {
 	o.guardMu.Lock()
 	defer o.guardMu.Unlock()
-	_, ok := o.guard[id]
-	return ok
+	e, ok := o.guard[id]
+	return e, ok
+}
+
+// guardUpdateEndpoint обновляет ожидаемый endpoint записи, только если она
+// всё ещё в реестре — иначе гонка со Stop/Delete воскресила бы удалённую.
+func (o *OperatorNativeWG) guardUpdateEndpoint(id, endpoint string) {
+	o.guardMu.Lock()
+	defer o.guardMu.Unlock()
+	if e, ok := o.guard[id]; ok {
+		e.endpoint = endpoint
+		o.guard[id] = e
+	}
 }
 
 func (o *OperatorNativeWG) guardLoop() {
@@ -79,7 +101,21 @@ func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
 	if bin == "" {
 		return
 	}
-	for _, e := range entries {
+	for id, e := range entries {
+		// Hostname-spec (DDNS): перерезолвить — адрес мог смениться, а
+		// kernel WG сам за чужим DNS не следит. Ошибка резолва не фатальна:
+		// работаем по последнему известному адресу.
+		expected := e.endpoint
+		if host, ok := splitEndpointHost(e.spec); ok && net.ParseIP(host) == nil {
+			if ip, port, rerr := o.resolveOnce(e.spec, resolveAttemptTimeout); rerr == nil {
+				if fresh := net.JoinHostPort(ip, strconv.Itoa(port)); fresh != expected {
+					o.appLog.Info("endpoint-guard", e.name,
+						fmt.Sprintf("%s резолвится в новый адрес %s (был %s)", e.spec, fresh, expected))
+					expected = fresh
+					o.guardUpdateEndpoint(id, fresh)
+				}
+			}
+		}
 		out, err := wgToolOutput(ctx, bin, "show", e.iface, "endpoints")
 		if err != nil {
 			// Интерфейс может отсутствовать переходно (пересоздание) —
@@ -87,15 +123,15 @@ func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
 			o.appLog.Full("endpoint-guard", e.name, "wg show: "+err.Error())
 			continue
 		}
-		if wgShowHasEndpoint(out, e.pubkey, e.endpoint) {
+		if wgShowHasEndpoint(out, e.pubkey, expected) {
 			continue
 		}
-		if err := wgToolRun(ctx, bin, "set", e.iface, "peer", e.pubkey, "endpoint", e.endpoint); err != nil {
+		if err := wgToolRun(ctx, bin, "set", e.iface, "peer", e.pubkey, "endpoint", expected); err != nil {
 			o.appLog.Warn("endpoint-guard", e.name, "восстановление endpoint не удалось: "+err.Error())
 			continue
 		}
 		o.appLog.Info("endpoint-guard", e.name,
-			fmt.Sprintf("kernel-endpoint слетел (NDMS переприменил конфиг) — восстановлен %s на %s", e.endpoint, e.iface))
+			fmt.Sprintf("kernel-endpoint слетел (NDMS переприменил конфиг или сменился DDNS-адрес) — выставлен %s на %s", expected, e.iface))
 	}
 }
 

--- a/internal/tunnel/nwg/endpoint_guard.go
+++ b/internal/tunnel/nwg/endpoint_guard.go
@@ -1,0 +1,112 @@
+package nwg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Endpoint-страж для v6-туннелей на ASC-прошивках. NDMS хранит в своём
+// конфиге заглушку 127.0.0.1:1 и ПЕРЕЗАПИСЫВАЕТ ею kernel-endpoint при любом
+// переприменении конфига: ребут роутера, up/down интерфейса из веба,
+// WAN-failover (на ASC делегирован NDMS), рестарт интерфейса его же
+// ping-check'ом. Событийной интеграции, покрывающей все эти случаи, нет —
+// страж СХОДИТСЯ к желаемому состоянию опросом: каждые guardInterval
+// сверяет `wg show <iface> endpoints` с ожидаемым и возвращает endpoint.
+//
+// Реестр живёт в памяти демона и наполняется в startNative; после рестарта
+// awgm его восстанавливает Start (EventReconnect для работающих
+// ASC-туннелей, EventBoot для v6-туннелей — orchestrator/decide.go).
+
+// guardIntervalDefault — период сверки. Достаточно короткий, чтобы разрыв
+// после NDMS-события был минутного масштаба худшего случая у ping-check
+// (сам страж и разрывает его порочный цикл «рестарт → заглушка → пинги
+// падают → рестарт»).
+var guardInterval = 20 * time.Second
+
+type guardEntry struct {
+	iface    string // kernel-имя (nwgN)
+	pubkey   string
+	endpoint string // каноническая форма [v6]:port
+	name     string // NDMS-имя для логов
+}
+
+func (o *OperatorNativeWG) guardRegister(id string, e guardEntry) {
+	o.guardMu.Lock()
+	if o.guard == nil {
+		o.guard = make(map[string]guardEntry)
+	}
+	o.guard[id] = e
+	o.guardMu.Unlock()
+	o.guardOnce.Do(func() { go o.guardLoop() })
+}
+
+func (o *OperatorNativeWG) guardUnregister(id string) {
+	o.guardMu.Lock()
+	delete(o.guard, id)
+	o.guardMu.Unlock()
+}
+
+func (o *OperatorNativeWG) guardHas(id string) bool {
+	o.guardMu.Lock()
+	defer o.guardMu.Unlock()
+	_, ok := o.guard[id]
+	return ok
+}
+
+func (o *OperatorNativeWG) guardLoop() {
+	ticker := time.NewTicker(guardInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		o.guardSweep(context.Background())
+	}
+}
+
+// guardSweep — один проход сверки. Вынесен из цикла ради тестов.
+func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
+	o.guardMu.Lock()
+	entries := make(map[string]guardEntry, len(o.guard))
+	for id, e := range o.guard {
+		entries[id] = e
+	}
+	o.guardMu.Unlock()
+	if len(entries) == 0 {
+		return
+	}
+
+	bin := wgToolLookup()
+	if bin == "" {
+		return
+	}
+	for _, e := range entries {
+		out, err := wgToolOutput(ctx, bin, "show", e.iface, "endpoints")
+		if err != nil {
+			// Интерфейс может отсутствовать переходно (пересоздание) —
+			// не шумим, следующий проход разберётся.
+			o.appLog.Full("endpoint-guard", e.name, "wg show: "+err.Error())
+			continue
+		}
+		if wgShowHasEndpoint(out, e.pubkey, e.endpoint) {
+			continue
+		}
+		if err := wgToolRun(ctx, bin, "set", e.iface, "peer", e.pubkey, "endpoint", e.endpoint); err != nil {
+			o.appLog.Warn("endpoint-guard", e.name, "восстановление endpoint не удалось: "+err.Error())
+			continue
+		}
+		o.appLog.Info("endpoint-guard", e.name,
+			fmt.Sprintf("kernel-endpoint слетел (NDMS переприменил конфиг) — восстановлен %s на %s", e.endpoint, e.iface))
+	}
+}
+
+// wgShowHasEndpoint парсит вывод `wg show <iface> endpoints`
+// (строки "PUBKEY\tENDPOINT") и сверяет endpoint нужного пира.
+func wgShowHasEndpoint(out, pubkey, endpoint string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == pubkey {
+			return fields[1] == endpoint
+		}
+	}
+	return false
+}

--- a/internal/tunnel/nwg/endpoint_guard.go
+++ b/internal/tunnel/nwg/endpoint_guard.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/tunnel/netutil"
 )
 
 // Endpoint-страж для v6-туннелей на ASC-прошивках. NDMS хранит в своём
@@ -19,6 +20,8 @@ import (
 // Для hostname-endpoint'ов (DDNS) ожидаемый адрес перерезолвливается на
 // каждом проходе — смена адреса за именем доезжает до ядра за один
 // интервал; при недоступном DNS страж работает по последнему известному.
+// Анти-флап: адрес меняется, только когда текущий выпал из ПОЛНОГО резолва
+// имени — round-robin-ротация записей не перекидывает живую сессию.
 //
 // Реестр живёт в памяти демона и наполняется в startNative; после рестарта
 // awgm его восстанавливает Start (EventReconnect для работающих
@@ -66,12 +69,28 @@ func (o *OperatorNativeWG) guardGet(id string) (guardEntry, bool) {
 	return e, ok
 }
 
-// guardUpdateEndpoint обновляет ожидаемый endpoint записи, только если она
-// всё ещё в реестре — иначе гонка со Stop/Delete воскресила бы удалённую.
-func (o *OperatorNativeWG) guardUpdateEndpoint(id, endpoint string) {
+// guardReplaceIfPresent обновляет запись, только если туннель всё ещё в
+// реестре: параллельный Stop/Delete (оркестратор — другой лок-домен, чем
+// service.Update) мог снять его со стражи, и безусловный register воскресил
+// бы запись навсегда. Возвращает, была ли запись заменена.
+func (o *OperatorNativeWG) guardReplaceIfPresent(id string, e guardEntry) bool {
 	o.guardMu.Lock()
 	defer o.guardMu.Unlock()
-	if e, ok := o.guard[id]; ok {
+	if _, ok := o.guard[id]; !ok {
+		return false
+	}
+	o.guard[id] = e
+	return true
+}
+
+// guardUpdateEndpoint обновляет ожидаемый endpoint записи, только если она
+// всё ещё в реестре И несёт тот же spec: иначе гонка со Stop/Delete
+// воскресила бы удалённую запись, а гонка с SyncPeer (сменил spec) —
+// затёрла бы свежий endpoint резолвом СТАРОГО имени.
+func (o *OperatorNativeWG) guardUpdateEndpoint(id, spec, endpoint string) {
+	o.guardMu.Lock()
+	defer o.guardMu.Unlock()
+	if e, ok := o.guard[id]; ok && e.spec == spec {
 		e.endpoint = endpoint
 		o.guard[id] = e
 	}
@@ -103,16 +122,22 @@ func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
 	}
 	for id, e := range entries {
 		// Hostname-spec (DDNS): перерезолвить — адрес мог смениться, а
-		// kernel WG сам за чужим DNS не следит. Ошибка резолва не фатальна:
-		// работаем по последнему известному адресу.
+		// kernel WG сам за чужим DNS не следит. Анти-флап: endpoint
+		// меняется, только когда текущий адрес ВЫПАЛ из полного резолва
+		// имени — ротация round-robin-записей не дёргает живую сессию.
+		// Ошибка резолва не фатальна: работаем по последнему известному.
 		expected := e.endpoint
 		if host, ok := splitEndpointHost(e.spec); ok && net.ParseIP(host) == nil {
-			if ip, port, rerr := o.resolveOnce(e.spec, resolveAttemptTimeout); rerr == nil {
-				if fresh := net.JoinHostPort(ip, strconv.Itoa(port)); fresh != expected {
-					o.appLog.Info("endpoint-guard", e.name,
-						fmt.Sprintf("%s резолвится в новый адрес %s (был %s)", e.spec, fresh, expected))
-					expected = fresh
-					o.guardUpdateEndpoint(id, fresh)
+			if ips, rerr := lookupAllWithTimeout(host, resolveAttemptTimeout); rerr == nil && len(ips) > 0 {
+				curHost, _, splitErr := net.SplitHostPort(expected)
+				if splitErr != nil || !ipInList(curHost, ips) {
+					if _, port, perr := net.SplitHostPort(e.spec); perr == nil {
+						fresh := net.JoinHostPort(pickEndpointIP(ips), port)
+						o.appLog.Info("endpoint-guard", e.name,
+							fmt.Sprintf("%s резолвится в новый адрес: %s (был %s)", e.spec, fresh, expected))
+						expected = fresh
+						o.guardUpdateEndpoint(id, e.spec, fresh)
+					}
 				}
 			}
 		}
@@ -126,6 +151,13 @@ func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
 		if wgShowHasEndpoint(out, e.pubkey, expected) {
 			continue
 		}
+		// Перепроверка прямо перед wg set: параллельный Stop/Delete/SyncPeer
+		// мог удалить или заменить запись, пока sweep резолвил и читал
+		// wg show — wg set по устаревшей записи воскресил бы удалённого
+		// пира (wg set создаёт пира, если ключа на интерфейсе нет).
+		if cur, ok := o.guardGet(id); !ok || cur.pubkey != e.pubkey || cur.iface != e.iface || cur.spec != e.spec {
+			continue
+		}
 		if err := wgToolRun(ctx, bin, "set", e.iface, "peer", e.pubkey, "endpoint", expected); err != nil {
 			o.appLog.Warn("endpoint-guard", e.name, "восстановление endpoint не удалось: "+err.Error())
 			continue
@@ -133,6 +165,57 @@ func (o *OperatorNativeWG) guardSweep(ctx context.Context) {
 		o.appLog.Info("endpoint-guard", e.name,
 			fmt.Sprintf("kernel-endpoint слетел (NDMS переприменил конфиг или сменился DDNS-адрес) — выставлен %s на %s", expected, e.iface))
 	}
+}
+
+// guardLookupIPs — полный резолв имени (все A/AAAA) для анти-флапа.
+// Переопределяется в тестах.
+var guardLookupIPs = netutil.LookupAllIPs
+
+// lookupAllWithTimeout ограничивает guardLookupIPs таймаутом (у net.LookupIP
+// без контекста собственного дедлайна нет).
+func lookupAllWithTimeout(host string, timeout time.Duration) ([]string, error) {
+	type result struct {
+		ips []string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ips, err := guardLookupIPs(host)
+		ch <- result{ips, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.ips, r.err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("resolve %s: timeout after %s", host, timeout)
+	}
+}
+
+// ipInList — адрес входит в список (сравнение через ParseIP: разные
+// текстовые записи одного адреса равны).
+func ipInList(ip string, ips []string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, s := range ips {
+		if other := net.ParseIP(s); other != nil && other.Equal(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// pickEndpointIP выбирает адрес из полного резолва с тем же предпочтением
+// v4, что и netutil.ResolveHost — семейство endpoint'а не должно зависеть
+// от того, каким путём (Start или страж) он получен.
+func pickEndpointIP(ips []string) string {
+	for _, s := range ips {
+		if ip := net.ParseIP(s); ip != nil && ip.To4() != nil {
+			return s
+		}
+	}
+	return ips[0]
 }
 
 // wgShowHasEndpoint парсит вывод `wg show <iface> endpoints`

--- a/internal/tunnel/nwg/endpoint_guard_test.go
+++ b/internal/tunnel/nwg/endpoint_guard_test.go
@@ -84,6 +84,64 @@ func TestGuardSweep_UnregisteredTunnelIgnored(t *testing.T) {
 	}
 }
 
+// DDNS-имя стало резолвиться в новый адрес: страж перерезолвливает spec на
+// каждом проходе, обновляет ожидание в реестре и доводит ядро до нового
+// адреса, даже если старый endpoint в ядре «на месте».
+func TestGuardSweep_ReresolvesDDNSAndUpdatesKernel(t *testing.T) {
+	op := newGuardTestOperator()
+	op.resolveFn = func(string) (string, int, error) { return "2a02::feed", 51820, nil }
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg3 peer PUB endpoint [2a02::feed]:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+	entry, _ := op.guardGet("awg20")
+	if entry.endpoint != "[2a02::feed]:51820" {
+		t.Fatalf("guard entry endpoint not updated: %+v", entry)
+	}
+}
+
+// DNS недоступен: страж работает по последнему известному адресу —
+// восстановление слетевшего endpoint'а не блокируется сбоем резолва.
+func TestGuardSweep_ResolveFailureFallsBackToLastKnown(t *testing.T) {
+	op := newGuardTestOperator()
+	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t127.0.0.1:1\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg3 peer PUB endpoint [2a02::1]:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+}
+
+// Литеральный spec не перерезолвливается — резолвер не дёргается вовсе.
+func TestGuardSweep_LiteralSpecSkipsResolve(t *testing.T) {
+	op := newGuardTestOperator()
+	resolves := 0
+	op.resolveFn = func(string) (string, int, error) { resolves++; return "", 0, context.DeadlineExceeded }
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "[2a02::1]:51820", name: "Wireguard3"})
+	_ = stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if resolves != 0 {
+		t.Fatalf("resolver must not run for literal spec, ran %d times", resolves)
+	}
+}
+
 func TestWGShowHasEndpoint(t *testing.T) {
 	out := "OTHER\t1.2.3.4:51820\nPUB\t[2a02::1]:51820\n"
 	if !wgShowHasEndpoint(out, "PUB", "[2a02::1]:51820") {

--- a/internal/tunnel/nwg/endpoint_guard_test.go
+++ b/internal/tunnel/nwg/endpoint_guard_test.go
@@ -1,0 +1,98 @@
+package nwg
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+)
+
+func newGuardTestOperator() *OperatorNativeWG {
+	return &OperatorNativeWG{
+		appLog: logging.NewScopedLogger(nil, logging.GroupTunnel, logging.SubOps),
+	}
+}
+
+// stubGuardWG подменяет wg show/set: show отдаёт заданный вывод, set пишется
+// в calls.
+func stubGuardWG(t *testing.T, showOut string, showErr error) *[][]string {
+	t.Helper()
+	origLookup, origRun, origOut := wgToolLookup, wgToolRun, wgToolOutput
+	var mu sync.Mutex
+	var calls [][]string
+	wgToolLookup = func() string { return "/opt/bin/wg" }
+	wgToolOutput = func(context.Context, string, ...string) (string, error) {
+		return showOut, showErr
+	}
+	wgToolRun = func(_ context.Context, binary string, args ...string) error {
+		mu.Lock()
+		calls = append(calls, append([]string{binary}, args...))
+		mu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { wgToolLookup, wgToolRun, wgToolOutput = origLookup, origRun, origOut })
+	return &calls
+}
+
+// Endpoint слетел (NDMS переприменил конфиг — в ядре заглушка) → страж
+// возвращает его на место.
+func TestGuardSweep_RestoresDriftedEndpoint(t *testing.T) {
+	op := newGuardTestOperator()
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t127.0.0.1:1\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg3 peer PUB endpoint [2a02::1]:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+}
+
+// Endpoint на месте → страж молчит.
+func TestGuardSweep_NoopWhenEndpointMatches(t *testing.T) {
+	op := newGuardTestOperator()
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 0 {
+		t.Fatalf("no wg set expected, got %v", *calls)
+	}
+}
+
+// После unregister (Stop/Delete) страж туннель не трогает.
+func TestGuardSweep_UnregisteredTunnelIgnored(t *testing.T) {
+	op := newGuardTestOperator()
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", name: "Wireguard3"})
+	op.guardUnregister("awg20")
+	calls := stubGuardWG(t, "PUB\t127.0.0.1:1\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 0 {
+		t.Fatalf("no wg set expected after unregister, got %v", *calls)
+	}
+	if op.guardHas("awg20") {
+		t.Fatal("guardHas must be false after unregister")
+	}
+}
+
+func TestWGShowHasEndpoint(t *testing.T) {
+	out := "OTHER\t1.2.3.4:51820\nPUB\t[2a02::1]:51820\n"
+	if !wgShowHasEndpoint(out, "PUB", "[2a02::1]:51820") {
+		t.Fatal("must find matching endpoint")
+	}
+	if wgShowHasEndpoint(out, "PUB", "[2a02::2]:51820") {
+		t.Fatal("mismatched endpoint must be reported")
+	}
+	if wgShowHasEndpoint(out, "MISSING", "[2a02::1]:51820") {
+		t.Fatal("missing peer must be reported as mismatch")
+	}
+}

--- a/internal/tunnel/nwg/endpoint_guard_test.go
+++ b/internal/tunnel/nwg/endpoint_guard_test.go
@@ -2,17 +2,42 @@ package nwg
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
 )
+
+// TestMain отодвигает тикер guardLoop за горизонт любого прогона: каждый
+// guardRegister через guardOnce запускает вечный цикл, и с дефолтными 20с
+// утёкший цикл раннего теста мог бы выполнить sweep поверх стабов позже
+// идущего теста (фантомные wg-вызовы, гонка с восстановлением глобалов).
+func TestMain(m *testing.M) {
+	guardInterval = time.Hour
+	os.Exit(m.Run())
+}
 
 func newGuardTestOperator() *OperatorNativeWG {
 	return &OperatorNativeWG{
 		appLog: logging.NewScopedLogger(nil, logging.GroupTunnel, logging.SubOps),
 	}
+}
+
+// stubGuardLookup подменяет полный резолв имени в sweep; счётчик вызовов
+// возвращается для ассертов.
+func stubGuardLookup(t *testing.T, ips []string, err error) *int {
+	t.Helper()
+	orig := guardLookupIPs
+	calls := new(int)
+	guardLookupIPs = func(string) ([]string, error) {
+		*calls++
+		return ips, err
+	}
+	t.Cleanup(func() { guardLookupIPs = orig })
+	return calls
 }
 
 // stubGuardWG подменяет wg show/set: show отдаёт заданный вывод, set пишется
@@ -84,12 +109,12 @@ func TestGuardSweep_UnregisteredTunnelIgnored(t *testing.T) {
 	}
 }
 
-// DDNS-имя стало резолвиться в новый адрес: страж перерезолвливает spec на
-// каждом проходе, обновляет ожидание в реестре и доводит ядро до нового
-// адреса, даже если старый endpoint в ядре «на месте».
+// DDNS-имя стало резолвиться в новый адрес (старый выпал из резолва):
+// страж обновляет ожидание в реестре и доводит ядро до нового адреса,
+// даже если старый endpoint в ядре «на месте».
 func TestGuardSweep_ReresolvesDDNSAndUpdatesKernel(t *testing.T) {
 	op := newGuardTestOperator()
-	op.resolveFn = func(string) (string, int, error) { return "2a02::feed", 51820, nil }
+	_ = stubGuardLookup(t, []string{"2a02::feed"}, nil)
 	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
 	calls := stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
 
@@ -108,11 +133,49 @@ func TestGuardSweep_ReresolvesDDNSAndUpdatesKernel(t *testing.T) {
 	}
 }
 
+// Анти-флап: round-robin DNS отдал записи в другом порядке, но текущий
+// адрес всё ещё среди них — endpoint не трогаем, живая сессия не дёргается.
+func TestGuardSweep_RoundRobinRotationNoFlap(t *testing.T) {
+	op := newGuardTestOperator()
+	_ = stubGuardLookup(t, []string{"2a02::2", "2a02::1"}, nil)
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 0 {
+		t.Fatalf("rotation must not flap endpoint, got %v", *calls)
+	}
+	entry, _ := op.guardGet("awg20")
+	if entry.endpoint != "[2a02::1]:51820" {
+		t.Fatalf("guard entry must be unchanged: %+v", entry)
+	}
+}
+
+// Dual-stack после переезда: текущий v6 выпал из резолва, у имени остались
+// A+AAAA — выбирается v4 (то же предпочтение, что у netutil.ResolveHost).
+func TestGuardSweep_DualStackPrefersV4WhenCurrentGone(t *testing.T) {
+	op := newGuardTestOperator()
+	_ = stubGuardLookup(t, []string{"2a02::2", "198.51.100.7"}, nil)
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
+	calls := stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
+
+	op.guardSweep(context.Background())
+
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg3 peer PUB endpoint 198.51.100.7:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+}
+
 // DNS недоступен: страж работает по последнему известному адресу —
 // восстановление слетевшего endpoint'а не блокируется сбоем резолва.
 func TestGuardSweep_ResolveFailureFallsBackToLastKnown(t *testing.T) {
 	op := newGuardTestOperator()
-	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
+	_ = stubGuardLookup(t, nil, context.DeadlineExceeded)
 	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard3"})
 	calls := stubGuardWG(t, "PUB\t127.0.0.1:1\n", nil)
 
@@ -130,15 +193,60 @@ func TestGuardSweep_ResolveFailureFallsBackToLastKnown(t *testing.T) {
 // Литеральный spec не перерезолвливается — резолвер не дёргается вовсе.
 func TestGuardSweep_LiteralSpecSkipsResolve(t *testing.T) {
 	op := newGuardTestOperator()
-	resolves := 0
-	op.resolveFn = func(string) (string, int, error) { resolves++; return "", 0, context.DeadlineExceeded }
+	lookups := stubGuardLookup(t, nil, context.DeadlineExceeded)
 	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "[2a02::1]:51820", name: "Wireguard3"})
 	_ = stubGuardWG(t, "PUB\t[2a02::1]:51820\n", nil)
 
 	op.guardSweep(context.Background())
 
-	if resolves != 0 {
-		t.Fatalf("resolver must not run for literal spec, ran %d times", resolves)
+	if *lookups != 0 {
+		t.Fatalf("resolver must not run for literal spec, ran %d times", *lookups)
+	}
+}
+
+// Запись заменена/удалена, пока sweep читал wg show: перепроверка перед
+// wg set не даёт установить endpoint по устаревшему снапшоту (wg set по
+// отсутствующему ключу воскресил бы удалённого пира).
+func TestGuardSweep_RecheckBeforeSetSkipsReplacedEntry(t *testing.T) {
+	op := newGuardTestOperator()
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "OLDKEY", endpoint: "[2a02::1]:51820", spec: "[2a02::1]:51820", name: "Wireguard3"})
+
+	origLookup, origRun, origOut := wgToolLookup, wgToolRun, wgToolOutput
+	var calls [][]string
+	wgToolLookup = func() string { return "/opt/bin/wg" }
+	wgToolOutput = func(context.Context, string, ...string) (string, error) {
+		// Пока sweep «читал» wg show, параллельный SyncPeer заменил пира.
+		op.guardReplaceIfPresent("awg20", guardEntry{iface: "nwg3", pubkey: "NEWKEY", endpoint: "[2a02::2]:51820", spec: "[2a02::2]:51820", name: "Wireguard3"})
+		return "NEWKEY\t[2a02::2]:51820\n", nil
+	}
+	wgToolRun = func(_ context.Context, binary string, args ...string) error {
+		calls = append(calls, append([]string{binary}, args...))
+		return nil
+	}
+	t.Cleanup(func() { wgToolLookup, wgToolRun, wgToolOutput = origLookup, origRun, origOut })
+
+	op.guardSweep(context.Background())
+
+	if len(calls) != 0 {
+		t.Fatalf("stale snapshot must not wg set, got %v", calls)
+	}
+}
+
+// guardUpdateEndpoint: не воскрешает удалённую запись и не затирает
+// заменённую (другой spec) резолвом старого имени.
+func TestGuardUpdateEndpoint_StaleTargetsIgnored(t *testing.T) {
+	op := newGuardTestOperator()
+
+	op.guardRegister("awg20", guardEntry{iface: "nwg3", pubkey: "PUB", endpoint: "[2a02::1]:51820", spec: "b.example.com:51820", name: "Wireguard3"})
+	op.guardUpdateEndpoint("awg20", "a.example.com:51820", "[2a02::feed]:51820")
+	if entry, _ := op.guardGet("awg20"); entry.endpoint != "[2a02::1]:51820" {
+		t.Fatalf("update with stale spec must be ignored: %+v", entry)
+	}
+
+	op.guardUnregister("awg20")
+	op.guardUpdateEndpoint("awg20", "b.example.com:51820", "[2a02::feed]:51820")
+	if op.guardHas("awg20") {
+		t.Fatal("update must not resurrect an unregistered entry")
 	}
 }
 

--- a/internal/tunnel/nwg/endpoint_ndms.go
+++ b/internal/tunnel/nwg/endpoint_ndms.go
@@ -34,13 +34,17 @@ func EndpointHostIsIPv6(endpoint string) bool {
 // несёт заглушку — после ребута роутера такому туннелю нужен полный Start
 // (orchestrator/decideBoot). IPv4-литерал → false: у него в NDMS реальный
 // endpoint и boot ничего делать не должен (историческое поведение).
+//
+// Критерий v6-литерала — форма с двоеточиями (как в EndpointHostIsIPv6),
+// НЕ ip.To4(): IPv4-mapped "::ffff:1.2.3.4" даёт To4()!=nil, но NDMS эту
+// форму отвергает и SyncPeer/Start кладут для неё заглушку — boot обязан
+// классифицировать её так же, иначе после ребута туннель не самолечится.
 func EndpointMayResolveIPv6(endpoint string) bool {
 	host, ok := splitEndpointHost(strings.TrimSpace(endpoint))
 	if !ok {
 		return false
 	}
-	ip := net.ParseIP(host)
-	return ip == nil || ip.To4() == nil
+	return net.ParseIP(host) == nil || strings.Contains(host, ":")
 }
 
 // canonicalV6Endpoint нормализует v6-endpoint к "[addr]:port" — форме,

--- a/internal/tunnel/nwg/endpoint_ndms.go
+++ b/internal/tunnel/nwg/endpoint_ndms.go
@@ -28,6 +28,21 @@ func EndpointHostIsIPv6(endpoint string) bool {
 	return ok && strings.Contains(host, ":") && net.ParseIP(host) != nil
 }
 
+// EndpointMayResolveIPv6 — endpoint МОЖЕТ дать IPv6-адрес при старте:
+// v6-литерал или hostname (во что резолвится — заранее неизвестно, например
+// DDNS только с AAAA). Если последний Start ушёл по v6-пути, конфиг NDMS
+// несёт заглушку — после ребута роутера такому туннелю нужен полный Start
+// (orchestrator/decideBoot). IPv4-литерал → false: у него в NDMS реальный
+// endpoint и boot ничего делать не должен (историческое поведение).
+func EndpointMayResolveIPv6(endpoint string) bool {
+	host, ok := splitEndpointHost(strings.TrimSpace(endpoint))
+	if !ok {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip == nil || ip.To4() == nil
+}
+
 // canonicalV6Endpoint нормализует v6-endpoint к "[addr]:port" — форме,
 // которую принимает wg set. ok=false, если это не v6-литерал с валидным
 // портом (в т.ч. для форм без порта — их нечего ставить в ядро).

--- a/internal/tunnel/nwg/endpoint_ndms.go
+++ b/internal/tunnel/nwg/endpoint_ndms.go
@@ -1,0 +1,44 @@
+package nwg
+
+import (
+	"net"
+	"strings"
+)
+
+// endpointHostIsIPv6 reports whether the "host:port" / "[host]:port" endpoint
+// carries an IPv6-literal host. Hostnames and IPv4 return false.
+func endpointHostIsIPv6(endpoint string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(endpoint))
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.To4() == nil
+}
+
+// ndmsEndpointPlaceholder — endpoint-заглушка для NDMS на этапе create.
+// Порт сохраняем из реального endpoint'а (информативно в NDMS UI), хост —
+// loopback: NDMS RCI-импорт и batch-команды отвергают IPv6-endpoint
+// («invalid endpoint format»), а endpoint на этапе create — временный:
+// Start в любом случае переставляет его (127.0.0.1:proxy у kmod-пути,
+// реальный у нативного ASC).
+func ndmsEndpointPlaceholder(endpoint string) string {
+	_, port, err := net.SplitHostPort(strings.TrimSpace(endpoint))
+	if err != nil || port == "" {
+		port = "51820"
+	}
+	return "127.0.0.1:" + port
+}
+
+// replaceConfEndpointLine переписывает строку `Endpoint = ...` в .conf,
+// сгенерированном config.GenerateForExport (там ровно одна такая строка).
+func replaceConfEndpointLine(conf, endpoint string) string {
+	lines := strings.Split(conf, "\n")
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "Endpoint") && strings.Contains(trimmed, "=") {
+			lines[i] = "Endpoint = " + endpoint
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/tunnel/nwg/endpoint_ndms.go
+++ b/internal/tunnel/nwg/endpoint_ndms.go
@@ -2,41 +2,94 @@ package nwg
 
 import (
 	"net"
+	"strconv"
 	"strings"
 )
 
-// endpointHostIsIPv6 reports whether the "host:port" / "[host]:port" endpoint
-// carries an IPv6-literal host. Hostnames and IPv4 return false.
-func endpointHostIsIPv6(endpoint string) bool {
-	host, _, err := net.SplitHostPort(strings.TrimSpace(endpoint))
-	if err != nil {
-		return false
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.To4() == nil
+// ndmsEndpointPlaceholder — endpoint-заглушка для NDMS: RCI не принимает
+// IPv6-endpoint ни в импорте .conf, ни в peer-командах, а endpoint в конфиге
+// NDMS для v6-туннеля в любом случае фиктивен — реальный живёт в ядре
+// (wg set, см. wg_tool.go/endpoint_guard.go).
+//
+// Порт 1 выбран сознательно: kmod-слоты awg_proxy слушают на 127.0.0.1 с
+// kernel-ephemeral портами (32768+), и заглушка с реальным remote-портом
+// (например 51820, попадает в ephemeral-диапазон) могла бы указать в ЧУЖОЙ
+// живой слот — kernel WG слал бы хендшейки в прокси другого туннеля. На
+// порт 1 ядро эфемерные сокеты не вешает.
+const ndmsEndpointPlaceholder = "127.0.0.1:1"
+
+// EndpointHostIsIPv6 — endpoint несёт IPv6-литерал хоста. Понимает все
+// реальные формы: "[v6]:port", "[v6]" без порта, голый "v6",
+// небракетированный "v6:port" (некоторые провайдеры так выгружают конфиги)
+// и IPv4-mapped "::ffff:1.2.3.4" (форма с двоеточиями — NDMS отвергает и
+// её). Hostname и IPv4 → false.
+func EndpointHostIsIPv6(endpoint string) bool {
+	host, ok := splitEndpointHost(strings.TrimSpace(endpoint))
+	return ok && strings.Contains(host, ":") && net.ParseIP(host) != nil
 }
 
-// ndmsEndpointPlaceholder — endpoint-заглушка для NDMS на этапе create.
-// Порт сохраняем из реального endpoint'а (информативно в NDMS UI), хост —
-// loopback: NDMS RCI-импорт и batch-команды отвергают IPv6-endpoint
-// («invalid endpoint format»), а endpoint на этапе create — временный:
-// Start в любом случае переставляет его (127.0.0.1:proxy у kmod-пути,
-// реальный у нативного ASC).
-func ndmsEndpointPlaceholder(endpoint string) string {
-	_, port, err := net.SplitHostPort(strings.TrimSpace(endpoint))
-	if err != nil || port == "" {
-		port = "51820"
+// canonicalV6Endpoint нормализует v6-endpoint к "[addr]:port" — форме,
+// которую принимает wg set. ok=false, если это не v6-литерал с валидным
+// портом (в т.ч. для форм без порта — их нечего ставить в ядро).
+func canonicalV6Endpoint(endpoint string) (string, bool) {
+	addr := strings.TrimSpace(endpoint)
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		if net.ParseIP(host) != nil && strings.Contains(host, ":") && validPortString(port) {
+			return net.JoinHostPort(host, port), true
+		}
+		return "", false
 	}
-	return "127.0.0.1:" + port
+	// Небракетированный v6:port — сплит по последнему двоеточию.
+	if i := strings.LastIndex(addr, ":"); i > 0 {
+		host, port := strings.Trim(addr[:i], "[]"), addr[i+1:]
+		if net.ParseIP(host) != nil && strings.Contains(host, ":") && validPortString(port) {
+			return net.JoinHostPort(host, port), true
+		}
+	}
+	return "", false
 }
 
-// replaceConfEndpointLine переписывает строку `Endpoint = ...` в .conf,
-// сгенерированном config.GenerateForExport (там ровно одна такая строка).
+func validPortString(p string) bool {
+	n, err := strconv.Atoi(p)
+	return err == nil && n >= 1 && n <= 65535
+}
+
+// splitEndpointHost достаёт хост из endpoint'а в любой из принимаемых форм.
+func splitEndpointHost(addr string) (string, bool) {
+	if addr == "" || strings.Contains(addr, "/") {
+		return "", false
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host, true
+	}
+	// "[v6]" без порта / голый IP-литерал.
+	if trimmed := strings.Trim(addr, "[]"); net.ParseIP(trimmed) != nil {
+		return trimmed, true
+	}
+	// Небракетированный v6:port.
+	if i := strings.LastIndex(addr, ":"); i > 0 {
+		host := strings.Trim(addr[:i], "[]")
+		if net.ParseIP(host) != nil && strings.Contains(host, ":") && validPortString(addr[i+1:]) {
+			return host, true
+		}
+	}
+	return "", false
+}
+
+// replaceConfEndpointLine переписывает строку `Endpoint = ...` в секции
+// [Peer] .conf'а, сгенерированного config.GenerateForExport. Скоуп по секции
+// принципиален: свободнотекстовые I-параметры в [Interface] могут содержать
+// строку с префиксом "Endpoint" — трогать её нельзя.
 func replaceConfEndpointLine(conf, endpoint string) string {
 	lines := strings.Split(conf, "\n")
+	inPeer := false
 	for i, l := range lines {
 		trimmed := strings.TrimSpace(l)
-		if strings.HasPrefix(trimmed, "Endpoint") && strings.Contains(trimmed, "=") {
+		if strings.HasPrefix(trimmed, "[") {
+			inPeer = strings.EqualFold(trimmed, "[peer]")
+			continue
+		}
+		if inPeer && strings.HasPrefix(trimmed, "Endpoint") && strings.Contains(trimmed, "=") {
 			lines[i] = "Endpoint = " + endpoint
 		}
 	}

--- a/internal/tunnel/nwg/endpoint_ndms_test.go
+++ b/internal/tunnel/nwg/endpoint_ndms_test.go
@@ -12,25 +12,41 @@ func TestEndpointHostIsIPv6(t *testing.T) {
 	cases := map[string]bool{
 		"[2a02:6b8::feed:ff]:51820": true,
 		"[::1]:1":                   true,
+		"2a02:6b8::feed:ff":         true, // голый v6
+		"[2a02:6b8::feed:ff]":       true, // скобки без порта
+		"2a02:6b8::feed:ff:51820":   true, // небракетированный v6:port (выгрузки провайдеров)
+		"[::ffff:1.2.3.4]:51820":    true, // IPv4-mapped — форма с двоеточиями, NDMS отвергает
 		"1.2.3.4:51820":             false,
+		"1.2.3.4":                   false,
 		"vpn.example.com:51820":     false,
-		"2a02:6b8::feed:ff":         false, // без порта SplitHostPort не парсит
 		"":                          false,
 		"garbage":                   false,
 	}
 	for ep, want := range cases {
-		if got := endpointHostIsIPv6(ep); got != want {
-			t.Errorf("endpointHostIsIPv6(%q) = %v, want %v", ep, got, want)
+		if got := EndpointHostIsIPv6(ep); got != want {
+			t.Errorf("EndpointHostIsIPv6(%q) = %v, want %v", ep, got, want)
 		}
 	}
 }
 
-func TestNdmsEndpointPlaceholder(t *testing.T) {
-	if got := ndmsEndpointPlaceholder("[2a02:6b8::1]:4433"); got != "127.0.0.1:4433" {
-		t.Errorf("placeholder = %q, want 127.0.0.1:4433", got)
+func TestCanonicalV6Endpoint(t *testing.T) {
+	cases := map[string]struct {
+		out string
+		ok  bool
+	}{
+		"[2a02:6b8::1]:4433":    {"[2a02:6b8::1]:4433", true},
+		"2a02:6b8::1:4433":      {"[2a02:6b8::1]:4433", true}, // небракетированный
+		"[2a02:6b8::1]":         {"", false},                  // без порта — нечего ставить в ядро
+		"[2a02:6b8::1]:0":       {"", false},
+		"[2a02:6b8::1]:notnum":  {"", false},
+		"1.2.3.4:51820":         {"", false},
+		"vpn.example.com:51820": {"", false},
 	}
-	if got := ndmsEndpointPlaceholder("broken"); got != "127.0.0.1:51820" {
-		t.Errorf("fallback = %q, want 127.0.0.1:51820", got)
+	for ep, want := range cases {
+		got, ok := canonicalV6Endpoint(ep)
+		if got != want.out || ok != want.ok {
+			t.Errorf("canonicalV6Endpoint(%q) = (%q, %v), want (%q, %v)", ep, got, ok, want.out, want.ok)
+		}
 	}
 }
 
@@ -54,11 +70,11 @@ func TestReplaceConfEndpointLine_GeneratedConf(t *testing.T) {
 		t.Fatalf("generated conf must carry the raw endpoint:\n%s", conf)
 	}
 
-	patched := replaceConfEndpointLine(conf, ndmsEndpointPlaceholder(stored.Peer.Endpoint))
+	patched := replaceConfEndpointLine(conf, ndmsEndpointPlaceholder)
 	if strings.Contains(patched, "2a02:6b8") {
 		t.Fatalf("v6 endpoint must be substituted:\n%s", patched)
 	}
-	if !strings.Contains(patched, "Endpoint = 127.0.0.1:51820") {
+	if !strings.Contains(patched, "Endpoint = "+ndmsEndpointPlaceholder) {
 		t.Fatalf("placeholder endpoint missing:\n%s", patched)
 	}
 	// Всё, кроме строки Endpoint, — байт-в-байт.
@@ -74,5 +90,19 @@ func TestReplaceConfEndpointLine_GeneratedConf(t *testing.T) {
 	}
 	if stripEndpoint(conf) != stripEndpoint(patched) {
 		t.Fatal("only the Endpoint line may change")
+	}
+}
+
+// Скоуп подмены — только секция [Peer]: строка с префиксом "Endpoint"
+// в [Interface] (теоретически возможна внутри свободнотекстовых I-параметров)
+// не трогается.
+func TestReplaceConfEndpointLine_PeerSectionOnly(t *testing.T) {
+	conf := "[Interface]\nPrivateKey = p\nEndpointLike = keep\nEndpoint = trap\n\n[Peer]\nPublicKey = k\nEndpoint = [2a02::1]:51820\n"
+	patched := replaceConfEndpointLine(conf, ndmsEndpointPlaceholder)
+	if !strings.Contains(patched, "Endpoint = trap") {
+		t.Fatalf("[Interface] Endpoint-like line must be untouched:\n%s", patched)
+	}
+	if !strings.Contains(patched, "[Peer]\nPublicKey = k\nEndpoint = "+ndmsEndpointPlaceholder) {
+		t.Fatalf("[Peer] Endpoint must be substituted:\n%s", patched)
 	}
 }

--- a/internal/tunnel/nwg/endpoint_ndms_test.go
+++ b/internal/tunnel/nwg/endpoint_ndms_test.go
@@ -33,9 +33,12 @@ func TestEndpointMayResolveIPv6(t *testing.T) {
 	cases := map[string]bool{
 		"[2a02:6b8::feed:ff]:51820": true,  // v6-литерал
 		"2a02:6b8::feed:ff:51820":   true,  // небракетированный v6:port
+		"[2a02::1]":                 true,  // v6 без порта — форма с двоеточиями, NDMS отвергнет
+		"[::ffff:1.2.3.4]:51820":    true,  // IPv4-mapped: To4()!=nil, но NDMS отвергает — Start кладёт заглушку, boot обязан чинить
 		"vpn.example.com:51820":     true,  // hostname — может резолвиться в v6 (DDNS c AAAA)
 		"1.2.3.4:51820":             false, // v4-литерал — в NDMS реальный endpoint, boot no-op
 		"1.2.3.4":                   false,
+		"vpn.example.com":           false, // hostname без порта — стартовать нечем, boot бессилен
 		"":                          false,
 	}
 	for ep, want := range cases {

--- a/internal/tunnel/nwg/endpoint_ndms_test.go
+++ b/internal/tunnel/nwg/endpoint_ndms_test.go
@@ -1,0 +1,78 @@
+package nwg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/tunnel/config"
+)
+
+func TestEndpointHostIsIPv6(t *testing.T) {
+	cases := map[string]bool{
+		"[2a02:6b8::feed:ff]:51820": true,
+		"[::1]:1":                   true,
+		"1.2.3.4:51820":             false,
+		"vpn.example.com:51820":     false,
+		"2a02:6b8::feed:ff":         false, // без порта SplitHostPort не парсит
+		"":                          false,
+		"garbage":                   false,
+	}
+	for ep, want := range cases {
+		if got := endpointHostIsIPv6(ep); got != want {
+			t.Errorf("endpointHostIsIPv6(%q) = %v, want %v", ep, got, want)
+		}
+	}
+}
+
+func TestNdmsEndpointPlaceholder(t *testing.T) {
+	if got := ndmsEndpointPlaceholder("[2a02:6b8::1]:4433"); got != "127.0.0.1:4433" {
+		t.Errorf("placeholder = %q, want 127.0.0.1:4433", got)
+	}
+	if got := ndmsEndpointPlaceholder("broken"); got != "127.0.0.1:51820" {
+		t.Errorf("fallback = %q, want 127.0.0.1:51820", got)
+	}
+}
+
+// Сквозная проверка: .conf для NDMS-импорта с v6-endpoint получает заглушку,
+// остальные строки не тронуты; v4-конфиг проходит байт-в-байт.
+func TestReplaceConfEndpointLine_GeneratedConf(t *testing.T) {
+	stored := &storage.AWGTunnel{
+		Name: "t1",
+		Interface: storage.AWGInterface{
+			PrivateKey:     "priv",
+			Address:        "10.0.0.2/32",
+			AWGObfuscation: storage.AWGObfuscation{Jc: 4, Jmin: 40, Jmax: 70},
+		},
+		Peer: storage.AWGPeer{
+			PublicKey: "pub",
+			Endpoint:  "[2a02:6b8::feed:ff]:51820",
+		},
+	}
+	conf := config.GenerateForExport(stored)
+	if !strings.Contains(conf, "Endpoint = [2a02:6b8::feed:ff]:51820") {
+		t.Fatalf("generated conf must carry the raw endpoint:\n%s", conf)
+	}
+
+	patched := replaceConfEndpointLine(conf, ndmsEndpointPlaceholder(stored.Peer.Endpoint))
+	if strings.Contains(patched, "2a02:6b8") {
+		t.Fatalf("v6 endpoint must be substituted:\n%s", patched)
+	}
+	if !strings.Contains(patched, "Endpoint = 127.0.0.1:51820") {
+		t.Fatalf("placeholder endpoint missing:\n%s", patched)
+	}
+	// Всё, кроме строки Endpoint, — байт-в-байт.
+	stripEndpoint := func(s string) string {
+		var out []string
+		for _, l := range strings.Split(s, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(l), "Endpoint") {
+				continue
+			}
+			out = append(out, l)
+		}
+		return strings.Join(out, "\n")
+	}
+	if stripEndpoint(conf) != stripEndpoint(patched) {
+		t.Fatal("only the Endpoint line may change")
+	}
+}

--- a/internal/tunnel/nwg/endpoint_ndms_test.go
+++ b/internal/tunnel/nwg/endpoint_ndms_test.go
@@ -29,6 +29,22 @@ func TestEndpointHostIsIPv6(t *testing.T) {
 	}
 }
 
+func TestEndpointMayResolveIPv6(t *testing.T) {
+	cases := map[string]bool{
+		"[2a02:6b8::feed:ff]:51820": true,  // v6-литерал
+		"2a02:6b8::feed:ff:51820":   true,  // небракетированный v6:port
+		"vpn.example.com:51820":     true,  // hostname — может резолвиться в v6 (DDNS c AAAA)
+		"1.2.3.4:51820":             false, // v4-литерал — в NDMS реальный endpoint, boot no-op
+		"1.2.3.4":                   false,
+		"":                          false,
+	}
+	for ep, want := range cases {
+		if got := EndpointMayResolveIPv6(ep); got != want {
+			t.Errorf("EndpointMayResolveIPv6(%q) = %v, want %v", ep, got, want)
+		}
+	}
+}
+
 func TestCanonicalV6Endpoint(t *testing.T) {
 	cases := map[string]struct {
 		out string

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -397,6 +397,7 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 			iface:    names.IfaceName,
 			pubkey:   pubkey,
 			endpoint: realEndpoint,
+			spec:     stored.Peer.Endpoint,
 			name:     names.NDMSName,
 		})
 		o.appLog.Info("start", names.NDMSName,

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -34,8 +34,11 @@ import (
 const (
 	resolveAttempts       = 3
 	resolveAttemptTimeout = 1500 * time.Millisecond
-	resolveRetryGap       = 300 * time.Millisecond
 )
+
+// resolveRetryGap — пауза между попытками резолва. Var ради тестов
+// (failing-resolve сценарии не должны спать по 2×300ms).
+var resolveRetryGap = 300 * time.Millisecond
 
 // OperatorNativeWG manages tunnels via Keenetic native WireGuard + awg_proxy.ko.
 type OperatorNativeWG struct {
@@ -933,6 +936,26 @@ func (o *OperatorNativeWG) fallbackResolve(stored *storage.AWGTunnel, resolveErr
 	port, _ := strconv.Atoi(portStr)
 	o.appLog.Warn("resolve-endpoint", stored.Peer.Endpoint, "DNS failed, using cached IP "+stored.ResolvedEndpointIP)
 	return stored.ResolvedEndpointIP, port, nil
+}
+
+// resolveEndpointFresh — как resolveEndpointWithFallback, но БЕЗ фолбэка на
+// кэшированный ResolvedEndpointIP. Вызывающему нужно живое состояние DNS
+// (SyncPeer по результату решает судьбу endpoint-стража), а кэш может нести
+// адрес ПРЕЖНЕГО endpoint'а — «подтверждённый» им v4/v6 снял бы стража или
+// увёз в ядро чужой адрес.
+func (o *OperatorNativeWG) resolveEndpointFresh(endpoint string) (string, int, error) {
+	var lastErr error
+	for attempt := 1; attempt <= resolveAttempts; attempt++ {
+		ip, port, err := o.resolveOnce(endpoint, resolveAttemptTimeout)
+		if err == nil {
+			return ip, port, nil
+		}
+		lastErr = err
+		if attempt < resolveAttempts {
+			time.Sleep(resolveRetryGap)
+		}
+	}
+	return "", 0, lastErr
 }
 
 // resolveEndpointWithFallback resolves the tunnel's endpoint with a short retry

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -312,14 +312,22 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 	}
 	o.appLog.Full("start", stored.Name, fmt.Sprintf("Resolving endpoint %s -> %s:%d", stored.Peer.Endpoint, endpointIP, endpointPort))
 
-	// v4 — исторический "%s:%d" байт-в-байт; v6 — стандартная скобочная
-	// форма [addr]:port (небракетированный v6 для парсера гарантированный
-	// мусор: адрес обрезается по последнему двоеточию). Поддержка v6
-	// нативным ASC-путём NDMS не подтверждена — при отказе NDMS вернёт
-	// явную ошибку старта; верифицированный v6-путь — awg_proxy kmod (#455).
-	realEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
+	// v4 — исторический "%s:%d" через RCI байт-в-байт. v6 через RCI NDMS не
+	// принимает вовсе (ни импорт, ни peer-команды — подтверждено автором на
+	// устройстве): endpoint выставляется напрямую в ядро через
+	// wireguard-tools по kernel-имени nwgN, ПОСЛЕ поднятия интерфейса —
+	// up/down у NDMS сбрасывает kernel-endpoint на значение из его конфига.
+	endpointIsV6 := false
 	if ip := net.ParseIP(endpointIP); ip != nil && ip.To4() == nil {
+		endpointIsV6 = true
+	}
+	realEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
+	if endpointIsV6 {
 		realEndpoint = net.JoinHostPort(endpointIP, strconv.Itoa(endpointPort))
+		// Fail fast до RCI-команд: без wg поднимать интерфейс бессмысленно.
+		if wgToolLookup() == "" {
+			return fmt.Errorf("IPv6 endpoint на прошивке с нативным ASC выставляется только через wireguard-tools, бинарь wg не найден — установите пакет: opkg install wireguard-tools")
+		}
 	}
 
 	// Sync address/MTU from storage
@@ -337,14 +345,26 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 		o.hookNotifier.ExpectHook(names.NDMSName, "running")
 	}
 
-	// Batch: set endpoint + connect via + up
-	cmds := []any{
-		payloads.CmdWireguardPeerEndpoint(names.NDMSName, pubkey, realEndpoint),
+	// Batch: (v4) set endpoint + connect via + up; (v6) endpoint не входит —
+	// его RCI отвергнет, ставим в ядро после up.
+	var cmds []any
+	if !endpointIsV6 {
+		cmds = append(cmds, payloads.CmdWireguardPeerEndpoint(names.NDMSName, pubkey, realEndpoint))
+	}
+	cmds = append(cmds,
 		payloads.CmdWireguardPeerConnect(names.NDMSName, pubkey, stored.ISPInterface),
 		payloads.CmdInterfaceUp(names.NDMSName, true),
-	}
+	)
 	if _, err := o.transport.PostBatch(ctx, cmds); err != nil {
 		return fmt.Errorf("start native: %w", err)
+	}
+
+	if endpointIsV6 {
+		if err := setKernelPeerEndpoint(ctx, names.IfaceName, pubkey, realEndpoint); err != nil {
+			return fmt.Errorf("start native: %w", err)
+		}
+		o.appLog.Info("start", names.NDMSName,
+			fmt.Sprintf("IPv6 endpoint %s выставлен в ядро через wg set %s (RCI NDMS v6 не принимает); при ребуте/up-down переустановит reconcile", realEndpoint, names.IfaceName))
 	}
 
 	viaInfo := ""

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -101,6 +101,17 @@ func (o *OperatorNativeWG) createViaImport(ctx context.Context, stored *storage.
 	// Generate .conf with all AWG params
 	confData := config.GenerateForExport(stored)
 
+	// NDMS RCI-импорт отвергает IPv6-endpoint в .conf («"WireguardN": invalid
+	// endpoint format») и создание падает целиком. Endpoint на этапе create —
+	// временный: Start переставляет его в любом случае (127.0.0.1:proxy у
+	// kmod-пути, реальный у нативного ASC). Для v6 подменяем строку Endpoint
+	// заглушкой; v4 и hostname NDMS принимает — оставляем как есть.
+	if endpointHostIsIPv6(stored.Peer.Endpoint) {
+		confData = replaceConfEndpointLine(confData, ndmsEndpointPlaceholder(stored.Peer.Endpoint))
+		o.appLog.Info("create", stored.Name,
+			"IPv6 endpoint: импорт .conf с endpoint-заглушкой (NDMS не принимает v6 в импорте), реальный endpoint выставит Start")
+	}
+
 	// Import via RCI — NDMS creates the interface and parses all params.
 	// ImportWireguardConfig is a multipart-upload helper with no new-layer equivalent yet.
 	res, err := o.commands.Wireguard.ImportWireguardConfig(ctx, []byte(confData), stored.Name+".conf")
@@ -203,15 +214,16 @@ func (o *OperatorNativeWG) createViaBatch(ctx context.Context, stored *storage.A
 		cmds = append(cmds, payloads.CmdInterfaceIPv6Address(ndmsName, ipv6Addr))
 	}
 
-	// Peer
+	// Peer. Endpoint на этапе create — временный (Start переставит его на
+	// 127.0.0.1:proxy или реальный); IPv6-литерал NDMS в create-команде не
+	// принимает — заглушка, как в createViaImport.
+	peerEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
+	if ip := net.ParseIP(endpointIP); ip != nil && ip.To4() == nil {
+		peerEndpoint = fmt.Sprintf("127.0.0.1:%d", endpointPort)
+	}
 	peerCfg := payloads.PeerConfig{
-		PublicKey: stored.Peer.PublicKey,
-		// Deliberately unbracketed "%s:%d" even for IPv6 literals: the
-		// NDMS RCI contract for the native-ASC endpoint field is unknown
-		// (bracketed form untested against real firmware), so the format
-		// is left as-is. IPv6 endpoints through the native ASC path are
-		// out of scope / unverified — the supported v6 path is awg_proxy.
-		Endpoint:    fmt.Sprintf("%s:%d", endpointIP, endpointPort),
+		PublicKey:   stored.Peer.PublicKey,
+		Endpoint:    peerEndpoint,
 		AllowedIPv4: []payloads.AllowedIP{{Address: "0.0.0.0", Mask: "0"}},
 	}
 	if hasIPv6AllowedIPs(stored.Peer.AllowedIPs) {
@@ -300,11 +312,15 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 	}
 	o.appLog.Full("start", stored.Name, fmt.Sprintf("Resolving endpoint %s -> %s:%d", stored.Peer.Endpoint, endpointIP, endpointPort))
 
-	// Deliberately unbracketed "%s:%d" even for IPv6 literals — the NDMS
-	// RCI contract for the native-ASC peer endpoint is unknown, so the
-	// historical format is preserved. IPv6 through the native ASC path is
-	// untested/out of scope; the verified v6 path is the awg_proxy kmod.
+	// v4 — исторический "%s:%d" байт-в-байт; v6 — стандартная скобочная
+	// форма [addr]:port (небракетированный v6 для парсера гарантированный
+	// мусор: адрес обрезается по последнему двоеточию). Поддержка v6
+	// нативным ASC-путём NDMS не подтверждена — при отказе NDMS вернёт
+	// явную ошибку старта; верифицированный v6-путь — awg_proxy kmod (#455).
 	realEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
+	if ip := net.ParseIP(endpointIP); ip != nil && ip.To4() == nil {
+		realEndpoint = net.JoinHostPort(endpointIP, strconv.Itoa(endpointPort))
+	}
 
 	// Sync address/MTU from storage
 	if err := o.SyncAddressMTU(ctx, stored); err != nil {

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -59,6 +59,12 @@ type OperatorNativeWG struct {
 	// supportsASC reports native ASC firmware support. Default:
 	// ndmsinfo.SupportsWireguardASC; overridable in tests.
 	supportsASC func() bool
+
+	// Endpoint-страж v6-туннелей на ASC (endpoint_guard.go): реестр
+	// «kernel-имя → ожидаемый endpoint», фоновая сверка wg show/set.
+	guardMu   sync.Mutex
+	guard     map[string]guardEntry
+	guardOnce sync.Once
 	// hasProxySlot reports a live kmod proxy slot on a listen port. Default:
 	// kmod.HasSlotListening; overridable in tests.
 	hasProxySlot func(listenPort int) bool
@@ -106,8 +112,8 @@ func (o *OperatorNativeWG) createViaImport(ctx context.Context, stored *storage.
 	// временный: Start переставляет его в любом случае (127.0.0.1:proxy у
 	// kmod-пути, реальный у нативного ASC). Для v6 подменяем строку Endpoint
 	// заглушкой; v4 и hostname NDMS принимает — оставляем как есть.
-	if endpointHostIsIPv6(stored.Peer.Endpoint) {
-		confData = replaceConfEndpointLine(confData, ndmsEndpointPlaceholder(stored.Peer.Endpoint))
+	if EndpointHostIsIPv6(stored.Peer.Endpoint) {
+		confData = replaceConfEndpointLine(confData, ndmsEndpointPlaceholder)
 		o.appLog.Info("create", stored.Name,
 			"IPv6 endpoint: импорт .conf с endpoint-заглушкой (NDMS не принимает v6 в импорте), реальный endpoint выставит Start")
 	}
@@ -219,7 +225,7 @@ func (o *OperatorNativeWG) createViaBatch(ctx context.Context, stored *storage.A
 	// принимает — заглушка, как в createViaImport.
 	peerEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
 	if ip := net.ParseIP(endpointIP); ip != nil && ip.To4() == nil {
-		peerEndpoint = fmt.Sprintf("127.0.0.1:%d", endpointPort)
+		peerEndpoint = ndmsEndpointPlaceholder
 	}
 	peerCfg := payloads.PeerConfig{
 		PublicKey:   stored.Peer.PublicKey,
@@ -296,6 +302,13 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 	names := NewNWGNames(stored.NWGIndex)
 	pubkey := stored.Peer.PublicKey
 
+	// Fail fast ДО каких-либо RCI-команд и резолва: v6-литерал без
+	// wireguard-tools стартовать невозможно (hostname→v6 ловится второй
+	// проверкой после резолва).
+	if EndpointHostIsIPv6(stored.Peer.Endpoint) && wgToolLookup() == "" {
+		return errWGToolMissing()
+	}
+
 	// Sync ASC params from storage to NDMS — they may have been added/changed
 	// via the edit form after the initial Create (e.g. imported as plain WG, then edited).
 	o.appLog.Full("start", stored.Name, "Syncing ASC params to NDMS")
@@ -320,14 +333,14 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 	endpointIsV6 := false
 	if ip := net.ParseIP(endpointIP); ip != nil && ip.To4() == nil {
 		endpointIsV6 = true
+		// hostname→v6-only резолв: прекчек по литералу выше не сработал.
+		if wgToolLookup() == "" {
+			return errWGToolMissing()
+		}
 	}
 	realEndpoint := fmt.Sprintf("%s:%d", endpointIP, endpointPort)
 	if endpointIsV6 {
 		realEndpoint = net.JoinHostPort(endpointIP, strconv.Itoa(endpointPort))
-		// Fail fast до RCI-команд: без wg поднимать интерфейс бессмысленно.
-		if wgToolLookup() == "" {
-			return fmt.Errorf("IPv6 endpoint на прошивке с нативным ASC выставляется только через wireguard-tools, бинарь wg не найден — установите пакет: opkg install wireguard-tools")
-		}
 	}
 
 	// Sync address/MTU from storage
@@ -345,26 +358,51 @@ func (o *OperatorNativeWG) startNative(ctx context.Context, stored *storage.AWGT
 		o.hookNotifier.ExpectHook(names.NDMSName, "running")
 	}
 
-	// Batch: (v4) set endpoint + connect via + up; (v6) endpoint не входит —
-	// его RCI отвергнет, ставим в ядро после up.
-	var cmds []any
-	if !endpointIsV6 {
-		cmds = append(cmds, payloads.CmdWireguardPeerEndpoint(names.NDMSName, pubkey, realEndpoint))
+	// Batch: endpoint + connect via + up. Для v6 в RCI уходит ЗАГЛУШКА —
+	// она перезаписывает возможный устаревший реальный endpoint в конфиге
+	// NDMS (например после смены v4→v6 в редакторе: иначе NDMS хранил бы и
+	// переприменял старый v4-адрес).
+	rciEndpoint := realEndpoint
+	if endpointIsV6 {
+		rciEndpoint = ndmsEndpointPlaceholder
 	}
-	cmds = append(cmds,
+	cmds := []any{
+		payloads.CmdWireguardPeerEndpoint(names.NDMSName, pubkey, rciEndpoint),
 		payloads.CmdWireguardPeerConnect(names.NDMSName, pubkey, stored.ISPInterface),
 		payloads.CmdInterfaceUp(names.NDMSName, true),
-	)
+	}
 	if _, err := o.transport.PostBatch(ctx, cmds); err != nil {
 		return fmt.Errorf("start native: %w", err)
 	}
 
 	if endpointIsV6 {
-		if err := setKernelPeerEndpoint(ctx, names.IfaceName, pubkey, realEndpoint); err != nil {
-			return fmt.Errorf("start native: %w", err)
+		// NDMS применяет up асинхронно и в ходе поднятия сам переписывает
+		// kernel-endpoint значением из конфига (заглушкой) — одиночный wg set
+		// сразу после батча может проиграть гонку или застать девайс ещё не
+		// созданным. Ретраи покрывают старт, endpoint-страж — все дальнейшие
+		// переприменения конфига NDMS (ребут, up/down, failover, ping-check).
+		var setErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			if attempt > 0 {
+				time.Sleep(wgSetRetryDelay)
+			}
+			if setErr = setKernelPeerEndpoint(ctx, names.IfaceName, pubkey, realEndpoint); setErr == nil {
+				break
+			}
 		}
+		if setErr != nil {
+			return fmt.Errorf("start native: %w", setErr)
+		}
+		o.guardRegister(stored.ID, guardEntry{
+			iface:    names.IfaceName,
+			pubkey:   pubkey,
+			endpoint: realEndpoint,
+			name:     names.NDMSName,
+		})
 		o.appLog.Info("start", names.NDMSName,
-			fmt.Sprintf("IPv6 endpoint %s выставлен в ядро через wg set %s (RCI NDMS v6 не принимает); при ребуте/up-down переустановит reconcile", realEndpoint, names.IfaceName))
+			fmt.Sprintf("IPv6 endpoint %s выставлен в ядро через wg set %s (RCI NDMS v6 не принимает); endpoint-страж следит за сбросами NDMS", realEndpoint, names.IfaceName))
+	} else {
+		o.guardUnregister(stored.ID)
 	}
 
 	viaInfo := ""
@@ -503,6 +541,7 @@ func (o *OperatorNativeWG) Stop(ctx context.Context, stored *storage.AWGTunnel) 
 	if !ndmsinfo.SupportsWireguardASC() {
 		_ = o.kmod.RemoveTunnel(stored.ID)
 	}
+	o.guardUnregister(stored.ID)
 
 	o.appLog.Info("stop", names.NDMSName, "tunnel stopped")
 	return nil
@@ -516,6 +555,7 @@ func (o *OperatorNativeWG) Delete(ctx context.Context, stored *storage.AWGTunnel
 	if !ndmsinfo.SupportsWireguardASC() {
 		_ = o.kmod.RemoveTunnel(stored.ID)
 	}
+	o.guardUnregister(stored.ID)
 
 	// 2. Remove ping-check profile (before interface deletion)
 	if stored.PingCheck != nil && stored.PingCheck.Enabled {

--- a/internal/tunnel/nwg/start_native_endpoint_test.go
+++ b/internal/tunnel/nwg/start_native_endpoint_test.go
@@ -3,7 +3,12 @@ package nwg
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,51 +19,118 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
-// startFakePoster — минимальный Poster для command.Commands: SyncAddressMTU
-// и SyncDNS в startNative идут через commands, а не через transport-стаб.
-type startFakePoster struct{}
+// eventLog — единая лента событий теста: RCI-батчи и вызовы wg, в порядке
+// исполнения. Даёт проверять ОТНОСИТЕЛЬНЫЙ порядок (wg set строго после
+// батча с interface up) — мутация «wg set до батча» должна валить тест.
+type eventLog struct {
+	mu     sync.Mutex
+	events []string
+}
 
-func (startFakePoster) Post(context.Context, any) (json.RawMessage, error) {
+func (l *eventLog) add(e string) {
+	l.mu.Lock()
+	l.events = append(l.events, e)
+	l.mu.Unlock()
+}
+
+func (l *eventLog) list() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.events...)
+}
+
+// recordingPoster фиксирует command-層 RCI-вызовы (SetASCParams и т.п.) —
+// fail-fast обязан случиться раньше ЛЮБОГО RCI, включая commands-путь.
+type recordingPoster struct {
+	mu    sync.Mutex
+	posts int
+}
+
+func (r *recordingPoster) Post(context.Context, any) (json.RawMessage, error) {
+	r.mu.Lock()
+	r.posts++
+	r.mu.Unlock()
 	return json.RawMessage(`{}`), nil
+}
+
+func (r *recordingPoster) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.posts
 }
 
 type startNopPublisher struct{}
 
 func (startNopPublisher) Publish(string, any) {}
 
-func newStartTestCommands() *command.Commands {
+func newStartTestCommands(poster *recordingPoster) *command.Commands {
 	q := query.NewQueries(query.Deps{
 		Getter: query.NewFakeGetter(),
 		Logger: query.NopLogger(),
 		IsOS5:  func() bool { return true },
 	})
-	poster := startFakePoster{}
 	sc := command.NewSaveCoordinator(poster, startNopPublisher{}, 500*time.Millisecond, 5*time.Second, 0, nil)
 	return command.NewCommands(command.Deps{Poster: poster, Save: sc, Queries: q, IsOS5: func() bool { return true }})
 }
 
-// stubWGTool подменяет lookup/run wg на время теста.
-func stubWGTool(t *testing.T, path string, run func(ctx context.Context, binary string, args ...string) error) *[][]string {
+// stubWGTool подменяет lookup/run wg; каждый вызов пишется в лог событий.
+func stubWGTool(t *testing.T, log *eventLog, path string, run func(ctx context.Context, binary string, args ...string) error) *[][]string {
 	t.Helper()
-	origLookup, origRun := wgToolLookup, wgToolRun
+	origLookup, origRun, origDelay := wgToolLookup, wgToolRun, wgSetRetryDelay
+	var mu sync.Mutex
 	var calls [][]string
 	wgToolLookup = func() string { return path }
+	wgSetRetryDelay = 0
 	wgToolRun = func(ctx context.Context, binary string, args ...string) error {
+		mu.Lock()
 		calls = append(calls, append([]string{binary}, args...))
+		mu.Unlock()
+		if log != nil {
+			log.add("wg " + strings.Join(args, " "))
+		}
 		if run != nil {
 			return run(ctx, binary, args...)
 		}
 		return nil
 	}
-	t.Cleanup(func() { wgToolLookup, wgToolRun = origLookup, origRun })
+	t.Cleanup(func() { wgToolLookup, wgToolRun, wgSetRetryDelay = origLookup, origRun, origDelay })
 	return &calls
 }
 
-func newStartTestOperator(t *testing.T, srvURL string, resolvedIP string, port int) *OperatorNativeWG {
+// rciBatchServer отвечает на батчи, сохраняет последнее тело запроса и
+// пишет каждый батч в лог событий.
+type rciBatchServer struct {
+	srv      *httptest.Server
+	mu       sync.Mutex
+	lastBody string
+}
+
+func (s *rciBatchServer) last() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastBody
+}
+
+func newRCIBatchServer(t *testing.T, log *eventLog) *rciBatchServer {
+	t.Helper()
+	s := &rciBatchServer{}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.lastBody = string(body)
+		s.mu.Unlock()
+		log.add("rci-batch")
+		_, _ = w.Write([]byte(`[{}, {}, {}]`))
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func newStartTestOperator(t *testing.T, srvURL string, poster *recordingPoster, resolvedIP string, port int) *OperatorNativeWG {
 	t.Helper()
 	return &OperatorNativeWG{
 		transport:   transport.NewWithURL(srvURL, transport.NewSemaphore(2)),
-		commands:    newStartTestCommands(),
+		commands:    newStartTestCommands(poster),
 		appLog:      logging.NewScopedLogger(nil, logging.GroupTunnel, logging.SubOps),
 		supportsASC: func() bool { return true },
 		resolveFn: func(endpoint string) (string, int, error) {
@@ -84,20 +156,46 @@ func startTestTunnel(endpoint string) *storage.AWGTunnel {
 	}
 }
 
-// v6: RCI-батч НЕ содержит endpoint-команду, endpoint уходит в ядро через
-// `wg set nwg3 peer PUBKEY endpoint [v6]:port` ПОСЛЕ батча с up.
-func TestStartNative_IPv6EndpointViaWGTool(t *testing.T) {
-	s := newRCIStubServer(t, `[{}, {}]`)
-	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::feed:ff", 51820)
-	calls := stubWGTool(t, "/opt/bin/wg", nil)
+// decodeBatchCommands разбирает lastBody батча в список JSON-команд.
+func decodeBatchCommands(t *testing.T, body string) []string {
+	t.Helper()
+	var arr []json.RawMessage
+	if err := json.Unmarshal([]byte(body), &arr); err != nil {
+		t.Fatalf("batch body is not a JSON array: %v\n%s", err, body)
+	}
+	out := make([]string, len(arr))
+	for i, raw := range arr {
+		out[i] = string(raw)
+	}
+	return out
+}
 
-	if err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::feed:ff]:51820")); err != nil {
+// v6: батч несёт endpoint-ЗАГЛУШКУ (перетирает возможный старый v4 в конфиге
+// NDMS), реальный [v6]:port уходит в ядро через wg set СТРОГО ПОСЛЕ батча,
+// туннель регистрируется в endpoint-страже.
+func TestStartNative_IPv6EndpointViaWGTool(t *testing.T) {
+	log := &eventLog{}
+	s := newRCIBatchServer(t, log)
+	poster := &recordingPoster{}
+	op := newStartTestOperator(t, s.srv.URL, poster, "2a02:6b8::feed:ff", 51820)
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := startTestTunnel("[2a02:6b8::feed:ff]:51820")
+	if err := op.startNative(context.Background(), stored); err != nil {
 		t.Fatalf("startNative: %v", err)
 	}
 
-	if strings.Contains(s.lastBody, "2a02:6b8") {
-		t.Fatalf("v6 endpoint must not reach RCI:\n%s", s.lastBody)
+	if strings.Contains(s.last(), "2a02:6b8") {
+		t.Fatalf("v6 endpoint must not reach RCI:\n%s", s.last())
 	}
+	cmds := decodeBatchCommands(t, s.last())
+	if len(cmds) != 3 {
+		t.Fatalf("batch must carry exactly 3 commands (endpoint-placeholder, connect, up), got %d:\n%s", len(cmds), s.last())
+	}
+	if !strings.Contains(cmds[0], ndmsEndpointPlaceholder) {
+		t.Fatalf("first batch command must set the placeholder endpoint, got %s", cmds[0])
+	}
+
 	if len(*calls) != 1 {
 		t.Fatalf("wg tool calls = %d, want 1: %v", len(*calls), *calls)
 	}
@@ -106,45 +204,104 @@ func TestStartNative_IPv6EndpointViaWGTool(t *testing.T) {
 	if got != want {
 		t.Fatalf("wg call = %q, want %q", got, want)
 	}
+
+	// Порядок: wg set — после RCI-батча (up/down NDMS сбрасывает endpoint).
+	events := log.list()
+	lastBatch, wgSet := -1, -1
+	for i, e := range events {
+		if e == "rci-batch" {
+			lastBatch = i
+		}
+		if strings.HasPrefix(e, "wg set") {
+			wgSet = i
+		}
+	}
+	if wgSet == -1 || wgSet < lastBatch {
+		t.Fatalf("wg set must come after the RCI batch, events: %v", events)
+	}
+
+	if !op.guardHas(stored.ID) {
+		t.Fatal("v6 tunnel must be registered in the endpoint guard")
+	}
 }
 
-// v4: прежний путь байт-в-байт — endpoint в RCI-батче, wg не вызывается.
+// v4: прежний путь — реальный endpoint в RCI-батче, wg не вызывается,
+// в страже туннеля нет.
 func TestStartNative_IPv4EndpointViaRCI(t *testing.T) {
-	s := newRCIStubServer(t, `[{}, {}, {}]`)
-	op := newStartTestOperator(t, s.srv.URL, "203.0.113.7", 51820)
-	calls := stubWGTool(t, "/opt/bin/wg", nil)
+	log := &eventLog{}
+	s := newRCIBatchServer(t, log)
+	poster := &recordingPoster{}
+	op := newStartTestOperator(t, s.srv.URL, poster, "203.0.113.7", 51820)
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
 
-	if err := op.startNative(context.Background(), startTestTunnel("203.0.113.7:51820")); err != nil {
+	stored := startTestTunnel("203.0.113.7:51820")
+	if err := op.startNative(context.Background(), stored); err != nil {
 		t.Fatalf("startNative: %v", err)
 	}
-	if !strings.Contains(s.lastBody, "203.0.113.7:51820") {
-		t.Fatalf("v4 endpoint must go through RCI:\n%s", s.lastBody)
+	cmds := decodeBatchCommands(t, s.last())
+	if len(cmds) != 3 || !strings.Contains(cmds[0], "203.0.113.7:51820") {
+		t.Fatalf("v4 endpoint must go through RCI as the first command:\n%s", s.last())
 	}
 	if len(*calls) != 0 {
 		t.Fatalf("wg tool must not be called for v4: %v", *calls)
 	}
+	if op.guardHas(stored.ID) {
+		t.Fatal("v4 tunnel must not be in the endpoint guard")
+	}
 }
 
-// Нет бинаря wg — понятная ошибка ДО RCI-команд (интерфейс не дёргаем).
+// Нет бинаря wg — ошибка ДО каких-либо RCI-команд: и transport-батчей,
+// и commands-пути (SetASCParams).
 func TestStartNative_IPv6WithoutWGToolFailsFast(t *testing.T) {
-	s := newRCIStubServer(t, `[{}, {}]`)
-	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::1", 51820)
-	stubWGTool(t, "", nil)
+	log := &eventLog{}
+	s := newRCIBatchServer(t, log)
+	poster := &recordingPoster{}
+	op := newStartTestOperator(t, s.srv.URL, poster, "2a02:6b8::1", 51820)
+	stubWGTool(t, log, "", nil)
 
 	err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::1]:51820"))
 	if err == nil || !strings.Contains(err.Error(), "wireguard-tools") {
 		t.Fatalf("want wireguard-tools hint error, got %v", err)
 	}
-	if s.lastBody != "" {
-		t.Fatalf("RCI must not be touched when wg is missing, got body:\n%s", s.lastBody)
+	if s.last() != "" {
+		t.Fatalf("transport RCI must not be touched, got body:\n%s", s.last())
+	}
+	if poster.count() != 0 {
+		t.Fatalf("commands RCI (SetASCParams etc.) must not be touched, got %d posts", poster.count())
 	}
 }
 
-// Ошибка wg set пробрасывается как ошибка старта.
+// Гонка с асинхронным поднятием интерфейса: первые попытки wg set падают
+// (девайса ещё нет) — ретраи добивают, старт успешен.
+func TestStartNative_WGSetRetries(t *testing.T) {
+	log := &eventLog{}
+	s := newRCIBatchServer(t, log)
+	poster := &recordingPoster{}
+	op := newStartTestOperator(t, s.srv.URL, poster, "2a02:6b8::1", 51820)
+	attempt := 0
+	calls := stubWGTool(t, log, "/opt/bin/wg", func(context.Context, string, ...string) error {
+		attempt++
+		if attempt < 3 {
+			return errors.New("Unable to modify interface: No such device")
+		}
+		return nil
+	})
+
+	if err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::1]:51820")); err != nil {
+		t.Fatalf("startNative must survive transient wg set failures: %v", err)
+	}
+	if len(*calls) != 3 {
+		t.Fatalf("wg set attempts = %d, want 3", len(*calls))
+	}
+}
+
+// Ошибка wg set после всех ретраев пробрасывается как ошибка старта.
 func TestStartNative_WGToolFailurePropagates(t *testing.T) {
-	s := newRCIStubServer(t, `[{}, {}]`)
-	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::1", 51820)
-	stubWGTool(t, "/opt/bin/wg", func(context.Context, string, ...string) error {
+	log := &eventLog{}
+	s := newRCIBatchServer(t, log)
+	poster := &recordingPoster{}
+	op := newStartTestOperator(t, s.srv.URL, poster, "2a02:6b8::1", 51820)
+	stubWGTool(t, log, "/opt/bin/wg", func(context.Context, string, ...string) error {
 		return context.DeadlineExceeded
 	})
 

--- a/internal/tunnel/nwg/start_native_endpoint_test.go
+++ b/internal/tunnel/nwg/start_native_endpoint_test.go
@@ -1,0 +1,155 @@
+package nwg
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/ndms/command"
+	"github.com/hoaxisr/awg-manager/internal/ndms/query"
+	"github.com/hoaxisr/awg-manager/internal/ndms/transport"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// startFakePoster — минимальный Poster для command.Commands: SyncAddressMTU
+// и SyncDNS в startNative идут через commands, а не через transport-стаб.
+type startFakePoster struct{}
+
+func (startFakePoster) Post(context.Context, any) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+type startNopPublisher struct{}
+
+func (startNopPublisher) Publish(string, any) {}
+
+func newStartTestCommands() *command.Commands {
+	q := query.NewQueries(query.Deps{
+		Getter: query.NewFakeGetter(),
+		Logger: query.NopLogger(),
+		IsOS5:  func() bool { return true },
+	})
+	poster := startFakePoster{}
+	sc := command.NewSaveCoordinator(poster, startNopPublisher{}, 500*time.Millisecond, 5*time.Second, 0, nil)
+	return command.NewCommands(command.Deps{Poster: poster, Save: sc, Queries: q, IsOS5: func() bool { return true }})
+}
+
+// stubWGTool подменяет lookup/run wg на время теста.
+func stubWGTool(t *testing.T, path string, run func(ctx context.Context, binary string, args ...string) error) *[][]string {
+	t.Helper()
+	origLookup, origRun := wgToolLookup, wgToolRun
+	var calls [][]string
+	wgToolLookup = func() string { return path }
+	wgToolRun = func(ctx context.Context, binary string, args ...string) error {
+		calls = append(calls, append([]string{binary}, args...))
+		if run != nil {
+			return run(ctx, binary, args...)
+		}
+		return nil
+	}
+	t.Cleanup(func() { wgToolLookup, wgToolRun = origLookup, origRun })
+	return &calls
+}
+
+func newStartTestOperator(t *testing.T, srvURL string, resolvedIP string, port int) *OperatorNativeWG {
+	t.Helper()
+	return &OperatorNativeWG{
+		transport:   transport.NewWithURL(srvURL, transport.NewSemaphore(2)),
+		commands:    newStartTestCommands(),
+		appLog:      logging.NewScopedLogger(nil, logging.GroupTunnel, logging.SubOps),
+		supportsASC: func() bool { return true },
+		resolveFn: func(endpoint string) (string, int, error) {
+			return resolvedIP, port, nil
+		},
+	}
+}
+
+func startTestTunnel(endpoint string) *storage.AWGTunnel {
+	return &storage.AWGTunnel{
+		ID:       "awg20",
+		Name:     "t-v6",
+		NWGIndex: 3,
+		Interface: storage.AWGInterface{
+			PrivateKey:     "priv",
+			Address:        "10.0.0.2/32",
+			AWGObfuscation: storage.AWGObfuscation{Jc: 4, Jmin: 40, Jmax: 70},
+		},
+		Peer: storage.AWGPeer{
+			PublicKey: "PUBKEY",
+			Endpoint:  endpoint,
+		},
+	}
+}
+
+// v6: RCI-батч НЕ содержит endpoint-команду, endpoint уходит в ядро через
+// `wg set nwg3 peer PUBKEY endpoint [v6]:port` ПОСЛЕ батча с up.
+func TestStartNative_IPv6EndpointViaWGTool(t *testing.T) {
+	s := newRCIStubServer(t, `[{}, {}]`)
+	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::feed:ff", 51820)
+	calls := stubWGTool(t, "/opt/bin/wg", nil)
+
+	if err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::feed:ff]:51820")); err != nil {
+		t.Fatalf("startNative: %v", err)
+	}
+
+	if strings.Contains(s.lastBody, "2a02:6b8") {
+		t.Fatalf("v6 endpoint must not reach RCI:\n%s", s.lastBody)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("wg tool calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	want := "/opt/bin/wg set nwg3 peer PUBKEY endpoint [2a02:6b8::feed:ff]:51820"
+	if got != want {
+		t.Fatalf("wg call = %q, want %q", got, want)
+	}
+}
+
+// v4: прежний путь байт-в-байт — endpoint в RCI-батче, wg не вызывается.
+func TestStartNative_IPv4EndpointViaRCI(t *testing.T) {
+	s := newRCIStubServer(t, `[{}, {}, {}]`)
+	op := newStartTestOperator(t, s.srv.URL, "203.0.113.7", 51820)
+	calls := stubWGTool(t, "/opt/bin/wg", nil)
+
+	if err := op.startNative(context.Background(), startTestTunnel("203.0.113.7:51820")); err != nil {
+		t.Fatalf("startNative: %v", err)
+	}
+	if !strings.Contains(s.lastBody, "203.0.113.7:51820") {
+		t.Fatalf("v4 endpoint must go through RCI:\n%s", s.lastBody)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("wg tool must not be called for v4: %v", *calls)
+	}
+}
+
+// Нет бинаря wg — понятная ошибка ДО RCI-команд (интерфейс не дёргаем).
+func TestStartNative_IPv6WithoutWGToolFailsFast(t *testing.T) {
+	s := newRCIStubServer(t, `[{}, {}]`)
+	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::1", 51820)
+	stubWGTool(t, "", nil)
+
+	err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::1]:51820"))
+	if err == nil || !strings.Contains(err.Error(), "wireguard-tools") {
+		t.Fatalf("want wireguard-tools hint error, got %v", err)
+	}
+	if s.lastBody != "" {
+		t.Fatalf("RCI must not be touched when wg is missing, got body:\n%s", s.lastBody)
+	}
+}
+
+// Ошибка wg set пробрасывается как ошибка старта.
+func TestStartNative_WGToolFailurePropagates(t *testing.T) {
+	s := newRCIStubServer(t, `[{}, {}]`)
+	op := newStartTestOperator(t, s.srv.URL, "2a02:6b8::1", 51820)
+	stubWGTool(t, "/opt/bin/wg", func(context.Context, string, ...string) error {
+		return context.DeadlineExceeded
+	})
+
+	err := op.startNative(context.Background(), startTestTunnel("[2a02:6b8::1]:51820"))
+	if err == nil || !strings.Contains(err.Error(), "wg set") {
+		t.Fatalf("want wg set error, got %v", err)
+	}
+}

--- a/internal/tunnel/nwg/start_native_endpoint_test.go
+++ b/internal/tunnel/nwg/start_native_endpoint_test.go
@@ -220,8 +220,15 @@ func TestStartNative_IPv6EndpointViaWGTool(t *testing.T) {
 		t.Fatalf("wg set must come after the RCI batch, events: %v", events)
 	}
 
-	if !op.guardHas(stored.ID) {
+	entry, ok := op.guardGet(stored.ID)
+	if !ok {
 		t.Fatal("v6 tunnel must be registered in the endpoint guard")
+	}
+	// spec обязателен: без него DDNS-перерезолв в sweep молча мёртв для
+	// туннелей, взятых под стражу при старте (главный путь наполнения).
+	if entry.pubkey != "PUBKEY" || entry.endpoint != "[2a02:6b8::feed:ff]:51820" ||
+		entry.spec != stored.Peer.Endpoint || entry.iface != "nwg3" {
+		t.Fatalf("guard entry incomplete: %+v", entry)
 	}
 }
 

--- a/internal/tunnel/nwg/sync.go
+++ b/internal/tunnel/nwg/sync.go
@@ -136,9 +136,16 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 	ndmsName := NewNWGNames(stored.NWGIndex).NDMSName
 	o.appLog.Full("replace-config", stored.Name, "Syncing peer parameters to NDMS")
 
+	// NDMS отвергает IPv6-endpoint в peer-командах: в RCI уходит заглушка,
+	// реальный endpoint живёт в ядре (wg set ниже + endpoint-страж).
+	rciEndpoint := stored.Peer.Endpoint
+	kernelEndpoint, kernelV6 := canonicalV6Endpoint(stored.Peer.Endpoint)
+	if kernelV6 {
+		rciEndpoint = ndmsEndpointPlaceholder
+	}
 	peerCfg := payloads.PeerConfig{
 		PublicKey: stored.Peer.PublicKey,
-		Endpoint:  stored.Peer.Endpoint,
+		Endpoint:  rciEndpoint,
 	}
 	if stored.Peer.PersistentKeepalive > 0 {
 		peerCfg.KeepaliveInterval = stored.Peer.PersistentKeepalive
@@ -190,6 +197,23 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 	if stored.ISPInterface != "" {
 		if _, err := o.transport.Post(ctx, payloads.CmdWireguardPeerConnect(ndmsName, stored.Peer.PublicKey, stored.ISPInterface)); err != nil {
 			o.appLog.Warn("sync-peer", ndmsName, "peer connect via: "+err.Error())
+		}
+	}
+
+	// Работающий v6-туннель: смена ключа/endpoint'а должна доехать до ядра
+	// сразу, а реестр стража — обновиться (иначе он восстановит старые
+	// значения поверх новых).
+	if kernelV6 && o.guardHas(stored.ID) {
+		ifaceName := NewNWGNames(stored.NWGIndex).IfaceName
+		if err := setKernelPeerEndpoint(ctx, ifaceName, stored.Peer.PublicKey, kernelEndpoint); err != nil {
+			o.appLog.Warn("sync-peer", ndmsName, "kernel endpoint: "+err.Error())
+		} else {
+			o.guardRegister(stored.ID, guardEntry{
+				iface:    ifaceName,
+				pubkey:   stored.Peer.PublicKey,
+				endpoint: kernelEndpoint,
+				name:     ndmsName,
+			})
 		}
 	}
 

--- a/internal/tunnel/nwg/sync.go
+++ b/internal/tunnel/nwg/sync.go
@@ -138,8 +138,25 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 
 	// NDMS отвергает IPv6-endpoint в peer-командах: в RCI уходит заглушка,
 	// реальный endpoint живёт в ядре (wg set ниже + endpoint-страж).
+	// Hostname резолвим здесь же (v4 предпочтителен — netutil.preferIPv4):
+	// AAAA-only-имя NDMS резолвить не умеет, ему тоже нужна заглушка.
 	rciEndpoint := stored.Peer.Endpoint
 	kernelEndpoint, kernelV6 := canonicalV6Endpoint(stored.Peer.Endpoint)
+	v4Confirmed := false
+	if !kernelV6 {
+		if host, ok := splitEndpointHost(stored.Peer.Endpoint); ok && net.ParseIP(host) != nil {
+			v4Confirmed = true // v4-литерал — endpoint'ом управляет сам NDMS
+		} else if ip, port, err := o.resolveEndpointWithFallback(stored); err == nil {
+			if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() == nil {
+				kernelEndpoint = net.JoinHostPort(ip, strconv.Itoa(port))
+				kernelV6 = true
+			} else {
+				v4Confirmed = true
+			}
+		}
+		// Ошибка резолва: ни v4, ни v6 не подтверждены — hostname уходит
+		// в RCI как раньше, судьба стража решается ниже.
+	}
 	if kernelV6 {
 		rciEndpoint = ndmsEndpointPlaceholder
 	}
@@ -202,8 +219,10 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 
 	// Работающий v6-туннель: смена ключа/endpoint'а должна доехать до ядра
 	// сразу, а реестр стража — обновиться (иначе он восстановит старые
-	// значения поверх новых).
-	if kernelV6 && o.guardHas(stored.ID) {
+	// значения поверх новых, а wg set по старому ключу вообще ВОСКРЕШАЕТ
+	// удалённого пира на интерфейсе).
+	switch {
+	case kernelV6 && o.guardHas(stored.ID):
 		ifaceName := NewNWGNames(stored.NWGIndex).IfaceName
 		if err := setKernelPeerEndpoint(ctx, ifaceName, stored.Peer.PublicKey, kernelEndpoint); err != nil {
 			o.appLog.Warn("sync-peer", ndmsName, "kernel endpoint: "+err.Error())
@@ -212,8 +231,25 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 				iface:    ifaceName,
 				pubkey:   stored.Peer.PublicKey,
 				endpoint: kernelEndpoint,
+				spec:     stored.Peer.Endpoint,
 				name:     ndmsName,
 			})
+		}
+	case v4Confirmed:
+		// Туннель вернулся на v4 — endpoint'ом снова управляет NDMS
+		// (реальный адрес ушёл в RCI выше), стражу здесь делать нечего.
+		if o.guardHas(stored.ID) {
+			o.guardUnregister(stored.ID)
+			o.appLog.Info("sync-peer", ndmsName, "endpoint теперь v4 — endpoint-страж снят, адресом управляет NDMS")
+		}
+	default:
+		// Резолв hostname'а не удался. Если ключ или endpoint изменились,
+		// реестр стража устарел — снять, иначе он воскресит старого пира.
+		if e, ok := o.guardGet(stored.ID); ok &&
+			(e.pubkey != stored.Peer.PublicKey || e.spec != stored.Peer.Endpoint) {
+			o.guardUnregister(stored.ID)
+			o.appLog.Warn("sync-peer", ndmsName,
+				"endpoint не резолвится, параметры пира изменились — endpoint-страж снят; если имя резолвится только в IPv6, перезапустите туннель")
 		}
 	}
 

--- a/internal/tunnel/nwg/sync.go
+++ b/internal/tunnel/nwg/sync.go
@@ -138,24 +138,35 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 
 	// NDMS отвергает IPv6-endpoint в peer-командах: в RCI уходит заглушка,
 	// реальный endpoint живёт в ядре (wg set ниже + endpoint-страж).
-	// Hostname резолвим здесь же (v4 предпочтителен — netutil.preferIPv4):
-	// AAAA-only-имя NDMS резолвить не умеет, ему тоже нужна заглушка.
+	// Hostname резолвим здесь же (v4 предпочтителен — netutil.preferIPv4),
+	// причём СВЕЖИМ резолвом, без кэш-фолбэка: кэш может нести адрес
+	// прежнего endpoint'а. AAAA-only-имя NDMS резолвить не умеет — ему
+	// тоже нужна заглушка.
 	rciEndpoint := stored.Peer.Endpoint
 	kernelEndpoint, kernelV6 := canonicalV6Endpoint(stored.Peer.Endpoint)
 	v4Confirmed := false
 	if !kernelV6 {
-		if host, ok := splitEndpointHost(stored.Peer.Endpoint); ok && net.ParseIP(host) != nil {
-			v4Confirmed = true // v4-литерал — endpoint'ом управляет сам NDMS
-		} else if ip, port, err := o.resolveEndpointWithFallback(stored); err == nil {
-			if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() == nil {
-				kernelEndpoint = net.JoinHostPort(ip, strconv.Itoa(port))
-				kernelV6 = true
-			} else {
-				v4Confirmed = true
+		host, ok := splitEndpointHost(stored.Peer.Endpoint)
+		switch {
+		case !ok:
+			// Пустой/мусорный endpoint — резолвить нечего.
+		case net.ParseIP(host) != nil:
+			// IP-литерал. Форма с двоеточиями — v6 без валидного порта
+			// (canonicalV6Endpoint дал false): в ядро её не поставить,
+			// v4 она не является. v4Confirmed — только настоящий v4.
+			v4Confirmed = !strings.Contains(host, ":")
+		default:
+			if ip, port, err := o.resolveEndpointFresh(stored.Peer.Endpoint); err == nil {
+				if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() == nil {
+					kernelEndpoint = net.JoinHostPort(ip, strconv.Itoa(port))
+					kernelV6 = true
+				} else {
+					v4Confirmed = true
+				}
 			}
+			// Ошибка резолва: ни v4, ни v6 не подтверждены — hostname
+			// уходит в RCI как раньше, судьба стража решается ниже.
 		}
-		// Ошибка резолва: ни v4, ни v6 не подтверждены — hostname уходит
-		// в RCI как раньше, судьба стража решается ниже.
 	}
 	if kernelV6 {
 		rciEndpoint = ndmsEndpointPlaceholder
@@ -217,23 +228,42 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 		}
 	}
 
-	// Работающий v6-туннель: смена ключа/endpoint'а должна доехать до ядра
-	// сразу, а реестр стража — обновиться (иначе он восстановит старые
-	// значения поверх новых, а wg set по старому ключу вообще ВОСКРЕШАЕТ
-	// удалённого пира на интерфейсе).
+	// Смена ключа/endpoint'а должна доехать до ядра сразу, а реестр стража —
+	// обновиться (устаревшая запись не просто восстановит старые значения:
+	// wg set по старому ключу ВОСКРЕШАЕТ удалённого RCI-батчем пира).
 	switch {
-	case kernelV6 && o.guardHas(stored.ID):
+	case kernelV6:
 		ifaceName := NewNWGNames(stored.NWGIndex).IfaceName
-		if err := setKernelPeerEndpoint(ctx, ifaceName, stored.Peer.PublicKey, kernelEndpoint); err != nil {
-			o.appLog.Warn("sync-peer", ndmsName, "kernel endpoint: "+err.Error())
-		} else {
-			o.guardRegister(stored.ID, guardEntry{
-				iface:    ifaceName,
-				pubkey:   stored.Peer.PublicKey,
-				endpoint: kernelEndpoint,
-				spec:     stored.Peer.Endpoint,
-				name:     ndmsName,
-			})
+		entry := guardEntry{
+			iface:    ifaceName,
+			pubkey:   stored.Peer.PublicKey,
+			endpoint: kernelEndpoint,
+			spec:     stored.Peer.Endpoint,
+			name:     ndmsName,
+		}
+		// Реестр — ДО wg set и независимо от его исхода: RCI-батч выше уже
+		// заменил пира, и упавший wg set не повод оставить в страже старый
+		// ключ. Свежая запись при упавшем wg set безопасна — страж сам
+		// доведёт endpoint на ближайшем проходе (≤guardInterval).
+		// Replace-if-present, не register: параллельный Stop/Delete
+		// (оркестратор, другой лок-домен) мог снять туннель со стражи —
+		// безусловный register воскресил бы запись навсегда.
+		guarded := o.guardReplaceIfPresent(stored.ID, entry)
+		err := setKernelPeerEndpoint(ctx, ifaceName, entry.pubkey, kernelEndpoint)
+		switch {
+		case err != nil && guarded:
+			o.appLog.Warn("sync-peer", ndmsName, "kernel endpoint: "+err.Error()+" — страж доведёт на ближайшем проходе")
+		case err != nil:
+			// Устройства нет (туннель не запускался) — endpoint доедет
+			// при старте, как и раньше.
+			o.appLog.Full("sync-peer", ndmsName, "kernel endpoint отложен до старта: "+err.Error())
+		case !guarded:
+			// Живой переход v4→v6 (реестр был пуст, устройство есть):
+			// заглушка уже ушла в RCI, без стража NDMS затрёт ею
+			// kernel-endpoint при первом же переприменении конфига.
+			o.guardRegister(stored.ID, entry)
+			o.appLog.Info("sync-peer", ndmsName,
+				fmt.Sprintf("endpoint теперь IPv6 — %s выставлен в ядро (%s), взят под endpoint-страж", kernelEndpoint, ifaceName))
 		}
 	case v4Confirmed:
 		// Туннель вернулся на v4 — endpoint'ом снова управляет NDMS
@@ -243,8 +273,10 @@ func (o *OperatorNativeWG) SyncPeer(ctx context.Context, stored *storage.AWGTunn
 			o.appLog.Info("sync-peer", ndmsName, "endpoint теперь v4 — endpoint-страж снят, адресом управляет NDMS")
 		}
 	default:
-		// Резолв hostname'а не удался. Если ключ или endpoint изменились,
-		// реестр стража устарел — снять, иначе он воскресит старого пира.
+		// Резолв hostname'а не удался (или endpoint непригоден). Если ключ
+		// или endpoint изменились, реестр стража устарел — снять, иначе он
+		// воскресит старого пира. При неизменном пире транзиентный сбой
+		// DNS защиту не снимает.
 		if e, ok := o.guardGet(stored.ID); ok &&
 			(e.pubkey != stored.Peer.PublicKey || e.spec != stored.Peer.Endpoint) {
 			o.guardUnregister(stored.ID)

--- a/internal/tunnel/nwg/sync_peer_v6_test.go
+++ b/internal/tunnel/nwg/sync_peer_v6_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
+// stubResolveGap обнуляет паузу между попытками резолва — failing-resolve
+// тесты не должны спать по 2×300ms.
+func stubResolveGap(t *testing.T) {
+	t.Helper()
+	orig := resolveRetryGap
+	resolveRetryGap = 0
+	t.Cleanup(func() { resolveRetryGap = orig })
+}
+
+// orderPin возвращает run-callback для stubWGTool, проверяющий, что к
+// моменту wg set RCI-батч уже ушёл: NDMS, применяя peer-команду, сбрасывает
+// kernel-endpoint — wg set ДО батча был бы затёрт заглушкой.
+func orderPin(t *testing.T, cs *captureServer) func(context.Context, string, ...string) error {
+	t.Helper()
+	return func(context.Context, string, ...string) error {
+		if len(cs.bodies) == 0 {
+			t.Error("wg set must run AFTER the RCI batch")
+		}
+		return nil
+	}
+}
+
 // SyncPeer с v6-endpoint'ом: в RCI уходит заглушка (NDMS отвергает v6 в
 // peer-командах), реальный endpoint доезжает до ядра wg set'ом и реестр
 // стража обновляется — для работающего туннеля.
@@ -16,7 +38,7 @@ func TestSyncPeer_IPv6EndpointUsesPlaceholderAndKernelSet(t *testing.T) {
 	op := newSyncTestOperator(t, cs.srv.URL)
 	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:1", name: "Wireguard5"})
 	log := &eventLog{}
-	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+	calls := stubWGTool(t, log, "/opt/bin/wg", orderPin(t, cs))
 
 	stored := &storage.AWGTunnel{
 		ID:       "awg20",
@@ -63,7 +85,7 @@ func TestSyncPeer_HostnameResolvesV6UsesPlaceholderAndKernelSet(t *testing.T) {
 	op.resolveFn = func(string) (string, int, error) { return "2a02:6b8::feed:ff", 51820, nil }
 	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:1", spec: "old.example.com:1", name: "Wireguard5"})
 	log := &eventLog{}
-	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+	calls := stubWGTool(t, log, "/opt/bin/wg", orderPin(t, cs))
 
 	stored := &storage.AWGTunnel{
 		ID:       "awg20",
@@ -128,6 +150,7 @@ func TestSyncPeer_V6ToV4LiteralUnregistersGuard(t *testing.T) {
 // стража снимается (wg set по старому ключу воскресил бы удалённого пира).
 // Hostname уходит в RCI как раньше.
 func TestSyncPeer_ResolveFailedChangedPeerDropsStaleGuard(t *testing.T) {
+	stubResolveGap(t)
 	cs := newCaptureServer(t)
 	op := newSyncTestOperator(t, cs.srv.URL)
 	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
@@ -157,7 +180,10 @@ func TestSyncPeer_ResolveFailedChangedPeerDropsStaleGuard(t *testing.T) {
 
 // Резолв упал, но пир НЕ менялся (правка keepalive и т.п.): реестр стража
 // не трогаем — транзиентный сбой DNS не должен снимать защиту endpoint'а.
+// Резолв в SyncPeer — свежий, БЕЗ кэш-фолбэка: кэшированный IP прежнего
+// endpoint'а не должен «подтверждать» v4 и снимать стража.
 func TestSyncPeer_ResolveFailedUnchangedPeerKeepsGuard(t *testing.T) {
+	stubResolveGap(t)
 	cs := newCaptureServer(t)
 	op := newSyncTestOperator(t, cs.srv.URL)
 	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
@@ -168,7 +194,10 @@ func TestSyncPeer_ResolveFailedUnchangedPeerKeepsGuard(t *testing.T) {
 	stored := &storage.AWGTunnel{
 		ID:       "awg20",
 		NWGIndex: 5,
-		Peer:     storage.AWGPeer{PublicKey: "KEY", Endpoint: "vpn.example.com:51820", PersistentKeepalive: 25},
+		// Отравленный кэш: v4-адрес ПРЕЖНЕГО endpoint'а. Фолбэк на него
+		// «подтвердил» бы v4 и снял стража — свежий резолв его игнорирует.
+		ResolvedEndpointIP: "1.2.3.4",
+		Peer:               storage.AWGPeer{PublicKey: "KEY", Endpoint: "vpn.example.com:51820", PersistentKeepalive: 25},
 	}
 	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
 		t.Fatalf("SyncPeer: %v", err)
@@ -178,13 +207,14 @@ func TestSyncPeer_ResolveFailedUnchangedPeerKeepsGuard(t *testing.T) {
 	}
 }
 
-// Остановленный v6-туннель (не в страже): только заглушка в RCI, wg не
-// вызывается — endpoint доедет при старте.
-func TestSyncPeer_IPv6StoppedTunnelSkipsKernelSet(t *testing.T) {
+// Живой переход v4→v6 (реестр пуст, устройство есть): wg set проходит,
+// туннель берётся под стражу — иначе NDMS затрёт kernel-endpoint заглушкой
+// при первом переприменении конфига, а чинить будет некому.
+func TestSyncPeer_LiveV4ToV6TransitionRegistersGuard(t *testing.T) {
 	cs := newCaptureServer(t)
 	op := newSyncTestOperator(t, cs.srv.URL)
 	log := &eventLog{}
-	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+	calls := stubWGTool(t, log, "/opt/bin/wg", orderPin(t, cs))
 
 	stored := &storage.AWGTunnel{
 		ID:       "awg21",
@@ -194,7 +224,117 @@ func TestSyncPeer_IPv6StoppedTunnelSkipsKernelSet(t *testing.T) {
 	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
 		t.Fatalf("SyncPeer: %v", err)
 	}
-	if len(*calls) != 0 {
-		t.Fatalf("wg set must not run for a stopped tunnel: %v", *calls)
+	if !strings.Contains(strings.Join(cs.bodies, "\n"), ndmsEndpointPlaceholder) {
+		t.Fatal("placeholder endpoint missing in RCI batch")
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	entry, ok := op.guardGet("awg21")
+	if !ok || entry.pubkey != "K" || entry.endpoint != "[2a02::1]:51820" || entry.spec != "[2a02::1]:51820" || entry.iface != "nwg6" {
+		t.Fatalf("tunnel must be guarded after live v4->v6 transition: %+v", entry)
+	}
+}
+
+// Туннель не запускался (kernel-устройства нет — wg set падает): под стражу
+// не берём, endpoint доедет при старте.
+func TestSyncPeer_IPv6DeviceMissingStaysUnguarded(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	log := &eventLog{}
+	noDevice := func(context.Context, string, ...string) error {
+		return context.DeadlineExceeded // «Unable to modify interface: No such device»
+	}
+	calls := stubWGTool(t, log, "/opt/bin/wg", noDevice)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg21",
+		NWGIndex: 6,
+		Peer:     storage.AWGPeer{PublicKey: "K", Endpoint: "[2a02::1]:51820"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("wg set attempts = %d, want 1: %v", len(*calls), *calls)
+	}
+	if op.guardHas("awg21") {
+		t.Fatal("tunnel without kernel device must not be guarded")
+	}
+}
+
+// Частичный отказ: RCI-батч уже заменил пира, wg set упал. Реестр стража
+// ОБЯЗАН перейти на новый ключ/endpoint — устаревшая запись с OLDKEY
+// воскресила бы удалённого пира первым же sweep'ом; свежую доведёт страж.
+func TestSyncPeer_WGSetFailureStillUpdatesGuardRegistry(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:1", spec: "[2a02::1]:1", name: "Wireguard5"})
+	log := &eventLog{}
+	failing := func(context.Context, string, ...string) error { return context.DeadlineExceeded }
+	_ = stubWGTool(t, log, "/opt/bin/wg", failing)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer:     storage.AWGPeer{PublicKey: "NEWKEY", Endpoint: "[2a02:6b8::feed:ff]:51820"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, "OLDKEY"); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	entry, ok := op.guardGet("awg20")
+	if !ok || entry.pubkey != "NEWKEY" || entry.endpoint != "[2a02:6b8::feed:ff]:51820" {
+		t.Fatalf("registry must carry the NEW peer even when wg set failed: %+v", entry)
+	}
+}
+
+// v6-литерал без порта — НЕ «подтверждённый v4»: при неизменном пире страж
+// остаётся (v4Confirmed по такой форме снял бы его с ложным «endpoint
+// теперь v4»).
+func TestSyncPeer_V6LiteralWithoutPortIsNotV4(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	resolves := 0
+	op.resolveFn = func(string) (string, int, error) { resolves++; return "", 0, context.DeadlineExceeded }
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "K", endpoint: "[2a02::1]:51820", spec: "[2a02::1]", name: "Wireguard5"})
+	log := &eventLog{}
+	_ = stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer:     storage.AWGPeer{PublicKey: "K", Endpoint: "[2a02::1]"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	if resolves != 0 {
+		t.Fatalf("IP literal must not be resolved, got %d resolves", resolves)
+	}
+	if !op.guardHas("awg20") {
+		t.Fatal("v6 literal without port must not be treated as confirmed v4")
+	}
+}
+
+// Пустой endpoint (листен-only пир) не гоняет резолвер — сохранение
+// настроек не должно платить секунды за DNS-ретраи.
+func TestSyncPeer_EmptyEndpointSkipsResolve(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	resolves := 0
+	op.resolveFn = func(string) (string, int, error) { resolves++; return "", 0, context.DeadlineExceeded }
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg21",
+		NWGIndex: 6,
+		Peer:     storage.AWGPeer{PublicKey: "K", Endpoint: ""},
+	}
+	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	if resolves != 0 || len(*calls) != 0 {
+		t.Fatalf("empty endpoint: resolves=%d wg=%v, want 0/none", resolves, *calls)
 	}
 }

--- a/internal/tunnel/nwg/sync_peer_v6_test.go
+++ b/internal/tunnel/nwg/sync_peer_v6_test.go
@@ -1,0 +1,76 @@
+package nwg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// SyncPeer с v6-endpoint'ом: в RCI уходит заглушка (NDMS отвергает v6 в
+// peer-командах), реальный endpoint доезжает до ядра wg set'ом и реестр
+// стража обновляется — для работающего туннеля.
+func TestSyncPeer_IPv6EndpointUsesPlaceholderAndKernelSet(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:1", name: "Wireguard5"})
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer: storage.AWGPeer{
+			PublicKey: "NEWKEY",
+			Endpoint:  "[2a02:6b8::feed:ff]:51820",
+		},
+	}
+	if err := op.SyncPeer(context.Background(), stored, "OLDKEY"); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+
+	body := strings.Join(cs.bodies, "\n")
+	if strings.Contains(body, "2a02:6b8") {
+		t.Fatalf("v6 endpoint must not reach RCI:\n%s", body)
+	}
+	if !strings.Contains(body, ndmsEndpointPlaceholder) {
+		t.Fatalf("placeholder endpoint missing in RCI batch:\n%s", body)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg5 peer NEWKEY endpoint [2a02:6b8::feed:ff]:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+
+	// Реестр стража обновлён новым ключом и endpoint'ом.
+	op.guardMu.Lock()
+	entry := op.guard["awg20"]
+	op.guardMu.Unlock()
+	if entry.pubkey != "NEWKEY" || entry.endpoint != "[2a02:6b8::feed:ff]:51820" {
+		t.Fatalf("guard entry not updated: %+v", entry)
+	}
+}
+
+// Остановленный v6-туннель (не в страже): только заглушка в RCI, wg не
+// вызывается — endpoint доедет при старте.
+func TestSyncPeer_IPv6StoppedTunnelSkipsKernelSet(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg21",
+		NWGIndex: 6,
+		Peer:     storage.AWGPeer{PublicKey: "K", Endpoint: "[2a02::1]:51820"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("wg set must not run for a stopped tunnel: %v", *calls)
+	}
+}

--- a/internal/tunnel/nwg/sync_peer_v6_test.go
+++ b/internal/tunnel/nwg/sync_peer_v6_test.go
@@ -54,6 +54,130 @@ func TestSyncPeer_IPv6EndpointUsesPlaceholderAndKernelSet(t *testing.T) {
 	}
 }
 
+// Hostname с AAAA-only резолвом на работающем туннеле: в RCI — заглушка
+// (NDMS такое имя не резолвит), в ядро — свежерезолвнутый v6, реестр
+// стража обновлён (ключ, endpoint и spec для перерезолва DDNS).
+func TestSyncPeer_HostnameResolvesV6UsesPlaceholderAndKernelSet(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.resolveFn = func(string) (string, int, error) { return "2a02:6b8::feed:ff", 51820, nil }
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:1", spec: "old.example.com:1", name: "Wireguard5"})
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer: storage.AWGPeer{
+			PublicKey: "NEWKEY",
+			Endpoint:  "vpn.example.com:51820",
+		},
+	}
+	if err := op.SyncPeer(context.Background(), stored, "OLDKEY"); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+
+	body := strings.Join(cs.bodies, "\n")
+	if !strings.Contains(body, ndmsEndpointPlaceholder) {
+		t.Fatalf("placeholder endpoint missing in RCI batch:\n%s", body)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("wg set calls = %d, want 1: %v", len(*calls), *calls)
+	}
+	got := strings.Join((*calls)[0], " ")
+	if got != "/opt/bin/wg set nwg5 peer NEWKEY endpoint [2a02:6b8::feed:ff]:51820" {
+		t.Fatalf("unexpected wg set: %q", got)
+	}
+	entry, ok := op.guardGet("awg20")
+	if !ok || entry.pubkey != "NEWKEY" || entry.endpoint != "[2a02:6b8::feed:ff]:51820" || entry.spec != "vpn.example.com:51820" {
+		t.Fatalf("guard entry not updated: %+v", entry)
+	}
+}
+
+// Смена endpoint'а работающего v6-туннеля на v4-литерал: реальный адрес
+// уходит в RCI (им управляет NDMS), страж снимается — иначе он воскресил бы
+// удалённого пира со старым ключом.
+func TestSyncPeer_V6ToV4LiteralUnregistersGuard(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:51820", spec: "[2a02::1]:51820", name: "Wireguard5"})
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer:     storage.AWGPeer{PublicKey: "NEWKEY", Endpoint: "1.2.3.4:51820"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, "OLDKEY"); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+
+	if !strings.Contains(strings.Join(cs.bodies, "\n"), "1.2.3.4:51820") {
+		t.Fatalf("real v4 endpoint must reach RCI:\n%s", strings.Join(cs.bodies, "\n"))
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("wg set must not run for v4 endpoint: %v", *calls)
+	}
+	if op.guardHas("awg20") {
+		t.Fatal("guard must be unregistered after switch to v4")
+	}
+}
+
+// Резолв hostname'а упал, а параметры пира изменились: устаревший реестр
+// стража снимается (wg set по старому ключу воскресил бы удалённого пира).
+// Hostname уходит в RCI как раньше.
+func TestSyncPeer_ResolveFailedChangedPeerDropsStaleGuard(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "OLDKEY", endpoint: "[2a02::1]:51820", spec: "old.example.com:51820", name: "Wireguard5"})
+	log := &eventLog{}
+	calls := stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer:     storage.AWGPeer{PublicKey: "NEWKEY", Endpoint: "vpn.example.com:51820"},
+	}
+	if err := op.SyncPeer(context.Background(), stored, "OLDKEY"); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+
+	if !strings.Contains(strings.Join(cs.bodies, "\n"), "vpn.example.com:51820") {
+		t.Fatalf("hostname must reach RCI unchanged on resolve failure:\n%s", strings.Join(cs.bodies, "\n"))
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("wg set must not run on resolve failure: %v", *calls)
+	}
+	if op.guardHas("awg20") {
+		t.Fatal("stale guard entry must be unregistered when peer changed and resolve failed")
+	}
+}
+
+// Резолв упал, но пир НЕ менялся (правка keepalive и т.п.): реестр стража
+// не трогаем — транзиентный сбой DNS не должен снимать защиту endpoint'а.
+func TestSyncPeer_ResolveFailedUnchangedPeerKeepsGuard(t *testing.T) {
+	cs := newCaptureServer(t)
+	op := newSyncTestOperator(t, cs.srv.URL)
+	op.resolveFn = func(string) (string, int, error) { return "", 0, context.DeadlineExceeded }
+	op.guardRegister("awg20", guardEntry{iface: "nwg5", pubkey: "KEY", endpoint: "[2a02::1]:51820", spec: "vpn.example.com:51820", name: "Wireguard5"})
+	log := &eventLog{}
+	_ = stubWGTool(t, log, "/opt/bin/wg", nil)
+
+	stored := &storage.AWGTunnel{
+		ID:       "awg20",
+		NWGIndex: 5,
+		Peer:     storage.AWGPeer{PublicKey: "KEY", Endpoint: "vpn.example.com:51820", PersistentKeepalive: 25},
+	}
+	if err := op.SyncPeer(context.Background(), stored, ""); err != nil {
+		t.Fatalf("SyncPeer: %v", err)
+	}
+	if !op.guardHas("awg20") {
+		t.Fatal("guard must survive transient resolve failure when peer unchanged")
+	}
+}
+
 // Остановленный v6-туннель (не в страже): только заглушка в RCI, wg не
 // вызывается — endpoint доедет при старте.
 func TestSyncPeer_IPv6StoppedTunnelSkipsKernelSet(t *testing.T) {

--- a/internal/tunnel/nwg/wg_tool.go
+++ b/internal/tunnel/nwg/wg_tool.go
@@ -1,0 +1,63 @@
+package nwg
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
+)
+
+// Установка IPv6-endpoint'а на ASC-прошивках (≥5.01.A.4): NDMS не принимает
+// v6-endpoint через RCI ни в импорте, ни в peer-командах (подтверждено
+// автором на устройстве) — endpoint выставляется напрямую в ядро через
+// wireguard-tools по kernel-имени интерфейса (nwgN).
+//
+// NDMS не перетирает выставленный так endpoint в обычной работе, но
+// сбрасывает при перезагрузке роутера и up/down интерфейса. Это закрывается
+// существующим reconcile-путём оркестратора (executeReconcileNativeWG:
+// туннель без хендшейка → полный Start → повторный wg set) — отдельный
+// вотчер не нужен.
+
+// wgToolCandidates — места, где Entware/прошивка держат бинарь wg
+// (пакет wireguard-tools).
+var wgToolCandidates = []string{"/opt/bin/wg", "/opt/usr/bin/wg", "/usr/bin/wg"}
+
+// wgToolLookup возвращает путь к первому исполняемому wg или "".
+// Переопределяется в тестах.
+var wgToolLookup = func() string {
+	for _, p := range wgToolCandidates {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return p
+		}
+	}
+	return ""
+}
+
+// wgToolRun запускает wg с аргументами. Переопределяется в тестах.
+var wgToolRun = func(ctx context.Context, binary string, args ...string) error {
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := sysexec.Run(runCtx, binary, args...)
+	if err != nil {
+		if res != nil && res.Stderr != "" {
+			return fmt.Errorf("%w: %s", err, res.Stderr)
+		}
+		return err
+	}
+	return nil
+}
+
+// setKernelPeerEndpoint выставляет endpoint пира напрямую в ядро:
+// `wg set <nwgN> peer <pubkey> endpoint <[v6]:port>`.
+func setKernelPeerEndpoint(ctx context.Context, ifaceName, pubkey, endpoint string) error {
+	bin := wgToolLookup()
+	if bin == "" {
+		return fmt.Errorf("IPv6 endpoint на прошивке с нативным ASC выставляется только через wireguard-tools, бинарь wg не найден — установите пакет: opkg install wireguard-tools")
+	}
+	if err := wgToolRun(ctx, bin, "set", ifaceName, "peer", pubkey, "endpoint", endpoint); err != nil {
+		return fmt.Errorf("wg set %s endpoint %s: %w", ifaceName, endpoint, err)
+	}
+	return nil
+}

--- a/internal/tunnel/nwg/wg_tool.go
+++ b/internal/tunnel/nwg/wg_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"time"
 
 	sysexec "github.com/hoaxisr/awg-manager/internal/sys/exec"
@@ -14,23 +15,27 @@ import (
 // автором на устройстве) — endpoint выставляется напрямую в ядро через
 // wireguard-tools по kernel-имени интерфейса (nwgN).
 //
-// NDMS не перетирает выставленный так endpoint в обычной работе, но
-// сбрасывает при перезагрузке роутера и up/down интерфейса. Это закрывается
-// существующим reconcile-путём оркестратора (executeReconcileNativeWG:
-// туннель без хендшейка → полный Start → повторный wg set) — отдельный
-// вотчер не нужен.
+// NDMS перезаписывает выставленный так endpoint своей заглушкой при любом
+// переприменении конфига (ребут роутера, up/down интерфейса, WAN-failover,
+// рестарт от его ping-check) — за возвратом следит endpoint-страж
+// (endpoint_guard.go), а после рестарта демона реестр стража наполняет
+// заново Start (EventReconnect/EventBoot → ActionStartNativeWG,
+// см. orchestrator/decide.go).
 
 // wgToolCandidates — места, где Entware/прошивка держат бинарь wg
 // (пакет wireguard-tools).
-var wgToolCandidates = []string{"/opt/bin/wg", "/opt/usr/bin/wg", "/usr/bin/wg"}
+var wgToolCandidates = []string{"/opt/bin/wg", "/opt/sbin/wg", "/opt/usr/bin/wg", "/usr/bin/wg"}
 
-// wgToolLookup возвращает путь к первому исполняемому wg или "".
-// Переопределяется в тестах.
+// wgToolLookup возвращает путь к первому исполняемому wg (кандидаты, затем
+// PATH) или "". Переопределяется в тестах.
 var wgToolLookup = func() string {
 	for _, p := range wgToolCandidates {
 		if info, err := os.Stat(p); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
 			return p
 		}
+	}
+	if p, err := exec.LookPath("wg"); err == nil {
+		return p
 	}
 	return ""
 }
@@ -49,12 +54,36 @@ var wgToolRun = func(ctx context.Context, binary string, args ...string) error {
 	return nil
 }
 
+// wgToolOutput — как wgToolRun, но возвращает stdout (для `wg show`).
+// Переопределяется в тестах.
+var wgToolOutput = func(ctx context.Context, binary string, args ...string) (string, error) {
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := sysexec.Run(runCtx, binary, args...)
+	if err != nil {
+		if res != nil && res.Stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, res.Stderr)
+		}
+		return "", err
+	}
+	return res.Stdout, nil
+}
+
+// wgSetRetryDelay — пауза между ретраями wg set в startNative (гонка с
+// асинхронным поднятием интерфейса NDMS). Переопределяется в тестах.
+var wgSetRetryDelay = 700 * time.Millisecond
+
+// errWGToolMissing — единый текст «нет wireguard-tools» с подсказкой.
+func errWGToolMissing() error {
+	return fmt.Errorf("IPv6 endpoint на прошивке с нативным ASC выставляется только через wireguard-tools, бинарь wg не найден — установите пакет: opkg install wireguard-tools")
+}
+
 // setKernelPeerEndpoint выставляет endpoint пира напрямую в ядро:
 // `wg set <nwgN> peer <pubkey> endpoint <[v6]:port>`.
 func setKernelPeerEndpoint(ctx context.Context, ifaceName, pubkey, endpoint string) error {
 	bin := wgToolLookup()
 	if bin == "" {
-		return fmt.Errorf("IPv6 endpoint на прошивке с нативным ASC выставляется только через wireguard-tools, бинарь wg не найден — установите пакет: opkg install wireguard-tools")
+		return errWGToolMissing()
 	}
 	if err := wgToolRun(ctx, bin, "set", ifaceName, "peer", pubkey, "endpoint", endpoint); err != nil {
 		return fmt.Errorf("wg set %s endpoint %s: %w", ifaceName, endpoint, err)


### PR DESCRIPTION
## Полевой отчёт

&gt; create NativeWG interface: import wireguard config: import wireguard: router returned no created interface (intersects=""; status: "Wireguard1": invalid endpoint format.)

Плюс подтверждение автора с устройства: **NDMS не принимает IPv6 endpoint через RCI вовсе** (ни импорт .conf, ни peer-команды) — выставить его можно только через wireguard-tools по kernel-имени интерфейса. Выставленный так endpoint NDMS в обычной работе не перетирает, но сбрасывает при перезагрузке роутера и up/down интерфейса.

## Коммит 1 — create с IPv6 endpoint (все прошивки)

Endpoint на этапе create — временный: Start в любом случае переставляет его. Поэтому:
- **createViaImport** (≥5.01.A.3): для v6 строка `Endpoint` в генерируемом .conf подменяется заглушкой — интерфейс создаётся; v4/hostname байт-в-байт как раньше. `GenerateForExport` не тронут (пользовательский экспорт несёт реальный endpoint).
- **createViaBatch** (старые прошивки): та же заглушка вместо небракетированного `%s:%d`.

## Коммит 2 — старт на ASC-прошивках (≥5.01.A.4)

- **startNative** при v6: RCI-батч несёт заглушку в endpoint-команде (перетирает возможный устаревший v4 в конфиге NDMS), затем connect + up, и только после up — `wg set nwgN peer &lt;pub&gt; endpoint [v6]:port`, потому что up/down сбрасывает kernel-endpoint на значение из конфига NDMS.
- **Fail fast** до каких-либо изменений в NDMS (до SetASCParams/resolve), если бинаря `wg` нет: понятная ошибка с подсказкой `opkg install wireguard-tools`; вторая проверка после resolve ловит hostname → v6.
- Kmod-путь (прошивки без ASC) не менялся — v6 там уже верифицирован (#455), NDMS видит только `127.0.0.1:proxy`.

## Коммит 3 — фиксы по агрессивному ревью

Ревью показало, что «reconcile переустановит endpoint» из первоначального плана — неправда: на ASC-прошивке decideBoot был пустым, decideNDMSHook подавлен для Running-туннелей, HasHandshake — presence-based, WAN-failover делегирован NDMS. Ни одно событие не приводило к повторному `wg set`. Отсюда:

- **Endpoint-страж** (`endpoint_guard.go`): реестр работающих v6-туннелей + тикер 20с. `wg show &lt;iface&gt; endpoints` → при дрейфе (NDMS переприменил свой конфиг на up/down) endpoint переустанавливается `wg set`'ом с Info-логом. Регистрация в startNative, снятие в Stop/Delete.
- **Восстановление после ребута роутера**: `tunnelState.EndpointV6` + ветка decideBoot для ASC — полный Start (в конфиге NDMS живёт заглушка, реальный endpoint был только в ядре и после ребута потерян).
- **SyncPeer** (редактирование пира): v6-endpoint больше не уходит в RCI (заглушка), для работающего туннеля реальный endpoint доезжает `wg set`'ом, запись стража обновляется.
- **Заглушка `127.0.0.1:1`** вместо `:51820`: kmod-слоты awg_proxy слушают kernel-ephemeral порты (32768–60999, включая 51820) — порт 1 ядро эфемерно не выдаёт, коллизия исключена.
- **wg set с 3 ретраями** (700мс): NDMS может пересоздавать интерфейс сразу после up.
- **replaceConfEndpointLine** ограничен секцией `[Peer]` — Endpoint-подобные строки в `[Interface]` не трогаются.
- **EndpointHostIsIPv6** покрывает portless/bare/небракетированные v6 и IPv4-mapped формы.
- **config.Parse: нормализация Endpoint** — `host:port`-валидация + `JoinHostPort` для v6 при импорте .conf; кривой endpoint отбивается сразу с внятной ошибкой, а не глубоко в RCI.

### Принятые остаточные риски
- Между up/down и следующим тиком стража — до 20с без правильного endpoint'а (WG сам переподнимет хендшейк после восстановления).
- В NDMS UI endpoint отображается заглушкой `127.0.0.1:1` — косметика, реальный живёт в ядре.
- classifyNWGState на ASC держит мёртвый v6-туннель в StateStarting — страж возвращает endpoint, дальше WG сам; отдельного age-гейта не добавляли.

## Что проверить на устройстве

1. Создание NativeWG-туннеля с `[v6]:port` — перестало падать на «invalid endpoint format».
2. Старт на ASC-прошивке с установленным wireguard-tools — хендшейк по v6.
3. Старт без wireguard-tools — понятная ошибка с подсказкой opkg, конфиг NDMS не тронут.
4. up/down интерфейса из веба Keenetic → страж в пределах ~20с возвращает endpoint (лог «kernel-endpoint слетел…»).
5. Перезагрузка роутера → boot-Start восстанавливает endpoint.
6. Редактирование пира работающего v6-туннеля → endpoint переустановлен сразу.

## Ворота
`gofmt`, `go build ./...`, `go vet ./...`, `go test ./...`, MIPS cross-build — зелёные. Тесты: v6 → батч с заглушкой + точная команда `wg set` после последнего RCI-батча + регистрация стража; v4 → прежний RCI-путь без wg; отсутствие wg → fail fast без единого RCI-вызова; ретраи wg set; страж restore/noop/unregister; SyncPeer v6; decideBoot ASC+v6 → StartNativeWG; нормализация Endpoint при импорте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMpizxmM8cr32RoHp5s9Eg