### PR TITLE
fix(api): swagger-спека мутаций приведена к фактической форме ответов

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Исправления
+
+- **«Некорректный ответ сервера» при создании/импорте IP-маршрутов** ([#578](https://github.com/hoaxisr/awg-manager/issues/578)) — swagger-спека мутаций static-routes (create/update/import) и client-routes (create/update/delete/toggle) объявляла списочный конверт, тогда как бэкенд возвращает одиночный объект; runtime-валидация ответов на фронте (появилась в 2.16.0) на этом падала, хотя сами маршруты сохранялись корректно. Аннотации приведены к фактической форме ответов; заодно выправлены спеки ещё 13 endpoint'ов, где объявлялся голый payload вместо конверта `{success,data}` (geo-expand, ndms/save-status, presets, resolve, router/staging, terminal/install, selective, subscriptions refresh/active-member/orphans) — валидацию они не роняли, но документировали неверную форму.
+
 ## [2.16.0] - 2026-07-17
 
 ### Новые возможности

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -173,6 +173,11 @@ const api_ClientRouteDTO: v.GenericSchema = v.looseObject({
 	tunnelId: v.optional(v.nullable(v.string())),
 });
 
+const api_ClientRouteToggleData: v.GenericSchema = v.looseObject({
+	enabled: v.optional(v.nullable(v.boolean())),
+	id: v.optional(v.nullable(v.string())),
+});
+
 const api_ClientRoutesListResponse: v.GenericSchema = v.looseObject({
 	data: v.optional(v.nullable(v.array(v.lazy(() => api_ClientRouteDTO)))),
 	success: v.optional(v.nullable(v.boolean())),
@@ -1841,6 +1846,17 @@ const api_SubscriptionMemberDTO: v.GenericSchema = v.looseObject({
 	transport: v.optional(v.nullable(v.string())),
 });
 
+const api_SubscriptionRefreshData: v.GenericSchema = v.looseObject({
+	added: v.optional(v.nullable(v.number())),
+	orphaned: v.optional(v.nullable(v.number())),
+	parseErrors: v.optional(v.nullable(v.array(v.string()))),
+	skippedDuplicate: v.optional(v.nullable(v.number())),
+	skippedOther: v.optional(v.nullable(v.number())),
+	skippedVmess: v.optional(v.nullable(v.number())),
+	updated: v.optional(v.nullable(v.number())),
+	when: v.optional(v.nullable(v.string())),
+});
+
 const api_SubscriptionRejectedDTO: v.GenericSchema = v.looseObject({
 	label: v.optional(v.nullable(v.string())),
 	port: v.optional(v.nullable(v.number())),
@@ -1941,6 +1957,10 @@ const api_SystemTunnelPeerDTO: v.GenericSchema = v.looseObject({
 const api_SystemTunnelsResponse: v.GenericSchema = v.looseObject({
 	data: v.optional(v.nullable(v.array(v.lazy(() => api_SystemTunnelDTO)))),
 	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_TerminalInstallData: v.GenericSchema = v.looseObject({
+	installed: v.optional(v.nullable(v.boolean())),
 });
 
 const api_TerminalStartData: v.GenericSchema = v.looseObject({
@@ -2398,7 +2418,9 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /freeturn/status": v.lazy(() => api_FreeTurnStatusResponse),
 	"GET /health": v.lazy(() => api_HealthResponse),
 	"GET /hydraroute/config": v.lazy(() => api_HydraRouteConfigResponse),
-	"GET /hydraroute/geo-expand": v.lazy(() => api_GeoExpandData),
+	"GET /hydraroute/geo-expand": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_GeoExpandData))),
+})]),
 	"GET /hydraroute/geo-files": v.lazy(() => api_GeoFilesResponse),
 	"GET /hydraroute/geo-tags": v.lazy(() => api_GeoTagsResponse),
 	"GET /hydraroute/ipset-usage": v.lazy(() => api_IpsetUsageResponse),
@@ -2416,10 +2438,14 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /managed/drift": v.lazy(() => api_ManagedServerDriftEnvelope),
 	"GET /managed/export": v.lazy(() => api_ManagedServerExportEnvelope),
 	"GET /monitoring/matrix": v.lazy(() => api_MonitoringSnapshotResponse),
-	"GET /ndms/save-status": v.lazy(() => api_SaveStatusDTO),
+	"GET /ndms/save-status": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SaveStatusDTO))),
+})]),
 	"GET /pingcheck/logs": v.lazy(() => api_PingLogsResponse),
 	"GET /pingcheck/status": v.lazy(() => api_PingCheckStatusResponse),
