### PR TITLE
fix(server): #571 — fallback на 0.0.0.0

### DIFF
--- a/internal/server/listen.go
+++ b/internal/server/listen.go
@@ -102,6 +102,15 @@ func (s *Server) resolveListenAddrs(spec ListenSpec, strict bool) ([]string, err
 	if strict && len(missing) > 0 {
 		return nil, fmt.Errorf("интерфейс(ы) без IPv4-адреса: %s", strings.Join(missing, ", "))
 	}
+	// Ни один интерфейс из списка не отрезолвился (#571: например, мусорное
+	// легаси server.interface) — fallback на 0.0.0.0, как до 2.16: демон
+	// только на loopback недостижим для пользователя. Heal сузит bind до
+	// желаемого spec, когда интерфейс получит IP.
+	if len(addrs) == 0 {
+		s.appLog.Warn("listen", "", "ни один интерфейс не имеет IPv4 ("+strings.Join(missing, ", ")+") — слушаю 0.0.0.0")
+		add("0.0.0.0")
+		return addrs, nil
+	}
 	if len(missing) > 0 {
 		s.appLog.Warn("listen", "", "интерфейсы без IPv4 пропущены (heal добиндит при появлении IP): "+strings.Join(missing, ", "))
 	}
@@ -109,8 +118,21 @@ func (s *Server) resolveListenAddrs(spec ListenSpec, strict bool) ([]string, err
 	return addrs, nil
 }
 
+// wildcardConflict — true, если два разных "ip:port" не могут слушать
+// одновременно: одинаковый порт и одна из сторон — wildcard 0.0.0.0.
+func wildcardConflict(a, b string) bool {
+	ha, pa, errA := net.SplitHostPort(a)
+	hb, pb, errB := net.SplitHostPort(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return pa == pb && ha != hb && (ha == "0.0.0.0" || hb == "0.0.0.0")
+}
+
 // applyListenLocked приводит активные листенеры к want (make-before-break):
-// СНАЧАЛА биндит недостающие адреса, ПОТОМ закрывает лишние. При
+// СНАЧАЛА биндит недостающие адреса, ПОТОМ закрывает лишние. Исключение —
+// wildcard/specific-конфликт на одном порту: там точечный break-before-make
+// с восстановлением при неудаче (см. closedConflicts ниже). При
 // bestEffort=false ошибка бинда любого нового адреса закрывает уже открытые
 // новые и оставляет старые нетронутыми — сервер никогда не остаётся без
 // листенера. bestEffort=true (boot/heal/revert) — недоступные адреса
@@ -123,6 +145,48 @@ func (s *Server) applyListenLocked(want []string, bestEffort bool) (int, error) 
 	wantSet := make(map[string]struct{}, len(want))
 	for _, a := range want {
 		wantSet[a] = struct{}{}
+	}
+
+	// Точечный break-before-make: wildcard и конкретный IP на одном порту не
+	// сосуществуют в LISTEN (EADDRINUSE), поэтому обречённый (не в want)
+	// листенер, конфликтующий с новым bind'ом, закрываем ДО открытия.
+	// Переходы «0.0.0.0 → конкретный интерфейс» (сужение fallback'а #571 или
+	// живая смена из API) без этого невозможны. Если bind, ради которого
+	// закрывали, не удался — закрытый адрес перебиндивается обратно.
+	closedConflicts := make(map[string]string) // закрытый адрес → want-адрес, ради которого закрыт
+	for addr, ln := range s.listen.listeners {
+		if _, keep := wantSet[addr]; keep {
+			continue
+		}
+		for _, w := range want {
+			if _, exists := s.listen.listeners[w]; exists || !wildcardConflict(addr, w) {
+				continue
+			}
+			ln.Close()
+			delete(s.listen.listeners, addr)
+			closedConflicts[addr] = w
+			s.appLog.Info("listen", addr, "listener closed (конфликт wildcard/интерфейс с "+w+")")
+			break
+		}
+	}
+	// restoreConflicts перебиндивает закрытые конфликтные адреса, чей
+	// want-адрес так и не открылся (all=true — все, путь ошибки).
+	restoreConflicts := func(all bool, opened map[string]net.Listener) {
+		for addr, w := range closedConflicts {
+			if !all {
+				if _, ok := opened[w]; ok {
+					continue
+				}
+			}
+			ln, err := net.Listen("tcp", addr)
+			if err != nil {
+				s.appLog.Warn("listen", addr, "restore bind failed: "+err.Error())
+				continue
+			}
+			s.listen.listeners[addr] = ln
+			go s.serveListener(ln)
+			s.appLog.Info("listen", addr, "listener restored")
+		}
 	}
 
 	opened := make(map[string]net.Listener)
@@ -139,10 +203,12 @@ func (s *Server) applyListenLocked(want []string, bestEffort bool) (int, error) 
 			for _, o := range opened {
 				o.Close()
 			}
+			restoreConflicts(true, nil)
 			return len(s.listen.listeners), fmt.Errorf("bind %s: %w", addr, err)
 		}
 		opened[addr] = ln
 	}
