### PR TITLE
fix(ui): иконка в кнопке пустого состояния съезжала вверх

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -578,13 +578,6 @@ label {
 	color: var(--text-muted);
 }
 
-.empty-state svg {
-	width: 64px;
-	height: 64px;
-	margin-bottom: 1rem;
-	opacity: 0.5;
-}
-
 /* Toast notifications */
 .toast-container {
 	position: fixed;


### PR DESCRIPTION
Широкое правило .empty-state svg цепляло иконку внутри кнопки-действия и добавляло ей margin-bottom+opacity — иконка вставала выше текста и блёкла. Декоративную иконку целиком стилизует сам EmptyState, правило было легаси. Удалено.