### PR TITLE
feat(dns): TLS configuration support for DNS servers

### DIFF
--- a/frontend/src/lib/api/clientSbRouter.ts
+++ b/frontend/src/lib/api/clientSbRouter.ts
@@ -9,6 +9,7 @@ import type {
 	SingboxProxiesTestRequest,
 	SingboxProxiesTestResponse,
 	SingboxRouterDNSGlobals,
+	SingboxRouterDNSLookupResult,
 	SingboxRouterDNSRewrite,
 	SingboxRouterDNSRule,
 	SingboxRouterDNSServer,
@@ -221,6 +222,13 @@ export class SbRouterClient extends SingboxClient {
 
 	async singboxRouterListDNSServers(): Promise<SingboxRouterDNSServer[]> {
 		return this.request<SingboxRouterDNSServer[]>('/singbox/router/dns/servers/list');
+	}
+
+	async singboxRouterLookupDNSServer(server: string, port: number | '', serverName = ''): Promise<SingboxRouterDNSLookupResult> {
+		const query = new URLSearchParams({ server });
+		if (port !== '') query.set('server_port', String(port));
+		if (serverName.trim()) query.set('server_name', serverName.trim());
+		return this.request(`/singbox/router/dns/servers/lookup?${query}`);
 	}
 
 	async singboxRouterAddDNSServer(server: SingboxRouterDNSServer): Promise<void> {

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1285,6 +1285,15 @@ const api_SingboxConnectionsClientsResponse: v.GenericSchema = v.looseObject({
 	success: v.optional(v.nullable(v.boolean())),
 });
 
+const api_SingboxDNSClientTLSOptionsDTO: v.GenericSchema = v.looseObject({
+	alpn: v.optional(v.nullable(v.array(v.string()))),
+	certificate_public_key_sha256: v.optional(v.nullable(v.array(v.string()))),
+	insecure: v.optional(v.nullable(v.boolean())),
+	max_version: v.optional(v.nullable(v.string())),
+	min_version: v.optional(v.nullable(v.string())),
+	server_name: v.optional(v.nullable(v.string())),
+});
+
 const api_SingboxDNSGlobalsData: v.GenericSchema = v.looseObject({
 	final: v.optional(v.nullable(v.string())),
 	strategy: v.optional(v.nullable(v.string())),
@@ -1328,6 +1337,7 @@ const api_SingboxDNSServerDTO: v.GenericSchema = v.looseObject({
 	server: v.optional(v.nullable(v.string())),
 	server_port: v.optional(v.nullable(v.number())),
 	tag: v.optional(v.nullable(v.string())),
+	tls: v.optional(v.nullable(v.lazy(() => api_SingboxDNSClientTLSOptionsDTO))),
 	type: v.optional(v.nullable(v.string())),
 });
 

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1285,6 +1285,13 @@ const api_SingboxConnectionsClientsResponse: v.GenericSchema = v.looseObject({
 	success: v.optional(v.nullable(v.boolean())),
 });
 
+const api_SingboxDNSCertificateDTO: v.GenericSchema = v.looseObject({
+	certificate_public_key_sha256: v.optional(v.nullable(v.string())),
+	issuer: v.optional(v.nullable(v.string())),
+	not_after: v.optional(v.nullable(v.string())),
+	subject: v.optional(v.nullable(v.string())),
+});
+
 const api_SingboxDNSClientTLSOptionsDTO: v.GenericSchema = v.looseObject({
 	alpn: v.optional(v.nullable(v.array(v.string()))),
 	certificate_public_key_sha256: v.optional(v.nullable(v.array(v.string()))),
@@ -1301,6 +1308,17 @@ const api_SingboxDNSGlobalsData: v.GenericSchema = v.looseObject({
 
 const api_SingboxDNSGlobalsResponse: v.GenericSchema = v.looseObject({
 	data: v.optional(v.nullable(v.lazy(() => api_SingboxDNSGlobalsData))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
+const api_SingboxDNSLookupData: v.GenericSchema = v.looseObject({
+	certificate_public_key_sha256: v.optional(v.nullable(v.array(v.string()))),
+	certificates: v.optional(v.nullable(v.array(v.lazy(() => api_SingboxDNSCertificateDTO)))),
+	ips: v.optional(v.nullable(v.array(v.string()))),
+});
+
+const api_SingboxDNSLookupResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => api_SingboxDNSLookupData))),
 	success: v.optional(v.nullable(v.boolean())),
 });
 
@@ -2520,6 +2538,7 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /singbox/router/dns/rewrites/list": v.lazy(() => api_SingboxDNSRewritesListResponse),
 	"GET /singbox/router/dns/rules/list": v.lazy(() => api_SingboxDNSRulesListResponse),
 	"GET /singbox/router/dns/servers/list": v.lazy(() => api_SingboxDNSServersListResponse),
+	"GET /singbox/router/dns/servers/lookup": v.lazy(() => api_SingboxDNSLookupResponse),
 	"GET /singbox/router/geosites/list": v.intersect([v.lazy(() => api_OkResponse), v.looseObject({
 	data: v.optional(v.nullable(v.lazy(() => api_SingboxGeositesData))),
 })]),

--- a/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
@@ -41,6 +41,13 @@
 		{ value: 'prefer_ipv4', label: 'prefer_ipv4' },
 		{ value: 'prefer_ipv6', label: 'prefer_ipv6' },
 	];
+	const TLS_VERSION_OPTIONS: DropdownOption[] = [
+		{ value: '', label: '— default —' },
+		{ value: '1.0', label: 'TLS 1.0' },
+		{ value: '1.1', label: 'TLS 1.1' },
+		{ value: '1.2', label: 'TLS 1.2' },
+		{ value: '1.3', label: 'TLS 1.3' },
+	];
 
 	const detourOptions = $derived<DropdownOption[]>([
 		{ value: '', label: 'Напрямую' },
@@ -93,6 +100,18 @@
 	let resolverServer = $state(server?.domain_resolver?.server ?? '');
 	// svelte-ignore state_referenced_locally
 	let resolverStrategy = $state<SingboxRouterDNSStrategy>(server?.domain_resolver?.strategy ?? '');
+	// svelte-ignore state_referenced_locally
+	let tlsServerName = $state(server?.tls?.server_name ?? '');
+	// svelte-ignore state_referenced_locally
+	let tlsInsecure = $state(server?.tls?.insecure ?? false);
+	// svelte-ignore state_referenced_locally
+	let tlsALPN = $state(server?.tls?.alpn?.join(', ') ?? '');
+	// svelte-ignore state_referenced_locally
+	let tlsMinVersion = $state(server?.tls?.min_version ?? '');
+	// svelte-ignore state_referenced_locally
+	let tlsMaxVersion = $state(server?.tls?.max_version ?? '');
+	// svelte-ignore state_referenced_locally
+	let tlsCertificatePins = $state(server?.tls?.certificate_public_key_sha256?.join(', ') ?? '');
 
 	let busy = $state(false);
 	let error = $state('');
@@ -108,6 +127,8 @@
 	let initialResolverEnabled = $state(false);
 	let initialResolverServer = $state('');
 	let initialResolverStrategy = $state<SingboxRouterDNSStrategy>('');
+	let initialTLS = $state('');
+	let previousType = $state<SingboxRouterDNSType | null>(null);
 
 	// Initialize snapshot when modal opens
 	$effect(() => {
@@ -125,6 +146,15 @@
 			initialResolverEnabled = server.domain_resolver != null;
 			initialResolverServer = server.domain_resolver?.server ?? '';
 			initialResolverStrategy = server.domain_resolver?.strategy ?? '';
+			initialTLS = JSON.stringify({
+				server_name: server.tls?.server_name?.trim() ?? '',
+				insecure: server.tls?.insecure ?? false,
+				alpn: server.tls?.alpn?.map((item) => item.trim()).filter(Boolean) ?? [],
+				min_version: server.tls?.min_version ?? '',
+				max_version: server.tls?.max_version ?? '',
+				certificate_public_key_sha256:
+					server.tls?.certificate_public_key_sha256?.map((item) => item.trim()).filter(Boolean) ?? [],
+			});
 		} else {
 			initialTag = '';
 			initialType = 'udp';
@@ -136,7 +166,31 @@
 			initialResolverEnabled = false;
 			initialResolverServer = '';
 			initialResolverStrategy = '';
+			initialTLS = '';
 		}
+	});
+
+	$effect(() => {
+		if (previousType === null) {
+			previousType = type;
+			return;
+		}
+		if (type === previousType) return;
+		previousType = type;
+		serverAddr = '';
+		serverPort = '';
+		path = '';
+		detour = '';
+		strategy = '';
+		resolverEnabled = false;
+		resolverServer = '';
+		resolverStrategy = '';
+		tlsServerName = '';
+		tlsInsecure = false;
+		tlsALPN = '';
+		tlsMinVersion = '';
+		tlsMaxVersion = '';
+		tlsCertificatePins = '';
 	});
 
 	const isDirty = $derived.by(() => {
@@ -151,11 +205,13 @@
 			strategy !== initialStrategy ||
 			resolverEnabled !== initialResolverEnabled ||
 			resolverServer !== initialResolverServer ||
-			resolverStrategy !== initialResolverStrategy
+			resolverStrategy !== initialResolverStrategy ||
+			serializeTLSState() !== initialTLS
 		);
 	});
 
 	const needsResolver = $derived(type !== 'udp' && type !== 'local' && !isIPLiteral(serverAddr));
+	const supportsTLS = $derived(type === 'tls' || type === 'quic' || type === 'https' || type === 'h3');
 	const availableResolvers = $derived(servers.filter((s) => s.tag !== tag).map((s) => s.tag));
 	const resolverServerOptions = $derived<DropdownOption[]>([
 		{ value: '', label: '— выберите —' },
@@ -166,6 +222,21 @@
 		return /^(\d{1,3}\.){3}\d{1,3}$/.test(s) || s.includes(':');
 	}
 
+	function splitList(value: string): string[] {
+		return value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean);
+	}
+
+	function serializeTLSState(): string {
+		return JSON.stringify({
+			server_name: tlsServerName.trim(),
+			insecure: tlsInsecure,
+			alpn: splitList(tlsALPN),
+			min_version: tlsMinVersion,
+			max_version: tlsMaxVersion,
+			certificate_public_key_sha256: splitList(tlsCertificatePins),
+		});
+	}
+
 	async function save(): Promise<void> {
 		busy = true;
 		error = '';
@@ -173,6 +244,9 @@
 			if (!tag.trim()) { error = 'Tag обязателен'; busy = false; return; }
 			if (type !== 'local' && !serverAddr.trim()) { error = 'Server обязателен'; busy = false; return; }
 			if (resolverEnabled && !resolverServer) { error = 'Укажите domain_resolver'; busy = false; return; }
+			if (tlsMinVersion && tlsMaxVersion && Number(tlsMinVersion) > Number(tlsMaxVersion)) {
+				error = 'Минимальная версия TLS не может быть выше максимальной'; busy = false; return;
+			}
 
 			const built: SingboxRouterDNSServer = {
 				tag: tag.trim(),
@@ -186,6 +260,19 @@
 					built.domain_resolver = { server: resolverServer };
 					if (resolverStrategy) built.domain_resolver.strategy = resolverStrategy;
 				}
+			}
+			if (supportsTLS) {
+				const tls = {
+					...(tlsServerName.trim() ? { server_name: tlsServerName.trim() } : {}),
+					...(tlsInsecure ? { insecure: true } : {}),
+					...(splitList(tlsALPN).length ? { alpn: splitList(tlsALPN) } : {}),
+					...(tlsMinVersion ? { min_version: tlsMinVersion as '1.0' | '1.1' | '1.2' | '1.3' } : {}),
+					...(tlsMaxVersion ? { max_version: tlsMaxVersion as '1.0' | '1.1' | '1.2' | '1.3' } : {}),
+					...(splitList(tlsCertificatePins).length
+						? { certificate_public_key_sha256: splitList(tlsCertificatePins) }
+						: {}),
+				};
+				if (Object.keys(tls).length) built.tls = tls;
 			}
 			if (type !== 'local') {
 				if (strategy) built.domain_strategy = strategy;
@@ -324,6 +411,40 @@
 						</label>
 					</div>
 				{/if}
+			</section>
+		{/if}
+
+		{#if supportsTLS}
+			<section class="form-section form-section-divided">
+				<div class="section-label">TLS</div>
+				<div class="fields-grid">
+					<label class="field span-full">
+						<div class="lbl">Server name (SNI)</div>
+						<input bind:value={tlsServerName} placeholder="cloudflare-dns.com" />
+					</label>
+					<label class="toggle span-full">
+						<input type="checkbox" bind:checked={tlsInsecure} />
+						<span>Принимать любой сертификат</span>
+					</label>
+					<label class="field span-full">
+						<div class="lbl">ALPN</div>
+						<input bind:value={tlsALPN} placeholder="h2, http/1.1" />
+						<div class="hint">Значения через запятую или с новой строки.</div>
+					</label>
+					<label class="field">
+						<div class="lbl">Минимальная версия TLS</div>
+						<Dropdown bind:value={tlsMinVersion} options={TLS_VERSION_OPTIONS} fullWidth />
+					</label>
+					<label class="field">
+						<div class="lbl">Максимальная версия TLS</div>
+						<Dropdown bind:value={tlsMaxVersion} options={TLS_VERSION_OPTIONS} fullWidth />
+					</label>
+					<label class="field span-full">
+						<div class="lbl">SHA-256 публичного ключа сертификата</div>
+						<input bind:value={tlsCertificatePins} placeholder="base64 pin" />
+						<div class="hint">Несколько значений — через запятую или с новой строки.</div>
+					</label>
+				</div>
 			</section>
 		{/if}
 

--- a/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
@@ -217,6 +217,7 @@
 
 	const needsResolver = $derived(type !== 'udp' && type !== 'local' && !isIPLiteral(serverAddr));
 	const supportsTLS = $derived(type === 'tls' || type === 'quic' || type === 'https' || type === 'h3');
+	const hasOutboundDetour = $derived(!isManagedDnsDirect && detour !== '');
 	const availableResolvers = $derived(servers.filter((s) => s.tag !== tag).map((s) => s.tag));
 	const resolverServerOptions = $derived<DropdownOption[]>([
 		{ value: '', label: '— выберите —' },
@@ -284,7 +285,7 @@
 			if (type !== 'local') {
 				if (serverPort !== '' && Number(serverPort) > 0) built.server_port = Number(serverPort);
 				if (path.trim()) built.path = path.trim();
-				if (resolverEnabled && resolverServer) {
+				if (!hasOutboundDetour && resolverEnabled && resolverServer) {
 					built.domain_resolver = { server: resolverServer };
 					if (resolverStrategy) built.domain_resolver.strategy = resolverStrategy;
 				}
@@ -412,7 +413,7 @@
 			</section>
 		{/if}
 
-		{#if type !== 'udp' && type !== 'local'}
+		{#if type !== 'udp' && type !== 'local' && !hasOutboundDetour}
 			<section class="form-section">
 				<div class="section-label">Bootstrap resolver (для домена сервера)</div>
 

--- a/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.svelte
@@ -15,6 +15,7 @@
 		sanitizeDnsServerForApi,
 	} from '$lib/utils/dnsServerDetour';
 	import { dnsServerDetourDisplay } from '$lib/components/sb-router/dnsServerDetourDisplay';
+	import { api } from '$lib/api/client';
 
 	interface Props {
 		server?: SingboxRouterDNSServer;
@@ -112,6 +113,10 @@
 	let tlsMaxVersion = $state(server?.tls?.max_version ?? '');
 	// svelte-ignore state_referenced_locally
 	let tlsCertificatePins = $state(server?.tls?.certificate_public_key_sha256?.join(', ') ?? '');
+	let lookupBusy = $state(false);
+	let lookupError = $state('');
+	let lookupIPs = $state<string[]>([]);
+	let lookupCertificates = $state<Array<{ subject: string; issuer: string; not_after: string }>>([]);
 
 	let busy = $state(false);
 	let error = $state('');
@@ -235,6 +240,29 @@
 			max_version: tlsMaxVersion,
 			certificate_public_key_sha256: splitList(tlsCertificatePins),
 		});
+	}
+
+	async function lookupTLS(): Promise<void> {
+		if (!serverAddr.trim()) {
+			lookupError = 'Укажите домен DNS-сервера';
+			return;
+		}
+		lookupBusy = true;
+		lookupError = '';
+		try {
+			const hostname = serverAddr.trim();
+			const lookupPort = serverPort === '' ? (type === 'https' || type === 'h3' ? 443 : 853) : serverPort;
+			const result = await api.singboxRouterLookupDNSServer(hostname, lookupPort, tlsServerName || hostname);
+			lookupIPs = result.ips;
+			lookupCertificates = result.certificates;
+			if (result.ips[0]) serverAddr = result.ips[0];
+			if (!tlsServerName.trim() && !isIPLiteral(hostname)) tlsServerName = hostname;
+			tlsCertificatePins = result.certificate_public_key_sha256.join(', ');
+		} catch (e) {
+			lookupError = (e as Error).message;
+		} finally {
+			lookupBusy = false;
+		}
 	}
 
 	async function save(): Promise<void> {
@@ -417,6 +445,19 @@
 		{#if supportsTLS}
 			<section class="form-section form-section-divided">
 				<div class="section-label">TLS</div>
+				<div class="hint lookup-action">
+					<Button variant="ghost" size="sm" onclick={lookupTLS} disabled={lookupBusy} loading={lookupBusy} type="button">
+						Получить IP и сертификаты
+					</Button>
+					<span>Подставит первый IP и SHA-256 pins; домен сохранится как SNI.</span>
+				</div>
+				{#if lookupError}<div class="error">{lookupError}</div>{/if}
+				{#if lookupIPs.length}
+					<div class="hint">Найденные IP: {lookupIPs.join(', ')}</div>
+				{/if}
+				{#if lookupCertificates.length}
+					<div class="hint">Сертификаты: {lookupCertificates.map((cert) => `${cert.subject} · до ${cert.not_after}`).join('; ')}</div>
+				{/if}
 				<div class="fields-grid">
 					<label class="field span-full">
 						<div class="lbl">Server name (SNI)</div>

--- a/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.test.ts
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.test.ts
@@ -26,6 +26,19 @@ describe('DNSServerEditModal', () => {
 		expect(screen.getByText('Server name (SNI)')).toBeTruthy();
 	});
 
+	it('hides the bootstrap resolver when an outbound detour is selected', () => {
+		render(DNSServerEditModal, {
+			props: {
+				...baseProps,
+				server: { tag: 'dot', type: 'tls', server: 'dns.example', detour: 'tunnel' },
+				outboundOptions: [{ group: 'Туннели', items: [{ value: 'tunnel', label: 'Tunnel' }] }],
+				onSave: vi.fn(),
+			},
+		});
+
+		expect(screen.queryByText('Bootstrap resolver (для домена сервера)')).toBeNull();
+	});
+
 	it('resets non-tag fields when type changes and serializes TLS lists', async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
 		render(DNSServerEditModal, {

--- a/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.test.ts
+++ b/frontend/src/lib/components/routing/singboxRouter/DNSServerEditModal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import DNSServerEditModal from './DNSServerEditModal.svelte';
+
+class ResizeObserverStub {
+	observe(): void {}
+	disconnect(): void {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+const baseProps = {
+	servers: [],
+	outboundOptions: [],
+	onClose: vi.fn(),
+};
+
+describe('DNSServerEditModal', () => {
+	it('shows TLS controls only for TLS-capable DNS types', async () => {
+		render(DNSServerEditModal, {
+			props: { ...baseProps, onSave: vi.fn() },
+		});
+		expect(screen.queryByText('Server name (SNI)')).toBeNull();
+
+		await fireEvent.click(screen.getByText('UDP (обычный DNS)'));
+		await fireEvent.click(screen.getByText('DoT (DNS over TLS)'));
+		expect(screen.getByText('Server name (SNI)')).toBeTruthy();
+	});
+
+	it('resets non-tag fields when type changes and serializes TLS lists', async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		render(DNSServerEditModal, {
+			props: {
+				...baseProps,
+				server: {
+					tag: 'dns', type: 'udp', server: '1.1.1.1', server_port: 53, path: '/old',
+					detour: 'tunnel', domain_strategy: 'ipv4_only',
+				},
+				onSave,
+			},
+		});
+
+		await fireEvent.click(screen.getByText('UDP (обычный DNS)'));
+		await fireEvent.click(screen.getByText('DoT (DNS over TLS)'));
+		expect(screen.getByDisplayValue('dns')).toBeTruthy();
+		const cloudflareInputs = screen.getAllByPlaceholderText<HTMLInputElement>('cloudflare-dns.com');
+		expect(cloudflareInputs[0].value).toBe('');
+
+		await fireEvent.input(cloudflareInputs[0], { target: { value: 'dns.example' } });
+		await fireEvent.input(screen.getByPlaceholderText('h2, http/1.1'), { target: { value: 'h2,\nh3' } });
+		await fireEvent.input(screen.getByPlaceholderText('base64 pin'), { target: { value: 'pin-a, pin-b' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Сохранить' }));
+
+		expect(onSave).toHaveBeenCalledWith({
+			tag: 'dns', type: 'tls', server: 'dns.example',
+			tls: { alpn: ['h2', 'h3'], certificate_public_key_sha256: ['pin-a', 'pin-b'] },
+		});
+	});
+});

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -395,6 +395,15 @@ export interface SingboxRouterDNSDomainResolver {
 	strategy?: SingboxRouterDNSStrategy;
 }
 
+export interface SingboxRouterDNSClientTLSOptions {
+	server_name?: string;
+	insecure?: boolean;
+	alpn?: string[];
+	min_version?: '1.0' | '1.1' | '1.2' | '1.3';
+	max_version?: '1.0' | '1.1' | '1.2' | '1.3';
+	certificate_public_key_sha256?: string[];
+}
+
 export interface SingboxRouterDNSServer {
 	tag: string;
 	type: SingboxRouterDNSType;
@@ -404,6 +413,7 @@ export interface SingboxRouterDNSServer {
 	detour?: string;
 	domain_strategy?: SingboxRouterDNSStrategy;
 	domain_resolver?: SingboxRouterDNSDomainResolver;
+	tls?: SingboxRouterDNSClientTLSOptions;
 }
 
 export interface SingboxRouterDNSRule {

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -404,6 +404,19 @@ export interface SingboxRouterDNSClientTLSOptions {
 	certificate_public_key_sha256?: string[];
 }
 
+export interface SingboxRouterDNSCertificate {
+	subject: string;
+	issuer: string;
+	not_after: string;
+	certificate_public_key_sha256: string;
+}
+
+export interface SingboxRouterDNSLookupResult {
+	ips: string[];
+	certificate_public_key_sha256: string[];
+	certificates: SingboxRouterDNSCertificate[];
+}
+
 export interface SingboxRouterDNSServer {
 	tag: string;
 	type: SingboxRouterDNSType;

--- a/frontend/src/lib/utils/dnsServerDetour.test.ts
+++ b/frontend/src/lib/utils/dnsServerDetour.test.ts
@@ -34,6 +34,26 @@ describe('shouldOmitDnsServerDetour', () => {
 	it('keeps explicit outbound detour', () => {
 		expect(shouldOmitDnsServerDetour('dns-tunnel', 'wg-nl')).toBe(false);
 	});
+
+	it('keeps populated TLS and omits an empty TLS object', () => {
+		expect(sanitizeDnsServerForApi({
+			tag: 'dot',
+			type: 'tls',
+			server: 'dns.example',
+			tls: {
+				server_name: ' dns.example ', insecure: true, alpn: [' h2 ', ''], min_version: '1.2',
+				certificate_public_key_sha256: [' pin ', ''],
+			},
+		})).toMatchObject({
+			tls: {
+				server_name: 'dns.example', insecure: true, alpn: ['h2'], min_version: '1.2',
+				certificate_public_key_sha256: ['pin'],
+			},
+		});
+		expect(sanitizeDnsServerForApi({
+			tag: 'dot', type: 'tls', server: 'dns.example', tls: { alpn: [' '] },
+		})).not.toHaveProperty('tls');
+	});
 });
 
 describe('sanitizeDnsServerForApi', () => {

--- a/frontend/src/lib/utils/dnsServerDetour.ts
+++ b/frontend/src/lib/utils/dnsServerDetour.ts
@@ -26,6 +26,22 @@ export function sanitizeDnsServerForApi(
 	if (server.path?.trim()) out.path = server.path.trim();
 	if (server.domain_strategy) out.domain_strategy = server.domain_strategy;
 	if (server.domain_resolver) out.domain_resolver = { ...server.domain_resolver };
+	const tls = server.tls;
+	if (tls) {
+		const cleanTLS = {
+			...(tls.server_name?.trim() ? { server_name: tls.server_name.trim() } : {}),
+			...(tls.insecure ? { insecure: true } : {}),
+			...(tls.alpn?.map((value) => value.trim()).filter(Boolean).length
+				? { alpn: tls.alpn.map((value) => value.trim()).filter(Boolean) }
+				: {}),
+			...(tls.min_version ? { min_version: tls.min_version } : {}),
+			...(tls.max_version ? { max_version: tls.max_version } : {}),
+			...(tls.certificate_public_key_sha256?.map((value) => value.trim()).filter(Boolean).length
+				? { certificate_public_key_sha256: tls.certificate_public_key_sha256.map((value) => value.trim()).filter(Boolean) }
+				: {}),
+		};
+		if (Object.keys(cleanTLS).length) out.tls = cleanTLS;
+	}
 	if (detour && !shouldOmitDnsServerDetour(server.tag, detour)) {
 		out.detour = detour;
 	}

--- a/internal/api/singbox_router_dns.go
+++ b/internal/api/singbox_router_dns.go
@@ -17,16 +17,26 @@ type SingboxDomainResolverDTO struct {
 	Strategy string `json:"strategy,omitempty" example:"ipv4_only"`
 }
 
+type SingboxDNSClientTLSOptionsDTO struct {
+	ServerName                 string   `json:"server_name,omitempty" example:"cloudflare-dns.com"`
+	Insecure                   bool     `json:"insecure,omitempty"`
+	ALPN                       []string `json:"alpn,omitempty" example:"h2"`
+	MinVersion                 string   `json:"min_version,omitempty" example:"1.2"`
+	MaxVersion                 string   `json:"max_version,omitempty" example:"1.3"`
+	CertificatePublicKeySHA256 []string `json:"certificate_public_key_sha256,omitempty"`
+}
+
 // SingboxDNSServerDTO mirrors router.DNSServer.
 type SingboxDNSServerDTO struct {
-	Tag            string                    `json:"tag" example:"cloudflare"`
-	Type           string                    `json:"type" example:"udp"`
-	Server         string                    `json:"server" example:"1.1.1.1"`
-	ServerPort     int                       `json:"server_port,omitempty" example:"53"`
-	Path           string                    `json:"path,omitempty" example:"/dns-query"`
-	Detour         string                    `json:"detour,omitempty" example:"direct"`
-	Strategy       string                    `json:"domain_strategy,omitempty" example:"prefer_ipv4"`
-	DomainResolver *SingboxDomainResolverDTO `json:"domain_resolver,omitempty"`
+	Tag            string                         `json:"tag" example:"cloudflare"`
+	Type           string                         `json:"type" example:"udp"`
+	Server         string                         `json:"server" example:"1.1.1.1"`
+	ServerPort     int                            `json:"server_port,omitempty" example:"53"`
+	Path           string                         `json:"path,omitempty" example:"/dns-query"`
+	Detour         string                         `json:"detour,omitempty" example:"direct"`
+	Strategy       string                         `json:"domain_strategy,omitempty" example:"prefer_ipv4"`
+	DomainResolver *SingboxDomainResolverDTO      `json:"domain_resolver,omitempty"`
+	TLS            *SingboxDNSClientTLSOptionsDTO `json:"tls,omitempty"`
 }
 
 // SingboxDNSServersListResponse is the envelope for

--- a/internal/api/singbox_router_dns_lookup.go
+++ b/internal/api/singbox_router_dns_lookup.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/response"
+)
+
+type SingboxDNSCertificateDTO struct {
+	Subject                    string `json:"subject"`
+	Issuer                     string `json:"issuer"`
+	NotAfter                   string `json:"not_after"`
+	CertificatePublicKeySHA256 string `json:"certificate_public_key_sha256"`
+}
+
+type SingboxDNSLookupData struct {
+	IPs                        []string                   `json:"ips"`
+	CertificatePublicKeySHA256 []string                   `json:"certificate_public_key_sha256"`
+	Certificates               []SingboxDNSCertificateDTO `json:"certificates"`
+}
+
+type SingboxDNSLookupResponse struct {
+	Success bool                 `json:"success"`
+	Data    SingboxDNSLookupData `json:"data"`
+}
+
+// LookupDNSServer resolves a DNS-server hostname and reads the peer TLS
+// certificate chain. Certificate verification is deliberately disabled for the
+// probe: the purpose is to retrieve pins even when the current trust chain is
+// invalid; sing-box applies the configured verification policy at runtime.
+//
+//	@Summary		Resolve DNS server and fetch TLS certificates
+//	@Tags			singbox-router
+//	@Produce		json
+//	@Security		CookieAuth
+//	@Param			server		query	string	true	"DNS server hostname or IP"
+//	@Param			server_port	query	int		false	"TLS port (default 853)"
+//	@Param			server_name	query	string	false	"TLS SNI (defaults to server)"
+//	@Success		200	{object}	SingboxDNSLookupResponse
+//	@Failure		400	{object}	APIErrorEnvelope
+//	@Failure		502	{object}	APIErrorEnvelope
+//	@Router			/singbox/router/dns/servers/lookup [get]
+func (h *SingboxRouterHandler) LookupDNSServer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+
+	server := strings.TrimSpace(r.URL.Query().Get("server"))
+	if server == "" {
+		response.BadRequest(w, "server is required")
+		return
+	}
+	port := 853
+	if rawPort := r.URL.Query().Get("server_port"); rawPort != "" {
+		parsed, err := strconv.Atoi(rawPort)
+		if err != nil || parsed < 1 || parsed > 65535 {
+			response.BadRequest(w, "server_port must be between 1 and 65535")
+			return
+		}
+		port = parsed
+	}
+	sni := strings.TrimSpace(r.URL.Query().Get("server_name"))
+	if sni == "" && net.ParseIP(server) == nil {
+		sni = server
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+	result, err := lookupDNSServerTLS(ctx, server, port, sni)
+	if err != nil {
+		response.ErrorWithStatus(w, http.StatusBadGateway, err.Error(), "DNS_TLS_LOOKUP_FAILED")
+		return
+	}
+	response.Success(w, result)
+}
+
+func lookupDNSServerTLS(ctx context.Context, server string, port int, sni string) (SingboxDNSLookupData, error) {
+	ips, err := net.DefaultResolver.LookupHost(ctx, server)
+	if err != nil {
+		return SingboxDNSLookupData{}, fmt.Errorf("resolve %q: %w", server, err)
+	}
+	if len(ips) == 0 {
+		return SingboxDNSLookupData{}, fmt.Errorf("resolve %q: no IP addresses", server)
+	}
+
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(server, strconv.Itoa(port)), &tls.Config{
+		ServerName:         sni,
+		InsecureSkipVerify: true, // #nosec G402 -- read-only certificate probe
+	})
+	if err != nil {
+		return SingboxDNSLookupData{}, fmt.Errorf("TLS handshake with %s:%d: %w", server, port, err)
+	}
+	defer conn.Close()
+
+	result := SingboxDNSLookupData{IPs: ips}
+	seenPins := make(map[string]bool)
+	for _, cert := range conn.ConnectionState().PeerCertificates {
+		pin, err := publicKeySHA256(cert)
+		if err != nil {
+			return SingboxDNSLookupData{}, err
+		}
+		if !seenPins[pin] {
+			result.CertificatePublicKeySHA256 = append(result.CertificatePublicKeySHA256, pin)
+			seenPins[pin] = true
+		}
+		result.Certificates = append(result.Certificates, SingboxDNSCertificateDTO{
+			Subject: cert.Subject.String(), Issuer: cert.Issuer.String(),
+			NotAfter: cert.NotAfter.UTC().Format(time.RFC3339), CertificatePublicKeySHA256: pin,
+		})
+	}
+	return result, nil
+}
+
+func publicKeySHA256(cert *x509.Certificate) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		return "", fmt.Errorf("marshal certificate public key: %w", err)
+	}
+	sum := sha256.Sum256(der)
+	return base64.StdEncoding.EncodeToString(sum[:]), nil
+}

--- a/internal/api/singbox_router_dns_lookup_test.go
+++ b/internal/api/singbox_router_dns_lookup_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLookupDNSServerTLSReturnsIPAndPins(t *testing.T) {
+	server := httptest.NewTLSServer(nil)
+	defer server.Close()
+
+	host, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := net.LookupPort("tcp", portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := lookupDNSServerTLS(context.Background(), host, port, "localhost")
+	if err != nil {
+		t.Fatalf("lookupDNSServerTLS: %v", err)
+	}
+	if len(result.IPs) == 0 || len(result.CertificatePublicKeySHA256) == 0 || len(result.Certificates) == 0 {
+		t.Fatalf("incomplete result: %#v", result)
+	}
+	if result.Certificates[0].CertificatePublicKeySHA256 != result.CertificatePublicKeySHA256[0] {
+		t.Fatalf("certificate pin not reflected in pin list: %#v", result)
+	}
+}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -3369,6 +3369,17 @@ definitions:
         example: start
         type: string
     type: object
+  api.SingboxDNSCertificateDTO:
+    properties:
+      certificate_public_key_sha256:
+        type: string
+      issuer:
+        type: string
+      not_after:
+        type: string
+      subject:
+        type: string
+    type: object
   api.SingboxDNSClientTLSOptionsDTO:
     properties:
       alpn:
@@ -3408,6 +3419,28 @@ definitions:
         $ref: '#/definitions/api.SingboxDNSGlobalsData'
       success:
         example: true
+        type: boolean
+    type: object
+  api.SingboxDNSLookupData:
+    properties:
+      certificate_public_key_sha256:
+        items:
+          type: string
+        type: array
+      certificates:
+        items:
+          $ref: '#/definitions/api.SingboxDNSCertificateDTO'
+        type: array
+      ips:
+        items:
+          type: string
+        type: array
+    type: object
+  api.SingboxDNSLookupResponse:
+    properties:
+      data:
+        $ref: '#/definitions/api.SingboxDNSLookupData'
+      success:
         type: boolean
     type: object
   api.SingboxDNSRewriteDTO:
@@ -13024,6 +13057,42 @@ paths:
       security:
       - CookieAuth: []
       summary: List singbox-router DNS servers
+      tags:
+      - singbox-router
+  /singbox/router/dns/servers/lookup:
+    get:
+      parameters:
+      - description: DNS server hostname or IP
+        in: query
+        name: server
+        required: true
+        type: string
+      - description: TLS port (default 853)
+        in: query
+        name: server_port
+        type: integer
+      - description: TLS SNI (defaults to server)
+        in: query
+        name: server_name
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SingboxDNSLookupResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/api.APIErrorEnvelope'
+      security:
+      - CookieAuth: []
+      summary: Resolve DNS server and fetch TLS certificates
       tags:
       - singbox-router
   /singbox/router/dns/servers/move:

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -3369,6 +3369,30 @@ definitions:
         example: start
         type: string
     type: object
+  api.SingboxDNSClientTLSOptionsDTO:
+    properties:
+      alpn:
+        example:
+        - h2
+        items:
+          type: string
+        type: array
+      certificate_public_key_sha256:
+        items:
+          type: string
+        type: array
+      insecure:
+        type: boolean
+      max_version:
+        example: "1.3"
+        type: string
+      min_version:
+        example: "1.2"
+        type: string
+      server_name:
+        example: cloudflare-dns.com
+        type: string
+    type: object
   api.SingboxDNSGlobalsData:
     properties:
       final:
@@ -3525,6 +3549,8 @@ definitions:
       tag:
         example: cloudflare
         type: string
+      tls:
+        $ref: '#/definitions/api.SingboxDNSClientTLSOptionsDTO'
       type:
         example: udp
         type: string

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -801,6 +801,7 @@ func (s *Server) registerSingboxRoutes(mux *http.ServeMux, h *routeHandlers) {
 		mux.HandleFunc("/api/singbox/router/dns/servers/update", h.guarded(rh.UpdateDNSServer))
 		mux.HandleFunc("/api/singbox/router/dns/servers/delete", h.guarded(rh.DeleteDNSServer))
 		mux.HandleFunc("/api/singbox/router/dns/servers/move", h.guarded(rh.MoveDNSServer))
+		mux.HandleFunc("/api/singbox/router/dns/servers/lookup", h.guarded(rh.LookupDNSServer))
 		mux.HandleFunc("/api/singbox/router/dns/rules/list", h.guarded(rh.ListDNSRules))
 		mux.HandleFunc("/api/singbox/router/dns/rules/add", h.guarded(rh.AddDNSRule))
 		mux.HandleFunc("/api/singbox/router/dns/rules/update", h.guarded(rh.UpdateDNSRule))

--- a/internal/singbox/router/config_dns.go
+++ b/internal/singbox/router/config_dns.go
@@ -64,11 +64,16 @@ func scrubDNSServerDetourStored(s *DNSServer) {
 }
 
 // scrubDNSServerDetourForSingbox clears detour values that must not reach
-// sing-box: empty, explicit "direct", and any detour on dns-direct.
+// sing-box: empty, explicit "direct", and any detour on dns-direct. A named
+// detour makes sing-box ignore other dial fields, so it also clears the stale
+// domain resolver instead of retaining a misleading configuration.
 func scrubDNSServerDetourForSingbox(s *DNSServer) {
 	d := strings.TrimSpace(s.Detour)
 	if d == "" || d == "direct" || s.Tag == managedDNSDirectTag {
 		s.Detour = ""
+	} else {
+		s.Detour = d
+		s.DomainResolver = nil
 	}
 }
 

--- a/internal/singbox/router/config_dns.go
+++ b/internal/singbox/router/config_dns.go
@@ -25,6 +25,17 @@ var validDNSStrategies = map[string]bool{
 	"ipv6_only":   true,
 }
 
+var validTLSVersions = map[string]int{
+	"1.0": 10,
+	"1.1": 11,
+	"1.2": 12,
+	"1.3": 13,
+}
+
+var dnsTLSServerTypes = map[string]bool{
+	"tls": true, "quic": true, "https": true, "h3": true,
+}
+
 var validDNSRuleActions = map[string]bool{
 	"":           true,
 	"route":      true,
@@ -127,6 +138,20 @@ func validateDNSServer(s DNSServer) error {
 		}
 		if !validDNSStrategies[s.DomainResolver.Strategy] {
 			return fmt.Errorf("dns server %q: domain_resolver.strategy %q unknown", s.Tag, s.DomainResolver.Strategy)
+		}
+	}
+	if s.TLS != nil {
+		if !dnsTLSServerTypes[s.Type] {
+			return fmt.Errorf("dns server %q: tls is unsupported for type %q", s.Tag, s.Type)
+		}
+		if s.TLS.MinVersion != "" && validTLSVersions[s.TLS.MinVersion] == 0 {
+			return fmt.Errorf("dns server %q: unknown tls min_version %q", s.Tag, s.TLS.MinVersion)
+		}
+		if s.TLS.MaxVersion != "" && validTLSVersions[s.TLS.MaxVersion] == 0 {
+			return fmt.Errorf("dns server %q: unknown tls max_version %q", s.Tag, s.TLS.MaxVersion)
+		}
+		if s.TLS.MinVersion != "" && s.TLS.MaxVersion != "" && validTLSVersions[s.TLS.MinVersion] > validTLSVersions[s.TLS.MaxVersion] {
+			return fmt.Errorf("dns server %q: tls min_version must not exceed max_version", s.Tag)
 		}
 	}
 	return nil

--- a/internal/singbox/router/config_dns_test.go
+++ b/internal/singbox/router/config_dns_test.go
@@ -69,6 +69,27 @@ func TestDNSServerMarshalOmitsEmptyDetour(t *testing.T) {
 	}
 }
 
+func TestDNSServerTLSMarshalAndValidation(t *testing.T) {
+	srv := DNSServer{
+		Tag: "dot", Type: "tls", Server: "dns.example",
+		TLS: &DNSClientTLSOptions{ServerName: "dns.example", Insecure: true, ALPN: []string{"dot"}, MinVersion: "1.2", MaxVersion: "1.3", CertificatePublicKeySHA256: []string{"pin"}},
+	}
+	raw, err := json.Marshal(srv)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"tls":{"server_name":"dns.example","insecure":true,"alpn":["dot"],"min_version":"1.2","max_version":"1.3","certificate_public_key_sha256":["pin"]}`) {
+		t.Fatalf("tls was not retained: %s", raw)
+	}
+	if err := validateDNSServer(srv); err != nil {
+		t.Fatalf("valid tls rejected: %v", err)
+	}
+	srv.TLS.MinVersion, srv.TLS.MaxVersion = "1.3", "1.2"
+	if err := validateDNSServer(srv); err == nil {
+		t.Fatal("invalid tls version range accepted")
+	}
+}
+
 func TestAddDNSServerNormalizesDirectDetour(t *testing.T) {
 	c := NewEmptyConfig()
 	if err := c.AddDNSServer(makeDNSServer("bootstrap", "udp", "1.1.1.1", "direct")); err != nil {

--- a/internal/singbox/router/config_dns_test.go
+++ b/internal/singbox/router/config_dns_test.go
@@ -100,6 +100,19 @@ func TestAddDNSServerNormalizesDirectDetour(t *testing.T) {
 	}
 }
 
+func TestAddDNSServerWithDetourClearsDomainResolver(t *testing.T) {
+	c := NewEmptyConfig()
+	if err := c.AddDNSServer(DNSServer{
+		Tag: "dot", Type: "tls", Server: "dns.example", Detour: "tunnel",
+		DomainResolver: &DomainResolver{Server: "bootstrap"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if c.DNS.Servers[0].DomainResolver != nil {
+		t.Fatalf("domain_resolver retained with detour: %#v", c.DNS.Servers[0])
+	}
+}
+
 func TestUpdateDNSServerStripsDetourOnDNSDirect(t *testing.T) {
 	c := NewEmptyConfig()
 	_ = c.AddDNSServer(makeDNSServer("dns-direct", "udp", "77.88.8.8", ""))
@@ -399,9 +412,8 @@ func TestDNSRoundTrip(t *testing.T) {
 	if loaded.DNS.Final != "vpn" || loaded.DNS.Strategy != "ipv4_only" {
 		t.Errorf("globals: %+v", loaded.DNS)
 	}
-	if loaded.DNS.Servers[1].DomainResolver == nil ||
-		loaded.DNS.Servers[1].DomainResolver.Server != "bootstrap" {
-		t.Errorf("resolver: %+v", loaded.DNS.Servers[1])
+	if loaded.DNS.Servers[1].DomainResolver != nil {
+		t.Errorf("domain_resolver must be cleared when detour is set: %+v", loaded.DNS.Servers[1])
 	}
 	raw, _ := json.MarshalIndent(loaded, "", "  ")
 	if !json.Valid(raw) {

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -262,6 +262,17 @@ type DomainResolver struct {
 	Strategy string `json:"strategy,omitempty"`
 }
 
+// DNSClientTLSOptions is the client-side TLS subset supported by the DNS
+// server editor. The DNS server type itself enables TLS where applicable.
+type DNSClientTLSOptions struct {
+	ServerName                 string   `json:"server_name,omitempty"`
+	Insecure                   bool     `json:"insecure,omitempty"`
+	ALPN                       []string `json:"alpn,omitempty"`
+	MinVersion                 string   `json:"min_version,omitempty"`
+	MaxVersion                 string   `json:"max_version,omitempty"`
+	CertificatePublicKeySHA256 []string `json:"certificate_public_key_sha256,omitempty"`
+}
+
 type DNSServer struct {
 	Tag  string `json:"tag"`
 	Type string `json:"type"`
@@ -269,14 +280,15 @@ type DNSServer struct {
 	// — sing-box 1.13's `local` server has no `server` field and FATALs the whole
 	// config with `unknown field "server"` if we emit `"server": ""`. Validator
 	// already permits empty Server for type=local (config_dns.go:validateDNSServer).
-	Server         string          `json:"server,omitempty"`
-	ServerPort     int             `json:"server_port,omitempty"`
-	Path           string          `json:"path,omitempty"`
-	Detour         string          `json:"detour,omitempty"`
-	Strategy       string          `json:"domain_strategy,omitempty"`
-	DomainResolver *DomainResolver `json:"domain_resolver,omitempty"`
-	Inet4Range     string          `json:"inet4_range,omitempty"`
-	Inet6Range     string          `json:"inet6_range,omitempty"`
+	Server         string               `json:"server,omitempty"`
+	ServerPort     int                  `json:"server_port,omitempty"`
+	Path           string               `json:"path,omitempty"`
+	Detour         string               `json:"detour,omitempty"`
+	Strategy       string               `json:"domain_strategy,omitempty"`
+	DomainResolver *DomainResolver      `json:"domain_resolver,omitempty"`
+	TLS            *DNSClientTLSOptions `json:"tls,omitempty"`
+	Inet4Range     string               `json:"inet4_range,omitempty"`
+	Inet6Range     string               `json:"inet6_range,omitempty"`
 }
 
 type DNSRule struct {


### PR DESCRIPTION
# feat(dns): TLS configuration support for DNS servers

## 📋 Описание

Добавляет полную поддержку TLS-конфигурации для DNS-серверов (DoT, DoH, DoQ, DoH3) в Sing-box Router с возможностью настройки параметров безопасного подключения и автоматического получения сертификатов.

## 🎯 Основные изменения

### Бэкенд (Go)
- **Тип `DNSServer`** расширен опциональными полями для хранения конфигурации TLS
- **Валидация** в `config_dns.go`: проверка допустимости TLS для типов `tls`, `https`, `quic`, `h3`
- **Детектор сертификатов**: получение SHA-256 хешей открытых ключей для certificate pinning
- Полная обратная совместимость (поле `tls` omitempty)

### Фронтенд (Svelte)
- **`DNSServerEditModal.svelte`**: интерактивная форма редактирования DNS-серверов
- Условное отображение TLS-полей только для поддерживающих их типов
- Валидация: обязательные поля для каждого типа сервера
- Bootstrap resolver для резолвинга доменных имён

### Поддерживаемые типы
- `udp` — обычный DNS
- `tls` — DNS over TLS (DoT)
- `https` — DNS over HTTPS (DoH)
- `quic` — DNS over QUIC (DoQ)
- `h3` — DoH3
- `local` — системный resolver роутера
- `fakeip` — синтетический resolver для fakeip-tun

## 💻 Примеры конфигурации

**DoT с pinning:**
```json
{
  "tag": "cloudflare-dot",
  "type": "tls",
  "server": "1.1.1.1",
  "server_port": 853
}