### PR TITLE
fix(freeturn): ResolveSystemName returns string, not (string, error)

### DIFF
--- a/internal/api/freeturn.go
+++ b/internal/api/freeturn.go
@@ -268,9 +268,7 @@ func (h *FreeTurnHandler) resolveExternalIP(ctx context.Context) (string, error)
 		fallback = h.queries.WANInterfaceAddress
 		if h.queries.Routes != nil && h.queries.Interfaces != nil {
 			if ndmsName, err := h.queries.Routes.GetDefaultGatewayInterface(ctx); err == nil && ndmsName != "" {
-				if kernel, err := h.queries.Interfaces.ResolveSystemName(ctx, ndmsName); err == nil {
-					wanKernel = kernel
-				}
+				wanKernel = h.queries.Interfaces.ResolveSystemName(ctx, ndmsName)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes compile error introduced in #604: InterfaceStore.ResolveSystemName has signature (ctx, ndmsName) string.