### PR TITLE
fix(freeturn): stable WAN IP in share links and manual peer input

### DIFF
--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -38,6 +38,7 @@
 	let checkingUpdates = $state(false);
 
 	let genProvider = $state('vk');
+	let genPeer = $state('');
 	let genMTU = $state(1376);
 	let genWG = $state('');
 	let genClientId = $state('');
@@ -432,12 +433,26 @@
 		}
 	}
 
-	async function generateLink(provider: string, mtu: number, wg: string, clientId: string, name: string) {
+	async function generateLink(
+		provider: string,
+		peer: string,
+		mtu: number,
+		wg: string,
+		clientId: string,
+		name: string
+	) {
 		if (!selectedServer) return;
 		generating = true;
 		try {
+			const listen = selectedServer.config.listen?.trim() ?? '';
+			let peerParam = peer.trim();
+			if (peerParam && !peerParam.includes(':')) {
+				const port = listen.includes(':') ? listen.split(':').pop() : listen;
+				if (port) peerParam = `${peerParam}:${port}`;
+			}
 			const result = await api.generateFreeTurnLink({
 				provider,
+				peer: peerParam || undefined,
 				mtu,
 				wg: wg.trim() || undefined,
 				clientId: clientId.trim() || undefined,
@@ -561,6 +576,7 @@
 			{generatedPeer}
 			{generatedClientId}
 			bind:genProvider
+			bind:genPeer
 			bind:genMTU
 			bind:genWG
 			bind:genClientId

--- a/frontend/src/lib/components/freeturn/ServerPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ServerPanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { Input, Button, Dropdown } from '$lib/components/ui';
 	import { RefreshCw } from 'lucide-svelte';
+	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
 	import { pluralize } from '$lib/utils/pluralize';
 	import type { FreeTurnServerConfig, FreeTurnProcessStatus } from '$lib/types';
 	import ProcessAlerts from './ProcessAlerts.svelte';
@@ -30,6 +32,7 @@
 		generatedPeer: string;
 		generatedClientId: string;
 		genProvider: string;
+		genPeer: string;
 		genMTU: number;
 		genWG: string;
 		genClientId: string;
@@ -39,7 +42,14 @@
 		onCheckUpdates?: () => void;
 		onSave: () => void;
 		onRevert: () => void;
-		onGenerate: (provider: string, mtu: number, wg: string, clientId: string, name: string) => void;
+		onGenerate: (
+			provider: string,
+			peer: string,
+			mtu: number,
+			wg: string,
+			clientId: string,
+			name: string
+		) => void;
 		onCopy: (text: string) => void;
 		defaultClientListenPort?: number;
 		serverInstanceId?: string;
@@ -63,6 +73,7 @@
 		generatedPeer,
 		generatedClientId,
 		genProvider = $bindable(),
+		genPeer = $bindable(),
 		genMTU = $bindable(),
 		genWG = $bindable(),
 		genClientId = $bindable(),
@@ -80,6 +91,28 @@
 
 	let allowlistPanel: ServerAllowlist | undefined = $state();
 	let savingAllowlist = $state(false);
+	let loadingWanPeer = $state(false);
+
+	const listenPort = $derived.by(() => {
+		const listen = server.listen?.trim() ?? '';
+		if (!listen) return '56000';
+		const idx = listen.lastIndexOf(':');
+		return idx >= 0 ? listen.slice(idx + 1) : listen;
+	});
+
+	async function fillWanPeer() {
+		loadingWanPeer = true;
+		try {
+			const ip = await api.getWANIP();
+			genPeer = ip.includes(':') ? ip : `${ip}:${listenPort}`;
+		} catch (e) {
+			notifications.error(
+				e instanceof Error ? e.message : 'Не удалось определить WAN IP'
+			);
+		} finally {
+			loadingWanPeer = false;
+		}
+	}
 
 	// WireGuard-конфиг в ссылке — свёрнут по умолчанию, раскрывается если уже заполнен.
 	let wgMore = $state(genWG.trim() !== '');
@@ -161,6 +194,26 @@
 
 <div class="ft-panel-accent">
 	<div class="section-label">Ссылка для клиента</div>
+	<div class="ft-gen-peer-row">
+		<div class="ft-gen-peer">
+			<Input
+				label="Peer (IP:порт для клиента)"
+				bind:value={genPeer}
+				placeholder={`пусто — авто · порт :${listenPort}`}
+			/>
+		</div>
+		<div class="ft-gen-peer-action">
+			<Button
+				variant="ghost"
+				size="sm"
+				loading={loadingWanPeer}
+				onclick={fillWanPeer}
+				title="Подставить внешний WAN IP роутера"
+			>
+				WAN IP
+			</Button>
+		</div>
+	</div>
 	<div class="ft-gen-row">
 		<div class="ft-gen-provider">
 			<Input label="Провайдер" bind:value={genProvider} placeholder="vk" />
@@ -205,7 +258,7 @@
 					size="sm"
 					loading={generating}
 					disabled={obfDirty}
-					onclick={() => onGenerate(genProvider, genMTU, genWG, genClientId, genName)}
+					onclick={() => onGenerate(genProvider, genPeer, genMTU, genWG, genClientId, genName)}
 				>
 					Сгенерировать
 				</Button>
@@ -219,8 +272,8 @@
 		</p>
 	{:else}
 		<p class="ft-hint">
-			Соберёт freeturn:// ссылку из обфускации/ключа сервера ниже и внешнего IP роутера.
-			Провайдер почти всегда <code>vk</code> — менять не нужно.
+			Соберёт freeturn:// ссылку из обфускации/ключа сервера ниже и адреса peer (вручную или
+			автоопределение WAN IP). Провайдер почти всегда <code>vk</code> — менять не нужно.
 		</p>
 	{/if}
 	{#if server.clientsFile}
@@ -336,6 +389,30 @@
 		border: 1px solid var(--color-accent-border);
 		border-radius: var(--radius);
 		margin-bottom: 0.875rem;
+	}
+
+	.ft-gen-peer-row {
+		display: flex;
+		gap: 0.625rem;
+		align-items: flex-end;
+		margin-bottom: 0.625rem;
+	}
+
+	.ft-gen-peer {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.ft-gen-peer :global(.input) {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+	}
+
+	.ft-gen-peer-action {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: flex-end;
+		padding-bottom: 0.125rem;
 	}
 
 	.ft-gen-row {

--- a/internal/api/freeturn.go
+++ b/internal/api/freeturn.go
@@ -3,14 +3,14 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
 	"time"
 
+	ndmsquery "github.com/hoaxisr/awg-manager/internal/ndms/query"
 	"github.com/hoaxisr/awg-manager/internal/freeturn"
 	"github.com/hoaxisr/awg-manager/internal/response"
-	"github.com/hoaxisr/awg-manager/internal/sys/httpclient"
+	"github.com/hoaxisr/awg-manager/internal/testing"
 )
 
 // FreeTurnService is the subset of *freeturn.Service the API layer needs.
@@ -49,11 +49,18 @@ type FreeTurnService interface {
 
 // FreeTurnHandler exposes FreeTurnService over HTTP.
 type FreeTurnHandler struct {
-	svc FreeTurnService
+	svc     FreeTurnService
+	queries *ndmsquery.Queries
 }
 
 func NewFreeTurnHandler(svc FreeTurnService) *FreeTurnHandler {
 	return &FreeTurnHandler{svc: svc}
+}
+
+// SetNDMSQueries wires NDMS reads used for stable WAN IP detection when
+// generating freeturn:// share links.
+func (h *FreeTurnHandler) SetNDMSQueries(q *ndmsquery.Queries) {
+	h.queries = q
 }
 
 // FreeTurnConfigResponse is the envelope for GET /api/freeturn/config.
@@ -251,29 +258,23 @@ type GenerateLinkResponse struct {
 	} `json:"data"`
 }
 
-// ipCheckURLs mirrors the services diagnostics.testTunnelConnectivity uses
-// to learn the router's own WAN-facing IP.
-var ipCheckURLs = []string{"https://ifconfig.me", "https://icanhazip.com", "https://ip.me"}
-
-func detectExternalIP(r *http.Request) (string, error) {
-	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+func (h *FreeTurnHandler) resolveExternalIP(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	var lastErr error
-	for _, url := range ipCheckURLs {
-		result, err := httpclient.DefaultClient.Do(ctx, httpclient.CallConfig{URL: url, MaxTime: 5 * time.Second})
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		ip := strings.TrimSpace(result.Body)
-		if ip != "" {
-			return ip, nil
+
+	var fallback testing.WANIPFallback
+	var wanKernel string
+	if h.queries != nil {
+		fallback = h.queries.WANInterfaceAddress
+		if h.queries.Routes != nil && h.queries.Interfaces != nil {
+			if ndmsName, err := h.queries.Routes.GetDefaultGatewayInterface(ctx); err == nil && ndmsName != "" {
+				if kernel, err := h.queries.Interfaces.ResolveSystemName(ctx, ndmsName); err == nil {
+					wanKernel = kernel
+				}
+			}
 		}
 	}
-	if lastErr == nil {
-		lastErr = errors.New("все IP-сервисы вернули пустой ответ")
-	}
-	return "", lastErr
+	return testing.GetWANIPBound(ctx, wanKernel, fallback)
 }
 
 // GenerateLink handles POST /api/freeturn/server/link. It builds a
@@ -668,8 +669,16 @@ func (h *FreeTurnHandler) generateLinkCore(w http.ResponseWriter, r *http.Reques
 	}
 
 	peer := strings.TrimSpace(req.Peer)
-	if peer == "" {
-		ip, ipErr := detectExternalIP(r)
+	if peer != "" {
+		if !strings.Contains(peer, ":") {
+			port := srvCfg.Listen
+			if idx := strings.LastIndex(port, ":"); idx != -1 {
+				port = port[idx+1:]
+			}
+			peer = peer + ":" + port
+		}
+	} else {
+		ip, ipErr := h.resolveExternalIP(r.Context())
 		if ipErr != nil {
 			response.Error(w, "Не удалось определить внешний IP: "+ipErr.Error()+". Укажите peer вручную.", "FREETURN_EXTERNAL_IP_FAILED")
 			return

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -156,6 +156,9 @@ func (s *Server) buildRouteHandlers() *routeHandlers {
 	h.eventsHandler = api.NewEventsHandler(s.bus, s.instanceID)
 
 	h.freeturnHandler = api.NewFreeTurnHandler(s.freeturnService)
+	if s.ndmsQueries != nil {
+		h.freeturnHandler.SetNDMSQueries(s.ndmsQueries)
+	}
 
 	// Auth middleware helper
 	h.guarded = s.authMiddleware.RequireAuthFunc

--- a/internal/testing/ip.go
+++ b/internal/testing/ip.go
@@ -149,18 +149,32 @@ type WANIPFallback func(ctx context.Context) (string, error)
 // returns whatever it produces. Errors from the fallback are surfaced;
 // the original external-probe error is only returned if fallback is nil.
 func GetWANIPWithFallback(ctx context.Context, fallback WANIPFallback) (string, error) {
-	ip, err := fetchIPAuto(ctx, "", "")
-	if err == nil {
+	return GetWANIPBound(ctx, "", fallback)
+}
+
+// GetWANIPBound probes external IP check services, optionally binding outbound
+// traffic to a kernel WAN interface (SO_BINDTODEVICE). When iface is empty,
+// the default route is used. On probe failure, fallback (typically the NDMS
+// address on the default-gateway interface) is tried.
+func GetWANIPBound(ctx context.Context, iface string, fallback WANIPFallback) (string, error) {
+	ip, err := fetchIPAuto(ctx, "", iface)
+	if err == nil && ip != "" {
 		return ip, nil
 	}
 	if fallback == nil {
-		return "", err
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("empty WAN IP")
 	}
 	fip, ferr := fallback(ctx)
 	if ferr == nil && fip != "" {
 		return fip, nil
 	}
-	return "", err
+	if err != nil {
+		return "", err
+	}
+	return "", ferr
 }
 
 // fetchIPAuto fetches IP using a specific service or falls back through the default list.


### PR DESCRIPTION
Detect external IP via WAN-bound probes (same path as /servers/wan-ip) instead of racing unrelated services. Add optional peer field and WAN IP button in the link generator UI.