-	"GET /presets": v.lazy(() => api_PresetsListResponse),
+	"GET /presets": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_PresetsListResponse))),
+})]),
 	"GET /proxy/config": v.lazy(() => api_ProxyConfigResponse),
 	"GET /proxy/instance": v.lazy(() => api_ProxyInstanceResponse),
 	"GET /proxy/instance/check-ip": v.lazy(() => api_DeviceProxyInstanceIPCheckResponse),
@@ -2433,7 +2459,9 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /routing/dns-routes": v.lazy(() => api_DnsRoutesListResponse),
 	"GET /routing/policy-devices": v.lazy(() => api_PolicyDevicesListResponse),
 	"GET /routing/policy-interfaces": v.lazy(() => api_PolicyInterfacesListResponse),
-	"GET /routing/resolve": v.lazy(() => api_ResolveResponse),
+	"GET /routing/resolve": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ResolveResponse))),
+})]),
 	"GET /routing/static-routes": v.lazy(() => api_StaticRoutesListResponse),
 	"GET /routing/tunnels": v.lazy(() => api_RoutingTunnelsResponse),
 	"GET /server/listen": v.lazy(() => api_ServerListenStateResponse),
@@ -2482,10 +2510,16 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /singbox/router/rules/list": v.lazy(() => api_SingboxRouterRulesListResponse),
 	"GET /singbox/router/rulesets/dat-url": v.lazy(() => api_SingboxRouterDatRuleSetURLResponse),
 	"GET /singbox/router/rulesets/list": v.lazy(() => api_SingboxRouterRuleSetsListResponse),
-	"GET /singbox/router/selective/snapshot/matchers": v.lazy(() => api_SelectiveSnapshotMatchersData),
-	"GET /singbox/router/selective/status": v.lazy(() => api_SelectiveStatusData),
+	"GET /singbox/router/selective/snapshot/matchers": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveSnapshotMatchersData))),
+})]),
+	"GET /singbox/router/selective/status": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveStatusData))),
+})]),
 	"GET /singbox/router/settings": v.lazy(() => api_SingboxRouterSettingsResponse),
-	"GET /singbox/router/staging": v.lazy(() => api_RouterStagingStatusResponse),
+	"GET /singbox/router/staging": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_RouterStagingStatusResponse))),
+})]),
 	"GET /singbox/router/status": v.lazy(() => api_SingboxRouterStatusResponse),
 	"GET /singbox/router/wan-interfaces": v.lazy(() => api_SingboxRouterWANInterfacesListResponse),
 	"GET /singbox/status": v.lazy(() => api_SingboxStatusResponse),
@@ -2534,10 +2568,16 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /amnezia-premium/login": v.lazy(() => api_AmneziaPremiumLoginResponse),
 	"POST /auth/login": v.lazy(() => api_LoginResponseRaw),
 	"POST /auth/logout": v.lazy(() => api_APIEnvelope),
-	"POST /client-routes/create": v.lazy(() => api_ClientRoutesListResponse),
-	"POST /client-routes/delete": v.lazy(() => api_ClientRoutesListResponse),
-	"POST /client-routes/toggle": v.lazy(() => api_ClientRoutesListResponse),
-	"POST /client-routes/update": v.lazy(() => api_ClientRoutesListResponse),
+	"POST /client-routes/create": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ClientRouteDTO))),
+})]),
+	"POST /client-routes/delete": v.lazy(() => api_OkResponse),
+	"POST /client-routes/toggle": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ClientRouteToggleData))),
+})]),
+	"POST /client-routes/update": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_ClientRouteDTO))),
+})]),
 	"POST /control/restart": v.lazy(() => api_TunnelControlResponse),
 	"POST /control/restart-all": v.lazy(() => api_APIEnvelope),
 	"POST /control/start": v.lazy(() => api_TunnelControlResponse),