+	restoreConflicts(false, opened)
 
 	// Zero-listener guard (best-effort пути: revert/heal): если ни один
 	// желаемый адрес не выжил (все бинды упали, пересечения с текущими нет —

--- a/internal/server/listen_test.go
+++ b/internal/server/listen_test.go
@@ -200,6 +200,81 @@ func TestResolveListenAddrs(t *testing.T) {
 	}
 }
 
+// Non-strict (boot/heal): если НИ ОДИН интерфейс из списка не отрезолвился в
+// IPv4 — fallback на 0.0.0.0, а не loopback-only (#571: мусорное легаси
+// server.interface до 2.16 маскировалось таким же fallback'ом, после — веб
+// оставался доступен только на 127.0.0.1).
+func TestResolveListenAddrs_AllMissingFallsBackToWildcard(t *testing.T) {
+	s := newListenTestServer(t)
+	addrs, err := s.resolveListenAddrs(ListenSpec{Port: 1234, Interfaces: []string{"no-such-iface0", "no-such-iface1"}}, false)
+	if err != nil {
+		t.Fatalf("non-strict resolve: %v", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "0.0.0.0:1234" {
+		t.Fatalf("all-missing resolve = %v, want fallback [0.0.0.0:1234]", addrs)
+	}
+	// Частичный резолв: fallback'а нет, поведение прежнее — IP выживших + loopback.
+	addrs, err = s.resolveListenAddrs(ListenSpec{Port: 1234, Interfaces: []string{"lo", "no-such-iface0"}}, false)
+	if err != nil {
+		t.Fatalf("partial resolve: %v", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "127.0.0.1:1234" {
+		t.Fatalf("partial resolve = %v, want [127.0.0.1:1234]", addrs)
+	}
+}
+
+// Heal-переход после fallback'а: интерфейс получил IP → make-before-break
+// сужает bind с 0.0.0.0 до конкретного адреса на том же порту (specific-bind
+// при живом wildcard-листенере того же процесса).
+func TestListen_HealNarrowsWildcardFallback(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	port := freeTCPPort(t)
+	s.listen.mu.Lock()
+	if _, err := s.applyListenLocked([]string{fmt.Sprintf("0.0.0.0:%d", port)}, true); err != nil {
+		s.listen.mu.Unlock()
+		t.Fatalf("bind wildcard: %v", err)
+	}
+	n, err := s.applyListenLocked([]string{fmt.Sprintf("127.0.0.1:%d", port)}, true)
+	s.listen.mu.Unlock()
+	if err != nil || n != 1 {
+		t.Fatalf("narrow to specific: n=%d err=%v, want 1 listener", n, err)
+	}
+	if _, ok := s.listen.listeners[fmt.Sprintf("127.0.0.1:%d", port)]; !ok {
+		t.Fatalf("listeners = %v, want only 127.0.0.1:%d", s.listen.listeners, port)
+	}
+	if !dialOK(t, port) {
+		t.Fatal("port unreachable after narrowing")
+	}
+}
+
+// API-путь того же конфликта: живая смена «все интерфейсы (0.0.0.0) →
+// конкретный» на том же порту. До фикса bind падал с EADDRINUSE об
+// собственный wildcard-листенер.
+func TestListen_BeginChangeFromWildcardToInterfaceSamePort(t *testing.T) {
+	s := newListenTestServer(t)
+	defer shutdownListeners(s)
+	port := freeTCPPort(t)
+	bindInitial(t, s, port) // пустой список интерфейсов = 0.0.0.0
+
+	token, _, addrs, err := s.BeginListenChange(port, []string{"lo"})
+	if err != nil {
+		t.Fatalf("BeginListenChange wildcard→lo: %v", err)
+	}
+	if len(addrs) != 1 || addrs[0] != fmt.Sprintf("127.0.0.1:%d", port) {
+		t.Fatalf("addrs = %v, want [127.0.0.1:%d]", addrs, port)
+	}
+	if !dialOK(t, port) {
+		t.Fatal("port unreachable after change")
+	}
+	if _, _, ok := s.ConfirmListenChange(token); !ok {
+		t.Fatal("confirm failed")
+	}
+	if _, ok := s.listen.listeners[fmt.Sprintf("0.0.0.0:%d", port)]; ok {
+		t.Fatal("wildcard listener must be gone after confirm")
+	}
+}
+
 // Zero-listener guard: если на откате прежний адрес уже занят другим
 // процессом, текущие листенеры сохраняются — демон не остаётся без единого
 // листенера (heal сойдётся к желаемому spec, когда адрес освободится).


### PR DESCRIPTION
До 2.16 мусорное server.interface маскировалось fallback'ом на 0.0.0.0. Мультилистенер 2.16 (665e3afd) в той же ситуации пропускал интерфейс и оставлял только 127.0.0.1 — веб недоступен из LAN, демон при этом жив («running»), туннели работают, ребут не помогает, откат на 2.15.1 чинит (#571).

- non-strict резолв: ни один интерфейс без IPv4 тогда bind на 0.0.0.0 + warning; heal сужает при появлении IP
 - починен wildcard/specific-конфликт на одном порту (EADDRINUSE об собственный листенер)