### PR TITLE
fix(storage): миграция V32 — нормализация псевдо-интерфейса "0.0.0.0"…

### DIFF
--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	CurrentSchemaVersion        = 31
+	CurrentSchemaVersion        = 32
 	DefaultPort                 = 2222
 	DefaultInterface            = "br0"
 	DefaultPingCheckTarget      = "8.8.8.8"
@@ -178,6 +178,9 @@ func (s *SettingsStore) Load() (*Settings, error) {
 		}
 		if settings.SchemaVersion < 31 {
 			s.migrateToV31(&settings)
+		}
+		if settings.SchemaVersion < 32 {
+			s.migrateToV32(&settings)
 		}
 	}
 

--- a/internal/storage/settings_migrate32_test.go
+++ b/internal/storage/settings_migrate32_test.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadFrom(t *testing.T, raw string) *Settings {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	settings, err := NewSettingsStore(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return settings
+}
+
+// migrateToV32: "0.0.0.0" — не имя интерфейса (#571, вписан руками ради
+// «слушать всё»); нормализуется в пустой список = все интерфейсы.
+
+// Пользователь уже на схеме 30/31 с ["0.0.0.0"] после V30.
+func TestMigrateToV32_NormalizesWildcardInInterfaces(t *testing.T) {
+	s := loadFrom(t, `{"schemaVersion":31,"server":{"port":2222,"interface":"0.0.0.0","interfaces":["0.0.0.0"]}}`)
+	if len(s.Server.Interfaces) != 0 {
+		t.Errorf("Interfaces = %v, want empty (bind all)", s.Server.Interfaces)
+	}
+	if s.Server.Interface != "" {
+		t.Errorf("legacy Interface = %q, want \"\" (downgrade: пусто = 0.0.0.0)", s.Server.Interface)
+	}
+	if s.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", s.SchemaVersion, CurrentSchemaVersion)
+	}
+}
+
+// Апгрейд напрямую с 2.15.x: V30 поднимает легаси "0.0.0.0" в список, V32
+// тут же нормализует — на диск мусор не попадает.
+func TestMigrateToV32_LegacyWildcardFrom29(t *testing.T) {
+	s := loadFrom(t, `{"schemaVersion":29,"server":{"port":2222,"interface":"0.0.0.0"}}`)
+	if len(s.Server.Interfaces) != 0 {
+		t.Errorf("Interfaces = %v, want empty (bind all)", s.Server.Interfaces)
+	}
+	if s.Server.Interface != "" {
+		t.Errorf("legacy Interface = %q, want \"\"", s.Server.Interface)
+	}
+}
+
+// Смесь: wildcard выкидывается, настоящие интерфейсы остаются.
+func TestMigrateToV32_KeepsRealInterfaces(t *testing.T) {
+	s := loadFrom(t, `{"schemaVersion":31,"server":{"port":2222,"interface":"br0","interfaces":["br0","0.0.0.0"]}}`)
+	if len(s.Server.Interfaces) != 1 || s.Server.Interfaces[0] != "br0" {
+		t.Errorf("Interfaces = %v, want [br0]", s.Server.Interfaces)
+	}
+	if s.Server.Interface != "br0" {
+		t.Errorf("legacy Interface = %q, want br0 (не тронут)", s.Server.Interface)
+	}
+}

--- a/internal/storage/settings_migrations.go
+++ b/internal/storage/settings_migrations.go
@@ -318,6 +318,27 @@ func (s *SettingsStore) migrateToV31(settings *Settings) {
 	settings.SchemaVersion = 31
 }
 
+// migrateToV32 normalizes the hand-written "0.0.0.0" pseudo-interface
+// (#571: users set it pre-2.16 to mean "listen everywhere" and the old
+// single-listener code accidentally honored it via its bind-all fallback).
+// It is not an interface name: the multi-listener resolve skips it, leaving
+// the daemon loopback-only. Dropping it from the list (empty list = 0.0.0.0)
+// and blanking the legacy field ("" = bind all on a downgraded binary)
+// preserves the intended semantics on both sides.
+func (s *SettingsStore) migrateToV32(settings *Settings) {
+	kept := settings.Server.Interfaces[:0]
+	for _, iface := range settings.Server.Interfaces {
+		if iface != "0.0.0.0" {
+			kept = append(kept, iface)
+		}
+	}
+	settings.Server.Interfaces = kept
+	if settings.Server.Interface == "0.0.0.0" {
+		settings.Server.Interface = ""
+	}
+	settings.SchemaVersion = 32
+}
+
 // migrateManagedServers moves a legacy singular managedServer into the
 // new ManagedServers slice. Idempotent. Caller holds s.mu.
 func (s *SettingsStore) migrateManagedServers() {


### PR DESCRIPTION
… (#571)

Рукописный interface: "0.0.0.0" до 2.16 случайно работал через fallback одиночного листенера, в 2.16 оставлял демона loopback-only. V32 выкидывает его из interfaces (пустой список = все интерфейсы) и обнуляет легаси-поле ("" = bind-all на downgrade).