@@ -2668,14 +2708,22 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /singbox/router/rulesets/bulk-detour": v.lazy(() => api_SingboxRouterBulkUpdatedResponse),
 	"POST /singbox/router/rulesets/delete": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/rulesets/update": v.lazy(() => api_OkResponse),
-	"POST /singbox/router/selective/install-conntrack": v.lazy(() => api_SelectiveStatusData),
-	"POST /singbox/router/selective/install-deps": v.lazy(() => api_SelectiveStatusData),
-	"POST /singbox/router/selective/rebuild": v.lazy(() => api_SelectiveStatusData),
-	"POST /singbox/router/selective/rebuild/cancel": v.lazy(() => api_SelectiveCancelData),
+	"POST /singbox/router/selective/install-conntrack": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveStatusData))),
+})]),
+	"POST /singbox/router/selective/install-deps": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveStatusData))),
+})]),
+	"POST /singbox/router/selective/rebuild": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveStatusData))),
+})]),
+	"POST /singbox/router/selective/rebuild/cancel": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SelectiveCancelData))),
+})]),
 	"POST /singbox/router/settings": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/staging/apply": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/staging/discard": v.lazy(() => api_OkResponse),
-	"POST /singbox/subscriptions/active-member": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/active-member": v.lazy(() => api_OkResponse),
 	"POST /singbox/subscriptions/create": v.lazy(() => api_SubscriptionResponse),
 	"POST /singbox/subscriptions/groups/create": v.lazy(() => api_SubscriptionGroupResponse),
 	"POST /singbox/subscriptions/groups/delete": v.lazy(() => api_APIEnvelope),
@@ -2683,23 +2731,33 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /singbox/subscriptions/members/exclude": v.lazy(() => api_SubscriptionResponse),
 	"POST /singbox/subscriptions/members/remove": v.lazy(() => api_APIEnvelope),
 	"POST /singbox/subscriptions/members/restore": v.lazy(() => api_SubscriptionResponse),
-	"POST /singbox/subscriptions/orphans/delete": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/orphans/delete": v.lazy(() => api_OkResponse),
 	"POST /singbox/subscriptions/preview": v.lazy(() => api_APIEnvelope),
-	"POST /singbox/subscriptions/refresh": v.lazy(() => api_SubscriptionResponse),
+	"POST /singbox/subscriptions/refresh": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SubscriptionRefreshData))),
+})]),
 	"POST /singbox/tunnels": v.lazy(() => api_APIEnvelope),
 	"POST /singbox/tunnels/delay-check": v.lazy(() => api_APIEnvelope),
 	"POST /singbox/tunnels/share-link": v.lazy(() => api_APIEnvelope),
 	"POST /singbox/update": v.lazy(() => api_SingboxStatusResponse),
-	"POST /static-routes/create": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /static-routes/create": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_StaticRouteDTO))),
+})]),
 	"POST /static-routes/delete": v.lazy(() => api_APIEnvelope),
-	"POST /static-routes/import": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /static-routes/import": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_StaticRouteDTO))),
+})]),
 	"POST /static-routes/set-enabled": v.lazy(() => api_APIEnvelope),
-	"POST /static-routes/update": v.lazy(() => api_StaticRoutesListResponse),
+	"POST /static-routes/update": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_StaticRouteDTO))),
+})]),
 	"POST /system-tunnels/asc": v.lazy(() => api_OkResponse),
 	"POST /system/hydraroute-control": v.lazy(() => api_APIEnvelope),
 	"POST /system/restart": v.lazy(() => api_APIEnvelope),
 	"POST /system/update/apply": v.lazy(() => api_UpdateApplyResponse),
-	"POST /terminal/install": v.lazy(() => api_TerminalStatusResponse),
+	"POST /terminal/install": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_TerminalInstallData))),
+})]),
 	"POST /terminal/start": v.lazy(() => api_TerminalStartResponse),
 	"POST /terminal/stop": v.lazy(() => api_APIEnvelope),
 	"POST /tunnels/create": v.lazy(() => api_APIEnvelope),

