### PR TITLE
Feature/freeturn

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6761,6 +6761,24 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6761,24 +6761,6 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -453,6 +453,7 @@ const api_FreeTurnStatusResponse: v.GenericSchema = v.looseObject({
 
 const api_GenerateLinkResponse: v.GenericSchema = v.looseObject({
 	data: v.optional(v.nullable(v.looseObject({
+	clientId: v.optional(v.nullable(v.string())),
 	link: v.optional(v.nullable(v.string())),
 	peer: v.optional(v.nullable(v.string())),
 }))),
@@ -2223,11 +2224,22 @@ const freeturn_Config: v.GenericSchema = v.looseObject({
 });
 
 const freeturn_LinkPayload: v.GenericSchema = v.looseObject({
+	bond: v.optional(v.nullable(v.boolean())),
+	cid: v.optional(v.nullable(v.string())),
+	dns: v.optional(v.nullable(v.string())),
+	dnss: v.optional(v.nullable(v.string())),
 	key: v.optional(v.nullable(v.string())),
+	listen: v.optional(v.nullable(v.string())),
+	mcap: v.optional(v.nullable(v.boolean())),
+	mode: v.optional(v.nullable(v.string())),
 	mtu: v.optional(v.nullable(v.number())),
+	n: v.optional(v.nullable(v.number())),
+	name: v.optional(v.nullable(v.string())),
 	obf: v.optional(v.nullable(v.string())),
 	peer: v.optional(v.nullable(v.string())),
 	provider: v.optional(v.nullable(v.string())),
+	spc: v.optional(v.nullable(v.number())),
+	transport: v.optional(v.nullable(v.string())),
 	v: v.optional(v.nullable(v.number())),
 	wg: v.optional(v.nullable(v.string())),
 });

--- a/frontend/src/lib/components/freeturn/ClientPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ClientPanel.svelte
@@ -109,7 +109,7 @@
 		сервер использует allowlist (-clients-file), этот же ID должен быть добавлен там владельцем
 		сервера — иначе сервер отклонит подключение с «Unauthorized Client ID»
 	</p>
-{#if client.manualCaptcha}
+	{#if client.manualCaptcha}
 		<p class="ft-hint">
 			Капча решается локальным HTTP-сервером самого freeturn-client на роутере
 			(127.0.0.1:8765) — снаружи он недоступен. Пробросьте порт с вашего ПК:

--- a/frontend/src/lib/components/freeturn/ClientPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ClientPanel.svelte
@@ -99,7 +99,17 @@
 			<FormToggle bind:checked={client.manualCaptcha} label="Ручная капча (-manual-captcha)" />
 		</div>
 	</div>
-	{#if client.manualCaptcha}
+	<Input
+		label="Client ID (-client-id)"
+		bind:value={client.clientId}
+		placeholder="оставьте пустым — сгенерируется и сохранится автоматически"
+	/>
+	<p class="ft-hint">
+		Заполняется автоматически из ссылки freeturn:// (поле «cid»), если она с ним пришла. Если
+		сервер использует allowlist (-clients-file), этот же ID должен быть добавлен там владельцем
+		сервера — иначе сервер отклонит подключение с «Unauthorized Client ID»
+	</p>
+{#if client.manualCaptcha}
 		<p class="ft-hint">
 			Капча решается локальным HTTP-сервером самого freeturn-client на роутере
 			(127.0.0.1:8765) — снаружи он недоступен. Пробросьте порт с вашего ПК:

--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -26,9 +26,12 @@
 	let genProvider = $state('vk');
 	let genMTU = $state(1376);
 	let genWG = $state('');
+	let genClientId = $state('');
+	let genName = $state('');
 	let generating = $state(false);
 	let generatedLink = $state('');
 	let generatedPeer = $state('');
+	let generatedClientId = $state('');
 
 	let statusPoll: ReturnType<typeof setInterval> | undefined;
 	let routerHost = $state('');
@@ -195,11 +198,21 @@
 					config.client.obfProfile = payload.obf as typeof config.client.obfProfile;
 				}
 				config.client.obfKey = payload.key ?? config.client.obfKey;
+				if (payload.n && payload.n > 0) config.client.streams = payload.n;
+				if (payload.spc && payload.spc > 0) config.client.streamsPerCred = payload.spc;
+				if (payload.cid) config.client.clientId = payload.cid;
+				if (payload.transport) config.client.transport = payload.transport as typeof config.client.transport;
+				if (payload.mode) config.client.mode = payload.mode as typeof config.client.mode;
+				if (typeof payload.bond === 'boolean') config.client.bond = payload.bond;
+				if (typeof payload.mcap === 'boolean') config.client.manualCaptcha = payload.mcap;
 			}
 			const wg = payload.wg?.trim() ? payload.wg : null;
 			importedWG = wg;
 
 			let msg = 'Ссылка распознана, поля заполнены — не забудьте сохранить';
+			if (payload.cid) {
+				msg += `. В ссылке был Client ID — если у сервера включён allowlist (-clients-file), владелец сервера должен добавить именно этот ID туда`;
+			}
 			if (wg) {
 				try {
 					const tunnel = await api.importConfig(wg, `FreeTurn ${payload.peer}`.slice(0, 60));
@@ -216,16 +229,19 @@
 		}
 	}
 
-	async function generateLink(provider: string, mtu: number, wg: string) {
+	async function generateLink(provider: string, mtu: number, wg: string, clientId: string, name: string) {
 		generating = true;
 		try {
 			const result = await api.generateFreeTurnLink({
 				provider,
 				mtu,
-				wg: wg.trim() || undefined
+				wg: wg.trim() || undefined,
+				clientId: clientId.trim() || undefined,
+				name: name.trim() || undefined
 			});
 			generatedLink = result.link;
 			generatedPeer = result.peer;
+			generatedClientId = result.clientId ?? '';
 		} catch (e) {
 			notifications.error('Не удалось сгенерировать ссылку: ' + errText(e));
 		} finally {
@@ -267,9 +283,12 @@
 		{generating}
 		{generatedLink}
 		{generatedPeer}
+		{generatedClientId}
 		bind:genProvider
 		bind:genMTU
 		bind:genWG
+		bind:genClientId
+		bind:genName
 		onToggle={toggleServer}
 		onSave={() => saveServerConfig(config!.server)}
 		onGenerate={generateLink}

--- a/frontend/src/lib/components/freeturn/ServerPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ServerPanel.svelte
@@ -15,12 +15,15 @@
 		generating: boolean;
 		generatedLink: string;
 		generatedPeer: string;
+		generatedClientId: string;
 		genProvider: string;
 		genMTU: number;
 		genWG: string;
+		genClientId: string;
+		genName: string;
 		onToggle: (on: boolean) => void;
 		onSave: () => void;
-		onGenerate: (provider: string, mtu: number, wg: string) => void;
+		onGenerate: (provider: string, mtu: number, wg: string, clientId: string, name: string) => void;
 		onCopy: (text: string) => void;
 	}
 
@@ -35,14 +38,23 @@
 		generating,
 		generatedLink,
 		generatedPeer,
+		generatedClientId,
 		genProvider = $bindable(),
 		genMTU = $bindable(),
 		genWG = $bindable(),
+		genClientId = $bindable(),
+		genName = $bindable(),
 		onToggle,
 		onSave,
 		onGenerate,
 		onCopy
 	}: Props = $props();
+
+	function randomClientId() {
+		const bytes = new Uint8Array(16);
+		crypto.getRandomValues(bytes);
+		genClientId = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+	}
 
 	const modeOptions = [
 		{ value: 'udp', label: 'udp' },
@@ -108,6 +120,22 @@
 		<Input label="Провайдер" bind:value={genProvider} placeholder="vk" />
 		<Input label="MTU" type="number" value={String(genMTU)} onchange={(v) => (genMTU = Number(v) || 1376)} />
 	</div>
+
+	<div class="ft-section-label">Client ID для этой ссылки (опционально)</div>
+	<div class="ft-grid-2">
+		<Input bind:value={genClientId} placeholder="оставьте пустым, если allowlist не используется" />
+		<Input bind:value={genName} placeholder="комментарий (например, имя получателя)" />
+	</div>
+	<div class="ft-footer" style="margin-bottom: 0.75rem">
+		<Button variant="ghost" size="sm" onclick={randomClientId}>Сгенерировать ID</Button>
+	</div>
+	{#if server.clientsFile}
+		<p class="ft-hint">
+			У сервера включён allowlist (-clients-file). Ссылка передаст этот Client ID клиенту, но
+			сама его никуда не регистрирует — добавьте его на сервере отдельно
+		</p>
+	{/if}
+
 	<div class="ft-section-label">WireGuard-конфиг клиента (опционально)</div>
 	<textarea
 		class="ft-textarea"
@@ -120,7 +148,12 @@
 	</p>
 
 	<div class="ft-footer">
-		<Button variant="primary" size="sm" loading={generating} onclick={() => onGenerate(genProvider, genMTU, genWG)}>
+		<Button
+			variant="primary"
+			size="sm"
+			loading={generating}
+			onclick={() => onGenerate(genProvider, genMTU, genWG, genClientId, genName)}
+		>
 			Сгенерировать ссылку
 		</Button>
 	</div>
@@ -130,6 +163,15 @@
 			<div class="ft-section-label" style="margin-top: 0">Готовая ссылка ({generatedPeer})</div>
 			<div class="ft-link-box">{generatedLink}</div>
 			<Button variant="ghost" size="sm" onclick={() => onCopy(generatedLink)}>Скопировать в буфер</Button>
+			{#if generatedClientId && server.clientsFile}
+				<p class="ft-hint" style="margin-top: 0.625rem">
+					У сервера включён allowlist — прежде чем отдавать эту ссылку, зарегистрируйте
+					Client ID <code>{generatedClientId}</code> в <code>{server.clientsFile}</code> по SSH:
+					бинарь сервера умеет <code>clients add {generatedClientId} "{genName || 'client'}"</code>
+					(укажите путь к файлу через переменную окружения <code>CLIENTS_FILE</code>, если бинарь
+					запускается не из той же директории)
+				</p>
+			{/if}
 		</div>
 	{/if}
 </Card>

--- a/frontend/src/lib/types/freeturn.ts
+++ b/frontend/src/lib/types/freeturn.ts
@@ -65,17 +65,32 @@ export interface FreeTurnStatus {
 	installing: boolean;
 }
 
-// Share-link payload: freeturn://base64(JSON), the same format produced by
-// the original freeturn-entware-installer web generator. Bundles the
-// server's connection params (+ optionally a WireGuard client config) so
-// the receiving side can auto-fill its form instead of retyping peer/obf/key.
+// Share-link payload: freeturn://base64(JSON). Two flavors exist and both
+// decode into this same shape — the upstream free-turn-proxy format (see
+// samosvalishe/free-turn-proxy docs/uri.md: v/provider/peer/transport/mode/
+// bond/obf/key/n/spc/cid/listen/dns/dnss/mcap/name) and the informal
+// freeturn-entware-installer one (v/provider/peer/obf/key/mtu/wg). `cid` is
+// a Client ID the link's creator generated and must separately allowlist in
+// their own server's clients.json (if -clients-file auth is on) — importing
+// a link does NOT do that registration for you.
 export interface FreeTurnLinkPayload {
 	v: number;
-	provider: string;
-	peer: string;
-	obf: string;
-	key: string;
-	mtu: number;
+	provider?: string;
+	peer?: string;
+	transport?: string;
+	mode?: string;
+	bond?: boolean;
+	obf?: string;
+	key?: string;
+	n?: number;
+	spc?: number;
+	cid?: string;
+	listen?: string;
+	dns?: string;
+	dnss?: string;
+	mcap?: boolean;
+	name?: string;
+	mtu?: number;
 	wg?: string;
 }
 
@@ -84,11 +99,16 @@ export interface FreeTurnGenerateLinkRequest {
 	provider?: string;
 	mtu?: number;
 	wg?: string;
+	clientId?: string;
+	name?: string;
+	n?: number;
+	streamsPerCred?: number;
 }
 
 export interface FreeTurnGenerateLinkResult {
 	link: string;
 	peer: string;
+	clientId?: string;
 }
 
 // #endregion

--- a/internal/api/freeturn.go
+++ b/internal/api/freeturn.go
@@ -179,22 +179,31 @@ func (h *FreeTurnHandler) StopServer(w http.ResponseWriter, r *http.Request) {
 
 // GenerateLinkRequest is the body for POST /api/freeturn/server/link.
 // All fields are optional: Peer overrides auto-detected external IP +
-// server listen port, Provider/MTU fall back to sensible defaults, and WG
+// server listen port, Provider/MTU fall back to sensible defaults, WG
 // lets the admin bundle a WireGuard client config into the link (same as
-// pasting one into the original web generator's textarea).
+// pasting one into the original web generator's textarea), and
+// ClientID/Name/N/StreamsPerCred are forwarded into the upstream `cid`/
+// `name`/`n`/`spc` fields (docs/uri.md) — if the server has -clients-file
+// allowlisting enabled, the admin still has to register ClientID there
+// themselves (this endpoint doesn't touch clients.json).
 type GenerateLinkRequest struct {
-	Peer     string `json:"peer,omitempty"`
-	Provider string `json:"provider,omitempty"`
-	MTU      int    `json:"mtu,omitempty"`
-	WG       string `json:"wg,omitempty"`
+	Peer           string `json:"peer,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	MTU            int    `json:"mtu,omitempty"`
+	WG             string `json:"wg,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	Name           string `json:"name,omitempty"`
+	N              int    `json:"n,omitempty"`
+	StreamsPerCred int    `json:"streamsPerCred,omitempty"`
 }
 
 // GenerateLinkResponse is the envelope for POST /api/freeturn/server/link.
 type GenerateLinkResponse struct {
 	Success bool   `json:"success" example:"true"`
 	Data    struct {
-		Link string `json:"link"`
-		Peer string `json:"peer"`
+		Link     string `json:"link"`
+		Peer     string `json:"peer"`
+		ClientID string `json:"clientId"`
 	} `json:"data"`
 }
 
@@ -272,20 +281,24 @@ func (h *FreeTurnHandler) GenerateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	link, err := freeturn.EncodeLink(freeturn.LinkPayload{
-		V:        1,
-		Provider: provider,
-		Peer:     peer,
-		Obf:      cfg.Server.ObfProfile,
-		Key:      cfg.Server.ObfKey,
-		MTU:      mtu,
-		WG:       req.WG,
+		V:              1,
+		Provider:       provider,
+		Peer:           peer,
+		Obf:            cfg.Server.ObfProfile,
+		Key:            cfg.Server.ObfKey,
+		MTU:            mtu,
+		WG:             req.WG,
+		ClientID:       strings.TrimSpace(req.ClientID),
+		Name:           strings.TrimSpace(req.Name),
+		N:              req.N,
+		StreamsPerCred: req.StreamsPerCred,
 	})
 	if err != nil {
 		response.InternalError(w, err.Error())
 		return
 	}
 
-	response.Success(w, map[string]string{"link": link, "peer": peer})
+	response.Success(w, map[string]string{"link": link, "peer": peer, "clientId": req.ClientID})
 }
 
 // DecodeLinkRequest is the body for POST /api/freeturn/link/decode.

--- a/internal/freeturn/freeturn_test.go
+++ b/internal/freeturn/freeturn_test.go
@@ -3,7 +3,9 @@ package freeturn
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -299,5 +301,76 @@ func TestEmbeddedBinaries_CoverAllArches(t *testing.T) {
 				t.Errorf("%s/%s: bad spec %+v", arch, name, sp)
 			}
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// link.go — официальный формат (#530): base64url + поля uri.md, и обратная
+// совместимость со старым неофициальным форматом (StdEncoding без padding).
+// ---------------------------------------------------------------------------
+
+func TestLink_Roundtrip_UpstreamFields(t *testing.T) {
+	p := LinkPayload{
+		V: 1, Provider: "vk", Peer: "1.2.3.4:56000",
+		Transport: "tcp", Mode: "udp", Bond: true,
+		Obf: "rtpopus2", Key: "aabb",
+		N: 4, StreamsPerCred: 2, ClientID: "deadbeefcafe",
+		Listen: "127.0.0.1:9000", DNSMode: "doh", DNSServers: "1.1.1.1",
+		ManualCaptcha: true, Name: "гость",
+	}
+	link, err := EncodeLink(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := DecodeLink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, p) {
+		t.Fatalf("roundtrip mismatch:\n got %+v\nwant %+v", got, p)
+	}
+}
+
+// Ссылка настоящего клиента/приложения: base64url без padding
+// (Go base64.RawURLEncoding, docs/uri.md) — в т.ч. с символами '-'/'_',
+// которых нет в стандартном алфавите.
+func TestDecodeLink_UpstreamBase64URL(t *testing.T) {
+	// Подбираем name, при котором url-safe кодирование содержит '-'/'_' —
+	// иначе тест не отличит алфавиты. Кириллица (байты ≥0xC0) даёт их быстро.
+	var p LinkPayload
+	var body string
+	for i := 0; i < 64; i++ {
+		p = LinkPayload{V: 1, Peer: "h:56000", ClientID: "cid1", Name: "я" + strings.Repeat("~", i)}
+		raw, _ := json.Marshal(p)
+		body = base64.RawURLEncoding.EncodeToString(raw)
+		if strings.ContainsAny(body, "-_") {
+			break
+		}
+		body = ""
+	}
+	if body == "" {
+		t.Fatal("could not construct a url-safe sample")
+	}
+	got, err := DecodeLink(LinkScheme + body)
+	if err != nil {
+		t.Fatalf("DecodeLink: %v", err)
+	}
+	if got.ClientID != "cid1" || got.Name != p.Name {
+		t.Fatalf("got %+v want %+v", got, p)
+	}
+}
+
+// Старый неофициальный формат (entware-installer / awg-manager до #530):
+// стандартный алфавит, padding срезан — обязан читаться и дальше.
+func TestDecodeLink_LegacyStdEncoding(t *testing.T) {
+	p := LinkPayload{V: 1, Provider: "vk", Peer: "h:56000", Obf: "rtpopus", Key: "aa", MTU: 1376, WG: "[Interface]\n"}
+	raw, _ := json.Marshal(p)
+	legacy := strings.TrimRight(base64.StdEncoding.EncodeToString(raw), "=")
+	got, err := DecodeLink(LinkScheme + legacy)
+	if err != nil {
+		t.Fatalf("DecodeLink(legacy): %v", err)
+	}
+	if !reflect.DeepEqual(got, p) {
+		t.Fatalf("legacy mismatch:\n got %+v\nwant %+v", got, p)
 	}
 }

--- a/internal/freeturn/link.go
+++ b/internal/freeturn/link.go
@@ -8,40 +8,66 @@ import (
 )
 
 // LinkPayload is the JSON structure embedded in a freeturn:// share link.
-// It mirrors the payload produced by the original web generator shipped in
-// freeturn-entware-installer (install.sh's generator.cgi): the server side
-// bundles its own connection parameters plus an optional WireGuard client
-// config, and the receiving side (this panel's client tab, or the
-// turn-proxy-android app) unpacks it to auto-fill its own form instead of
-// the admin re-typing peer/obf/key by hand.
+//
+// Two link flavors exist in the wild and this type/DecodeLink accept both:
+//
+//   - The upstream free-turn-proxy format (see docs/uri.md in
+//     samosvalishe/free-turn-proxy): base64url, no padding
+//     (Go base64.RawURLEncoding), fields v/provider/peer/transport/mode/
+//     bond/obf/key/n/spc/cid/listen/dns/dnss/mcap/name. Notably it never
+//     includes the VK call link itself (unique per recipient) — the
+//     receiving client still has to enter -links by hand.
+//   - The informal freeturn-entware-installer format (install.sh's
+//     generator.cgi): standard base64 alphabet, padding stripped
+//     (JS btoa().replace(/=+$/, '')), fields v/provider/peer/obf/key/mtu/wg.
+//
+// EncodeLink (our own "generate link" button) emits the upstream format so
+// links we produce are consumable by the real client binary/app too; the
+// extra `wg` field is additive — an official-format-only parser just
+// ignores unknown JSON keys. DecodeLink accepts either.
 type LinkPayload struct {
 	V        int    `json:"v"`
-	Provider string `json:"provider"`
-	Peer     string `json:"peer"`
-	Obf      string `json:"obf"`
-	Key      string `json:"key"`
-	MTU      int    `json:"mtu"`
-	WG       string `json:"wg,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Peer     string `json:"peer,omitempty"`
+
+	Transport string `json:"transport,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	Bond      bool   `json:"bond,omitempty"`
+
+	Obf string `json:"obf,omitempty"`
+	Key string `json:"key,omitempty"`
+
+	N              int    `json:"n,omitempty"`   // -n, parallel TURN streams
+	StreamsPerCred int    `json:"spc,omitempty"` // -streams-per-cred
+	ClientID       string `json:"cid,omitempty"` // -client-id — owner must allowlist this in clients.json
+	Listen         string `json:"listen,omitempty"`
+	DNSMode        string `json:"dns,omitempty"`
+	DNSServers     string `json:"dnss,omitempty"`
+	ManualCaptcha  bool   `json:"mcap,omitempty"`
+	Name           string `json:"name,omitempty"` // comment for the owner's own clients.json entry
+
+	// awg-manager extensions, not part of the upstream spec:
+	MTU int    `json:"mtu,omitempty"`
+	WG  string `json:"wg,omitempty"` // optional bundled WireGuard client config
 }
 
 // LinkScheme is the URI scheme prefix used by freeturn:// share links.
 const LinkScheme = "freeturn://"
 
-// EncodeLink builds a freeturn:// link from p. Matches the reference JS
-// implementation bit-for-bit: standard base64 alphabet over the JSON bytes,
-// with '=' padding stripped (JS: btoa(...).replace(/=+$/, '')).
+// EncodeLink builds a freeturn:// link from p using the upstream encoding:
+// base64url, no padding (Go base64.RawURLEncoding) over the JSON bytes.
 func EncodeLink(p LinkPayload) (string, error) {
 	raw, err := json.Marshal(p)
 	if err != nil {
 		return "", err
 	}
-	encoded := strings.TrimRight(base64.StdEncoding.EncodeToString(raw), "=")
-	return LinkScheme + encoded, nil
+	return LinkScheme + base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
 // DecodeLink parses a freeturn:// link back into its payload. Accepts the
-// link with or without the scheme prefix, and re-pads the base64 body since
-// the generator strips padding before building the link.
+// link with or without the scheme prefix, either base64 alphabet
+// (standard '+/' or URL-safe '-_'), and with or without '=' padding —
+// covering both the upstream format and the older entware-installer one.
 func DecodeLink(link string) (LinkPayload, error) {
 	var p LinkPayload
 	body := strings.TrimSpace(link)
@@ -49,9 +75,15 @@ func DecodeLink(link string) (LinkPayload, error) {
 	if body == "" {
 		return p, fmt.Errorf("пустая ссылка")
 	}
+
+	// Normalize to the standard alphabet so both flavors decode the same
+	// way, then re-pad (both flavors strip '=' before building the link).
+	body = strings.TrimRight(body, "=")
+	body = strings.NewReplacer("-", "+", "_", "/").Replace(body)
 	if pad := len(body) % 4; pad != 0 {
 		body += strings.Repeat("=", 4-pad)
 	}
+
 	raw, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
 		return p, fmt.Errorf("не удалось декодировать base64: %w", err)

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1301,6 +1301,8 @@ definitions:
     properties:
       data:
         properties:
+          clientId:
+            type: string
           link:
             type: string
           peer:
@@ -6101,19 +6103,47 @@ definitions:
     type: object
   freeturn.LinkPayload:
     properties:
+      bond:
+        type: boolean
+      cid:
+        description: -client-id — owner must allowlist this in clients.json
+        type: string
+      dns:
+        type: string
+      dnss:
+        type: string
       key:
         type: string
+      listen:
+        type: string
+      mcap:
+        type: boolean
+      mode:
+        type: string
       mtu:
+        description: 'awg-manager extensions, not part of the upstream spec:'
         type: integer
+      "n":
+        description: -n, parallel TURN streams
+        type: integer
+      name:
+        description: comment for the owner's own clients.json entry
+        type: string
       obf:
         type: string
       peer:
         type: string
       provider:
         type: string
+      spc:
+        description: -streams-per-cred
+        type: integer
+      transport:
+        type: string
       v:
         type: integer
       wg:
+        description: optional bundled WireGuard client config
         type: string
     type: object
   freeturn.ProcessStatus:


### PR DESCRIPTION
Добавил поддержку официального формата ссылки freeturn:// (поля cid/n/spc) и Client ID в UI клиента/сервера — закрывает пробел, из-за которого allowlist на сервере не работал через ссылку