### PR TITLE
Fix/issue 584 obf key gen

### DIFF
--- a/frontend/src/lib/components/freeturn/ServerPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ServerPanel.svelte
@@ -78,6 +78,9 @@
 	}
 
 	const dirtyKeys = $derived(changedKeys(server, saved));
+	// Ссылка собирается бэкендом из СОХРАНЁННОГО конфига — с несохранённым
+	// профилем/ключом обфускации в неё молча попали бы старые значения (#584).
+	const obfDirty = $derived(dirtyKeys.includes('obfProfile') || dirtyKeys.includes('obfKey'));
 	const dirtyCount = $derived(dirtyKeys.length);
 
 	function changed(...keys: (keyof FreeTurnServerConfig)[]): boolean {
@@ -117,15 +120,23 @@
 			variant="primary"
 			size="sm"
 			loading={generating}
+			disabled={obfDirty}
 			onclick={() => onGenerate(genProvider, genMTU, genWG, genClientId, genName)}
 		>
 			Сгенерировать
 		</Button>
 	</div>
-	<p class="ft-hint">
-		Соберёт freeturn:// ссылку из обфускации/ключа сервера ниже и внешнего IP роутера —
-		передавайте её только доверенному получателю
-	</p>
+	{#if obfDirty}
+		<p class="ft-hint">
+			Профиль/ключ обфускации изменены, но не сохранены — сначала сохраните настройки,
+			иначе в ссылку попадут старые значения
+		</p>
+	{:else}
+		<p class="ft-hint">
+			Соберёт freeturn:// ссылку из обфускации/ключа сервера ниже и внешнего IP роутера —
+			передавайте её только доверенному получателю
+		</p>
+	{/if}
 	{#if server.clientsFile}
 		<p class="ft-hint">
 			У сервера включён allowlist (-clients-file): без Client ID в ссылке (раздел ниже)

--- a/frontend/src/lib/components/freeturn/ServerPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ServerPanel.svelte
@@ -70,6 +70,13 @@
 		genClientId = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 	}
 
+	// -obf-key: 32 байта → 64 hex-символа (#584 — ключ негде было взять).
+	function randomObfKey() {
+		const bytes = new Uint8Array(32);
+		crypto.getRandomValues(bytes);
+		server.obfKey = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+	}
+
 	const dirtyKeys = $derived(changedKeys(server, saved));
 	const dirtyCount = $derived(dirtyKeys.length);
 
@@ -196,12 +203,17 @@
 			</p>
 		</div>
 		<Dropdown label="Профиль (-obf-profile)" bind:value={server.obfProfile} options={obfOptions} />
-		<Input
-			label="Ключ обфускации (-obf-key)"
-			type="password"
-			bind:value={server.obfKey}
-			placeholder="64 hex-символа"
-		/>
+		<div>
+			<Input
+				label="Ключ обфускации (-obf-key)"
+				type="password"
+				bind:value={server.obfKey}
+				placeholder="64 hex-символа"
+			/>
+			<div class="ft-gen-idrow">
+				<Button variant="ghost" size="sm" onclick={randomObfKey}>Сгенерировать ключ</Button>
+			</div>
+		</div>
 		<div class="ft-span">
 			<Input
 				label="Файл allowlist клиентов (-clients-file)"

--- a/internal/freeturn/freeturn_test.go
+++ b/internal/freeturn/freeturn_test.go
@@ -95,6 +95,32 @@ func TestBuildServerArgs(t *testing.T) {
 	}
 }
 
+func TestValidateObfKey(t *testing.T) {
+	valid := strings.Repeat("ab", 32) // 64 hex-символа
+	cases := []struct {
+		name    string
+		profile string
+		key     string
+		wantErr bool
+	}{
+		{"no-profile", "", "", false},
+		{"none-profile", "none", "", false},
+		{"none-ignores-key", "none", "xx", false},
+		{"empty-key", "rtpopus2", "", true},
+		{"short-key", "rtpopus2", "deadbeef", true},
+		{"non-hex-key", "rtpopus2", strings.Repeat("zz", 32), true},
+		{"valid", "rtpopus2", valid, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateObfKey(c.profile, c.key)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validateObfKey(%q, %q) = %v, wantErr=%v", c.profile, c.key, err, c.wantErr)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // store.go
 // ---------------------------------------------------------------------------

--- a/internal/freeturn/service.go
+++ b/internal/freeturn/service.go
@@ -1,6 +1,7 @@
 package freeturn
 
 import (
+	"encoding/hex"
 	"errors"
 	"strconv"
 	"sync"
@@ -100,6 +101,9 @@ func (s *Service) StartClient() error {
 	if cfg.Client.Provider == "vk" && cfg.Client.Links == "" {
 		return errors.New("укажите ссылку(-и) VK Calls (-links) — обязательны для provider=vk")
 	}
+	if err := validateObfKey(cfg.Client.ObfProfile, cfg.Client.ObfKey); err != nil {
+		return err
+	}
 	return s.clientProc.Start(buildClientArgs(cfg.Client))
 }
 
@@ -115,7 +119,28 @@ func (s *Service) StartServer() error {
 	if cfg.Server.Connect == "" {
 		return errors.New("укажите backend-адрес (-connect)")
 	}
+	if err := validateObfKey(cfg.Server.ObfProfile, cfg.Server.ObfKey); err != nil {
+		return err
+	}
 	return s.serverProc.Start(buildServerArgs(cfg.Server))
+}
+
+// validateObfKey — ключ обфускации обязателен при профиле ≠ none и должен
+// быть 64 hex-символа (32 байта); иначе бинарь падает с опак-ошибкой (#584).
+func validateObfKey(profile, key string) error {
+	if profile == "" || profile == "none" {
+		return nil
+	}
+	if key == "" {
+		return errors.New("сгенерируйте или укажите ключ обфускации (-obf-key) — обязателен при профиле ≠ none")
+	}
+	if len(key) != 64 {
+		return errors.New("ключ обфускации (-obf-key) должен состоять из 64 hex-символов")
+	}
+	if _, err := hex.DecodeString(key); err != nil {
+		return errors.New("ключ обфускации (-obf-key) должен состоять из 64 hex-символов")
+	}
+	return nil
 }
 
 func (s *Service) StopServer() error {


### PR DESCRIPTION
Closes #584. Поле -obf-key негде было заполнить , поэтому «делало больно».

- Кнопка «Сгенерировать ключ» в серверной панели (32 байта к 64 hex,
  зеркало randomClientId); клиент получает ключ через freeturn://-ссылку.
- StartServer/StartClient валидируют ключ при профиле ≠ none (64 hex) —
  понятная ошибка.
- Гейт генерации ссылки при несохранённых obf-полях 