--- a/frontend/src/lib/api/validate.test.ts
+++ b/frontend/src/lib/api/validate.test.ts
@@ -97,6 +97,22 @@ describe('validateApiResponse', () => {
 			ApiValidationError,
 		);
 	});
+
+	// #578: мутации static-routes возвращают одиночный объект, но аннотации
+	// объявляли списочный конверт (data: массив) → «Некорректный ответ
+	// сервера» при каждом create/update/import, хотя бэкенд всё сохранял.
+	it('#578: одиночный объект валиден на мутациях static-routes, list требует массив', () => {
+		const single = {
+			success: true,
+			data: { id: 'sr_1', name: 'Telegram', tunnelID: 't1', subnets: ['1.2.3.0/24'], enabled: true },
+		};
+		for (const ep of ['/static-routes/create', '/static-routes/update', '/static-routes/import']) {
+			expect(() => validateApiResponse('POST', ep, single)).not.toThrow();
+		}
+		expect(() => validateApiResponse('GET', '/static-routes/list', single)).toThrow(
+			ApiValidationError,
+		);
+	});
 });
 
 describe('schemas.gen.ts инварианты', () => {

--- a/internal/api/clientroutes.go
+++ b/internal/api/clientroutes.go
@@ -26,6 +26,12 @@ type ClientRoutesListResponse struct {
 	Data    []ClientRouteDTO `json:"data"`
 }
 
+// ClientRouteToggleData is the payload of POST /client-routes/toggle.
+type ClientRouteToggleData struct {
+	ID      string `json:"id" example:"cr_001"`
+	Enabled bool   `json:"enabled" example:"true"`
+}
+
 // ClientRouteHandler handles client route CRUD operations.
 type ClientRouteHandler struct {
 	svc clientroute.Service
@@ -80,7 +86,7 @@ func (h *ClientRouteHandler) HandleList(w http.ResponseWriter, r *http.Request) 
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	ClientRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=ClientRouteDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/create [post]
@@ -108,7 +114,7 @@ func (h *ClientRouteHandler) HandleCreate(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	ClientRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=ClientRouteDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/update [post]
@@ -139,7 +145,7 @@ func (h *ClientRouteHandler) HandleUpdate(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	ClientRoutesListResponse
+//	@Success		200	{object}	OkResponse
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/delete [post]
@@ -170,7 +176,7 @@ func (h *ClientRouteHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			id	query	string	true	"Route id"
-//	@Success		200	{object}	ClientRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=ClientRouteToggleData}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/client-routes/toggle [post]

--- a/internal/api/hydraroute.go
+++ b/internal/api/hydraroute.go
@@ -582,7 +582,7 @@ func (h *HydraRouteHandler) GetGeoTags(w http.ResponseWriter, r *http.Request) {
 //	@Security		CookieAuth
 //	@Param			kind	query	string	true	"geosite or geoip"
 //	@Param			tag	query	string	true	"Tag name"
-//	@Success		200	{object}	GeoExpandData
+//	@Success		200	{object}	APIEnvelope{data=GeoExpandData}
 //	@Router			/hydraroute/geo-expand [get]
 func (h *HydraRouteHandler) ExpandGeoTag(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/ndms.go
+++ b/internal/api/ndms.go
@@ -45,7 +45,7 @@ type SaveStatusDTO struct {
 //	@Tags			ndms
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SaveStatusDTO
+//	@Success		200	{object}	APIEnvelope{data=SaveStatusDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/ndms/save-status [get]

--- a/internal/api/presets.go
+++ b/internal/api/presets.go
@@ -26,7 +26,7 @@ type PresetsListResponse struct {
 //	@Summary	List unified presets
 //	@Tags		presets
 //	@Produce	json
-//	@Success	200	{object}	PresetsListResponse
+//	@Success	200	{object}	APIEnvelope{data=PresetsListResponse}
 //	@Router		/presets [get]
 func (h *PresetsHandler) List(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -29,7 +29,7 @@ type ResolveResponse struct {
 //	@Produce		json
 //	@Security		CookieAuth
 //	@Param			domain	query	string	true	"Hostname to resolve"
-//	@Success		200	{object}	ResolveResponse
+//	@Success		200	{object}	APIEnvelope{data=ResolveResponse}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/routing/resolve [get]

--- a/internal/api/singbox_router_staging.go
+++ b/internal/api/singbox_router_staging.go
@@ -49,7 +49,7 @@ func writeJSONStatus(w http.ResponseWriter, code int, v any) {
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	RouterStagingStatusResponse
+//	@Success		200	{object}	APIEnvelope{data=RouterStagingStatusResponse}
 //	@Failure		405	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/staging [get]

--- a/internal/api/singbox_selective.go
+++ b/internal/api/singbox_selective.go
@@ -194,7 +194,7 @@ func NewSelectiveHandler(settings *storage.SettingsStore, configDir string, buil
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SelectiveStatusData
+//	@Success		200	{object}	APIEnvelope{data=SelectiveStatusData}
 //	@Router			/singbox/router/selective/status [get]
 func (h *SelectiveHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
 	response.Success(w, h.statusData(r.Context()))
@@ -249,7 +249,7 @@ func (h *SelectiveHandler) statusData(ctx context.Context) SelectiveStatusData {
 //	@Security		CookieAuth
 //	@Param			offset	query		int	false	"Zero-based record offset"	default(0)
 //	@Param			limit	query		int	false	"Page size (max 1000)"		default(200)
-//	@Success		200		{object}	SelectiveSnapshotMatchersData
+//	@Success		200		{object}	APIEnvelope{data=SelectiveSnapshotMatchersData}
 //	@Failure		405		{object}	APIErrorEnvelope
 //	@Failure		500		{object}	APIErrorEnvelope
 //	@Router			/singbox/router/selective/snapshot/matchers [get]
@@ -295,7 +295,7 @@ func queryIntDefault(r *http.Request, key string, def int) int {
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SelectiveStatusData
+//	@Success		200	{object}	APIEnvelope{data=SelectiveStatusData}
 //	@Failure		409	{object}	APIErrorEnvelope	"already installing"
 //	@Router			/singbox/router/selective/install-deps [post]
 func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
@@ -345,7 +345,7 @@ func (h *SelectiveHandler) InstallDeps(w http.ResponseWriter, r *http.Request) {
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SelectiveStatusData
+//	@Success		200	{object}	APIEnvelope{data=SelectiveStatusData}
 //	@Router			/singbox/router/selective/install-conntrack [post]
 func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -386,7 +386,7 @@ func (h *SelectiveHandler) InstallConntrack(w http.ResponseWriter, r *http.Reque
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		202	{object}	SelectiveStatusData	"rebuild started (or already running); rebuilding reflects live state"
+//	@Success		202	{object}	APIEnvelope{data=SelectiveStatusData}	"rebuild started (or already running); rebuilding reflects live state"
 //	@Failure		409	{object}	APIErrorEnvelope	"sing-box config apply in progress"
 //	@Failure		503	{object}	APIErrorEnvelope	"builder not configured"
 //	@Router			/singbox/router/selective/rebuild [post]
@@ -488,7 +488,7 @@ func (h *SelectiveHandler) respondRebuildAccepted(w http.ResponseWriter, r *http
 //	@Tags			singbox-router
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	SelectiveCancelData
+//	@Success		200	{object}	APIEnvelope{data=SelectiveCancelData}
 //	@Failure		405	{object}	APIErrorEnvelope
 //	@Router			/singbox/router/selective/rebuild/cancel [post]
 func (h *SelectiveHandler) CancelRebuild(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/staticroute.go
+++ b/internal/api/staticroute.go
@@ -102,7 +102,7 @@ func (h *StaticRouteHandler) List(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	StaticRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=StaticRouteDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/create [post]
@@ -131,7 +131,7 @@ func (h *StaticRouteHandler) Create(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	StaticRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=StaticRouteDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/update [post]
@@ -238,7 +238,7 @@ type staticRouteImportReq struct {
 //	@Accept			json
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	StaticRoutesListResponse
+//	@Success		200	{object}	APIEnvelope{data=StaticRouteDTO}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/static-routes/import [post]

--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -336,6 +336,19 @@ func (h *SubscriptionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}{true})
 }
 
+// SubscriptionRefreshData mirrors subscription.RefreshResult for swagger
+// (the subscription package is outside swag's parse dirs).
+type SubscriptionRefreshData struct {
+	When             string   `json:"when" example:"2026-07-20T12:00:00Z"`
+	Added            int      `json:"added" example:"1"`
+	Updated          int      `json:"updated" example:"2"`
+	Orphaned         int      `json:"orphaned" example:"0"`
+	SkippedVmess     int      `json:"skippedVmess" example:"0"`
+	SkippedOther     int      `json:"skippedOther" example:"0"`
+	SkippedDuplicate int      `json:"skippedDuplicate" example:"0"`
+	ParseErrors      []string `json:"parseErrors,omitempty"`
+}
+
 // Refresh handles POST /api/singbox/subscriptions/refresh?id=
 //
 //	@Summary		Refresh sing-box subscription
@@ -343,7 +356,7 @@ func (h *SubscriptionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 //	@Tags			subscriptions
 //	@Produce		json
 //	@Param			id	query		string	false	"subscription id"
-//	@Success		200	{object}	SubscriptionResponse
+//	@Success		200	{object}	APIEnvelope{data=SubscriptionRefreshData}
 //	@Failure		409	{object}	APIErrorEnvelope	"фильтр и исключения скрывают все серверы (ALL_MEMBERS_FILTERED)"
 //	@Failure		422	{object}	APIErrorEnvelope	"sing-box validation rejected the refreshed subscription"
 //	@Failure		500	{object}	APIErrorEnvelope

--- a/internal/api/subscription_members.go
+++ b/internal/api/subscription_members.go
@@ -19,7 +19,7 @@ import (
 //	@Produce		json
 //	@Param			id	query		string				true	"subscription id"
 //	@Param			req	body		ActiveMemberRequest	true	"member tag"
-//	@Success		200	{object}	SubscriptionResponse
+//	@Success		200	{object}	OkResponse
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/subscriptions/active-member [post]
@@ -178,7 +178,7 @@ func (h *SubscriptionHandler) GetStream(w http.ResponseWriter, r *http.Request) 
 //	@Tags			subscriptions
 //	@Produce		json
 //	@Param			id	query		string	true	"subscription id"
-//	@Success		200	{object}	SubscriptionResponse
+//	@Success		200	{object}	OkResponse
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/singbox/subscriptions/orphans/delete [post]
 func (h *SubscriptionHandler) OrphansDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -44,6 +44,11 @@ type TerminalStatusResponse struct {
 	SessionActive bool `json:"sessionActive" example:"false"`
 }
 
+// TerminalInstallData is the payload of POST /terminal/install.
+type TerminalInstallData struct {
+	Installed bool `json:"installed" example:"true"`
+}
+
 // Status returns the current terminal state.
 // GET /api/terminal/status
 //
@@ -74,7 +79,7 @@ func (h *TerminalHandler) Status(w http.ResponseWriter, r *http.Request) {
 //	@Tags			terminal
 //	@Produce		json
 //	@Security		CookieAuth
-//	@Success		200	{object}	TerminalStatusResponse
+//	@Success		200	{object}	APIEnvelope{data=TerminalInstallData}
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/terminal/install [post]

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -449,6 +449,15 @@ definitions:
         example: tun_abc123
         type: string
     type: object
+  api.ClientRouteToggleData:
+    properties:
+      enabled:
+        example: true
+        type: boolean
+      id:
+        example: cr_001
+        type: string
+    type: object
   api.ClientRoutesListResponse:
     properties:
       data:
@@ -5126,6 +5135,34 @@ definitions:
         example: ws
         type: string
     type: object
+  api.SubscriptionRefreshData:
+    properties:
+      added:
+        example: 1
+        type: integer
+      orphaned:
+        example: 0
+        type: integer
+      parseErrors:
+        items:
+          type: string
+        type: array
+      skippedDuplicate:
+        example: 0
+        type: integer
+      skippedOther:
+        example: 0
+        type: integer
+      skippedVmess:
+        example: 0
+        type: integer
+      updated:
+        example: 2
+        type: integer
+      when:
+        example: "2026-07-20T12:00:00Z"
+        type: string
+    type: object
   api.SubscriptionRejectedDTO:
     properties:
       label:
@@ -5353,6 +5390,12 @@ definitions:
       path:
         example: /opt/etc/HydraRoute/geosite_GA.dat
         type: string
+    type: object
+  api.TerminalInstallData:
+    properties:
+      installed:
+        example: true
+        type: boolean
     type: object
   api.TerminalStartData:
     properties:
@@ -7042,7 +7085,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.ClientRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.ClientRouteDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -7070,7 +7118,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.ClientRoutesListResponse'
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
@@ -7100,7 +7148,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.ClientRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.ClientRouteToggleData'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -7130,7 +7183,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.ClientRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.ClientRouteDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -8130,7 +8188,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.GeoExpandData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.GeoExpandData'
+              type: object
       security:
       - CookieAuth: []
       summary: HydraRoute geo tag expand
@@ -9396,7 +9459,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SaveStatusDTO'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SaveStatusDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -9511,7 +9579,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.PresetsListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.PresetsListResponse'
+              type: object
       summary: List unified presets
       tags:
       - presets
@@ -10025,7 +10098,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.ResolveResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.ResolveResponse'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -13937,7 +14015,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SelectiveStatusData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveStatusData'
+              type: object
       security:
       - CookieAuth: []
       summary: Install conntrack-tools package
@@ -13951,7 +14034,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SelectiveStatusData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveStatusData'
+              type: object
         "409":
           description: already installing
           schema:
@@ -13970,7 +14058,12 @@ paths:
           description: rebuild started (or already running); rebuilding reflects live
             state
           schema:
-            $ref: '#/definitions/api.SelectiveStatusData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveStatusData'
+              type: object
         "409":
           description: sing-box config apply in progress
           schema:
@@ -13995,7 +14088,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SelectiveCancelData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveCancelData'
+              type: object
         "405":
           description: Method Not Allowed
           schema:
@@ -14026,7 +14124,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SelectiveSnapshotMatchersData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveSnapshotMatchersData'
+              type: object
         "405":
           description: Method Not Allowed
           schema:
@@ -14048,7 +14151,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SelectiveStatusData'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SelectiveStatusData'
+              type: object
       security:
       - CookieAuth: []
       summary: Selective-bypass status
@@ -14160,7 +14268,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.RouterStagingStatusResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.RouterStagingStatusResponse'
+              type: object
         "405":
           description: Method Not Allowed
           schema:
@@ -14338,7 +14451,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SubscriptionResponse'
+            $ref: '#/definitions/api.OkResponse'
         "400":
           description: Bad Request
           schema:
@@ -14856,7 +14969,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SubscriptionResponse'
+            $ref: '#/definitions/api.OkResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -14915,7 +15028,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.SubscriptionResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.SubscriptionRefreshData'
+              type: object
         "409":
           description: фильтр и исключения скрывают все серверы (ALL_MEMBERS_FILTERED)
           schema:
@@ -15357,7 +15475,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.StaticRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.StaticRouteDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -15409,7 +15532,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.StaticRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.StaticRouteDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -15485,7 +15613,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.StaticRoutesListResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.StaticRouteDTO'
+              type: object
         "400":
           description: Bad Request
           schema:
@@ -15810,7 +15943,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.TerminalStatusResponse'
+            allOf:
+            - $ref: '#/definitions/api.APIEnvelope'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.TerminalInstallData'
+              type: object
         "400":
           description: Bad Request
           schema:


### PR DESCRIPTION
Мутации static-routes и client-routes объявляли списочный конверт при одиночном объекте в ответе — runtime-валидация фронта падала с «Некорректный ответ сервера», хотя бэкенд всё сохранял. Сверка по всем хендлерам: заодно выправлены 13 endpoint'ов с голым payload вместо конверта {success,data}. Только аннотации/DTO, рантайм не менялся.