### PR TITLE
feat(freeturn): captcha UI, simple wizard, and AWG tunnel linking

### DIFF
--- a/cmd/awg-manager/awg_listen_ports.go
+++ b/cmd/awg-manager/awg_listen_ports.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/hoaxisr/awg-manager/internal/freeturn"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// awgListenPortChecker marks localhost ports referenced by AWG tunnel peer
+// endpoints so freeturn clients avoid colliding with existing WG configs.
+type awgListenPortChecker struct {
+	store *storage.AWGTunnelStore
+}
+
+func (a *awgListenPortChecker) OccupiedLocalListenPorts() (map[int]bool, error) {
+	tunnels, err := a.store.List()
+	if err != nil {
+		return nil, err
+	}
+	used := map[int]bool{}
+	for _, tun := range tunnels {
+		if port, ok := freeturn.LocalListenPort(tun.Peer.Endpoint); ok {
+			used[port] = true
+		}
+	}
+	return used, nil
+}

--- a/cmd/awg-manager/wiring_tunnels.go
+++ b/cmd/awg-manager/wiring_tunnels.go
@@ -194,6 +194,7 @@ func (a *app) setupServices() {
 		"/opt/bin/freeturn-client",
 		"/opt/bin/freeturn-server",
 	)
+	a.freeturnService.SetListenPortChecker(&awgListenPortChecker{store: a.awgStore})
 	a.deferOnExit(a.freeturnService.Stop)
 
 	// Unified facade: kernel → custom loop, NativeWG → NDMS native

--- a/entware/files/etc/init.d/S99awg-manager
+++ b/entware/files/etc/init.d/S99awg-manager
@@ -75,6 +75,14 @@ start() {
 
     echo "Starting $DESC..."
 
+    # Child processes (freeturn-client, sing-box, …) log in UTC unless TZ
+    # matches the router — Keenetic stores POSIX zone in /var/TZ or /etc/TZ.
+    if [ -r /var/TZ ]; then
+        export TZ="$(cat /var/TZ)"
+    elif [ -r /etc/TZ ]; then
+        export TZ="$(cat /etc/TZ)"
+    fi
+
     # Start daemon (port is read from settings.json)
     start-stop-daemon -S -b -m -p "$PID_FILE" -x "$BIN" -- \
         -data-dir "$DATA_DIR"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6761,24 +6761,6 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",

--- a/frontend/src/lib/api/clientFreeturn.ts
+++ b/frontend/src/lib/api/clientFreeturn.ts
@@ -1,9 +1,10 @@
 import type {
 	FreeTurnAllowlistAddResult,
 	FreeTurnAllowlistStatus,
+	FreeTurnCaptchaOverview,
 	FreeTurnClientConfig,
 	FreeTurnClientInstance,
-	FreeTurnConfig,
+	FreeTurnDeleteClientResult,
 	FreeTurnGenerateLinkRequest,
 	FreeTurnGenerateLinkResult,
 	FreeTurnLinkPayload,
@@ -70,8 +71,11 @@ export class FreeturnClient extends SubscriptionsClient {
 		});
 	}
 
-	async deleteFreeTurnClient(id: string): Promise<void> {
-		await this.request(`/freeturn/clients/${encodeURIComponent(id)}`, { method: 'DELETE' });
+	async deleteFreeTurnClient(id: string): Promise<FreeTurnDeleteClientResult> {
+		return this.request<FreeTurnDeleteClientResult>(
+			`/freeturn/clients/${encodeURIComponent(id)}`,
+			{ method: 'DELETE' }
+		);
 	}
 
 	async deleteFreeTurnServer(id: string): Promise<void> {
@@ -95,6 +99,10 @@ export class FreeturnClient extends SubscriptionsClient {
 	async getFreeTurnStatus(forceRemote = false): Promise<FreeTurnStatus> {
 		const q = forceRemote ? '?forceRemote=1' : '';
 		return this.request<FreeTurnStatus>(`/freeturn/status${q}`);
+	}
+
+	async getFreeTurnCaptchaStatus(): Promise<FreeTurnCaptchaOverview> {
+		return this.request<FreeTurnCaptchaOverview>('/freeturn/captcha/status');
 	}
 
 	async startFreeTurnClient(id = 'default'): Promise<{ message: string }> {

--- a/frontend/src/lib/api/clientFreeturn.ts
+++ b/frontend/src/lib/api/clientFreeturn.ts
@@ -4,6 +4,7 @@ import type {
 	FreeTurnCaptchaOverview,
 	FreeTurnClientConfig,
 	FreeTurnClientInstance,
+	FreeTurnConfig,
 	FreeTurnDeleteClientResult,
 	FreeTurnGenerateLinkRequest,
 	FreeTurnGenerateLinkResult,

--- a/frontend/src/lib/api/clientTunnels.ts
+++ b/frontend/src/lib/api/clientTunnels.ts
@@ -183,10 +183,15 @@ export class TunnelsClient extends CoreClient {
 	// #region Import
 	// ─────────────────────────────────────────────
 
-	async importConfig(content: string, name?: string, backend?: string): Promise<AWGTunnel> {
+	async importConfig(
+		content: string,
+		name?: string,
+		backend?: string,
+		freeTurnClientId?: string
+	): Promise<AWGTunnel> {
 		return this.request('/import/conf', {
 			method: 'POST',
-			body: JSON.stringify({ content, name, backend })
+			body: JSON.stringify({ content, name, backend, freeTurnClientId })
 		});
 	}
 

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -497,6 +497,11 @@ const api_FreeTurnAllowlistResponse: v.GenericSchema = v.looseObject({
 	success: v.optional(v.nullable(v.boolean())),
 });
 
+const api_FreeTurnCaptchaStatusResponse: v.GenericSchema = v.looseObject({
+	data: v.optional(v.nullable(v.lazy(() => freeturn_CaptchaOverview))),
+	success: v.optional(v.nullable(v.boolean())),
+});
+
 const api_FreeTurnClientInstanceResponse: v.GenericSchema = v.looseObject({
 	data: v.optional(v.nullable(v.lazy(() => freeturn_ClientInstance))),
 	success: v.optional(v.nullable(v.boolean())),
@@ -2328,6 +2333,26 @@ const freeturn_AllowlistStatus: v.GenericSchema = v.looseObject({
 	enabled: v.optional(v.nullable(v.boolean())),
 });
 
+const freeturn_CaptchaClientStatus: v.GenericSchema = v.looseObject({
+	active: v.optional(v.nullable(v.boolean())),
+	canOpen: v.optional(v.nullable(v.boolean())),
+	captchaSession: v.optional(v.nullable(v.number())),
+	clientId: v.optional(v.nullable(v.string())),
+	clientName: v.optional(v.nullable(v.string())),
+	pendingStreams: v.optional(v.nullable(v.number())),
+	portContention: v.optional(v.nullable(v.boolean())),
+	queued: v.optional(v.nullable(v.boolean())),
+	url: v.optional(v.nullable(v.string())),
+	waiting: v.optional(v.nullable(v.boolean())),
+});
+
+const freeturn_CaptchaOverview: v.GenericSchema = v.looseObject({
+	clients: v.optional(v.nullable(v.array(v.lazy(() => freeturn_CaptchaClientStatus)))),
+	ownerClientId: v.optional(v.nullable(v.string())),
+	ownerName: v.optional(v.nullable(v.string())),
+	portOpen: v.optional(v.nullable(v.boolean())),
+});
+
 const freeturn_ClientConfig: v.GenericSchema = v.looseObject({
 	bond: v.optional(v.nullable(v.boolean())),
 	browser: v.optional(v.nullable(v.string())),
@@ -2396,6 +2421,7 @@ const freeturn_LinkPayload: v.GenericSchema = v.looseObject({
 const freeturn_ProcessStatus: v.GenericSchema = v.looseObject({
 	binary: v.optional(v.nullable(v.string())),
 	binaryPresent: v.optional(v.nullable(v.boolean())),
+	dtlsConnections: v.optional(v.nullable(v.number())),
 	lastError: v.optional(v.nullable(v.string())),
 	log: v.optional(v.nullable(v.string())),
 	pid: v.optional(v.nullable(v.number())),
@@ -2513,6 +2539,7 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"GET /dns-routes/list": v.lazy(() => api_DnsRoutesListResponse),
 	"GET /download/outbounds": v.lazy(() => api_DownloadOutboundsResponse),
 	"GET /external-tunnels": v.lazy(() => api_ExternalTunnelsResponse),
+	"GET /freeturn/captcha/status": v.lazy(() => api_FreeTurnCaptchaStatusResponse),
 	"GET /freeturn/config": v.lazy(() => api_FreeTurnConfigResponse),
 	"GET /freeturn/servers/{id}/allowlist": v.lazy(() => api_FreeTurnAllowlistResponse),
 	"GET /freeturn/status": v.lazy(() => api_FreeTurnStatusResponse),

--- a/frontend/src/lib/components/freeturn/CaptchaModal.svelte
+++ b/frontend/src/lib/components/freeturn/CaptchaModal.svelte
@@ -117,7 +117,9 @@
 	function openCaptchaTab(): boolean {
 		const url = preferredCaptchaUrl;
 		if (!url || typeof window === 'undefined') return false;
-		const w = window.open(url, localTunnelReady ? '_blank' : popupWindowName, 'noopener,noreferrer');
+		// Без noopener: с ним window.open возвращает null (нельзя понять, открылась
+		// ли вкладка), а страница-хелпер не может закрыть popup через window.opener.
+		const w = window.open(url, localTunnelReady ? '_blank' : popupWindowName);
 		captchaTabOpen = w != null;
 		return captchaTabOpen;
 	}
@@ -129,7 +131,7 @@
 
 	function openInNewTab() {
 		if (!captchaLoadUrl) return;
-		window.open(captchaLoadUrl, '_blank', 'noopener,noreferrer');
+		window.open(captchaLoadUrl, '_blank');
 	}
 
 	function openLocalTunnelTab() {

--- a/frontend/src/lib/components/freeturn/CaptchaModal.svelte
+++ b/frontend/src/lib/components/freeturn/CaptchaModal.svelte
@@ -458,10 +458,4 @@
 	.ft-captcha-warn {
 		color: var(--color-warning);
 	}
-
-	.ft-captcha-warn-inline {
-		display: block;
-		margin-top: 0.5rem;
-		color: var(--color-warning);
-	}
 </style>

--- a/frontend/src/lib/components/freeturn/CaptchaModal.svelte
+++ b/frontend/src/lib/components/freeturn/CaptchaModal.svelte
@@ -1,0 +1,467 @@
+<script lang="ts">
+	import { Modal, Button, FormToggle } from '$lib/components/ui';
+	import type { FreeTurnCaptchaOverview } from '$lib/types';
+
+	interface Props {
+		open: boolean;
+		clientId: string | null;
+		clientName?: string;
+		captchaUrl: string | null;
+		overview: FreeTurnCaptchaOverview | null;
+		onclose: () => void;
+		onSelectClient: (id: string) => void;
+		captchaAutoOpen?: boolean;
+		onCaptchaAutoOpenChange?: (enabled: boolean) => void;
+	}
+
+	let {
+		open = $bindable(false),
+		clientId,
+		clientName = '',
+		captchaUrl,
+		overview,
+		onclose,
+		onSelectClient,
+		captchaAutoOpen = true,
+		onCaptchaAutoOpenChange
+	}: Props = $props();
+
+	const captchaBaseUrl = $derived(captchaUrl ? `${captchaUrl}` : null);
+
+	const queuedClients = $derived(
+		(overview?.clients ?? []).filter((c) => c.waiting && c.queued)
+	);
+
+	const openableClients = $derived(
+		(overview?.clients ?? []).filter((c) => c.canOpen)
+	);
+
+	const activeClient = $derived(
+		openableClients.find((c) => c.active) ?? openableClients[0] ?? null
+	);
+
+	const currentClient = $derived(
+		(overview?.clients ?? []).find((c) => c.clientId === clientId) ?? null
+	);
+
+	const isQueued = $derived(
+		queuedClients.some((c) => c.clientId === clientId)
+	);
+
+	const LOCAL_CAPTCHA_URL = 'http://127.0.0.1:8765/';
+
+	let sessionKey = $state(0);
+	let lastCaptchaSession = $state(0);
+	let autoOpenedForSession = $state(0);
+	let sawWaiting = $state(false);
+	let localTunnelReady = $state<boolean | null>(null);
+	let captchaTabOpen = $state(false);
+
+	const sshTunnelCmd = $derived.by(() => {
+		if (typeof window === 'undefined') return '';
+		const host = window.location.hostname || '192.168.90.60';
+		return `ssh -N -L 8765:127.0.0.1:8765 root@${host}`;
+	});
+
+	$effect(() => {
+		if (!open) {
+			sawWaiting = false;
+			return;
+		}
+		if (currentClient?.waiting) sawWaiting = true;
+	});
+
+	$effect(() => {
+		const session = currentClient?.captchaSession ?? 0;
+		if (!open || session <= 0) return;
+		if (session !== lastCaptchaSession) {
+			lastCaptchaSession = session;
+			sessionKey = session;
+			autoOpenedForSession = 0;
+		}
+	});
+
+	const captchaLoadUrl = $derived(
+		captchaBaseUrl
+			? `${captchaBaseUrl}${captchaBaseUrl.includes('?') ? '&' : '?'}_s=${sessionKey}`
+			: null
+	);
+
+	const preferredCaptchaUrl = $derived(
+		localTunnelReady ? LOCAL_CAPTCHA_URL : captchaLoadUrl
+	);
+
+	const captchaResolved = $derived(
+		sawWaiting && Boolean(currentClient && !currentClient.waiting && !isQueued)
+	);
+
+	const popupWindowName = $derived(`freeturn-captcha-${clientId ?? 'default'}`);
+
+	async function probeLocalTunnel(): Promise<boolean> {
+		if (typeof window === 'undefined') return false;
+		try {
+			const ctrl = new AbortController();
+			const timer = setTimeout(() => ctrl.abort(), 1500);
+			await fetch(LOCAL_CAPTCHA_URL, { mode: 'no-cors', signal: ctrl.signal });
+			clearTimeout(timer);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	function selectClient(id: string) {
+		onSelectClient(id);
+	}
+
+	function openCaptchaTab(): boolean {
+		const url = preferredCaptchaUrl;
+		if (!url || typeof window === 'undefined') return false;
+		const w = window.open(url, localTunnelReady ? '_blank' : popupWindowName, 'noopener,noreferrer');
+		captchaTabOpen = w != null;
+		return captchaTabOpen;
+	}
+
+	function reloadCaptcha() {
+		sessionKey += 1;
+		openCaptchaTab();
+	}
+
+	function openInNewTab() {
+		if (!captchaLoadUrl) return;
+		window.open(captchaLoadUrl, '_blank', 'noopener,noreferrer');
+	}
+
+	function openLocalTunnelTab() {
+		window.open(LOCAL_CAPTCHA_URL, '_blank', 'noopener,noreferrer');
+	}
+
+	async function copySshCommand() {
+		if (!sshTunnelCmd || typeof navigator === 'undefined' || !navigator.clipboard) return;
+		try {
+			await navigator.clipboard.writeText(sshTunnelCmd);
+		} catch {
+			// ignore
+		}
+	}
+
+	$effect(() => {
+		if (!open) {
+			localTunnelReady = null;
+			captchaTabOpen = false;
+			return;
+		}
+		let cancelled = false;
+		void probeLocalTunnel().then((ok) => {
+			if (!cancelled) localTunnelReady = ok;
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	$effect(() => {
+		if (!open || !preferredCaptchaUrl || isQueued || !captchaAutoOpen) return;
+		if (localTunnelReady === null) return;
+		const session = currentClient?.captchaSession ?? sessionKey;
+		if (session <= 0) return;
+		if (session === autoOpenedForSession) return;
+		autoOpenedForSession = session;
+		openCaptchaTab();
+	});
+</script>
+
+<Modal
+	{open}
+	title="Прохождение VK-капчи"
+	size="md"
+	bodyLayout="default"
+	closeOnBackdrop={false}
+	{onclose}
+>
+	<div class="ft-captcha-wrap">
+		{#if currentClient?.pendingStreams && currentClient.pendingStreams > 1}
+			<div class="ft-captcha-queue">
+				Осталось потоков с нерешённой капчей: {currentClient.pendingStreams}.
+				Один gg = один поток — не закрывайте модалку, freeturn по очереди откроет новую
+				сессию капчи.
+				{#if currentClient.portContention}
+					Часть потоков не успела занять порт 8765 — freeturn повторит auth позже (это нормально).
+				{/if}
+			</div>
+		{:else if overview && overview.clients.some((c) => c.waiting && c.queued)}
+			<div class="ft-captcha-queue">
+				{#if overview.ownerName}
+					Сейчас активна капча клиента «{overview.ownerName}». Остальные ждут в очереди —
+					freeturn использует один порт 8765 на роутер.
+				{:else}
+					Несколько клиентов ждут капчу. Решайте по одному — порт 8765 общий для всех
+					экземпляров freeturn.
+				{/if}
+			</div>
+		{/if}
+
+		{#if openableClients.length > 1}
+			<div class="ft-captcha-tabs">
+				{#each openableClients as c (c.clientId)}
+					<button
+						type="button"
+						class="ft-captcha-tab"
+						class:ft-captcha-tab-active={c.clientId === clientId}
+						onclick={() => selectClient(c.clientId)}
+					>
+						{c.clientName || c.clientId}
+						{#if c.active}
+							<span class="ft-captcha-badge">активна</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		{#if isQueued}
+			<p class="ft-captcha-warn">
+				Этот клиент в очереди.
+				{#if activeClient}
+					Сначала откройте капчу для «{activeClient.clientName || activeClient.clientId}».
+				{/if}
+			</p>
+		{:else if captchaResolved}
+			<div class="ft-captcha-ok">
+				Капча для текущего потока принята. Freeturn продолжит получение TURN-кредов.
+				{#if currentClient?.pendingStreams && currentClient.pendingStreams > 1}
+					Дождитесь следующей сессии — окно капчи откроется снова автоматически.
+				{:else}
+					Можно закрыть это окно.
+				{/if}
+			</div>
+		{:else if captchaLoadUrl}
+			<div class="ft-captcha-panel">
+				{#if localTunnelReady}
+					<div class="ft-captcha-ok">
+						SSH-туннель на <code>127.0.0.1:8765</code> обнаружен — откроется прямой доступ
+						(галочка, как при ручном SSH).
+					</div>
+				{:else}
+					<p class="ft-captcha-lead">
+						Галочка VK работает только с <code>127.0.0.1:8765</code> (localhost). Через LAN
+						VK часто показывает вход VK ID — после входа страница должна вернуться с
+						галочкой. Если зависло — используйте SSH-туннель ниже.
+					</p>
+				{/if}
+
+				<div class="ft-captcha-status" class:ft-captcha-status-ok={captchaTabOpen}>
+					{#if localTunnelReady === null}
+						Проверяем SSH-туннель…
+					{:else if captchaTabOpen}
+						Вкладка капчи открыта — пройдите «Я не робот» там.
+					{:else}
+						Нажмите «Открыть капчу». Если вкладка не появилась — разрешите pop-up.
+					{/if}
+				</div>
+
+				<div class="ft-captcha-actions">
+					<Button variant="primary" size="md" onclick={() => openCaptchaTab()}>
+						{localTunnelReady ? 'Открыть 127.0.0.1:8765' : 'Открыть капчу'}
+					</Button>
+					{#if !localTunnelReady && captchaLoadUrl}
+						<Button variant="secondary" size="sm" onclick={openInNewTab}>Прокси (новая вкладка)</Button>
+					{/if}
+					<button type="button" class="ft-captcha-link" onclick={reloadCaptcha}>
+						Новая сессия (если протухла)
+					</button>
+				</div>
+
+				{#if !localTunnelReady && sshTunnelCmd}
+					<div class="ft-captcha-ssh">
+						<p class="ft-captcha-ssh-title">Надёжный способ (как у вас через SSH):</p>
+						<code class="ft-captcha-ssh-cmd">{sshTunnelCmd}</code>
+						<div class="ft-captcha-actions">
+							<Button variant="secondary" size="sm" onclick={copySshCommand}>Скопировать</Button>
+							<Button variant="ghost" size="sm" onclick={openLocalTunnelTab}>
+								Открыть 127.0.0.1:8765
+							</Button>
+						</div>
+						<p class="ft-captcha-ssh-hint">
+							В PowerShell/CMD выполните команду, затем «Открыть 127.0.0.1:8765» или
+							<code>http://127.0.0.1:8765</code> в браузере.
+						</p>
+					</div>
+				{/if}
+			</div>
+		{:else}
+			<p class="ft-captcha-warn">Сервер капчи не активен. Подождите или проверьте лог клиента.</p>
+		{/if}
+
+		<p class="ft-captcha-hint">
+			{#if clientName}
+				Клиент: {clientName}.
+			{/if}
+			Если видите серый квадрат с жёлтым треугольником — сессия протухла: «Новая сессия» или
+			дождитесь строки <code>Triggering manual captcha fallback</code> в логе.
+		</p>
+	</div>
+
+	{#snippet actions()}
+		{#if onCaptchaAutoOpenChange}
+			<FormToggle
+				checked={captchaAutoOpen}
+				onchange={onCaptchaAutoOpenChange}
+				label="Авто-открытие"
+				size="sm"
+			/>
+		{/if}
+		<Button variant="ghost" size="sm" onclick={onclose}>Закрыть</Button>
+	{/snippet}
+</Modal>
+
+<style>
+	.ft-captcha-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 0.625rem;
+	}
+
+	.ft-captcha-queue {
+		padding: 0.5rem 0.625rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-warning);
+		background: var(--color-warning-tint);
+		font-size: 0.8125rem;
+		color: var(--color-text-primary);
+	}
+
+	.ft-captcha-tabs {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+	}
+
+	.ft-captcha-tab {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.25rem 0.5rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-secondary);
+		font-size: 0.75rem;
+		cursor: pointer;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-captcha-tab-active {
+		border-color: var(--color-accent-border);
+		color: var(--color-text-primary);
+		background: var(--color-bg-primary);
+	}
+
+	.ft-captcha-badge {
+		font-size: 0.6875rem;
+		color: var(--color-warning);
+	}
+
+	.ft-captcha-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-secondary);
+	}
+
+	.ft-captcha-lead {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--color-text-primary);
+		line-height: 1.45;
+	}
+
+	.ft-captcha-status {
+		margin: 0;
+		padding: 0.5rem 0.625rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-primary);
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-captcha-status-ok {
+		border-color: var(--color-accent-border);
+		color: var(--color-text-primary);
+	}
+
+	.ft-captcha-ok {
+		padding: 0.625rem 0.75rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-success);
+		background: color-mix(in srgb, var(--color-success) 12%, transparent);
+		font-size: 0.8125rem;
+		color: var(--color-text-primary);
+	}
+
+	.ft-captcha-actions {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.ft-captcha-link {
+		background: none;
+		border: none;
+		color: var(--color-accent);
+		font-size: 0.75rem;
+		cursor: pointer;
+		padding: 0.125rem 0.25rem;
+	}
+
+	.ft-captcha-ssh {
+		padding-top: 0.5rem;
+		border-top: 1px dashed var(--color-border);
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.ft-captcha-ssh-title {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-captcha-ssh-cmd {
+		display: block;
+		padding: 0.5rem 0.625rem;
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		font-size: 0.6875rem;
+		word-break: break-all;
+	}
+
+	.ft-captcha-ssh-hint {
+		margin: 0;
+		font-size: 0.6875rem;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-captcha-warn,
+	.ft-captcha-hint {
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		margin: 0;
+	}
+
+	.ft-captcha-warn {
+		color: var(--color-warning);
+	}
+
+	.ft-captcha-warn-inline {
+		display: block;
+		margin-top: 0.5rem;
+		color: var(--color-warning);
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/ClientPanel.svelte
+++ b/frontend/src/lib/components/freeturn/ClientPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Input, Button, Dropdown, FormToggle } from '$lib/components/ui';
 	import { pluralize } from '$lib/utils/pluralize';
-	import type { FreeTurnClientConfig, FreeTurnProcessStatus } from '$lib/types';
+	import type { FreeTurnClientConfig, FreeTurnCaptchaClientStatus, FreeTurnProcessStatus } from '$lib/types';
 	import ProcessAlerts from './ProcessAlerts.svelte';
 	import SettingRows from './SettingRows.svelte';
 	import SettingRow from './SettingRow.svelte';
@@ -13,8 +13,8 @@
 		/** Снапшот сохранённого конфига — для dirty-подсветки и счётчика. */
 		saved: FreeTurnClientConfig | null;
 		status?: FreeTurnProcessStatus;
+		captchaStatus?: FreeTurnCaptchaClientStatus | null;
 		saving: boolean;
-		routerHost: string;
 		importing: boolean;
 		importedWG: string | null;
 	installAvailable: boolean;
@@ -32,14 +32,16 @@
 		onRevert: () => void;
 		onImport: (link: string) => void;
 		onCopy: (text: string) => void;
+		onOpenCaptcha?: () => void;
+		captchaAutoOpen?: boolean;
 	}
 
 	let {
 		client,
 		saved,
 		status,
+		captchaStatus = null,
 		saving,
-		routerHost,
 		importing,
 		importedWG,
 		installAvailable,
@@ -56,7 +58,9 @@
 		onSave,
 		onRevert,
 		onImport,
-		onCopy
+		onCopy,
+		onOpenCaptcha,
+		captchaAutoOpen = true
 	}: Props = $props();
 
 	let importLink = $state('');
@@ -114,6 +118,35 @@
 	{onCheckUpdates}
 />
 
+{#if captchaStatus?.waiting && captchaAutoOpen}
+	<div class="ft-captcha-banner">
+		<span>
+			{#if captchaStatus.pendingStreams && captchaStatus.pendingStreams > 1}
+				Нужна капча для {captchaStatus.pendingStreams} потоков — решайте по одному, не закрывайте окно.
+				{#if captchaStatus.portContention}
+					Сейчас порт 8765 занят другим потоком; остальные ждут очереди freeturn.
+				{/if}
+			{:else if captchaStatus.queued}
+				Требуется капча, но сейчас активен другой клиент — дождитесь очереди.
+			{:else if captchaStatus.canOpen}
+				Требуется прохождение VK-капчи для этого клиента.
+			{:else}
+				Клиент ждёт решения капчи.
+			{/if}
+		</span>
+		<div class="ft-captcha-banner-actions">
+			{#if captchaStatus.canOpen && onOpenCaptcha}
+				<Button variant="secondary" size="sm" onclick={onOpenCaptcha}>Открыть капчу</Button>
+			{/if}
+		</div>
+	</div>
+{:else if captchaStatus?.waiting && !captchaAutoOpen && onOpenCaptcha}
+	<p class="ft-captcha-manual">
+		Капча нужна, авто-окно отключено.
+		<Button variant="ghost" size="sm" onclick={onOpenCaptcha}>Открыть вручную</Button>
+	</p>
+{/if}
+
 <div class="ft-panel-accent">
 	<div class="section-label">Импорт по ссылке freeturn://</div>
 	<div class="ft-import-row">
@@ -138,7 +171,7 @@
 		id="turn"
 		label="TURN-сервер и провайдер"
 		summary={turnSummary}
-		dirty={changed('peer', 'provider', 'links', 'streamsPerCred', 'manualCaptcha', 'clientId')}
+		dirty={changed('peer', 'provider', 'links', 'streamsPerCred', 'clientId')}
 		expanded={expanded === 'turn'}
 		ontoggle={toggleSection}
 	>
@@ -164,18 +197,11 @@
 			value={String(client.streamsPerCred)}
 			onchange={(v) => (client.streamsPerCred = Number(v) || 0)}
 		/>
-		<div class="ft-toggle-slot">
-			<FormToggle bind:checked={client.manualCaptcha} label="Ручная капча (-manual-captcha)" />
-		</div>
-		{#if client.manualCaptcha}
-			<p class="ft-hint ft-span">
-				Капча решается локальным HTTP-сервером самого freeturn-client на роутере
-				(127.0.0.1:8765) — снаружи он недоступен. Пробросьте порт с вашего ПК:
-				<code>ssh -N -L 8765:127.0.0.1:8765 root@{routerHost || '<IP роутера>'}</code>
-				и откройте <code>http://127.0.0.1:8765</code> в браузере (порт SSH может отличаться
-				от 22 — на Keenetic часто 222).
-			</p>
-		{/if}
+		<p class="ft-hint ft-span">
+			Если авто-капча не проходит, freeturn откроет локальный сервер на порту 8765.
+			awg-manager покажет окно прохождения автоматически (включите «Авто-открытие» в модалке).
+			При нескольких клиентах порт 8765 один — капчи решаются по очереди.
+		</p>
 		<div class="ft-span">
 			<Input
 				label="Client ID (-client-id)"
@@ -334,6 +360,38 @@
 	.ft-dirty-note {
 		font-size: 0.75rem;
 		color: var(--color-warning);
+	}
+
+	.ft-captcha-banner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.625rem;
+		padding: 0.625rem 0.75rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-warning);
+		background: var(--color-warning-tint);
+		font-size: 0.8125rem;
+		margin-bottom: 0.875rem;
+		color: var(--color-text-primary);
+	}
+
+	.ft-captcha-banner-actions {
+		display: inline-flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+	}
+
+	.ft-captcha-manual {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		margin: 0 0 0.875rem;
 	}
 
 	@media (max-width: 640px) {

--- a/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+	import { Button, Input, Dropdown } from '$lib/components/ui';
+	import StepPill from '$lib/components/sb-router/StepPill.svelte';
+	import WizardStep from '$lib/components/sb-router/WizardStep.svelte';
+	import ProcessLogBox from './ProcessLogBox.svelte';
+	import LinkParamsSummary from './LinkParamsSummary.svelte';
+	import { browserOptions } from './options';
+	import { api } from '$lib/api/client';
+	import type { FreeTurnClientConfig, FreeTurnLinkPayload, FreeTurnProcessStatus } from '$lib/types';
+
+	interface Props {
+		client: FreeTurnClientConfig;
+		running?: boolean;
+		saving?: boolean;
+		status?: FreeTurnProcessStatus;
+		onSave: (cfg: FreeTurnClientConfig) => void | Promise<void>;
+		onToggle: (on: boolean) => void | Promise<void>;
+		onImportLink: (link: string) => void | Promise<void>;
+	}
+
+	let {
+		client,
+		running = false,
+		saving = false,
+		status,
+		onSave,
+		onToggle,
+		onImportLink
+	}: Props = $props();
+
+	let importLink = $state('');
+	let importing = $state(false);
+	let starting = $state(false);
+	let linkParams = $state<FreeTurnLinkPayload | null>(null);
+
+	const linksCount = $derived(
+		client.links ? client.links.split(',').filter((s) => s.trim()).length : 0
+	);
+
+	const step1Done = $derived(!!client.peer.trim());
+	const step2Done = $derived(step1Done && !!client.links?.trim());
+	const step3Done = $derived(
+		step2Done && client.streams > 0 && client.streamsPerCred > 0 && !!client.browser
+	);
+	const canSave = $derived((step1Done || step2Done) && !saving && !starting);
+	const canStart = $derived(step3Done && !saving && !starting);
+
+	async function applyImport() {
+		const link = importLink.trim();
+		if (!link) return;
+		importing = true;
+		try {
+			await onImportLink(link);
+			try {
+				linkParams = await api.decodeFreeTurnLink(link);
+			} catch {
+				linkParams = null;
+			}
+			importLink = '';
+		} finally {
+			importing = false;
+		}
+	}
+
+	async function saveOnly() {
+		if (!canSave) return;
+		await onSave(client);
+	}
+
+	async function startOnly() {
+		if (!canStart || running) return;
+		starting = true;
+		try {
+			await onToggle(true);
+		} finally {
+			starting = false;
+		}
+	}
+
+	async function saveAndStart() {
+		if (!canStart) return;
+		starting = true;
+		try {
+			await onSave(client);
+			if (!running) await onToggle(true);
+		} finally {
+			starting = false;
+		}
+	}
+</script>
+
+<div class="ft-simple-wrap">
+	<p class="ft-simple-lead">
+		Импорт freeturn:// → VK-ссылки → потоки и капча → запуск клиента.
+	</p>
+
+	<div class="ft-simple-steps">
+		<StepPill n={1} label="freeturn://" active={true} done={step1Done} />
+		<StepPill n={2} label="VK-ссылки" active={step1Done} done={step2Done} />
+		<StepPill n={3} label="Потоки" active={step2Done} done={step3Done} />
+		<StepPill n={4} label="Запуск" active={step3Done} done={running} />
+	</div>
+
+	<WizardStep n={1} title="Ссылка freeturn://" hint="с сервера freeturn на VPS" active={true}>
+		<p class="ft-hint">
+			Вставьте ссылку — заполнятся peer, obf, ключ и другие параметры клиента.
+		</p>
+		<div class="ft-import-row">
+			<Input bind:value={importLink} placeholder="freeturn://…" />
+			<Button variant="primary" size="sm" loading={importing} disabled={!importLink.trim()} onclick={applyImport}>
+				Импорт
+			</Button>
+		</div>
+		{#if client.peer.trim()}
+			<p class="ft-readonly">peer: <code>{client.peer}</code></p>
+		{/if}
+		<LinkParamsSummary {linkParams} peer={client.peer} />
+	</WizardStep>
+
+	<WizardStep
+		n={2}
+		title="Ссылки VK Calls (-links)"
+		hint="через запятую, каждая — отдельный пул кредов"
+		active={step1Done}
+	>
+		<textarea
+			class="ft-simple-textarea"
+			bind:value={client.links}
+			placeholder="https://vk.com/call/join/…"
+			rows="4"
+		></textarea>
+		{#if linksCount > 0}
+			<p class="ft-hint">
+				{linksCount} {linksCount === 1 ? 'ссылка' : linksCount < 5 ? 'ссылки' : 'ссылок'} —
+				столько же независимых пулов TURN-кредов.
+			</p>
+		{/if}
+	</WizardStep>
+
+	<WizardStep
+		n={3}
+		title="Потоки и капча"
+		hint="-n, -streams-per-cred, -browser"
+		active={step2Done}
+	>
+		<div class="ft-simple-grid">
+			<Input
+				label="Потоков TURN (-n)"
+				type="number"
+				value={String(client.streams)}
+				onchange={(v) => (client.streams = Math.max(1, Number(v) || 0))}
+			/>
+			<Input
+				label="Потоков на кред (-streams-per-cred)"
+				type="number"
+				value={String(client.streamsPerCred)}
+				onchange={(v) => (client.streamsPerCred = Math.max(1, Number(v) || 0))}
+			/>
+		</div>
+		<p class="ft-hint">
+			Суммарно до {linksCount * client.streamsPerCred || client.streamsPerCred} потоков на все
+			ссылки (×{linksCount || 1} кред{linksCount === 1 ? '' : 'а'}). Каждый поток может
+			потребовать отдельную VK-капчу.
+		</p>
+
+		<Dropdown
+			label="Браузер для авто-капчи (-browser)"
+			bind:value={client.browser}
+			options={browserOptions}
+		/>
+		<p class="ft-hint">
+			Headless-браузер на роутере для автоматического решения VK Smart Captcha. Если не
+			справится — freeturn откроет ручную капчу (окно в awg-manager с авто-открытием).
+		</p>
+
+		<p class="ft-readonly">
+			listen: <code>{client.listen || '127.0.0.1:9000'}</code> (назначается автоматически; учитываются порты AWG-плиток)
+		</p>
+	</WizardStep>
+
+	<WizardStep n={4} title="Запустить клиент" hint="сохранение и включение инстанса" active={step3Done}>
+		<div class="ft-simple-actions">
+			<Button variant="secondary" loading={saving} disabled={!canSave} onclick={saveOnly}>Сохранить</Button>
+			{#if !running}
+				<Button variant="secondary" loading={starting} disabled={!canStart} onclick={startOnly}>
+					Запустить
+				</Button>
+				<Button variant="primary" loading={starting} disabled={!canStart} onclick={saveAndStart}>
+					Сохранить и запустить
+				</Button>
+			{:else}
+				<Button variant="secondary" onclick={() => onToggle(false)}>Остановить</Button>
+				<Button variant="primary" loading={saving} disabled={!canSave} onclick={saveOnly}>
+					Сохранить настройки
+				</Button>
+			{/if}
+		</div>
+	</WizardStep>
+
+	<ProcessLogBox log={status?.log} />
+</div>
+
+<style>
+	.ft-simple-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.ft-simple-lead {
+		margin: 0 0 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-simple-steps {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.ft-import-row {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+		margin-top: 0.5rem;
+	}
+
+	.ft-simple-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+		gap: 0.625rem;
+		margin-top: 0.5rem;
+	}
+
+	.ft-simple-textarea {
+		width: 100%;
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		padding: 0.5rem 0.625rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+		resize: vertical;
+	}
+
+	.ft-readonly {
+		margin: 0.625rem 0 0;
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+	}
+
+	.ft-hint {
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		margin: 0.375rem 0 0;
+	}
+
+	.ft-simple-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
@@ -114,7 +114,7 @@
 		{#if client.peer.trim()}
 			<p class="ft-readonly">peer: <code>{client.peer}</code></p>
 		{/if}
-		<LinkParamsSummary {linkParams} peer={client.peer} />
+		<LinkParamsSummary payload={linkParams} peer={client.peer} />
 	</WizardStep>
 
 	<WizardStep

--- a/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
@@ -1,0 +1,369 @@
+<script lang="ts">
+	import { RefreshCw } from 'lucide-svelte';
+	import { Button, Input, Dropdown } from '$lib/components/ui';
+	import { api } from '$lib/api/client';
+	import { notifications } from '$lib/stores/notifications';
+	import StepPill from '$lib/components/sb-router/StepPill.svelte';
+	import WizardStep from '$lib/components/sb-router/WizardStep.svelte';
+	import ServerWgBind from './ServerWgBind.svelte';
+	import ProcessLogBox from './ProcessLogBox.svelte';
+	import LinkParamsSummary from './LinkParamsSummary.svelte';
+	import { obfOptions } from './options';
+	import { obfProfileHints, randomObfKeyHex } from './obfHints';
+	import type { FreeTurnLinkPayload, FreeTurnProcessStatus, FreeTurnServerConfig } from '$lib/types';
+
+	interface Props {
+		server: FreeTurnServerConfig;
+		running?: boolean;
+		saving?: boolean;
+		generating?: boolean;
+		status?: FreeTurnProcessStatus;
+		defaultClientListenPort?: number;
+		generatedLink?: string;
+		generatedPeer?: string;
+		genProvider: string;
+		genPeer: string;
+		genMTU: number;
+		genWG: string;
+		genClientId: string;
+		genName: string;
+		onSave: (cfg: FreeTurnServerConfig) => void | Promise<void>;
+		onToggle: (on: boolean) => void | Promise<void>;
+		onGenerate: (
+			provider: string,
+			peer: string,
+			mtu: number,
+			wg: string,
+			clientId: string,
+			name: string
+		) => Promise<import('$lib/types').FreeTurnGenerateLinkResult | null>;
+		onCopy: (text: string) => void;
+	}
+
+	let {
+		server,
+		running = false,
+		saving = false,
+		generating = false,
+		status,
+		defaultClientListenPort = 9000,
+		generatedLink = '',
+		generatedPeer = '',
+		genProvider = $bindable(),
+		genPeer = $bindable(),
+		genMTU = $bindable(),
+		genWG = $bindable(),
+		genClientId = $bindable(),
+		genName = $bindable(),
+		onSave,
+		onToggle,
+		onGenerate,
+		onCopy
+	}: Props = $props();
+
+	let starting = $state(false);
+	let loadingWanPeer = $state(false);
+	let linkParams = $state<FreeTurnLinkPayload | null>(null);
+
+	const listenPort = $derived.by(() => {
+		const listen = server.listen?.trim() ?? '';
+		if (!listen) return '56000';
+		const idx = listen.lastIndexOf(':');
+		return idx >= 0 ? listen.slice(idx + 1) : listen;
+	});
+
+	const step1Done = $derived(!!server.connect.trim());
+	const step2Done = $derived(step1Done && !!server.listen.trim());
+	const step3Done = $derived(
+		step2Done && server.obfProfile !== 'none' ? !!server.obfKey?.trim() : step2Done
+	);
+	const canSave = $derived(step1Done && !saving && !starting);
+	const canStart = $derived(step3Done && !saving && !starting);
+
+	const obfHint = $derived(obfProfileHints[server.obfProfile] ?? '');
+
+	function ensureObfKey() {
+		if (server.obfProfile !== 'none' && !server.obfKey?.trim()) {
+			server.obfKey = randomObfKeyHex();
+		}
+	}
+
+	function randomClientId() {
+		const bytes = new Uint8Array(16);
+		crypto.getRandomValues(bytes);
+		genClientId = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+	}
+
+	async function fillWanPeer() {
+		loadingWanPeer = true;
+		try {
+			const ip = await api.getWANIP();
+			genPeer = ip.includes(':') ? ip : `${ip}:${listenPort}`;
+		} catch (e) {
+			notifications.error(e instanceof Error ? e.message : 'Не удалось определить WAN IP');
+		} finally {
+			loadingWanPeer = false;
+		}
+	}
+
+	async function saveOnly() {
+		if (!canSave) return;
+		ensureObfKey();
+		await onSave(server);
+	}
+
+	async function startOnly() {
+		if (!canStart || running) return;
+		starting = true;
+		try {
+			await onToggle(true);
+		} finally {
+			starting = false;
+		}
+	}
+
+	async function saveAndGenerateLink() {
+		if (!step3Done) return;
+		ensureObfKey();
+		await onSave(server);
+		await generateLinkNow();
+	}
+
+	async function generateLinkNow() {
+		let peerParam = genPeer.trim();
+		if (peerParam && !peerParam.includes(':')) {
+			peerParam = `${peerParam}:${listenPort}`;
+		}
+		const result = await onGenerate(genProvider, peerParam, genMTU, genWG, genClientId, genName);
+		if (result?.link) {
+			try {
+				linkParams = await api.decodeFreeTurnLink(result.link);
+			} catch {
+				linkParams = null;
+			}
+		}
+	}
+
+	async function saveStartAndLink() {
+		if (!canStart) return;
+		starting = true;
+		try {
+			ensureObfKey();
+			await onSave(server);
+			if (!running) await onToggle(true);
+			await generateLinkNow();
+		} finally {
+			starting = false;
+		}
+	}
+</script>
+
+<div class="ft-simple-wrap">
+	<p class="ft-simple-lead">
+		Сервер freeturn: WG-пир → автоматический порт → обфускация → ссылка для клиента.
+	</p>
+
+	<div class="ft-simple-steps">
+		<StepPill n={1} label="WG · пир" active={true} done={step1Done} />
+		<StepPill n={2} label="Порт" active={step1Done} done={step2Done} />
+		<StepPill n={3} label="Obf" active={step2Done} done={step3Done} />
+		<StepPill n={4} label="Ссылка" active={step3Done} done={!!generatedLink} />
+	</div>
+
+	<WizardStep n={1} title="WireGuard: сервер · пир" hint="backend (-connect) заполнится автоматически" active={true}>
+		<ServerWgBind
+			autoApply
+			compact
+			clientListenPort={defaultClientListenPort}
+			onConnect={(addr) => {
+				server.connect = addr;
+			}}
+			onPeerConf={(conf) => {
+				genWG = conf;
+			}}
+		/>
+		{#if server.connect.trim()}
+			<p class="ft-readonly">
+				-connect: <code>{server.connect}</code>
+			</p>
+		{/if}
+	</WizardStep>
+
+	<WizardStep
+		n={2}
+		title="Порт приёма (-listen)"
+		hint="назначается автоматически при создании инстанса"
+		active={step1Done}
+	>
+		<p class="ft-readonly">
+			<code>{server.listen || '0.0.0.0:56000'}</code>
+		</p>
+		<p class="ft-hint">
+			Порт выбирается автоматически (56000, 56001, …) — менять не нужно, если не создаёте
+			несколько серверов freeturn параллельно.
+		</p>
+	</WizardStep>
+
+	<WizardStep n={3} title="Обфускация" hint="маскирует freeturn-трафик от DPI" active={step2Done}>
+		<Dropdown label="Профиль (-obf-profile)" bind:value={server.obfProfile} options={obfOptions} />
+		{#if obfHint}
+			<p class="ft-hint">{obfHint}</p>
+		{/if}
+		<Input
+			label="Ключ (-obf-key)"
+			type="password"
+			bind:value={server.obfKey}
+			placeholder="64 hex-символа"
+		/>
+		<div class="ft-inline-actions">
+			<Button variant="ghost" size="sm" onclick={() => (server.obfKey = randomObfKeyHex())}>
+				Сгенерировать ключ
+			</Button>
+		</div>
+		<p class="ft-hint">
+			Ключ должен совпадать у сервера и клиента — он зашивается в freeturn:// ссылку.
+		</p>
+	</WizardStep>
+
+	<WizardStep n={4} title="Ссылка для клиента" hint="сохраните сервер и сгенерируйте freeturn://" active={step3Done}>
+		<div class="ft-gen-peer-row">
+			<Input
+				label="Peer для клиента (WAN IP:порт)"
+				bind:value={genPeer}
+				placeholder={`пусто — авто · порт :${listenPort}`}
+			/>
+			<Button variant="ghost" size="sm" loading={loadingWanPeer} onclick={fillWanPeer}>WAN IP</Button>
+		</div>
+		<div class="ft-gen-row">
+			<Input label="Провайдер" bind:value={genProvider} placeholder="vk" />
+			<Input label="MTU" type="number" value={String(genMTU)} onchange={(v) => (genMTU = Number(v) || 1376)} />
+			<div class="ft-gen-cid">
+				<Input label="Client ID" bind:value={genClientId} placeholder="необязательно" />
+				<Button variant="ghost" size="sm" onclick={randomClientId} title="Сгенерировать">
+					<RefreshCw size={14} />
+				</Button>
+			</div>
+			<Input bind:value={genName} label="Комментарий" placeholder="имя получателя" />
+		</div>
+
+		<div class="ft-simple-actions">
+			<Button variant="secondary" loading={saving} disabled={!canSave} onclick={saveOnly}>Сохранить</Button>
+			{#if !running}
+				<Button variant="secondary" loading={starting} disabled={!canStart} onclick={startOnly}>
+					Запустить
+				</Button>
+			{:else}
+				<Button variant="secondary" onclick={() => onToggle(false)}>Остановить</Button>
+			{/if}
+			<Button variant="primary" loading={starting} disabled={!canStart} onclick={saveStartAndLink}>
+				Сохранить, запустить и получить ссылку
+			</Button>
+			<Button
+				variant="ghost"
+				size="sm"
+				loading={generating}
+				disabled={!step3Done}
+				onclick={saveAndGenerateLink}
+			>
+				Только сгенерировать ссылку
+			</Button>
+		</div>
+
+		{#if generatedLink}
+			<div class="ft-result">
+				<div class="section-label">freeturn:// ({generatedPeer || 'peer'})</div>
+				<div class="ft-link-box">{generatedLink}</div>
+				<Button variant="ghost" size="sm" onclick={() => onCopy(generatedLink)}>Скопировать</Button>
+				<LinkParamsSummary payload={linkParams} peer={generatedPeer} />
+			</div>
+		{/if}
+	</WizardStep>
+
+	<ProcessLogBox log={status?.log} />
+</div>
+
+<style>
+	.ft-simple-wrap {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.ft-simple-lead {
+		margin: 0 0 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+
+	.ft-simple-steps {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.ft-simple-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
+	}
+
+	.ft-readonly {
+		margin: 0.5rem 0 0;
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+	}
+
+	.ft-hint {
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		margin: 0.375rem 0 0;
+	}
+
+	.ft-inline-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 0.375rem;
+	}
+
+	.ft-gen-peer-row {
+		display: flex;
+		gap: 0.5rem;
+		align-items: flex-end;
+	}
+
+	.ft-gen-peer-row :global(.field) {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.ft-gen-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.625rem;
+		align-items: flex-end;
+		margin-top: 0.625rem;
+	}
+
+	.ft-gen-cid {
+		display: flex;
+		gap: 0.375rem;
+		align-items: flex-end;
+	}
+
+	.ft-result {
+		margin-top: 0.875rem;
+		padding: 0.875rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-tertiary);
+	}
+
+	.ft-link-box {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		word-break: break-all;
+		margin: 0.375rem 0 0.625rem;
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -163,7 +163,11 @@
 			clientId: c.clientId ?? '',
 			sub: c.sub ?? '',
 			browser:
-				c.browser === 'chromium' ? 'chrome' : (c.browser === 'safari' || c.browser === 'chrome' ? c.browser : 'firefox'),
+				(c.browser as string) === 'chromium'
+					? 'chrome'
+					: c.browser === 'safari' || c.browser === 'chrome'
+						? c.browser
+						: 'firefox',
 			streams: c.streams > 0 ? c.streams : 10,
 			streamsPerCred: c.streamsPerCred > 0 ? c.streamsPerCred : 10
 		};

--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -3,19 +3,24 @@
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
 	import { copyToClipboard as copyText } from '$lib/utils/clipboard';
-	import { Tabs } from '$lib/components/ui';
+	import { Tabs, FormToggle, Button } from '$lib/components/ui';
 	import type {
 		FreeTurnClientConfig,
 		FreeTurnClientInstance,
+		FreeTurnCaptchaOverview,
 		FreeTurnConfig,
+		FreeTurnGenerateLinkResult,
 		FreeTurnServerConfig,
 		FreeTurnServerInstance,
 		FreeTurnStatus
 	} from '$lib/types';
-	import ClientPanel from './ClientPanel.svelte';
-	import ServerPanel from './ServerPanel.svelte';
-	import StatusStrip from './StatusStrip.svelte';
+	import ProcessAlerts from './ProcessAlerts.svelte';
 	import InstanceBar from './InstanceBar.svelte';
+	import CaptchaModal from './CaptchaModal.svelte';
+	import FreeTurnClientSimple from './FreeTurnClientSimple.svelte';
+	import FreeTurnServerSimple from './FreeTurnServerSimple.svelte';
+	import { readCaptchaAutoOpen, writeCaptchaAutoOpen } from './captchaPrefs';
+	import { parseLocalListenPort, patchWgConfEndpoint } from '$lib/utils/serverPeerOptions';
 
 	type FtTab = 'client' | 'server';
 
@@ -29,8 +34,6 @@
 
 	let selectedClientId = $state('default');
 	let selectedServerId = $state('default');
-
-	let expanded: string | null = $state(null);
 
 	let importing = $state(false);
 	let importedWG: string | null = $state(null);
@@ -49,7 +52,11 @@
 	let generatedClientId = $state('');
 
 	let statusPoll: ReturnType<typeof setInterval> | undefined;
-	let routerHost = $state('');
+
+	let captchaOverview = $state<FreeTurnCaptchaOverview | null>(null);
+	let captchaModalOpen = $state(false);
+	let captchaModalClientId = $state<string | null>(null);
+	let captchaAutoOpen = $state(readCaptchaAutoOpen());
 
 	const ftTabs = [
 		{ id: 'client', label: 'Клиент' },
@@ -100,17 +107,45 @@
 		return port > 0 ? port : 9000;
 	});
 
+	const captchaModalClient = $derived(
+		captchaOverview?.clients.find((c) => c.clientId === captchaModalClientId) ?? null
+	);
+
+	const selectedCaptchaStatus = $derived(
+		captchaOverview?.clients.find((c) => c.clientId === selectedClientId) ?? null
+	);
+
 	function errText(e: unknown): string {
 		return e instanceof Error ? e.message : String(e ?? '');
 	}
 
+	function anyClientRunning(): boolean {
+		return status?.clients.some((c) => c.status?.running) ?? false;
+	}
+
 	onMount(async () => {
-		routerHost = window.location.hostname;
-		await Promise.all([loadConfig(), loadStatus(false)]);
+		await Promise.all([loadConfig(), loadStatus(false), loadCaptchaStatus()]);
 		loading = false;
-		statusPoll = setInterval(() => void loadStatus(), 3000);
-		// Проверку апстрим-релиза (GitHub) не делаем автоматически — только по
-		// кнопке «Проверить обновления» (роутер часто без доступа к GitHub).
+		if (typeof window !== 'undefined') {
+			const params = new URLSearchParams(window.location.search);
+			if (params.get('captcha') === '1') {
+				captchaAutoOpen = true;
+				writeCaptchaAutoOpen(true);
+				setTimeout(() => maybeAutoOpenCaptchaModal(), 500);
+			}
+		}
+		statusPoll = setInterval(async () => {
+			await loadStatus(false);
+			if (
+				anyClientRunning() ||
+				captchaModalOpen ||
+				captchaOverview?.clients.some((c) => c.waiting)
+			) {
+				await loadCaptchaStatus();
+			} else {
+				captchaOverview = null;
+			}
+		}, 3000);
 	});
 
 	onDestroy(() => {
@@ -126,7 +161,11 @@
 			obfKey: c.obfKey ?? '',
 			dnsServers: c.dnsServers ?? '',
 			clientId: c.clientId ?? '',
-			sub: c.sub ?? ''
+			sub: c.sub ?? '',
+			browser:
+				c.browser === 'chromium' ? 'chrome' : (c.browser === 'safari' || c.browser === 'chrome' ? c.browser : 'firefox'),
+			streams: c.streams > 0 ? c.streams : 10,
+			streamsPerCred: c.streamsPerCred > 0 ? c.streamsPerCred : 10
 		};
 	}
 
@@ -175,6 +214,55 @@
 		} catch {
 			// Молча — как ping-бейджи списка туннелей.
 		}
+	}
+
+	async function loadCaptchaStatus() {
+		if (!anyClientRunning() && !captchaModalOpen) {
+			captchaOverview = null;
+			return;
+		}
+		try {
+			captchaOverview = await api.getFreeTurnCaptchaStatus();
+			maybeAutoOpenCaptchaModal();
+		} catch {
+			// Молча — капча опциональна.
+		}
+	}
+
+	function maybeAutoOpenCaptchaModal() {
+		if (!captchaOverview || !captchaAutoOpen) return;
+		const openable = captchaOverview.clients.filter((c) => c.canOpen);
+		if (openable.length === 0) return;
+		const target =
+			openable.find((c) => c.clientId === selectedClientId && c.canOpen) ??
+			openable.find((c) => c.active) ??
+			openable[0];
+		if (!target) return;
+		captchaModalClientId = target.clientId;
+		captchaModalOpen = true;
+	}
+
+	function setCaptchaAutoOpen(enabled: boolean) {
+		captchaAutoOpen = enabled;
+		writeCaptchaAutoOpen(enabled);
+		if (!enabled) captchaModalOpen = false;
+	}
+
+	function openCaptchaModal(clientId?: string) {
+		const id = clientId ?? selectedClientId;
+		const entry = captchaOverview?.clients.find((c) => c.clientId === id);
+		if (!entry?.canOpen && !entry?.waiting) return;
+		captchaModalClientId = id;
+		captchaModalOpen = true;
+	}
+
+	function closeCaptchaModal() {
+		captchaModalOpen = false;
+	}
+
+	function selectCaptchaClient(id: string) {
+		captchaModalClientId = id;
+		selectedClientId = id;
 	}
 
 	async function checkUpdates() {
@@ -269,14 +357,13 @@
 		patchServerInConfig(selectedServerId, $state.snapshot(savedServer.config));
 	}
 
-	async function toggleClient(on: boolean) {
-		if (!selectedClient) return;
+	async function toggleClientInstance(id: string, on: boolean) {
 		try {
 			if (on) {
-				await api.startFreeTurnClient(selectedClient.id);
+				await api.startFreeTurnClient(id);
 				notifications.success('FreeTurn клиент запущен');
 			} else {
-				await api.stopFreeTurnClient(selectedClient.id);
+				await api.stopFreeTurnClient(id);
 				notifications.success('FreeTurn клиент остановлен');
 			}
 		} catch (e) {
@@ -286,14 +373,13 @@
 		}
 	}
 
-	async function toggleServer(on: boolean) {
-		if (!selectedServer) return;
+	async function toggleServerInstance(id: string, on: boolean) {
 		try {
 			if (on) {
-				await api.startFreeTurnServer(selectedServer.id);
+				await api.startFreeTurnServer(id);
 				notifications.success('FreeTurn сервер запущен');
 			} else {
-				await api.stopFreeTurnServer(selectedServer.id);
+				await api.stopFreeTurnServer(id);
 				notifications.success('FreeTurn сервер остановлен');
 			}
 		} catch (e) {
@@ -326,13 +412,30 @@
 	}
 
 	async function deleteClient(id: string) {
-		const name = config?.clients.find((c) => c.id === id)?.name ?? id;
-		if (!confirm(`Удалить клиент «${name}»? Настройки инстанса будут потеряны.`)) return;
+		const inst = config?.clients.find((c) => c.id === id);
+		const name = inst?.name ?? id;
+		const listen = inst?.config.listen?.trim();
+		const confirmMsg = listen
+			? `Удалить клиент «${name}»?\n\nБудут удалены настройки инстанса и AWG-туннели, созданные при импорте freeturn:// для этого клиента. Ручные туннели с тем же портом не затронуты.`
+			: `Удалить клиент «${name}»?\n\nБудут удалены настройки инстанса и AWG-туннели, созданные при импорте freeturn:// для этого клиента.`;
+		if (!confirm(confirmMsg)) return;
 		try {
-			await api.deleteFreeTurnClient(id);
+			const result = await api.deleteFreeTurnClient(id);
 			await loadConfig();
 			await loadStatus();
-			notifications.success('Клиент удалён');
+			let msg = 'Клиент удалён';
+			const n = result.deletedTunnels?.length ?? 0;
+			if (n > 0) {
+				msg += `, AWG-туннелей удалено: ${n}`;
+			}
+			if (result.tunnelErrors?.length) {
+				notifications.error(
+					'Клиент удалён, но часть AWG-туннелей не удалось убрать: ' +
+						result.tunnelErrors.join('; ')
+				);
+			} else {
+				notifications.success(msg);
+			}
 		} catch (e) {
 			notifications.error('Не удалось удалить: ' + errText(e));
 		}
@@ -419,8 +522,18 @@
 			}
 			if (wg) {
 				try {
-					const tunnel = await api.importConfig(wg, `FreeTurn ${payload.peer}`.slice(0, 60));
-					msg += `. Создан туннель «${tunnel.name}»`;
+					const listenPort =
+						parseLocalListenPort(c.listen) ??
+						parseLocalListenPort(payload.listen) ??
+						9000;
+					const wgForImport = patchWgConfEndpoint(wg, listenPort);
+					const tunnel = await api.importConfig(
+						wgForImport,
+						`FreeTurn ${payload.peer}`.slice(0, 60),
+						undefined,
+						selectedClientId
+					);
+					msg += `. Создан туннель «${tunnel.name}» (Endpoint 127.0.0.1:${listenPort})`;
 				} catch (e) {
 					notifications.error('Поля заполнены, но не удалось создать туннель из конфига: ' + errText(e));
 				}
@@ -440,8 +553,8 @@
 		wg: string,
 		clientId: string,
 		name: string
-	) {
-		if (!selectedServer) return;
+	): Promise<FreeTurnGenerateLinkResult | null> {
+		if (!selectedServer) return null;
 		generating = true;
 		try {
 			const listen = selectedServer.config.listen?.trim() ?? '';
@@ -462,42 +575,49 @@
 			generatedLink = result.link;
 			generatedPeer = result.peer;
 			generatedClientId = result.clientId ?? '';
+			return result;
 		} catch (e) {
 			notifications.error('Не удалось сгенерировать ссылку: ' + errText(e));
+			return null;
 		} finally {
 			generating = false;
 		}
 	}
 
 	const clientBarItems = $derived(
-		(config ? config.clients : []).map((c: FreeTurnClientInstance) => ({
-			id: c.id,
-			name: c.name,
-			running: status?.clients.find((s) => s.id === c.id)?.status.running
-		}))
+		(config ? config.clients : []).map((c: FreeTurnClientInstance) => {
+			const st = status?.clients.find((s) => s.id === c.id)?.status ?? status?.client;
+			return {
+				id: c.id,
+				name: c.name,
+				running: st?.running,
+				startedAt: st?.startedAt,
+				pid: st?.pid,
+				dtlsConnections: st?.dtlsConnections,
+				binaryPresent: st?.binaryPresent
+			};
+		})
 	);
 	const serverBarItems = $derived(
-		(config ? config.servers : []).map((s: FreeTurnServerInstance) => ({
-			id: s.id,
-			name: s.name,
-			running: status?.servers.find((st) => st.id === s.id)?.status.running
-		}))
+		(config ? config.servers : []).map((s: FreeTurnServerInstance) => {
+			const st = status?.servers.find((x) => x.id === s.id)?.status ?? status?.server;
+			return {
+				id: s.id,
+				name: s.name,
+				running: st?.running,
+				startedAt: st?.startedAt,
+				pid: st?.pid,
+				binaryPresent: st?.binaryPresent
+			};
+		})
 	);
 </script>
-
-<StatusStrip
-	client={clientStatus}
-	server={serverStatus}
-	onToggleClient={toggleClient}
-	onToggleServer={toggleServer}
-/>
 
 <Tabs
 	tabs={ftTabs}
 	active={ftTab}
 	onchange={(id) => {
 		ftTab = id as FtTab;
-		expanded = null;
 	}}
 	urlParam="ft"
 	defaultTab="client"
@@ -505,88 +625,105 @@
 
 {#if loading || !config}
 	<div class="ft-loading">Загрузка…</div>
-{:else if ftTab === 'client'}
-	<InstanceBar
-		items={clientBarItems}
-		selectedId={selectedClientId}
-		onSelect={(id) => {
-			selectedClientId = id;
-		}}
-		onAdd={addClient}
-		onDelete={deleteClient}
-		onRename={renameClient}
-	/>
-	{#if selectedClient}
-		<ClientPanel
-			client={selectedClient.config}
-			saved={savedClient?.config ?? null}
-			status={clientStatus}
-			{saving}
-			{routerHost}
-			{importing}
-			{importedWG}
-			installAvailable={status?.installAvailable ?? false}
-			installVersion={status?.installVersion}
-			installedVersion={status?.installedVersion}
-			updateAvailable={status?.updateAvailable ?? false}
-			remoteVersion={status?.remoteVersion}
-			remoteCheckError={status?.remoteCheckError}
-			installing={installing || (status?.installing ?? false)}
-			{checkingUpdates}
-			bind:expanded
-			onInstall={install}
-			onCheckUpdates={checkUpdates}
-			onSave={() => saveClientConfig(selectedClient!.config)}
-			onRevert={revertClient}
-			onImport={applyImportLink}
-			onCopy={copy}
-		/>
-	{/if}
 {:else}
-	<InstanceBar
-		items={serverBarItems}
-		selectedId={selectedServerId}
-		onSelect={(id) => {
-			selectedServerId = id;
-		}}
-		onAdd={addServer}
-		onDelete={deleteServer}
-		onRename={renameServer}
+	<ProcessAlerts
+		status={ftTab === 'client' ? clientStatus : serverStatus}
+		installAvailable={status?.installAvailable ?? false}
+		installVersion={status?.installVersion}
+		installedVersion={status?.installedVersion}
+		updateAvailable={status?.updateAvailable ?? false}
+		remoteVersion={status?.remoteVersion}
+		remoteCheckError={status?.remoteCheckError}
+		installing={installing || (status?.installing ?? false)}
+		{checkingUpdates}
+		onInstall={install}
+		onCheckUpdates={checkUpdates}
 	/>
-	{#if selectedServer}
-		<ServerPanel
-			server={selectedServer.config}
-			serverInstanceId={selectedServer.id}
-			saved={savedServer?.config ?? null}
-			status={serverStatus}
-			{saving}
-			defaultClientListenPort={defaultClientListenPort}
-			installAvailable={status?.installAvailable ?? false}
-			installVersion={status?.installVersion}
-			installedVersion={status?.installedVersion}
-			updateAvailable={status?.updateAvailable ?? false}
-			remoteVersion={status?.remoteVersion}
-			remoteCheckError={status?.remoteCheckError}
-			installing={installing || (status?.installing ?? false)}
-			{checkingUpdates}
-			onInstall={install}
-			onCheckUpdates={checkUpdates}
-			{generating}
-			{generatedLink}
-			{generatedPeer}
-			{generatedClientId}
-			bind:genProvider
-			bind:genPeer
-			bind:genMTU
-			bind:genWG
-			bind:genClientId
-			bind:genName
-			bind:expanded
-			onSave={() => saveServerConfig(selectedServer!.config)}
-			onRevert={revertServer}
-			onGenerate={generateLink}
-			onCopy={copy}
+
+	{#if ftTab === 'client'}
+		<InstanceBar
+			items={clientBarItems}
+			selectedId={selectedClientId}
+			onSelect={(id) => {
+				selectedClientId = id;
+			}}
+			onToggle={toggleClientInstance}
+			onAdd={addClient}
+			onDelete={deleteClient}
+			onRename={renameClient}
 		/>
+		{#if selectedClient}
+			<div class="ft-captcha-prefs">
+				<FormToggle
+					checked={captchaAutoOpen}
+					onchange={setCaptchaAutoOpen}
+					label="Авто-открытие окна капчи"
+					hint="Включено — модалка и окно капчи откроются сами. Выключите, если не хотите pop-up — тогда «Открыть капчу» по кнопке."
+					size="sm"
+				/>
+				{#if !captchaAutoOpen && (selectedCaptchaStatus?.canOpen || selectedCaptchaStatus?.waiting)}
+					<Button variant="secondary" size="sm" onclick={() => openCaptchaModal(selectedClientId)}>
+						Открыть капчу
+					</Button>
+				{/if}
+			</div>
+
+			<FreeTurnClientSimple
+				client={selectedClient.config}
+				running={clientStatus?.running ?? false}
+				status={clientStatus}
+				{saving}
+				onSave={saveClientConfig}
+				onToggle={(on) => toggleClientInstance(selectedClientId, on)}
+				onImportLink={applyImportLink}
+			/>
+		{/if}
+
+		<CaptchaModal
+			bind:open={captchaModalOpen}
+			clientId={captchaModalClientId}
+			clientName={captchaModalClient?.clientName}
+			captchaUrl={captchaModalClient?.url ?? null}
+			overview={captchaOverview}
+			captchaAutoOpen={captchaAutoOpen}
+			onCaptchaAutoOpenChange={setCaptchaAutoOpen}
+			onclose={closeCaptchaModal}
+			onSelectClient={selectCaptchaClient}
+		/>
+	{:else}
+		<InstanceBar
+			items={serverBarItems}
+			selectedId={selectedServerId}
+			onSelect={(id) => {
+				selectedServerId = id;
+			}}
+			onToggle={toggleServerInstance}
+			onAdd={addServer}
+			onDelete={deleteServer}
+			onRename={renameServer}
+		/>
+		{#if selectedServer}
+			<FreeTurnServerSimple
+				server={selectedServer.config}
+				running={serverStatus?.running ?? false}
+				status={serverStatus}
+				{saving}
+				{generating}
+				defaultClientListenPort={defaultClientListenPort}
+				{generatedLink}
+				{generatedPeer}
+				bind:genProvider
+				bind:genPeer
+				bind:genMTU
+				bind:genWG
+				bind:genClientId
+				bind:genName
+				onSave={saveServerConfig}
+				onToggle={(on) => toggleServerInstance(selectedServerId, on)}
+				onGenerate={generateLink}
+				onCopy={copy}
+			/>
+		{/if}
 	{/if}
 {/if}
 
@@ -595,5 +732,17 @@
 		padding: 2rem;
 		text-align: center;
 		color: var(--color-text-secondary);
+	}
+
+	.ft-captcha-prefs {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.75rem 1rem;
+		margin: 0.75rem 0 1rem;
+		padding: 0.625rem 0.75rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-secondary);
 	}
 </style>

--- a/frontend/src/lib/components/freeturn/InstanceBar.svelte
+++ b/frontend/src/lib/components/freeturn/InstanceBar.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui';
+	import { Button, Toggle } from '$lib/components/ui';
 	import { Pencil, X } from 'lucide-svelte';
+	import { formatUptime } from './uptime';
 
 	interface InstanceItem {
 		id: string;
 		name: string;
 		running?: boolean;
+		startedAt?: string;
+		pid?: number;
+		dtlsConnections?: number;
+		binaryPresent?: boolean;
 	}
 
 	interface Props {
@@ -13,6 +18,7 @@
 		selectedId: string;
 		canDelete?: boolean;
 		onSelect: (id: string) => void;
+		onToggle: (id: string, on: boolean) => void;
 		onAdd: () => void;
 		onDelete: (id: string) => void;
 		onRename?: (id: string, name: string) => void;
@@ -23,6 +29,7 @@
 		selectedId,
 		canDelete = true,
 		onSelect,
+		onToggle,
 		onAdd,
 		onDelete,
 		onRename
@@ -42,12 +49,29 @@
 		if (name && onRename) onRename(id, name);
 		renamingId = null;
 	}
+
+	function meta(item: InstanceItem): string {
+		if (!item.running) return 'остановлен';
+		return ['запущен', formatUptime(item.startedAt), item.pid ? `PID ${item.pid}` : '']
+			.filter(Boolean)
+			.join(' · ');
+	}
 </script>
 
 <div class="ft-instance-bar">
 	<div class="ft-instance-list">
 		{#each items as item (item.id)}
-			<div class="ft-instance-chip" class:active={item.id === selectedId}>
+			<div class="ft-instance-row" class:active={item.id === selectedId}>
+				<button type="button" class="ft-instance-main" onclick={() => onSelect(item.id)}>
+					<span class="ft-chip-dot" class:running={item.running}></span>
+					{#if renamingId === item.id}
+						<!-- rename handled below -->
+					{:else}
+						<span class="ft-instance-name">{item.name}</span>
+						<span class="ft-instance-meta">{meta(item)}</span>
+					{/if}
+				</button>
+
 				{#if renamingId === item.id}
 					<input
 						class="ft-rename-input"
@@ -58,11 +82,26 @@
 						}}
 						onblur={() => commitRename(item.id)}
 					/>
-				{:else}
-					<button type="button" class="ft-chip-btn" onclick={() => onSelect(item.id)}>
-						<span class="ft-chip-dot" class:running={item.running}></span>
-						<span class="ft-chip-label">{item.name}</span>
-					</button>
+				{:else if item.running}
+					<span
+						class="ft-instance-dtls"
+						class:live={(item.dtlsConnections ?? 0) > 0}
+						title="Активные DTLS-соединения (обновляется каждые 3 с)"
+					>
+						DTLS {(item.dtlsConnections ?? 0).toLocaleString('ru-RU')}
+					</span>
+				{/if}
+
+				<div class="ft-instance-actions">
+					<Toggle
+						checked={!!item.running}
+						onchange={(on) => onToggle(item.id, on)}
+						disabled={item.binaryPresent === false}
+						controlled
+						size="sm"
+						label=""
+						ariaLabel="{item.name}: запустить или остановить"
+					/>
 					{#if onRename}
 						<button
 							type="button"
@@ -83,7 +122,7 @@
 							<X size={14} />
 						</button>
 					{/if}
-				{/if}
+				</div>
 			</div>
 		{/each}
 	</div>
@@ -102,36 +141,79 @@
 
 	.ft-instance-list {
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: column;
 		gap: 0.5rem;
 		flex: 1;
 		min-width: 0;
 	}
 
-	.ft-instance-chip {
-		display: inline-flex;
+	.ft-instance-row {
+		display: flex;
 		align-items: center;
-		gap: 0.125rem;
+		gap: 0.5rem;
+		padding: 0.375rem 0.5rem 0.375rem 0.625rem;
 		background: var(--color-bg-secondary);
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius);
-		padding: 0.125rem;
 	}
 
-	.ft-instance-chip.active {
+	.ft-instance-dtls {
+		margin-left: auto;
+		font-size: 0.6875rem;
+		font-family: var(--font-mono);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		white-space: nowrap;
+	}
+
+	.ft-instance-dtls.live {
+		color: var(--color-success);
+		border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+	}
+
+	.ft-instance-row.active {
 		border-color: var(--color-accent);
+		background: var(--color-bg-primary);
 	}
 
-	.ft-chip-btn {
-		display: inline-flex;
+	.ft-instance-main {
+		display: flex;
 		align-items: center;
-		gap: 0.375rem;
-		padding: 0.25rem 0.5rem;
+		gap: 0.5rem;
+		flex: 1;
+		min-width: 0;
+		padding: 0.125rem 0;
 		background: none;
 		border: none;
 		color: inherit;
 		cursor: pointer;
+		text-align: left;
+	}
+
+	.ft-instance-name {
 		font-size: 0.8125rem;
+		font-weight: 600;
+		white-space: nowrap;
+	}
+
+	.ft-instance-meta {
+		font-size: 0.6875rem;
+		color: var(--color-text-secondary);
+		font-family: var(--font-mono);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.ft-instance-actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.125rem;
+		flex-shrink: 0;
 	}
 
 	.ft-chip-dot {
@@ -139,6 +221,7 @@
 		height: 0.5rem;
 		border-radius: 50%;
 		background: var(--color-text-muted);
+		flex-shrink: 0;
 	}
 
 	.ft-chip-dot.running {
@@ -160,10 +243,23 @@
 	}
 
 	.ft-rename-input {
+		flex: 1;
 		font-size: 0.8125rem;
 		padding: 0.25rem 0.5rem;
-		border: none;
-		background: transparent;
-		min-width: 6rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+		min-width: 0;
+	}
+
+	@media (max-width: 640px) {
+		.ft-instance-main {
+			flex-wrap: wrap;
+		}
+
+		.ft-instance-meta {
+			flex-basis: 100%;
+			padding-left: 1rem;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/freeturn/LinkParamsSummary.svelte
+++ b/frontend/src/lib/components/freeturn/LinkParamsSummary.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import type { FreeTurnLinkPayload } from '$lib/types';
+
+	interface Props {
+		payload: FreeTurnLinkPayload | null;
+		peer?: string;
+	}
+
+	let { payload, peer = '' }: Props = $props();
+
+	const rows = $derived.by(() => {
+		if (!payload) return [];
+		const out: { k: string; v: string }[] = [];
+		if (payload.peer || peer) out.push({ k: 'peer', v: payload.peer || peer });
+		if (payload.provider) out.push({ k: 'provider', v: payload.provider });
+		if (payload.obf) out.push({ k: 'obf', v: payload.obf });
+		if (payload.key) out.push({ k: 'key', v: `${payload.key.slice(0, 8)}…` });
+		if (payload.cid) out.push({ k: 'client ID', v: payload.cid });
+		if (payload.mtu) out.push({ k: 'MTU', v: String(payload.mtu) });
+		if (payload.n) out.push({ k: 'потоков', v: String(payload.n) });
+		if (payload.spc) out.push({ k: 'на кред', v: String(payload.spc) });
+		if (payload.listen) out.push({ k: 'listen', v: payload.listen });
+		if (payload.name) out.push({ k: 'имя', v: payload.name });
+		if (payload.wg) out.push({ k: 'WireGuard', v: 'конфиг в ссылке' });
+		return out;
+	});
+</script>
+
+{#if payload && rows.length > 0}
+	<div class="ft-link-params">
+		<div class="section-label">Параметры в ссылке</div>
+		<dl class="ft-link-params-grid">
+			{#each rows as row (row.k)}
+				<dt>{row.k}</dt>
+				<dd>{row.v}</dd>
+			{/each}
+		</dl>
+	</div>
+{/if}
+
+<style>
+	.ft-link-params {
+		margin-top: 0.75rem;
+		padding: 0.625rem 0.75rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-tertiary);
+	}
+
+	.ft-link-params-grid {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.25rem 0.75rem;
+		margin: 0.375rem 0 0;
+		font-size: 0.75rem;
+	}
+
+	dt {
+		color: var(--color-text-secondary);
+		font-family: var(--font-mono);
+	}
+
+	dd {
+		margin: 0;
+		font-family: var(--font-mono);
+		word-break: break-all;
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
+++ b/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	interface Props {
+		log?: string;
+		title?: string;
+		maxHeight?: string;
+	}
+
+	let { log = '', title = 'Лог процесса', maxHeight = '200px' }: Props = $props();
+</script>
+
+<section class="ft-log-panel">
+	<div class="section-label">{title}</div>
+	<pre class="ft-log-box" style:max-height={maxHeight}>{log?.trim() || 'лог пуст — запустите процесс'}</pre>
+</section>
+
+<style>
+	.ft-log-panel {
+		margin-top: 0.75rem;
+		padding: 0.75rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-secondary);
+	}
+
+	.ft-log-box {
+		overflow-y: auto;
+		padding: 0.5rem 0.625rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-primary);
+		color: var(--color-text-secondary);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		white-space: pre-wrap;
+		word-break: break-all;
+		margin: 0;
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/ServerWgBind.svelte
+++ b/frontend/src/lib/components/freeturn/ServerWgBind.svelte
@@ -15,9 +15,19 @@
 		onConnect: (addr: string) => void;
 		onPeerConf: (conf: string) => void;
 		clientListenPort?: number;
+		/** В простом режиме: применить сразу при выборе пира */
+		autoApply?: boolean;
+		/** Компактный вид без лишних рамок */
+		compact?: boolean;
 	}
 
-	let { onConnect, onPeerConf, clientListenPort = 9000 }: Props = $props();
+	let {
+		onConnect,
+		onPeerConf,
+		clientListenPort = 9000,
+		autoApply = false,
+		compact = false
+	}: Props = $props();
 
 	let snap: ServersSnapshot | null = $state(null);
 	let selected = $state('');
@@ -64,14 +74,28 @@
 			loading = false;
 		}
 	}
+
+	let lastAutoSelected = $state('');
+	$effect(() => {
+		if (!autoApply || !selected || selected === lastAutoSelected) return;
+		lastAutoSelected = selected;
+		void apply();
+	});
 </script>
 
-<div class="ft-wg-bind">
-	<div class="section-label">Привязка к WG-серверу</div>
+<div class="ft-wg-bind" class:ft-wg-compact={compact}>
+	{#if !compact}
+		<div class="section-label">Привязка к WG-серверу</div>
+	{/if}
 	<p class="ft-hint">
-		Выберите поднятый WG-сервер и пира — backend (-connect) заполнится как
-		<code>127.0.0.1:&lt;listenPort&gt;</code>, конфиг пира попадёт в генератор ссылки с Endpoint
-		<code>{endpointHint}</code> для клиента FreeTurn.
+		{#if compact}
+			Выберите поднятый WG-сервер и пира — адрес backend (-connect) заполнится как
+			<code>127.0.0.1:&lt;listenPort&gt;</code>, конфиг пира попадёт в ссылку для клиента.
+		{:else}
+			Выберите поднятый WG-сервер и пира — backend (-connect) заполнится как
+			<code>127.0.0.1:&lt;listenPort&gt;</code>, конфиг пира попадёт в генератор ссылки с Endpoint
+			<code>{endpointHint}</code> для клиента FreeTurn.
+		{/if}
 	</p>
 	<div class="ft-wg-row">
 		<Dropdown
@@ -79,21 +103,35 @@
 			bind:value={selected}
 			options={options}
 			placeholder={options.length ? 'Выберите…' : 'Нет поднятых WG-серверов с пирами'}
-			disabled={!options.length}
+			disabled={!options.length || loading}
 		/>
-		<Button variant="secondary" size="sm" loading={loading} disabled={!selected} onclick={apply}>
-			Применить
-		</Button>
+		{#if !autoApply}
+			<Button variant="secondary" size="sm" loading={loading} disabled={!selected} onclick={apply}>
+				Применить
+			</Button>
+		{/if}
 	</div>
-	<div class="ft-wg-port">
-		<Input
-			label="Endpoint клиента FreeTurn (порт)"
-			type="number"
-			value={String(endpointPort)}
-			onchange={(v) => (endpointPort = Number(v) || 9000)}
-		/>
-		<span class="ft-hint">Адрес: <code>127.0.0.1</code>, порт — listen клиента freeturn (вкладка «Клиент»)</span>
-	</div>
+	{#if compact}
+		<div class="ft-wg-port">
+			<Input
+				label="Endpoint клиента FreeTurn (порт)"
+				type="number"
+				value={String(endpointPort)}
+				onchange={(v) => (endpointPort = Number(v) || 9000)}
+			/>
+			<span class="ft-hint">Порт listen клиента freeturn (вкладка «Клиент»), адрес <code>127.0.0.1</code></span>
+		</div>
+	{:else}
+		<div class="ft-wg-port">
+			<Input
+				label="Endpoint клиента FreeTurn (порт)"
+				type="number"
+				value={String(endpointPort)}
+				onchange={(v) => (endpointPort = Number(v) || 9000)}
+			/>
+			<span class="ft-hint">Адрес: <code>127.0.0.1</code>, порт — listen клиента freeturn (вкладка «Клиент»)</span>
+		</div>
+	{/if}
 	{#if error}
 		<p class="ft-err">{error}</p>
 	{/if}
@@ -106,6 +144,13 @@
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius);
 		background: var(--color-bg-secondary);
+	}
+
+	.ft-wg-bind.ft-wg-compact {
+		margin-bottom: 0;
+		padding: 0;
+		border: none;
+		background: transparent;
 	}
 
 	.ft-wg-row {

--- a/frontend/src/lib/components/freeturn/captchaPrefs.ts
+++ b/frontend/src/lib/components/freeturn/captchaPrefs.ts
@@ -1,0 +1,19 @@
+const STORAGE_KEY = 'awg.freeturn.captchaAutoOpen';
+
+/** Whether to auto-open the captcha modal when freeturn needs manual captcha. Default: true. */
+export function readCaptchaAutoOpen(): boolean {
+	if (typeof localStorage === 'undefined') return true;
+	try {
+		return localStorage.getItem(STORAGE_KEY) !== '0';
+	} catch {
+		return true;
+	}
+}
+
+export function writeCaptchaAutoOpen(enabled: boolean): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, enabled ? '1' : '0');
+	} catch {
+		// private mode etc.
+	}
+}

--- a/frontend/src/lib/components/freeturn/obfHints.ts
+++ b/frontend/src/lib/components/freeturn/obfHints.ts
@@ -1,0 +1,12 @@
+export const obfProfileHints: Record<string, string> = {
+	none: 'Без маскировки — только для отладки',
+	rtpopus: 'Маскирует трафик под RTP/Opus (базовый профиль)',
+	rtpopus2: 'Рекомендуется — усиленная маскировка, хороший баланс',
+	rtpopus3: 'Максимальная маскировка, чуть больше накладных расходов'
+};
+
+export function randomObfKeyHex(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/frontend/src/lib/components/freeturn/options.ts
+++ b/frontend/src/lib/components/freeturn/options.ts
@@ -16,3 +16,10 @@ export const obfOptions = [
 	{ value: 'rtpopus2', label: 'rtpopus2' },
 	{ value: 'rtpopus3', label: 'rtpopus3' }
 ];
+
+/** Headless-браузер freeturn на роутере для авто-капчи VK (-browser). */
+export const browserOptions = [
+	{ value: 'firefox', label: 'Firefox' },
+	{ value: 'chrome', label: 'Chrome' },
+	{ value: 'safari', label: 'Safari' }
+];

--- a/frontend/src/lib/types/freeturn.ts
+++ b/frontend/src/lib/types/freeturn.ts
@@ -18,7 +18,7 @@ export interface FreeTurnClientConfig {
 	obfProfile: 'none' | 'rtpopus' | 'rtpopus2' | 'rtpopus3';
 	obfKey?: string;
 	streamsPerCred: number;
-	browser: 'chrome' | 'firefox';
+	browser: 'chrome' | 'firefox' | 'safari';
 	manualCaptcha: boolean;
 	dnsMode: 'plain' | 'doh' | 'auto';
 	dnsServers?: string;
@@ -62,6 +62,7 @@ export interface FreeTurnProcessStatus {
 	startedAt?: string;
 	lastError?: string;
 	log?: string;
+	dtlsConnections?: number;
 	binary: string;
 	binaryPresent: boolean;
 }
@@ -140,6 +141,32 @@ export interface FreeTurnAllowlistStatus {
 
 export interface FreeTurnAllowlistAddResult extends FreeTurnAllowlistStatus {
 	needsRestart?: boolean;
+}
+
+export interface FreeTurnCaptchaClientStatus {
+	clientId: string;
+	clientName: string;
+	waiting: boolean;
+	active: boolean;
+	queued: boolean;
+	canOpen: boolean;
+	url?: string;
+	pendingStreams?: number;
+	portContention?: boolean;
+	captchaSession?: number;
+}
+
+export interface FreeTurnCaptchaOverview {
+	portOpen: boolean;
+	ownerClientId?: string;
+	ownerName?: string;
+	clients: FreeTurnCaptchaClientStatus[];
+}
+
+export interface FreeTurnDeleteClientResult {
+	message?: string;
+	deletedTunnels?: string[];
+	tunnelErrors?: string[];
 }
 
 // #endregion

--- a/frontend/src/lib/types/tunnels.ts
+++ b/frontend/src/lib/types/tunnels.ts
@@ -84,6 +84,7 @@ export interface AWGTunnel {
 	connectivityCheck?: ConnectivityCheckConfig;
 	warnings?: string[];
 	backend?: 'nativewg' | 'kernel';
+	freeTurnClientId?: string;
 }
 
 export interface TunnelListItem {

--- a/frontend/src/lib/utils/serverPeerOptions.test.ts
+++ b/frontend/src/lib/utils/serverPeerOptions.test.ts
@@ -3,6 +3,8 @@ import {
   encodeServerPeerValue,
   decodeServerPeerValue,
   buildServerPeerDropdownOptions,
+  parseLocalListenPort,
+  patchWgConfEndpoint,
 } from './serverPeerOptions';
 import type { ServersSnapshot } from '$lib/stores/servers';
 import type { ManagedServer, WireguardServer } from '$lib/types';
@@ -98,5 +100,28 @@ describe('buildServerPeerDropdownOptions', () => {
     });
     const opt = buildServerPeerDropdownOptions(s)[0];
     expect(decodeServerPeerValue(opt.value).serverId).toBe('sys1');
+  });
+});
+
+describe('parseLocalListenPort', () => {
+  it('parses host:port and bare port', () => {
+    expect(parseLocalListenPort('127.0.0.1:9001')).toBe(9001);
+    expect(parseLocalListenPort('9002')).toBe(9002);
+    expect(parseLocalListenPort('')).toBeNull();
+    expect(parseLocalListenPort('bad')).toBeNull();
+  });
+});
+
+describe('patchWgConfEndpoint', () => {
+  it('replaces [Peer] Endpoint with local listen port', () => {
+    const conf = `[Interface]
+PrivateKey = x
+
+[Peer]
+PublicKey = y
+Endpoint = 127.0.0.1:9000
+AllowedIPs = 0.0.0.0/0`;
+    expect(patchWgConfEndpoint(conf, 9001)).toContain('Endpoint = 127.0.0.1:9001');
+    expect(patchWgConfEndpoint(conf, 9001)).not.toContain(':9000');
   });
 });

--- a/frontend/src/lib/utils/serverPeerOptions.ts
+++ b/frontend/src/lib/utils/serverPeerOptions.ts
@@ -118,6 +118,19 @@ export function wgEndpointHint(localPort: number): string {
 	return `127.0.0.1:${localPort}`;
 }
 
+/** Порт из freeturn -listen (127.0.0.1:9001 → 9001). */
+export function parseLocalListenPort(listen: string | undefined | null): number | null {
+	const raw = listen?.trim();
+	if (!raw) return null;
+	const m = raw.match(/:(\d+)$/);
+	if (m) {
+		const port = Number(m[1]);
+		return port > 0 && port <= 65535 ? port : null;
+	}
+	const port = Number(raw);
+	return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+}
+
 /** Подставляет локальный Endpoint в [Peer] секцию конфига клиента. */
 export function patchWgConfEndpoint(conf: string, localPort: number): string {
 	const host = '127.0.0.1';

--- a/frontend/src/routes/freeturn/captcha/+page.svelte
+++ b/frontend/src/routes/freeturn/captcha/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	onMount(() => {
+		goto('/?tab=freeturn&captcha=1', { replaceState: true });
+	});
+</script>

--- a/internal/api/freeturn.go
+++ b/internal/api/freeturn.go
@@ -10,6 +10,7 @@ import (
 	ndmsquery "github.com/hoaxisr/awg-manager/internal/ndms/query"
 	"github.com/hoaxisr/awg-manager/internal/freeturn"
 	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/testing"
 )
 
@@ -45,12 +46,18 @@ type FreeTurnService interface {
 	AddServerAllowlistClient(serverID, clientID, comment string) (freeturn.AddAllowlistResult, error)
 	RemoveServerAllowlistClient(serverID, clientID string) error
 	DisableServerAllowlist(serverID string) error
+	CaptchaStatus() freeturn.CaptchaOverview
+	CaptchaStatusForClient(id string) (freeturn.CaptchaClientStatus, bool)
 }
 
 // FreeTurnHandler exposes FreeTurnService over HTTP.
 type FreeTurnHandler struct {
 	svc     FreeTurnService
 	queries *ndmsquery.Queries
+
+	awgStore       *storage.AWGTunnelStore
+	tunnelSvc      TunnelService
+	tunnelsHandler *TunnelsHandler
 }
 
 func NewFreeTurnHandler(svc FreeTurnService) *FreeTurnHandler {
@@ -423,6 +430,8 @@ func (h *FreeTurnHandler) ServeClients(w http.ResponseWriter, r *http.Request) {
 		h.startClientInstance(w, r, id)
 	case len(sub) == 1 && sub[0] == "stop":
 		h.stopClientInstance(w, r, id)
+	case len(sub) >= 1 && sub[0] == "captcha":
+		h.serveClientCaptcha(w, r, id, sub[1:])
 	default:
 		response.ErrorWithStatus(w, http.StatusNotFound, "Not found", "NOT_FOUND")
 	}
@@ -501,7 +510,15 @@ func (h *FreeTurnHandler) serveClientByID(w http.ResponseWriter, r *http.Request
 			response.Error(w, err.Error(), "FREETURN_CLIENT_DELETE_FAILED")
 			return
 		}
-		response.Success(w, map[string]string{"message": "deleted"})
+		deletedTunnels, tunnelErrors := h.deleteLinkedAwgTunnels(r.Context(), id)
+		if h.tunnelsHandler != nil && len(deletedTunnels) > 0 {
+			h.tunnelsHandler.publishTunnelList(r.Context())
+		}
+		response.Success(w, map[string]any{
+			"message":        "deleted",
+			"deletedTunnels": deletedTunnels,
+			"tunnelErrors":   tunnelErrors,
+		})
 	default:
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
 	}

--- a/internal/api/freeturn.go
+++ b/internal/api/freeturn.go
@@ -82,6 +82,12 @@ type FreeTurnStatusResponse struct {
 	Data    freeturn.Status `json:"data"`
 }
 
+// FreeTurnCaptchaStatusResponse is the envelope for GET /api/freeturn/captcha/status.
+type FreeTurnCaptchaStatusResponse struct {
+	Success bool                     `json:"success" example:"true"`
+	Data    freeturn.CaptchaOverview `json:"data"`
+}
+
 // FreeTurnClientInstanceResponse is the envelope for a single client instance.
 type FreeTurnClientInstanceResponse struct {
 	Success bool                    `json:"success" example:"true"`

--- a/internal/api/freeturn_captcha.go
+++ b/internal/api/freeturn_captcha.go
@@ -11,6 +11,12 @@ import (
 )
 
 // GetCaptchaStatus handles GET /api/freeturn/captcha/status.
+//
+//	@Summary	Get FreeTurn VK captcha queue and per-client status
+//	@Tags		freeturn
+//	@Produce	json
+//	@Success	200	{object}	FreeTurnCaptchaStatusResponse
+//	@Router		/freeturn/captcha/status [get]
 func (h *FreeTurnHandler) GetCaptchaStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")

--- a/internal/api/freeturn_captcha.go
+++ b/internal/api/freeturn_captcha.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/freeturn"
+	"github.com/hoaxisr/awg-manager/internal/response"
+)
+
+// GetCaptchaStatus handles GET /api/freeturn/captcha/status.
+func (h *FreeTurnHandler) GetCaptchaStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
+		return
+	}
+	response.Success(w, h.svc.CaptchaStatus())
+}
+
+func (h *FreeTurnHandler) serveClientCaptcha(w http.ResponseWriter, r *http.Request, clientID string, sub []string) {
+	if len(sub) == 1 && sub[0] == "status" {
+		if r.Method != http.MethodGet {
+			response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
+			return
+		}
+		st, ok := h.svc.CaptchaStatusForClient(clientID)
+		if !ok {
+			response.ErrorWithStatus(w, http.StatusNotFound, "client not found", "NOT_FOUND")
+			return
+		}
+		response.Success(w, st)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet, http.MethodPost, http.MethodHead:
+	default:
+		response.ErrorWithStatus(w, http.StatusMethodNotAllowed, "Method not allowed", "METHOD_NOT_ALLOWED")
+		return
+	}
+
+	if !freeturn.CaptchaPortOpen() {
+		response.ErrorWithStatus(w, http.StatusServiceUnavailable, "captcha server is not active", "CAPTCHA_INACTIVE")
+		return
+	}
+
+	proxyBase := captchaProxyBase(r, clientID)
+
+	if len(sub) >= 1 && sub[0] == "generic_proxy" {
+		if freeturn.ShouldDelegateGenericProxyToFreeturn(r.URL.Query().Get("proxy_url")) {
+			// freeturn rewrites VK OAuth HTML/redirects for localhost:8765; reuse it.
+			proxy := freeturn.NewCaptchaReverseProxy(proxyBase, "/generic_proxy")
+			proxy.ServeHTTP(w, r)
+			return
+		}
+		freeturn.ServeCaptchaGenericProxy(w, r, proxyBase)
+		return
+	}
+
+	targetPath := "/"
+	if len(sub) > 0 {
+		targetPath = "/" + path.Join(sub...)
+	}
+	proxy := freeturn.NewCaptchaReverseProxy(proxyBase, targetPath)
+	proxy.ServeHTTP(w, r)
+}
+
+func captchaProxyBase(r *http.Request, clientID string) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+		parts := strings.Split(fwd, ",")
+		if proto := strings.TrimSpace(parts[0]); proto != "" {
+			scheme = proto
+		}
+	}
+	host := r.Host
+	if fwd := r.Header.Get("X-Forwarded-Host"); fwd != "" {
+		parts := strings.Split(fwd, ",")
+		if h := strings.TrimSpace(parts[0]); h != "" {
+			host = h
+		}
+	}
+	return scheme + "://" + host + "/api/freeturn/clients/" + url.PathEscape(clientID) + "/captcha"
+}

--- a/internal/api/freeturn_linked.go
+++ b/internal/api/freeturn_linked.go
@@ -44,6 +44,9 @@ func (h *FreeTurnHandler) deleteLinkedAwgTunnels(ctx context.Context, clientID s
 			errs = append(errs, fmt.Sprintf("%s (%s): %v", tun.Name, tun.ID, err))
 			continue
 		}
+		if h.tunnelsHandler != nil && h.tunnelsHandler.traffic != nil {
+			h.tunnelsHandler.traffic.Clear(tun.ID)
+		}
 		deleted = append(deleted, tun.ID)
 	}
 	return deleted, errs

--- a/internal/api/freeturn_linked.go
+++ b/internal/api/freeturn_linked.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// SetLinkedTunnelCleanup wires AWG tunnel store + service so deleting a
+// freeturn client also removes tunnels tagged with freeTurnClientId.
+func (h *FreeTurnHandler) SetLinkedTunnelCleanup(store *storage.AWGTunnelStore, svc TunnelService) {
+	h.awgStore = store
+	h.tunnelSvc = svc
+}
+
+// SetTunnelsHandler publishes tunnel list SSE after linked tunnel cleanup.
+func (h *FreeTurnHandler) SetTunnelsHandler(th *TunnelsHandler) {
+	h.tunnelsHandler = th
+}
+
+func tunnelLinkedToFreeTurnClient(tun storage.AWGTunnel, clientID string) bool {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return false
+	}
+	return strings.TrimSpace(tun.FreeTurnClientID) == clientID
+}
+
+func (h *FreeTurnHandler) deleteLinkedAwgTunnels(ctx context.Context, clientID string) (deleted []string, errs []string) {
+	if h.awgStore == nil || h.tunnelSvc == nil || strings.TrimSpace(clientID) == "" {
+		return nil, nil
+	}
+	tunnels, err := h.awgStore.List()
+	if err != nil {
+		return nil, []string{err.Error()}
+	}
+	for _, tun := range tunnels {
+		if !tunnelLinkedToFreeTurnClient(tun, clientID) {
+			continue
+		}
+		if err := h.tunnelSvc.Delete(ctx, tun.ID); err != nil {
+			errs = append(errs, fmt.Sprintf("%s (%s): %v", tun.Name, tun.ID, err))
+			continue
+		}
+		deleted = append(deleted, tun.ID)
+	}
+	return deleted, errs
+}

--- a/internal/api/freeturn_linked_test.go
+++ b/internal/api/freeturn_linked_test.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+func TestTunnelLinkedToFreeTurnClient(t *testing.T) {
+	tun := storage.AWGTunnel{ID: "awgm1", FreeTurnClientID: "client-a"}
+	if !tunnelLinkedToFreeTurnClient(tun, "client-a") {
+		t.Fatal("tagged tunnel must match its client id")
+	}
+	if tunnelLinkedToFreeTurnClient(tun, "client-b") {
+		t.Fatal("must not match another client id")
+	}
+	if tunnelLinkedToFreeTurnClient(storage.AWGTunnel{Peer: storage.AWGPeer{Endpoint: "127.0.0.1:9000"}}, "client-a") {
+		t.Fatal("manual tunnel without tag must not match")
+	}
+}

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
@@ -56,9 +57,10 @@ func (h *ImportHandler) SetTunnelsHandler(th *TunnelsHandler) {
 //	@Router			/import/conf [post]
 func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
 	req, ok := parseJSON[struct {
-		Content string `json:"content"`
-		Name    string `json:"name"`
-		Backend string `json:"backend"` // "nativewg" | "kernel" (default: "kernel")
+		Content          string `json:"content"`
+		Name             string `json:"name"`
+		Backend          string `json:"backend"` // "nativewg" | "kernel" (default: "kernel")
+		FreeTurnClientID string `json:"freeTurnClientId,omitempty"`
 	}](w, r, http.MethodPost)
 	if !ok {
 		return
@@ -76,7 +78,7 @@ func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Post-import defaults: PingCheck
+	// Post-import defaults: PingCheck + optional freeturn link tag
 	if stored, err := h.store.Get(tunnel.ID); err == nil {
 		changed := false
 		if h.pingCheck != nil && stored.PingCheck == nil {
@@ -91,6 +93,10 @@ func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
 				Timeout:       5,
 				Restart:       true,
 			}
+			changed = true
+		}
+		if id := strings.TrimSpace(req.FreeTurnClientID); id != "" {
+			stored.FreeTurnClientID = id
 			changed = true
 		}
 		if changed {

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -44,24 +44,28 @@ func (h *ImportHandler) SetTunnelsHandler(th *TunnelsHandler) {
 	h.tunnelsHandler = th
 }
 
+// ImportConfRequest is the body for POST /import/conf.
+type ImportConfRequest struct {
+	Content          string `json:"content"`
+	Name             string `json:"name"`
+	Backend          string `json:"backend"` // "nativewg" | "kernel" (default: "kernel")
+	FreeTurnClientID string `json:"freeTurnClientId,omitempty"`
+}
+
 // ImportConf imports a WireGuard/AmneziaWG config file.
 //
 //	@Summary		Import tunnel config
 //	@Tags			import
 //	@Accept			json
 //	@Produce		json
+//	@Param			body	body		ImportConfRequest	true	"Config content and optional metadata"
 //	@Security		CookieAuth
 //	@Success		200	{object}	APIEnvelope
 //	@Failure		400	{object}	APIErrorEnvelope
 //	@Failure		500	{object}	APIErrorEnvelope
 //	@Router			/import/conf [post]
 func (h *ImportHandler) ImportConf(w http.ResponseWriter, r *http.Request) {
-	req, ok := parseJSON[struct {
-		Content          string `json:"content"`
-		Name             string `json:"name"`
-		Backend          string `json:"backend"` // "nativewg" | "kernel" (default: "kernel")
-		FreeTurnClientID string `json:"freeTurnClientId,omitempty"`
-	}](w, r, http.MethodPost)
+	req, ok := parseJSON[ImportConfRequest](w, r, http.MethodPost)
 	if !ok {
 		return
 	}

--- a/internal/freeturn/captcha.go
+++ b/internal/freeturn/captcha.go
@@ -1,0 +1,207 @@
+package freeturn
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const DefaultCaptchaPort = 8765
+
+// CaptchaClientStatus describes captcha state for one freeturn-client instance.
+type CaptchaClientStatus struct {
+	ClientID   string `json:"clientId"`
+	ClientName string `json:"clientName"`
+	// Waiting: client log indicates manual captcha is required (auto failed or -manual-captcha).
+	Waiting bool `json:"waiting"`
+	// Active: this client's process currently owns the local captcha HTTP server (:8765).
+	Active bool `json:"active"`
+	// Queued: waiting but another client holds :8765 — solve the active one first.
+	Queued bool `json:"queued"`
+	// CanOpen: UI may open the proxied captcha page for this client.
+	CanOpen bool   `json:"canOpen"`
+	URL     string `json:"url,omitempty"`
+	// PendingStreams: VK-auth streams in this client still waiting on manual captcha.
+	PendingStreams int `json:"pendingStreams,omitempty"`
+	// PortContention: manual captcha port :8765 is busy with another stream's session.
+	PortContention bool `json:"portContention,omitempty"`
+	// CaptchaSession: manual captcha (re)starts in this process run — bump to reload iframe.
+	CaptchaSession int `json:"captchaSession,omitempty"`
+}
+
+// CaptchaOverview aggregates captcha state across all client instances.
+type CaptchaOverview struct {
+	PortOpen      bool                  `json:"portOpen"`
+	OwnerClientID string                `json:"ownerClientId,omitempty"`
+	OwnerName     string                `json:"ownerName,omitempty"`
+	Clients       []CaptchaClientStatus `json:"clients"`
+}
+
+var captchaLogMarkers = []string{
+	"MANUAL CAPTCHA SOLVING NEEDED",
+	"Triggering manual captcha fallback",
+	"ACTION REQUIRED: MANUAL CAPTCHA",
+}
+
+// Lines after a captcha marker that mean the challenge was solved and the client moved on.
+var captchaResolvedMarkers = []string{
+	"[Captcha] received success token from browser",
+	"Established DTLS connection",
+}
+
+// logIndicatesCaptchaWaiting reports whether recent process output shows that
+// manual captcha solving is in progress. Only the tail is checked so an old
+// captcha banner from a previous run does not keep the UI open forever.
+// If a captcha marker is followed by a resolved marker (token received, DTLS
+// up), the client is no longer waiting even though the marker remains in log.
+func logIndicatesCaptchaWaiting(log string) bool {
+	if log == "" {
+		return false
+	}
+	if summary := analyzeCaptchaLog(log); summary.PendingStreams > 0 {
+		return true
+	}
+	lines := captchaLogTailLines(log, 40)
+	lastMarker := -1
+	for i, line := range lines {
+		for _, marker := range captchaLogMarkers {
+			if strings.Contains(line, marker) {
+				lastMarker = i
+			}
+		}
+	}
+	if lastMarker < 0 {
+		return false
+	}
+	for _, line := range lines[lastMarker+1:] {
+		for _, resolved := range captchaResolvedMarkers {
+			if strings.Contains(line, resolved) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func captchaLogTailLines(log string, maxLines int) []string {
+	lines := strings.Split(strings.TrimSpace(log), "\n")
+	if maxLines <= 0 || len(lines) <= maxLines {
+		return lines
+	}
+	return lines[len(lines)-maxLines:]
+}
+
+func captchaProxyPath(clientID string) string {
+	return "/api/freeturn/clients/" + url.PathEscape(clientID) + "/captcha/"
+}
+
+// CaptchaStatus inspects running client processes, logs and the shared captcha
+// listen port (8765 — hardcoded in upstream free-turn-proxy).
+func (s *Service) CaptchaStatus() CaptchaOverview {
+	cfg, err := s.store.Load()
+	if err != nil {
+		cfg = DefaultConfig()
+	}
+
+	candidatePIDs := make([]int, 0, len(cfg.Clients))
+	clientStatuses := make([]ProcessStatus, 0, len(cfg.Clients))
+	for _, inst := range cfg.Clients {
+		st := s.clientProcs.get(inst.ID).Status()
+		clientStatuses = append(clientStatuses, st)
+		if st.Running && st.PID != 0 {
+			candidatePIDs = append(candidatePIDs, st.PID)
+		}
+	}
+
+	ownerPID, portOpen := captchaListenerPIDAmong(candidatePIDs)
+
+	out := CaptchaOverview{
+		PortOpen: portOpen,
+		Clients:  make([]CaptchaClientStatus, 0, len(cfg.Clients)),
+	}
+
+	waitingIDs := make([]string, 0, len(cfg.Clients))
+	for i, inst := range cfg.Clients {
+		st := clientStatuses[i]
+		captchaSummary := analyzeCaptchaLog(st.Log)
+		waiting := st.Running && logIndicatesCaptchaWaiting(st.Log)
+		active := portOpen && st.Running && st.PID != 0 && st.PID == ownerPID
+
+		if active {
+			out.OwnerClientID = inst.ID
+			out.OwnerName = inst.Name
+		}
+		if waiting {
+			waitingIDs = append(waitingIDs, inst.ID)
+		}
+
+		out.Clients = append(out.Clients, CaptchaClientStatus{
+			ClientID:       inst.ID,
+			ClientName:     inst.Name,
+			Waiting:        waiting,
+			Active:         active,
+			PendingStreams: captchaSummary.PendingStreams,
+			PortContention: captchaSummary.PortContention,
+			CaptchaSession: captchaSummary.CaptchaSession,
+		})
+	}
+
+	multipleWaiting := len(waitingIDs) > 1
+	for i := range out.Clients {
+		c := &out.Clients[i]
+		switch {
+		case !portOpen || !c.Waiting:
+			continue
+		case c.Active:
+			c.CanOpen = true
+			c.URL = captchaProxyPath(c.ClientID)
+		case multipleWaiting && out.OwnerClientID != "" && out.OwnerClientID != c.ClientID:
+			c.Queued = true
+		default:
+			// Single waiting client, or owner PID could not be resolved.
+			c.CanOpen = true
+			c.URL = captchaProxyPath(c.ClientID)
+		}
+	}
+
+	return out
+}
+
+// CaptchaStatusForClient returns one client's slice of CaptchaOverview.
+func (s *Service) CaptchaStatusForClient(id string) (CaptchaClientStatus, bool) {
+	all := s.CaptchaStatus()
+	for _, c := range all.Clients {
+		if c.ClientID == id {
+			return c, true
+		}
+	}
+	return CaptchaClientStatus{}, false
+}
+
+// CaptchaPortOpen is a cheap probe used before proxying.
+func CaptchaPortOpen() bool {
+	_, ok := captchaListenerPIDAmong(nil)
+	return ok
+}
+
+func captchaListenerPIDAmong(candidatePIDs []int) (int, bool) {
+	return socketListenerPIDAmong("127.0.0.1", DefaultCaptchaPort, candidatePIDs)
+}
+
+func captchaListenerPID(port int) (int, bool) {
+	if port != DefaultCaptchaPort {
+		return socketListenerPID("127.0.0.1", port)
+	}
+	return captchaListenerPIDAmong(nil)
+}
+
+// OwnerHint builds a short user-facing queue message.
+func (o CaptchaOverview) OwnerHint() string {
+	if o.OwnerName != "" {
+		return fmt.Sprintf("Сначала решите капчу для «%s»", o.OwnerName)
+	}
+	if o.OwnerClientID != "" {
+		return fmt.Sprintf("Сначала решите капчу для клиента %s", o.OwnerClientID)
+	}
+	return ""
+}

--- a/internal/freeturn/captcha.go
+++ b/internal/freeturn/captcha.go
@@ -1,7 +1,6 @@
 package freeturn
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -186,22 +185,4 @@ func CaptchaPortOpen() bool {
 
 func captchaListenerPIDAmong(candidatePIDs []int) (int, bool) {
 	return socketListenerPIDAmong("127.0.0.1", DefaultCaptchaPort, candidatePIDs)
-}
-
-func captchaListenerPID(port int) (int, bool) {
-	if port != DefaultCaptchaPort {
-		return socketListenerPID("127.0.0.1", port)
-	}
-	return captchaListenerPIDAmong(nil)
-}
-
-// OwnerHint builds a short user-facing queue message.
-func (o CaptchaOverview) OwnerHint() string {
-	if o.OwnerName != "" {
-		return fmt.Sprintf("Сначала решите капчу для «%s»", o.OwnerName)
-	}
-	if o.OwnerClientID != "" {
-		return fmt.Sprintf("Сначала решите капчу для клиента %s", o.OwnerClientID)
-	}
-	return ""
 }

--- a/internal/freeturn/captcha_crypto_shim.js
+++ b/internal/freeturn/captcha_crypto_shim.js
@@ -1,0 +1,99 @@
+// VK Smart Captcha PoW needs crypto.subtle.digest, which browsers block outside
+// secure contexts (HTTPS or localhost). awg-manager is often opened via
+// http://192.168.x.x — inject this shim into proxied captcha HTML.
+(function () {
+	'use strict';
+	var c = globalThis.crypto;
+	if (!c) {
+		c = {};
+		globalThis.crypto = c;
+	}
+	if (c.subtle && typeof c.subtle.digest === 'function') return;
+
+	function rotr(n, x) {
+		return (x >>> n) | (x << (32 - n));
+	}
+
+	function sha256(msg) {
+		var K = [
+			0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+			0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+			0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+			0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+			0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+			0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+			0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+			0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+		];
+		var H = [
+			0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+		];
+		var i;
+		var bitLen = msg.length * 8;
+		var withLen = new Uint8Array(((msg.length + 9 + 63) >> 6) << 6);
+		withLen.set(msg);
+		withLen[msg.length] = 0x80;
+		var view = new DataView(withLen.buffer);
+		view.setUint32(withLen.length - 4, bitLen, false);
+
+		for (var off = 0; off < withLen.length; off += 64) {
+			var w = new Uint32Array(64);
+			for (i = 0; i < 16; i++) w[i] = view.getUint32(off + i * 4, false);
+			for (i = 16; i < 64; i++) {
+				var s0 = rotr(7, w[i - 15]) ^ rotr(18, w[i - 15]) ^ (w[i - 15] >>> 3);
+				var s1 = rotr(17, w[i - 2]) ^ rotr(19, w[i - 2]) ^ (w[i - 2] >>> 10);
+				w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+			}
+			var a = H[0],
+				b = H[1],
+				c2 = H[2],
+				d = H[3],
+				e = H[4],
+				f = H[5],
+				g = H[6],
+				h = H[7];
+			for (i = 0; i < 64; i++) {
+				var S1 = rotr(6, e) ^ rotr(11, e) ^ rotr(25, e);
+				var ch = (e & f) ^ (~e & g);
+				var t1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+				var S0 = rotr(2, a) ^ rotr(13, a) ^ rotr(22, a);
+				var maj = (a & b) ^ (a & c2) ^ (b & c2);
+				var t2 = (S0 + maj) >>> 0;
+				h = g;
+				g = f;
+				f = e;
+				e = (d + t1) >>> 0;
+				d = c2;
+				c2 = b;
+				b = a;
+				a = (t1 + t2) >>> 0;
+			}
+			H[0] = (H[0] + a) >>> 0;
+			H[1] = (H[1] + b) >>> 0;
+			H[2] = (H[2] + c2) >>> 0;
+			H[3] = (H[3] + d) >>> 0;
+			H[4] = (H[4] + e) >>> 0;
+			H[5] = (H[5] + f) >>> 0;
+			H[6] = (H[6] + g) >>> 0;
+			H[7] = (H[7] + h) >>> 0;
+		}
+		var out = new Uint8Array(32);
+		var outView = new DataView(out.buffer);
+		for (i = 0; i < 8; i++) outView.setUint32(i * 4, H[i], false);
+		return out;
+	}
+
+	c.subtle = {
+		digest: function (algorithm, data) {
+			var name = typeof algorithm === 'string' ? algorithm : algorithm && algorithm.name;
+			if (name !== 'SHA-256') {
+				return Promise.reject(new Error('Only SHA-256 is supported by captcha shim'));
+			}
+			var u8 =
+				data instanceof ArrayBuffer
+					? new Uint8Array(data)
+					: new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+			return Promise.resolve(sha256(u8).buffer);
+		}
+	};
+})();

--- a/internal/freeturn/captcha_generic_proxy.go
+++ b/internal/freeturn/captcha_generic_proxy.go
@@ -1,0 +1,157 @@
+package freeturn
+
+import (
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Captcha proxy hosts allowed when awg-manager handles /generic_proxy directly.
+var captchaGenericProxyHosts = []string{
+	".vk.com", ".vk.ru", ".vkontakte.ru",
+	".userapi.com", ".okcdn.ru", ".mycdn.me",
+	".api.vk.com", ".api.vk.ru",
+	".id.vk.ru", ".id.vk.com",
+	".appteka.ru", ".apptracer.ru",
+	".vkuser.net", ".vk-cdn.net",
+}
+
+// ServeCaptchaGenericProxy handles GET/POST .../captcha/generic_proxy?proxy_url=...
+// For VK OAuth hosts it delegates to freeturn's own :8765 generic_proxy so HTML
+// rewriting and login redirects stay in the freeturn funnel. Extended allowlist
+// hosts (appteka.ru) are fetched directly here.
+func ServeCaptchaGenericProxy(w http.ResponseWriter, r *http.Request, proxyBase string) {
+	targetRaw := r.URL.Query().Get("proxy_url")
+	target, err := url.Parse(targetRaw)
+	if err != nil || target.Host == "" || target.Scheme == "" {
+		http.Error(w, "Bad URL", http.StatusBadRequest)
+		return
+	}
+	if !isAllowedCaptchaGenericHost(target.Hostname()) {
+		http.Error(w, "Forbidden host", http.StatusForbidden)
+		return
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Transport: http.DefaultTransport,
+		Rewrite: func(req *httputil.ProxyRequest) {
+			out := req.Out
+			out.URL = target
+			out.Host = target.Host
+			rewriteGenericProxyHeaders(out, target, proxyBase)
+		},
+		ModifyResponse: func(res *http.Response) error {
+			stripGenericProxyResponseHeaders(res.Header)
+			rewriteCaptchaResponseHeaders(res.Header, proxyBase)
+
+			ct := res.Header.Get("Content-Type")
+			if !shouldRewriteCaptchaContentType(ct) {
+				return nil
+			}
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			_ = res.Body.Close()
+			rewritten := rewriteLocalCaptchaURLsPreserveRedirectURI(string(body), proxyBase)
+			rewritten = injectCaptchaNavShim(rewritten, proxyBase)
+			rewritten = injectCaptchaCryptoShim(rewritten)
+			res.Body = io.NopCloser(strings.NewReader(rewritten))
+			res.ContentLength = int64(len(rewritten))
+			res.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+			res.Header.Del("Content-Encoding")
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			http.Error(w, "captcha proxy error: "+err.Error(), http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func isAllowedCaptchaGenericHost(hostname string) bool {
+	host := strings.ToLower(hostname)
+	for _, suffix := range captchaGenericProxyHosts {
+		s := strings.TrimPrefix(suffix, ".")
+		if host == s || strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func rewriteGenericProxyHeaders(req *http.Request, target *url.URL, proxyBase string) {
+	targetOrigin := target.Scheme + "://" + target.Host
+	base := strings.TrimSuffix(proxyBase, "/")
+
+	for _, h := range []string{
+		"Accept-Encoding",
+		"X-Requested-With",
+		"X-Android-Package",
+		"X-Android-Cert",
+	} {
+		req.Header.Del(h)
+	}
+
+	for _, headerName := range []string{"Origin", "Referer"} {
+		val := req.Header.Get(headerName)
+		if val == "" {
+			continue
+		}
+		if strings.HasPrefix(val, base) || strings.HasPrefix(val, captchaUpstream) ||
+			strings.HasPrefix(val, "http://localhost:") || strings.HasPrefix(val, "http://127.0.0.1:") {
+			if headerName == "Origin" {
+				req.Header.Set("Origin", targetOrigin)
+			} else {
+				req.Header.Set("Referer", targetOrigin+"/")
+			}
+			continue
+		}
+	}
+	if o := req.Header.Get("Origin"); o != "" && !strings.EqualFold(o, targetOrigin) {
+		// Browser may still send awg-manager origin on XHR; VK expects target origin.
+		if strings.Contains(o, "/api/freeturn/clients/") {
+			req.Header.Set("Origin", targetOrigin)
+		}
+	}
+}
+
+func stripGenericProxyResponseHeaders(h http.Header) {
+	for _, name := range []string{
+		"Content-Security-Policy",
+		"Content-Security-Policy-Report-Only",
+		"X-Content-Security-Policy",
+		"X-WebKit-CSP",
+		"Cross-Origin-Opener-Policy",
+		"Cross-Origin-Embedder-Policy",
+		"Cross-Origin-Resource-Policy",
+		"X-Frame-Options",
+		"Strict-Transport-Security",
+	} {
+		h.Del(name)
+	}
+	h.Set("Access-Control-Allow-Origin", "*")
+	normalizeCaptchaSetCookies(h)
+}
+
+func normalizeCaptchaSetCookies(h http.Header) {
+	cookies := (&http.Response{Header: h}).Cookies()
+	if len(cookies) == 0 {
+		return
+	}
+	h.Del("Set-Cookie")
+	for _, c := range cookies {
+		c.Domain = ""
+		c.Secure = false
+		if c.SameSite == http.SameSiteNoneMode || c.SameSite == http.SameSiteStrictMode {
+			c.SameSite = http.SameSiteLaxMode
+		}
+		h.Add("Set-Cookie", c.String())
+	}
+}
+
+// DrainAndClose is used in tests.
+func DrainAndClose(r io.ReadCloser) { _ = r.Close() }

--- a/internal/freeturn/captcha_generic_proxy.go
+++ b/internal/freeturn/captcha_generic_proxy.go
@@ -152,6 +152,3 @@ func normalizeCaptchaSetCookies(h http.Header) {
 		h.Add("Set-Cookie", c.String())
 	}
 }
-
-// DrainAndClose is used in tests.
-func DrainAndClose(r io.ReadCloser) { _ = r.Close() }

--- a/internal/freeturn/captcha_linux.go
+++ b/internal/freeturn/captcha_linux.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+package freeturn
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const captchaPortCacheTTL = 3 * time.Second
+
+var captchaPortCache struct {
+	mu      sync.Mutex
+	until   time.Time
+	port    int
+	open    bool
+	owner   int
+	pidsKey string
+}
+
+// socketListenerPID returns the PID of a process listening on host:port, or false.
+func socketListenerPID(host string, port int) (int, bool) {
+	return socketListenerPIDAmong(host, port, nil)
+}
+
+// socketListenerPIDAmong resolves the listener PID by scanning only candidatePIDs
+// when provided. Falls back to a full /proc scan only if the port is open but
+// none of the candidates own it (rare).
+func socketListenerPIDAmong(host string, port int, candidatePIDs []int) (int, bool) {
+	key := pidsCacheKey(candidatePIDs)
+	if pid, open, ok := captchaPortCacheGet(port, key); ok {
+		return pid, open
+	}
+
+	inodes := listenerInodes(host, port)
+	if len(inodes) == 0 {
+		captchaPortCacheSet(port, key, 0, false)
+		return 0, false
+	}
+
+	for _, pid := range candidatePIDs {
+		if pid <= 0 {
+			continue
+		}
+		if pidOwnsInodes(pid, inodes) {
+			captchaPortCacheSet(port, key, pid, true)
+			return pid, true
+		}
+	}
+
+	if len(candidatePIDs) == 0 {
+		pid, ok := findListenerPIDByInodes(inodes)
+		captchaPortCacheSet(port, key, pid, ok)
+		return pid, ok
+	}
+
+	// Port is open but not owned by a known freeturn client PID.
+	captchaPortCacheSet(port, key, 0, true)
+	return 0, true
+}
+
+func listenerInodes(host string, port int) map[string]struct{} {
+	wantPort := fmt.Sprintf("%04X", port)
+	wantAddr4 := ipv4Hex(host) + ":" + wantPort
+	out := make(map[string]struct{})
+	for _, procFile := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		collectListenerInodes(procFile, wantAddr4, out)
+	}
+	return out
+}
+
+func findListenerPIDByInodes(inodes map[string]struct{}) (int, bool) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, false
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(ent.Name())
+		if err != nil {
+			continue
+		}
+		if pidOwnsInodes(pid, inodes) {
+			return pid, true
+		}
+	}
+	return 0, false
+}
+
+func pidOwnsInodes(pid int, inodes map[string]struct{}) bool {
+	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	fds, err := os.ReadDir(fdDir)
+	if err != nil {
+		return false
+	}
+	for _, fd := range fds {
+		link, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(link, "socket:[") {
+			continue
+		}
+		inode := strings.TrimSuffix(strings.TrimPrefix(link, "socket:["), "]")
+		if _, ok := inodes[inode]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func pidsCacheKey(pids []int) string {
+	if len(pids) == 0 {
+		return ""
+	}
+	b := strings.Builder{}
+	for i, pid := range pids {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(pid))
+	}
+	return b.String()
+}
+
+func captchaPortCacheGet(port int, pidsKey string) (pid int, open bool, ok bool) {
+	captchaPortCache.mu.Lock()
+	defer captchaPortCache.mu.Unlock()
+	if time.Now().Before(captchaPortCache.until) && captchaPortCache.port == port && captchaPortCache.pidsKey == pidsKey {
+		return captchaPortCache.owner, captchaPortCache.open, true
+	}
+	return 0, false, false
+}
+
+func captchaPortCacheSet(port int, pidsKey string, owner int, open bool) {
+	captchaPortCache.mu.Lock()
+	defer captchaPortCache.mu.Unlock()
+	captchaPortCache.port = port
+	captchaPortCache.pidsKey = pidsKey
+	captchaPortCache.owner = owner
+	captchaPortCache.open = open
+	captchaPortCache.until = time.Now().Add(captchaPortCacheTTL)
+}
+
+func collectListenerInodes(procFile, wantAddr4 string, out map[string]struct{}) {
+	f, err := os.Open(procFile)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Scan() // skip header
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 10 {
+			continue
+		}
+		local := fields[1]
+		state := fields[3]
+		// 0A = TCP_LISTEN
+		if state != "0A" {
+			continue
+		}
+		if local == wantAddr4 {
+			out[fields[9]] = struct{}{}
+		}
+	}
+}
+
+func ipv4Hex(host string) string {
+	switch host {
+	case "127.0.0.1", "localhost":
+		return "0100007F"
+	default:
+		parts := strings.Split(host, ".")
+		if len(parts) != 4 {
+			return ""
+		}
+		var b [4]byte
+		for i, p := range parts {
+			n, err := strconv.Atoi(p)
+			if err != nil || n < 0 || n > 255 {
+				return ""
+			}
+			b[i] = byte(n)
+		}
+		return fmt.Sprintf("%02X%02X%02X%02X", b[3], b[2], b[1], b[0])
+	}
+}

--- a/internal/freeturn/captcha_linux.go
+++ b/internal/freeturn/captcha_linux.go
@@ -24,11 +24,6 @@ var captchaPortCache struct {
 	pidsKey string
 }
 
-// socketListenerPID returns the PID of a process listening on host:port, or false.
-func socketListenerPID(host string, port int) (int, bool) {
-	return socketListenerPIDAmong(host, port, nil)
-}
-
 // socketListenerPIDAmong resolves the listener PID by scanning only candidatePIDs
 // when provided. Falls back to a full /proc scan only if the port is open but
 // none of the candidates own it (rare).
@@ -67,10 +62,13 @@ func socketListenerPIDAmong(host string, port int, candidatePIDs []int) (int, bo
 
 func listenerInodes(host string, port int) map[string]struct{} {
 	wantPort := fmt.Sprintf("%04X", port)
-	wantAddr4 := ipv4Hex(host) + ":" + wantPort
+	wantAddrs := make(map[string]struct{})
+	for _, hex := range ipv4HexForms(host) {
+		wantAddrs[hex+":"+wantPort] = struct{}{}
+	}
 	out := make(map[string]struct{})
 	for _, procFile := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
-		collectListenerInodes(procFile, wantAddr4, out)
+		collectListenerInodes(procFile, wantAddrs, out)
 	}
 	return out
 }
@@ -150,7 +148,7 @@ func captchaPortCacheSet(port int, pidsKey string, owner int, open bool) {
 	captchaPortCache.until = time.Now().Add(captchaPortCacheTTL)
 }
 
-func collectListenerInodes(procFile, wantAddr4 string, out map[string]struct{}) {
+func collectListenerInodes(procFile string, wantAddrs map[string]struct{}, out map[string]struct{}) {
 	f, err := os.Open(procFile)
 	if err != nil {
 		return
@@ -170,29 +168,33 @@ func collectListenerInodes(procFile, wantAddr4 string, out map[string]struct{}) 
 		if state != "0A" {
 			continue
 		}
-		if local == wantAddr4 {
+		if _, ok := wantAddrs[local]; ok {
 			out[fields[9]] = struct{}{}
 		}
 	}
 }
 
-func ipv4Hex(host string) string {
-	switch host {
-	case "127.0.0.1", "localhost":
-		return "0100007F"
-	default:
-		parts := strings.Split(host, ".")
-		if len(parts) != 4 {
-			return ""
+// ipv4HexForms returns both /proc/net/tcp representations of an IPv4 address:
+// the kernel prints the raw __be32 with %08X, so little-endian hosts (mipsel,
+// aarch64) show 127.0.0.1 as 0100007F while big-endian mips shows 7F000001.
+func ipv4HexForms(host string) []string {
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) != 4 {
+		return nil
+	}
+	var b [4]byte
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return nil
 		}
-		var b [4]byte
-		for i, p := range parts {
-			n, err := strconv.Atoi(p)
-			if err != nil || n < 0 || n > 255 {
-				return ""
-			}
-			b[i] = byte(n)
-		}
-		return fmt.Sprintf("%02X%02X%02X%02X", b[3], b[2], b[1], b[0])
+		b[i] = byte(n)
+	}
+	return []string{
+		fmt.Sprintf("%02X%02X%02X%02X", b[3], b[2], b[1], b[0]),
+		fmt.Sprintf("%02X%02X%02X%02X", b[0], b[1], b[2], b[3]),
 	}
 }

--- a/internal/freeturn/captcha_log.go
+++ b/internal/freeturn/captcha_log.go
@@ -1,0 +1,77 @@
+package freeturn
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CaptchaLogSummary is derived from freeturn-client stderr for UI hints.
+type CaptchaLogSummary struct {
+	// PendingStreams: VK-auth streams that still need manual captcha or retry.
+	PendingStreams int `json:"pendingStreams,omitempty"`
+	// PortContention: another stream already holds :8765 (bind: address already in use).
+	PortContention bool `json:"portContention,omitempty"`
+	// CaptchaSession: how many times manual captcha was triggered this run (iframe reload key).
+	CaptchaSession int `json:"captchaSession,omitempty"`
+}
+
+var captchaPortBusyMarkers = []string{
+	"address already in use",
+}
+
+var captchaStreamPendingMarkers = []string{
+	"Triggering manual captcha fallback",
+	"CAPTCHA_WAIT_REQUIRED",
+	"manual captcha failed",
+	"Falling back to manual captcha",
+}
+
+var captchaStreamResolvedMarkers = []string{
+	"Got token from browser",
+	"Established DTLS connection",
+}
+
+// analyzeCaptchaLog inspects process output for multi-stream manual captcha state.
+func analyzeCaptchaLog(log string) CaptchaLogSummary {
+	if log == "" {
+		return CaptchaLogSummary{}
+	}
+	pending := make(map[int]struct{})
+	out := CaptchaLogSummary{}
+
+	for _, line := range strings.Split(log, "\n") {
+		if strings.Contains(line, "Triggering manual captcha fallback") {
+			out.CaptchaSession++
+		}
+		if lineMatchesAny(line, captchaPortBusyMarkers) && strings.Contains(line, "8765") {
+			out.PortContention = true
+		}
+
+		streamID := parseFreeturnStreamID(line)
+		if streamID <= 0 {
+			continue
+		}
+
+		switch {
+		case lineMatchesAny(line, captchaStreamResolvedMarkers):
+			delete(pending, streamID)
+		case lineMatchesAny(line, captchaStreamPendingMarkers):
+			pending[streamID] = struct{}{}
+		}
+	}
+
+	out.PendingStreams = len(pending)
+	return out
+}
+
+func parseFreeturnStreamID(line string) int {
+	m := freeturnStreamLineRE.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return 0
+	}
+	id, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return id
+}

--- a/internal/freeturn/captcha_log_test.go
+++ b/internal/freeturn/captcha_log_test.go
@@ -1,0 +1,33 @@
+package freeturn
+
+import "testing"
+
+func TestAnalyzeCaptchaLog_multiStreamContention(t *testing.T) {
+	log := `
+2026/07/22 10:43:48 [INFO] [STREAM 1] [Captcha] Triggering manual captcha fallback
+2026/07/22 10:43:50 [INFO] [Captcha] received success token from browser (1236 bytes)
+2026/07/22 10:43:50 [INFO] [STREAM 1] [Captcha] Got token from browser
+2026/07/22 10:43:51 [INFO] [STREAM 1] Established DTLS connection
+2026/07/22 10:43:53 [INFO] [STREAM 10] [Captcha] Triggering manual captcha fallback
+2026/07/22 10:43:53 [INFO] [STREAM 3] [Captcha] Triggering manual captcha fallback
+2026/07/22 10:43:53 [WARN] [STREAM 3] [Captcha] Manual solver error: captcha listeners failed: 127.0.0.1:8765 (listen tcp 127.0.0.1:8765: bind: address already in use)
+2026/07/22 10:43:53 [WARN] [STREAM 3] [Captcha] manual captcha failed (attempt 2): captcha listeners failed: 127.0.0.1:8765 (listen tcp 127.0.0.1:8765: bind: address already in use)
+2026/07/22 10:43:53 [WARN] [STREAM 3] [VK Auth] Failed with client_id=6287487: provider backoff active
+CAPTCHA_WAIT_REQUIRED
+2026/07/22 10:43:53 [INFO] [STREAM 9] [Captcha] Triggering manual captcha fallback
+2026/07/22 10:43:53 [WARN] [STREAM 9] [Captcha] manual captcha failed (attempt 2): captcha listeners failed: 127.0.0.1:8765 (listen tcp 127.0.0.1:8765: bind: address already in use)
+2026/07/22 10:44:00 [INFO] [Captcha] received success token from browser (1240 bytes)
+2026/07/22 10:44:00 [INFO] [STREAM 10] [Captcha] Got token from browser
+2026/07/22 10:44:01 [INFO] [STREAM 40] Established DTLS connection
+`
+	summary := analyzeCaptchaLog(log)
+	if !summary.PortContention {
+		t.Fatal("expected port contention")
+	}
+	if summary.PendingStreams != 2 {
+		t.Fatalf("pending = %d, want 2 (streams 3 and 9)", summary.PendingStreams)
+	}
+	if !logIndicatesCaptchaWaiting(log) {
+		t.Fatal("log should still indicate captcha waiting")
+	}
+}

--- a/internal/freeturn/captcha_other.go
+++ b/internal/freeturn/captcha_other.go
@@ -10,9 +10,9 @@ import (
 
 const captchaDialProbe = 200 * time.Millisecond
 
-// socketListenerPID is only implemented on Linux (production routers).
+// socketListenerPIDAmong is only implemented on Linux (production routers).
 // Dev builds on Windows/macOS fall back to a dial probe without PID attribution.
-func socketListenerPID(host string, port int) (int, bool) {
+func socketListenerPIDAmong(host string, port int, _ []int) (int, bool) {
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), captchaDialProbe)
 	if err != nil {
 		return 0, false

--- a/internal/freeturn/captcha_other.go
+++ b/internal/freeturn/captcha_other.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package freeturn
+
+import (
+	"net"
+	"strconv"
+	"time"
+)
+
+const captchaDialProbe = 200 * time.Millisecond
+
+// socketListenerPID is only implemented on Linux (production routers).
+// Dev builds on Windows/macOS fall back to a dial probe without PID attribution.
+func socketListenerPID(host string, port int) (int, bool) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), captchaDialProbe)
+	if err != nil {
+		return 0, false
+	}
+	_ = conn.Close()
+	return 0, true
+}

--- a/internal/freeturn/captcha_proxy.go
+++ b/internal/freeturn/captcha_proxy.go
@@ -180,8 +180,11 @@ func injectCaptchaBaseTag(html, baseHref string) string {
 				return html[:pos] + tag + html[pos:]
 			}
 		}
+	case strings.Contains(lower, "<html>"):
+		return strings.Replace(html, "<html>", "<html>"+tag, 1)
 	}
-	return html
+	// Headless fragment: parsers hoist leading <base> into the implied <head>.
+	return tag + html
 }
 
 // injectCaptchaPopupHelper adds a banner on the freeturn success page and tries to

--- a/internal/freeturn/captcha_proxy.go
+++ b/internal/freeturn/captcha_proxy.go
@@ -1,0 +1,233 @@
+package freeturn
+
+import (
+	_ "embed"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+//go:embed captcha_crypto_shim.js
+var captchaCryptoShimJS string
+
+const captchaUpstream = "http://127.0.0.1:8765"
+
+var localCaptchaOrigins = []string{
+	"http://localhost:8765",
+	"http://127.0.0.1:8765",
+	"http://[::1]:8765",
+}
+
+// NewCaptchaReverseProxy forwards browser traffic to freeturn's local captcha
+// server and rewrites localhost:8765 URLs to the awg-manager proxy base.
+func NewCaptchaReverseProxy(proxyBase string, targetPath string) *httputil.ReverseProxy {
+	upstream, _ := url.Parse(captchaUpstream)
+	base := strings.TrimSuffix(proxyBase, "/")
+
+	proxy := httputil.NewSingleHostReverseProxy(upstream)
+	origDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		origDirector(req)
+		inQuery := req.URL.RawQuery
+		req.URL.Path = targetPath
+		req.URL.RawPath = ""
+		req.URL.RawQuery = inQuery
+		req.Host = upstream.Host
+		// freeturn rewrites Origin/Referer only from localhost:8765 to VK; without
+		// this shim the browser sends awg-manager URLs and VK rejects captcha checks.
+		rewriteOutboundCaptchaHeaders(req, base)
+	}
+	proxy.ModifyResponse = func(res *http.Response) error {
+		rewriteCaptchaResponseHeaders(res.Header, base)
+		stripGenericProxyResponseHeaders(res.Header)
+		normalizeCaptchaSetCookies(res.Header)
+
+		ct := res.Header.Get("Content-Type")
+		if !shouldRewriteCaptchaContentType(ct) {
+			return nil
+		}
+
+		body, err := readMaybeGzip(res.Body, res.Header.Get("Content-Encoding"))
+		if err != nil {
+			return err
+		}
+		if err := res.Body.Close(); err != nil {
+			return err
+		}
+
+		rewritten := rewriteCaptchaBody(string(body), base)
+		rewritten = injectCaptchaPopupHelper(rewritten)
+		res.Body = io.NopCloser(strings.NewReader(rewritten))
+		res.ContentLength = int64(len(rewritten))
+		res.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+		res.Header.Del("Content-Encoding")
+		return nil
+	}
+	return proxy
+}
+
+// rewriteOutboundCaptchaHeaders maps browser Origin/Referer from the awg-manager
+// proxy URL back to 127.0.0.1:8765 before forwarding to freeturn-client.
+func rewriteOutboundCaptchaHeaders(req *http.Request, proxyBase string) {
+	base := strings.TrimSuffix(proxyBase, "/")
+	local := captchaUpstream
+
+	if origin := req.Header.Get("Origin"); origin != "" {
+		if strings.EqualFold(origin, base) || strings.HasPrefix(origin, base+"/") {
+			req.Header.Set("Origin", local)
+		}
+	}
+	if ref := req.Header.Get("Referer"); ref != "" {
+		if strings.HasPrefix(ref, base) {
+			suffix := strings.TrimPrefix(ref, base)
+			if suffix == "" {
+				suffix = "/"
+			}
+			req.Header.Set("Referer", local+suffix)
+		}
+	}
+}
+
+func rewriteCaptchaURL(raw, base string) string {
+	base = strings.TrimSuffix(base, "/")
+	for _, origin := range localCaptchaOrigins {
+		if strings.HasPrefix(raw, origin) {
+			return base + strings.TrimPrefix(raw, origin)
+		}
+	}
+	if strings.HasPrefix(raw, "/") && !strings.HasPrefix(raw, "//") {
+		return base + raw
+	}
+	if u, err := url.Parse(raw); err == nil && u.Scheme != "" {
+		if isVKOAuthNavigationHost(u.Hostname()) && !strings.Contains(raw, "/generic_proxy?proxy_url=") {
+			return base + "/generic_proxy?proxy_url=" + url.QueryEscape(raw)
+		}
+	}
+	return raw
+}
+
+func isVKOAuthNavigationHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "id.vk.ru", "id.vk.com", "oauth.vk.com", "oauth.vk.ru":
+		return true
+	default:
+		return false
+	}
+}
+
+func rewriteCaptchaBody(body, base string) string {
+	body = rewriteLocalCaptchaURLsPreserveRedirectURI(body, base)
+	replacements := [][2]string{
+		{`"/generic_proxy`, `"` + base + `/generic_proxy`},
+		{`'/generic_proxy`, `'` + base + `/generic_proxy`},
+		{`"/local-captcha-result`, `"` + base + `/local-captcha-result`},
+		{`'/local-captcha-result`, `'` + base + `/local-captcha-result`},
+	}
+	for _, pair := range replacements {
+		body = strings.ReplaceAll(body, pair[0], pair[1])
+	}
+	if shouldInjectCaptchaBaseTag(body) {
+		body = injectCaptchaBaseTag(body, base+"/")
+	}
+	body = injectCaptchaNavShim(body, base)
+	return injectCaptchaCryptoShim(body)
+}
+
+func injectCaptchaNavShim(html, base string) string {
+	if !strings.Contains(strings.ToLower(html), "<html") &&
+		!strings.Contains(strings.ToLower(html), "<head") {
+		return html
+	}
+	escaped := strings.ReplaceAll(base, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	shim := `<script>(function(){var b="` + escaped + `";var l=["http://127.0.0.1:8765","http://localhost:8765","http://[::1]:8765"];` +
+		`function isVK(u){return/^https:\\/\\/([^\\/]+\\.)?(id\\.vk\\.(ru|com)|oauth\\.vk\\.(com|ru))\\/?/i.test(u);}` +
+		`function rw(u){var s=String(u||"");for(var i=0;i<l.length;i++){if(s.indexOf(l[i])===0)return b+s.slice(l[i].length);}` +
+		`if(s.indexOf("/")===0&&s.indexOf("//")!==0)return b+s;` +
+		`if(isVK(s)&&s.indexOf("/generic_proxy?")<0)return b+"/generic_proxy?proxy_url="+encodeURIComponent(s);return s;}` +
+		`try{var a=Location.prototype.assign,r=Location.prototype.replace;` +
+		`Location.prototype.assign=function(u){return a.call(this,rw(u));};` +
+		`Location.prototype.replace=function(u){return r.call(this,rw(u));};` +
+		`var d=Object.getOwnPropertyDescriptor(Location.prototype,"href");` +
+		`if(d&&d.set){Object.defineProperty(Location.prototype,"href",{get:d.get,set:function(v){d.set.call(this,rw(v));},configurable:true,enumerable:true});}}catch(e){}` +
+		`var op=window.open;window.open=function(u,n,f){return op.call(window,u?rw(u):u,n,f);};` +
+		`document.addEventListener("click",function(e){var el=e.target&&e.target.closest?e.target.closest("a"):null;if(!el||!el.href)return;var n=rw(el.href);if(n!==el.href){e.preventDefault();location.assign(n);}},true);` +
+		`document.addEventListener("submit",function(e){var f=e.target;if(!f||!f.action)return;var n=rw(f.action);if(n!==f.action)f.action=n;},true);})();</script>`
+	lower := strings.ToLower(html)
+	if strings.Contains(lower, "<head>") {
+		return strings.Replace(html, "<head>", "<head>"+shim, 1)
+	}
+	if strings.Contains(lower, "</body>") {
+		return strings.Replace(html, "</body>", shim+"</body>", 1)
+	}
+	return shim + html
+}
+
+func injectCaptchaBaseTag(html, baseHref string) string {
+	tag := `<base href="` + baseHref + `">`
+	lower := strings.ToLower(html)
+	switch {
+	case strings.Contains(lower, "<head>"):
+		return strings.Replace(html, "<head>", "<head>"+tag, 1)
+	case strings.Contains(lower, "<head "):
+		if idx := strings.Index(lower, "<head"); idx >= 0 {
+			if end := strings.Index(html[idx:], ">"); end >= 0 {
+				pos := idx + end + 1
+				return html[:pos] + tag + html[pos:]
+			}
+		}
+	}
+	return html
+}
+
+// injectCaptchaPopupHelper adds a banner on the freeturn success page and tries to
+// close popup windows opened from awg-manager after captcha is accepted.
+func injectCaptchaPopupHelper(html string) string {
+	helper := `<script>(function(){` +
+		`if(location.pathname.indexOf("local-captcha-result")<0)return;` +
+		`var b=document.createElement("div");` +
+		`b.style.cssText="margin:12px;padding:12px 14px;border-radius:8px;background:#1a472a;color:#e8f5e9;font:14px/1.4 sans-serif;text-align:center";` +
+		`b.textContent="Капча принята. Можно закрыть это окно — freeturn продолжит работу.";` +
+		`document.body?document.body.insertBefore(b,document.body.firstChild):document.documentElement.appendChild(b);` +
+		`setTimeout(function(){try{if(window.opener)window.close()}catch(e){}},2500);` +
+		`})();</script>`
+	if strings.Contains(strings.ToLower(html), "</body>") {
+		return strings.Replace(html, "</body>", helper+"</body>", 1)
+	}
+	return html + helper
+}
+
+func injectCaptchaCryptoShim(html string) string {
+	tag := "<script>" + captchaCryptoShimJS + "</script>"
+	lower := strings.ToLower(html)
+	switch {
+	case strings.Contains(lower, "<head>"):
+		return strings.Replace(html, "<head>", "<head>"+tag, 1)
+	case strings.Contains(lower, "<head "):
+		if idx := strings.Index(lower, "<head"); idx >= 0 {
+			if end := strings.Index(html[idx:], ">"); end >= 0 {
+				pos := idx + end + 1
+				return html[:pos] + tag + html[pos:]
+			}
+		}
+	case strings.Contains(lower, "<html>"):
+		return strings.Replace(html, "<html>", "<html>"+tag, 1)
+	}
+	return tag + html
+}
+
+func readMaybeGzip(r io.Reader, encoding string) ([]byte, error) {
+	if encoding != "gzip" {
+		return io.ReadAll(r)
+	}
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return io.ReadAll(r)
+	}
+	defer gz.Close()
+	return io.ReadAll(gz)
+}

--- a/internal/freeturn/captcha_rewrite.go
+++ b/internal/freeturn/captcha_rewrite.go
@@ -1,0 +1,117 @@
+package freeturn
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ShouldDelegateGenericProxyToFreeturn reports whether the request should be
+// forwarded to freeturn's own :8765/generic_proxy (VK OAuth HTML rewriting).
+func ShouldDelegateGenericProxyToFreeturn(proxyURL string) bool {
+	host := hostnameFromProxyURL(proxyURL)
+	if host == "" {
+		return false
+	}
+	if needsExtendedGenericProxyHost(host) {
+		return false
+	}
+	return isAllowedCaptchaGenericHost(host)
+}
+
+func hostnameFromProxyURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// needsExtendedGenericProxyHost reports hosts blocked by freeturn :8765 generic_proxy
+// but required for VK Smart Captcha (sdk-api.appteka.ru, etc.).
+func needsExtendedGenericProxyHost(hostname string) bool {
+	host := strings.ToLower(hostname)
+	for _, suffix := range captchaExtendedGenericProxyHosts {
+		s := strings.TrimPrefix(suffix, ".")
+		if host == s || strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+var captchaExtendedGenericProxyHosts = []string{
+	".appteka.ru",
+	".apptracer.ru",
+}
+
+func rewriteLocalCaptchaURLs(s, base string) string {
+	return rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s, base, false)
+}
+
+func rewriteLocalCaptchaURLsPreserveRedirectURI(s, base string) string {
+	return rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s, base, true)
+}
+
+func rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s, base string, preserveRedirectURI bool) string {
+	if !preserveRedirectURI {
+		base = strings.TrimSuffix(base, "/")
+		for _, origin := range localCaptchaOrigins {
+			s = strings.ReplaceAll(s, origin, base)
+		}
+		for _, origin := range localCaptchaOrigins {
+			enc := url.QueryEscape(origin)
+			s = strings.ReplaceAll(s, enc, url.QueryEscape(base))
+		}
+		return s
+	}
+
+	var out strings.Builder
+	lower := strings.ToLower(s)
+	i := 0
+	for {
+		idx := strings.Index(lower[i:], "redirect_uri=")
+		if idx < 0 {
+			out.WriteString(rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s[i:], base, false))
+			break
+		}
+		abs := i + idx
+		out.WriteString(rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s[i:abs], base, false))
+		j := abs + len("redirect_uri=")
+		for j < len(s) && s[j] != '&' && s[j] != '"' && s[j] != '\'' {
+			j++
+		}
+		out.WriteString(s[abs:j])
+		i = j
+	}
+	return out.String()
+}
+
+func shouldRewriteCaptchaContentType(ct string) bool {
+	ct = strings.ToLower(ct)
+	return strings.Contains(ct, "text/html") ||
+		strings.Contains(ct, "application/xhtml+xml") ||
+		strings.Contains(ct, "javascript") ||
+		strings.Contains(ct, "application/json") ||
+		strings.Contains(ct, "text/plain")
+}
+
+func shouldInjectCaptchaBaseTag(html string) bool {
+	if strings.Contains(html, "__ftpCaptcha") ||
+		strings.Contains(html, "not_robot_captcha") ||
+		strings.Contains(html, "local-captcha-result") {
+		return true
+	}
+	lower := strings.ToLower(html)
+	return !strings.Contains(lower, "id.vk.ru") &&
+		!strings.Contains(lower, "id.vk.com") &&
+		!strings.Contains(lower, "oauth.vk.com")
+}
+
+func rewriteCaptchaResponseHeaders(h http.Header, base string) {
+	if loc := h.Get("Location"); loc != "" {
+		if rewritten := rewriteCaptchaURL(loc, base); rewritten != loc {
+			h.Set("Location", rewritten)
+		}
+	}
+}

--- a/internal/freeturn/captcha_rewrite.go
+++ b/internal/freeturn/captcha_rewrite.go
@@ -45,10 +45,6 @@ var captchaExtendedGenericProxyHosts = []string{
 	".apptracer.ru",
 }
 
-func rewriteLocalCaptchaURLs(s, base string) string {
-	return rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s, base, false)
-}
-
 func rewriteLocalCaptchaURLsPreserveRedirectURI(s, base string) string {
 	return rewriteLocalCaptchaURLsMaybePreserveRedirectURI(s, base, true)
 }

--- a/internal/freeturn/captcha_test.go
+++ b/internal/freeturn/captcha_test.go
@@ -1,0 +1,143 @@
+package freeturn
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestLogIndicatesCaptchaWaiting(t *testing.T) {
+	if logIndicatesCaptchaWaiting("") {
+		t.Fatal("empty log")
+	}
+	if logIndicatesCaptchaWaiting("connected ok\nstreams ready") {
+		t.Fatal("benign log")
+	}
+	log := strings.Repeat("line\n", 50) + "Triggering manual captcha fallback\n"
+	if !logIndicatesCaptchaWaiting(log) {
+		t.Fatal("expected marker in tail")
+	}
+	stale := "Triggering manual captcha fallback\n" + strings.Repeat("ok\n", 50)
+	if logIndicatesCaptchaWaiting(stale) {
+		t.Fatal("stale marker outside tail should be ignored")
+	}
+	resolved := "Triggering manual captcha fallback\n" +
+		"[Captcha] received success token from browser (128 bytes)\n" +
+		strings.Repeat("noise\n", 5)
+	if logIndicatesCaptchaWaiting(resolved) {
+		t.Fatal("success token after marker should clear waiting")
+	}
+	dtls := "Triggering manual captcha fallback\n" +
+		"2026/07/22 18:16:07 [INFO] [STREAM 1] Established DTLS connection\n"
+	if logIndicatesCaptchaWaiting(dtls) {
+		t.Fatal("DTLS after marker should clear waiting")
+	}
+}
+
+func TestRewriteCaptchaBody(t *testing.T) {
+	base := "https://router.example/api/freeturn/clients/a/captcha"
+	in := `window.__ftpCaptcha={"local":"http://localhost:8765"}; fetch("/generic_proxy?x=1"); action="/local-captcha-result"`
+	out := rewriteCaptchaBody(in, base)
+	for _, want := range []string{
+		base,
+		base + `/generic_proxy?x=1`,
+		base + `/local-captcha-result`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "localhost:8765") {
+		t.Fatalf("localhost not rewritten: %q", out)
+	}
+	if !strings.Contains(out, "crypto.subtle") {
+		t.Fatalf("crypto shim not injected: %q", out)
+	}
+	if !strings.Contains(out, `<base href="`) {
+		t.Fatalf("base tag not injected: %q", out)
+	}
+}
+
+func TestRewriteOutboundCaptchaHeaders(t *testing.T) {
+	base := "https://router.example/api/freeturn/clients/home/captcha"
+	req, _ := http.NewRequest(http.MethodPost, base+"/generic_proxy?proxy_url=x", nil)
+	req.Header.Set("Origin", base)
+	req.Header.Set("Referer", base+"/not_robot_captcha?session=1")
+
+	rewriteOutboundCaptchaHeaders(req, base)
+
+	if got := req.Header.Get("Origin"); got != captchaUpstream {
+		t.Fatalf("Origin = %q, want %q", got, captchaUpstream)
+	}
+	if got := req.Header.Get("Referer"); got != captchaUpstream+"/not_robot_captcha?session=1" {
+		t.Fatalf("Referer = %q", got)
+	}
+}
+
+func TestNeedsExtendedGenericProxyHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"sdk-api.appteka.ru", true},
+		{"id.vk.ru", false},
+		{"api.vk.ru", false},
+	}
+	for _, tc := range cases {
+		if got := needsExtendedGenericProxyHost(tc.host); got != tc.want {
+			t.Fatalf("%q extended=%v want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+func TestRewriteCaptchaURLRedirectsToProxy(t *testing.T) {
+	base := "http://192.168.1.1/api/freeturn/clients/x/captcha"
+	got := rewriteCaptchaURL("http://127.0.0.1:8765/not_robot_captcha?code=1", base)
+	want := base + "/not_robot_captcha?code=1"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestRewriteLocalCaptchaURLEncoded(t *testing.T) {
+	base := "http://router/api/freeturn/clients/a/captcha"
+	in := "redirect_uri=http%3A%2F%2F127.0.0.1%3A8765%2Fcb&next=http%3A%2F%2F127.0.0.1%3A8765%2Fok"
+	out := rewriteLocalCaptchaURLsPreserveRedirectURI(in, base)
+	if !strings.Contains(out, "redirect_uri=http%3A%2F%2F127.0.0.1%3A8765%2Fcb") {
+		t.Fatalf("redirect_uri must stay localhost for VK OAuth: %q", out)
+	}
+}
+
+func TestRewriteCaptchaURLWrapsVKOAuth(t *testing.T) {
+	base := "http://192.168.1.1/api/freeturn/clients/x/captcha"
+	got := rewriteCaptchaURL("https://id.vk.ru/authorize?foo=1", base)
+	if !strings.Contains(got, "/generic_proxy?proxy_url=") {
+		t.Fatalf("VK OAuth URL should be wrapped: %q", got)
+	}
+}
+
+func TestRewriteLocalCaptchaURLEncodedLegacy(t *testing.T) {
+	base := "http://router/api/freeturn/clients/a/captcha"
+	in := "href=http%3A%2F%2F127.0.0.1%3A8765%2Fcb"
+	out := rewriteLocalCaptchaURLs(in, base)
+	if strings.Contains(out, "127.0.0.1") {
+		t.Fatalf("non-redirect_uri localhost should be rewritten: %q", out)
+	}
+}
+func TestIsAllowedCaptchaGenericHost(t *testing.T) {
+	cases := []struct {
+		host string
+		ok   bool
+	}{
+		{"sdk-api.appteka.ru", true},
+		{"sdk-api.apptracer.ru", true},
+		{"api.vk.ru", true},
+		{"id.vk.ru", true},
+		{"evil.example.com", false},
+	}
+	for _, tc := range cases {
+		if got := isAllowedCaptchaGenericHost(tc.host); got != tc.ok {
+			t.Fatalf("%q allowed=%v want %v", tc.host, got, tc.ok)
+		}
+	}
+}

--- a/internal/freeturn/captcha_test.go
+++ b/internal/freeturn/captcha_test.go
@@ -119,7 +119,7 @@ func TestRewriteCaptchaURLWrapsVKOAuth(t *testing.T) {
 func TestRewriteLocalCaptchaURLEncodedLegacy(t *testing.T) {
 	base := "http://router/api/freeturn/clients/a/captcha"
 	in := "href=http%3A%2F%2F127.0.0.1%3A8765%2Fcb"
-	out := rewriteLocalCaptchaURLs(in, base)
+	out := rewriteLocalCaptchaURLsMaybePreserveRedirectURI(in, base, false)
 	if strings.Contains(out, "127.0.0.1") {
 		t.Fatalf("non-redirect_uri localhost should be rewritten: %q", out)
 	}

--- a/internal/freeturn/dtls_stats.go
+++ b/internal/freeturn/dtls_stats.go
@@ -1,0 +1,63 @@
+package freeturn
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var freeturnStreamLineRE = regexp.MustCompile(`\[STREAM (\d+)\]`)
+
+var dtlsEstablishedMarkers = []string{
+	"Established DTLS connection",
+}
+
+var dtlsDownMarkers = []string{
+	"DTLS connection closed",
+	"DTLS handshake failed",
+	"DTLS disconnected",
+	"stream closed",
+	"[FATAL]",
+}
+
+// countActiveDTLSConnections returns how many freeturn streams currently have
+// an established DTLS session according to the process log tail. Per-stream
+// state is derived from the last matching line for each [STREAM N] id.
+func countActiveDTLSConnections(log string) int {
+	if log == "" {
+		return 0
+	}
+	states := make(map[int]bool)
+	for _, line := range strings.Split(log, "\n") {
+		m := freeturnStreamLineRE.FindStringSubmatch(line)
+		if len(m) < 2 {
+			continue
+		}
+		id, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		switch {
+		case lineMatchesAny(line, dtlsEstablishedMarkers):
+			states[id] = true
+		case lineMatchesAny(line, dtlsDownMarkers):
+			states[id] = false
+		}
+	}
+	n := 0
+	for _, up := range states {
+		if up {
+			n++
+		}
+	}
+	return n
+}
+
+func lineMatchesAny(line string, markers []string) bool {
+	for _, m := range markers {
+		if strings.Contains(line, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/freeturn/dtls_stats_test.go
+++ b/internal/freeturn/dtls_stats_test.go
@@ -1,0 +1,18 @@
+package freeturn
+
+import "testing"
+
+func TestCountActiveDTLSConnections(t *testing.T) {
+	log := `
+2026/07/22 18:16:07 [INFO] [STREAM 1] Established DTLS connection
+2026/07/22 18:16:07 [INFO] [STREAM 6] Established DTLS connection
+2026/07/22 18:16:08 [INFO] [STREAM 3] Established DTLS connection
+2026/07/22 18:16:09 [INFO] [STREAM 1] DTLS connection closed
+`
+	if got := countActiveDTLSConnections(log); got != 2 {
+		t.Fatalf("count = %d, want 2 (streams 6 and 3)", got)
+	}
+	if countActiveDTLSConnections("") != 0 {
+		t.Fatal("empty log")
+	}
+}

--- a/internal/freeturn/freeturn_test.go
+++ b/internal/freeturn/freeturn_test.go
@@ -74,7 +74,7 @@ func TestBuildClientArgs_FullAndZero(t *testing.T) {
 		"-links", "https://vk.ru/call/join/a", "-n", "4", "-transport", "tcp",
 		"-mode", "udp", "-bond", "-turn", "turn.host", "-port", "3478",
 		"-obf-profile", "rtpopus2", "-obf-key", "deadbeef",
-		"-streams-per-cred", "2", "-browser", "chromium", "-manual-captcha",
+		"-streams-per-cred", "2", "-browser", "chrome", "-manual-captcha",
 		"-dns-mode", "doh", "-dns-servers", "1.1.1.1", "-client-id", "cid",
 		"-sub", "s", "-debug",
 	}

--- a/internal/freeturn/listen_ports.go
+++ b/internal/freeturn/listen_ports.go
@@ -45,14 +45,6 @@ func LocalListenPort(addr string) (int, bool) {
 	return localListenPort(addr)
 }
 
-// LocalListenPortMatch reports whether listen and endpoint refer to the same
-// localhost port (127.0.0.1, localhost, ::1).
-func LocalListenPortMatch(listen, endpoint string) bool {
-	p1, ok1 := localListenPort(listen)
-	p2, ok2 := localListenPort(endpoint)
-	return ok1 && ok2 && p1 == p2
-}
-
 func mergeListenPorts(maps ...map[int]bool) map[int]bool {
 	out := map[int]bool{}
 	for _, m := range maps {

--- a/internal/freeturn/listen_ports.go
+++ b/internal/freeturn/listen_ports.go
@@ -1,0 +1,74 @@
+package freeturn
+
+import (
+	"net"
+	"strconv"
+	"strings"
+)
+
+// LocalListenPortChecker reports localhost listen ports already claimed outside
+// freeturn (e.g. AWG tunnel peer endpoints on 127.0.0.1:PORT).
+type LocalListenPortChecker interface {
+	OccupiedLocalListenPorts() (map[int]bool, error)
+}
+
+func isLocalHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "127.0.0.1", "localhost", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
+func localListenPort(addr string) (int, bool) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return 0, false
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, false
+	}
+	if !isLocalHost(host) {
+		return 0, false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port <= 0 || port > 65535 {
+		return 0, false
+	}
+	return port, true
+}
+
+// LocalListenPort parses host:port and returns the port when host is localhost.
+func LocalListenPort(addr string) (int, bool) {
+	return localListenPort(addr)
+}
+
+// LocalListenPortMatch reports whether listen and endpoint refer to the same
+// localhost port (127.0.0.1, localhost, ::1).
+func LocalListenPortMatch(listen, endpoint string) bool {
+	p1, ok1 := localListenPort(listen)
+	p2, ok2 := localListenPort(endpoint)
+	return ok1 && ok2 && p1 == p2
+}
+
+func mergeListenPorts(maps ...map[int]bool) map[int]bool {
+	out := map[int]bool{}
+	for _, m := range maps {
+		for port := range m {
+			out[port] = true
+		}
+	}
+	return out
+}
+
+func clientListenPorts(clients []ClientInstance) map[int]bool {
+	used := map[int]bool{}
+	for _, c := range clients {
+		if port, err := listenPort(c.Config.Listen); err == nil {
+			used[port] = true
+		}
+	}
+	return used
+}

--- a/internal/freeturn/listen_ports_test.go
+++ b/internal/freeturn/listen_ports_test.go
@@ -1,0 +1,52 @@
+package freeturn
+
+import "testing"
+
+func TestNextClientListen_SkipsReserved(t *testing.T) {
+	clients := []ClientInstance{
+		{Config: ClientConfig{Listen: "127.0.0.1:9000"}},
+	}
+	reserved := map[int]bool{9001: true}
+	got := nextClientListen(clients, reserved)
+	if got != "127.0.0.1:9002" {
+		t.Fatalf("got %q want 127.0.0.1:9002", got)
+	}
+}
+
+func TestNextClientListen_NoReserved(t *testing.T) {
+	clients := []ClientInstance{
+		{Config: ClientConfig{Listen: "127.0.0.1:9000"}},
+	}
+	got := nextClientListen(clients, nil)
+	if got != "127.0.0.1:9001" {
+		t.Fatalf("got %q want 127.0.0.1:9001", got)
+	}
+}
+
+func TestLocalListenPortMatch(t *testing.T) {
+	if !LocalListenPortMatch("127.0.0.1:9001", "localhost:9001") {
+		t.Fatal("same localhost port must match")
+	}
+	if LocalListenPortMatch("127.0.0.1:9001", "127.0.0.1:9000") {
+		t.Fatal("different ports must not match")
+	}
+	if LocalListenPortMatch("127.0.0.1:9001", "1.2.3.4:9001") {
+		t.Fatal("non-localhost endpoint must not match")
+	}
+}
+
+func TestNormalizeBrowser(t *testing.T) {
+	cases := map[string]string{
+		"chromium": "chrome",
+		"Chrome":   "chrome",
+		"firefox":  "firefox",
+		"safari":   "safari",
+		"":         "firefox",
+		"edge":     "firefox",
+	}
+	for in, want := range cases {
+		if got := normalizeBrowser(in); got != want {
+			t.Fatalf("normalizeBrowser(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/freeturn/listen_ports_test.go
+++ b/internal/freeturn/listen_ports_test.go
@@ -23,14 +23,11 @@ func TestNextClientListen_NoReserved(t *testing.T) {
 	}
 }
 
-func TestLocalListenPortMatch(t *testing.T) {
-	if !LocalListenPortMatch("127.0.0.1:9001", "localhost:9001") {
-		t.Fatal("same localhost port must match")
+func TestLocalListenPort(t *testing.T) {
+	if port, ok := LocalListenPort("localhost:9001"); !ok || port != 9001 {
+		t.Fatalf("LocalListenPort(localhost:9001) = %d, %v", port, ok)
 	}
-	if LocalListenPortMatch("127.0.0.1:9001", "127.0.0.1:9000") {
-		t.Fatal("different ports must not match")
-	}
-	if LocalListenPortMatch("127.0.0.1:9001", "1.2.3.4:9001") {
+	if _, ok := LocalListenPort("1.2.3.4:9001"); ok {
 		t.Fatal("non-localhost endpoint must not match")
 	}
 }

--- a/internal/freeturn/process.go
+++ b/internal/freeturn/process.go
@@ -221,6 +221,7 @@ func (p *process) Status() ProcessStatus {
 	if running {
 		st.PID = pid
 		st.StartedAt = p.startedAt
+		st.DtlsConnections = countActiveDTLSConnections(st.Log)
 	}
 	return st
 }
@@ -237,7 +238,7 @@ func binaryPresent(path string) bool {
 }
 
 func freeturnRuntimeEnv(base []string) []string {
-	return routerclock.AppendTZFromRouter(base)
+	return routerclock.WithTZFromRouter(base)
 }
 
 func (p *process) drain(r io.Reader) {

--- a/internal/freeturn/service.go
+++ b/internal/freeturn/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
@@ -37,11 +38,29 @@ type Service struct {
 	remoteCache *remoteReleaseCache
 
 	appLog *logging.ScopedLogger
+
+	listenPortChecker LocalListenPortChecker
 }
 
 // SetLogger wires the UI-visible journal (nil-safe scoped logger).
 func (s *Service) SetLogger(appLogger logging.AppLogger) {
 	s.appLog = logging.NewScopedLogger(appLogger, logging.GroupRouting, "freeturn")
+}
+
+// SetListenPortChecker wires external localhost listen ports (AWG tunnel endpoints, etc.).
+func (s *Service) SetListenPortChecker(c LocalListenPortChecker) {
+	s.listenPortChecker = c
+}
+
+func (s *Service) occupiedLocalListenPorts() map[int]bool {
+	if s.listenPortChecker == nil {
+		return nil
+	}
+	used, err := s.listenPortChecker.OccupiedLocalListenPorts()
+	if err != nil || len(used) == 0 {
+		return nil
+	}
+	return used
 }
 
 // NewService wires up config storage and process managers per instance id.
@@ -82,6 +101,7 @@ func (s *Service) UpdateClientInstance(id string, cfg ClientConfig) error {
 	if err := validateUniqueListens(listens, idx, cfg.Listen); err != nil {
 		return err
 	}
+	cfg.Browser = normalizeBrowser(cfg.Browser)
 	full.Clients[idx].Config = cfg
 	return s.store.Save(full)
 }
@@ -112,7 +132,8 @@ func (s *Service) CreateClient(in CreateClientInput) (ClientInstance, error) {
 	if in.Config != nil {
 		cfg = *in.Config
 	}
-	cfg.Listen = nextClientListen(full.Clients)
+	cfg.Browser = normalizeBrowser(cfg.Browser)
+	cfg.Listen = nextClientListen(full.Clients, s.occupiedLocalListenPorts())
 	name := in.Name
 	if name == "" {
 		name = fmt.Sprintf("Клиент %d", len(full.Clients)+1)
@@ -457,7 +478,7 @@ func buildClientArgs(c ClientConfig) []string {
 	if c.StreamsPerCred > 0 {
 		args = append(args, "-streams-per-cred", strconv.Itoa(c.StreamsPerCred))
 	}
-	str("-browser", c.Browser)
+	str("-browser", normalizeBrowser(c.Browser))
 	flag("-manual-captcha", c.ManualCaptcha)
 	str("-dns-mode", c.DNSMode)
 	str("-dns-servers", c.DNSServers)
@@ -465,6 +486,17 @@ func buildClientArgs(c ClientConfig) []string {
 	str("-sub", c.Sub)
 	flag("-debug", c.Debug)
 	return args
+}
+
+func normalizeBrowser(b string) string {
+	switch strings.ToLower(strings.TrimSpace(b)) {
+	case "chrome", "firefox", "safari":
+		return strings.ToLower(strings.TrimSpace(b))
+	case "chromium":
+		return "chrome"
+	default:
+		return "firefox"
+	}
 }
 
 func buildServerArgs(c ServerConfig) []string {

--- a/internal/freeturn/service.go
+++ b/internal/freeturn/service.go
@@ -478,7 +478,9 @@ func buildClientArgs(c ClientConfig) []string {
 	if c.StreamsPerCred > 0 {
 		args = append(args, "-streams-per-cred", strconv.Itoa(c.StreamsPerCred))
 	}
-	str("-browser", normalizeBrowser(c.Browser))
+	if strings.TrimSpace(c.Browser) != "" {
+		str("-browser", normalizeBrowser(c.Browser))
+	}
 	flag("-manual-captcha", c.ManualCaptcha)
 	str("-dns-mode", c.DNSMode)
 	str("-dns-servers", c.DNSServers)

--- a/internal/freeturn/types.go
+++ b/internal/freeturn/types.go
@@ -31,7 +31,7 @@ type ClientConfig struct {
 	ObfKey     string `json:"obfKey,omitempty"` // -obf-key, 64 hex chars, required if obfProfile != none
 
 	StreamsPerCred int    `json:"streamsPerCred"` // -streams-per-cred, provider=vk only
-	Browser        string `json:"browser"`        // -browser, chrome|firefox|safari, provider=vk only
+	Browser        string `json:"browser" swaggertype:"string" enums:"chrome,firefox,safari"` // -browser, provider=vk only
 	ManualCaptcha  bool   `json:"manualCaptcha"`  // -manual-captcha, provider=vk only
 
 	DNSMode    string `json:"dnsMode"`              // -dns-mode, plain|doh|auto

--- a/internal/freeturn/types.go
+++ b/internal/freeturn/types.go
@@ -31,7 +31,7 @@ type ClientConfig struct {
 	ObfKey     string `json:"obfKey,omitempty"` // -obf-key, 64 hex chars, required if obfProfile != none
 
 	StreamsPerCred int    `json:"streamsPerCred"` // -streams-per-cred, provider=vk only
-	Browser        string `json:"browser"`        // -browser, chrome|firefox, provider=vk only
+	Browser        string `json:"browser"`        // -browser, chrome|firefox|safari, provider=vk only
 	ManualCaptcha  bool   `json:"manualCaptcha"`  // -manual-captcha, provider=vk only
 
 	DNSMode    string `json:"dnsMode"`              // -dns-mode, plain|doh|auto
@@ -149,6 +149,9 @@ type ProcessStatus struct {
 	// confirmations — so the panel can show whether the tunnel actually
 	// connected instead of just "running".
 	Log string `json:"log,omitempty"`
+	// DtlsConnections is the number of freeturn streams with an established
+	// DTLS session in the current log tail (0 when not running).
+	DtlsConnections int `json:"dtlsConnections,omitempty"`
 	// Binary is the configured binary path; BinaryPresent reports whether
 	// an executable actually exists there. awg-manager does NOT ship the
 	// freeturn binaries — the panel uses this to show an honest

--- a/internal/freeturn/validate.go
+++ b/internal/freeturn/validate.go
@@ -59,13 +59,8 @@ func serverListenAddresses(servers []ServerInstance) []string {
 	return out
 }
 
-func nextClientListen(clients []ClientInstance) string {
-	used := map[int]bool{}
-	for _, c := range clients {
-		if port, err := listenPort(c.Config.Listen); err == nil {
-			used[port] = true
-		}
-	}
+func nextClientListen(clients []ClientInstance, reserved map[int]bool) string {
+	used := mergeListenPorts(clientListenPorts(clients), reserved)
 	for port := 9000; port < 9100; port++ {
 		if !used[port] {
 			return fmt.Sprintf("127.0.0.1:%d", port)

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -1423,6 +1423,14 @@ definitions:
         example: true
         type: boolean
     type: object
+  api.FreeTurnCaptchaStatusResponse:
+    properties:
+      data:
+        $ref: '#/definitions/freeturn.CaptchaOverview'
+      success:
+        example: true
+        type: boolean
+    type: object
   api.FreeTurnClientInstanceResponse:
     properties:
       data:
@@ -1771,6 +1779,18 @@ definitions:
       success:
         example: true
         type: boolean
+    type: object
+  api.ImportConfRequest:
+    properties:
+      backend:
+        description: '"nativewg" | "kernel" (default: "kernel")'
+        type: string
+      content:
+        type: string
+      freeTurnClientId:
+        type: string
+      name:
+        type: string
     type: object
   api.IpsetUsageData:
     properties:
@@ -6386,13 +6406,66 @@ definitions:
       enabled:
         type: boolean
     type: object
+  freeturn.CaptchaClientStatus:
+    properties:
+      active:
+        description: 'Active: this client''s process currently owns the local captcha
+          HTTP server (:8765).'
+        type: boolean
+      canOpen:
+        description: 'CanOpen: UI may open the proxied captcha page for this client.'
+        type: boolean
+      captchaSession:
+        description: 'CaptchaSession: manual captcha (re)starts in this process run
+          — bump to reload iframe.'
+        type: integer
+      clientId:
+        type: string
+      clientName:
+        type: string
+      pendingStreams:
+        description: 'PendingStreams: VK-auth streams in this client still waiting
+          on manual captcha.'
+        type: integer
+      portContention:
+        description: 'PortContention: manual captcha port :8765 is busy with another
+          stream''s session.'
+        type: boolean
+      queued:
+        description: 'Queued: waiting but another client holds :8765 — solve the active
+          one first.'
+        type: boolean
+      url:
+        type: string
+      waiting:
+        description: 'Waiting: client log indicates manual captcha is required (auto
+          failed or -manual-captcha).'
+        type: boolean
+    type: object
+  freeturn.CaptchaOverview:
+    properties:
+      clients:
+        items:
+          $ref: '#/definitions/freeturn.CaptchaClientStatus'
+        type: array
+      ownerClientId:
+        type: string
+      ownerName:
+        type: string
+      portOpen:
+        type: boolean
+    type: object
   freeturn.ClientConfig:
     properties:
       bond:
         description: -bond, only meaningful with mode=tcp
         type: boolean
       browser:
-        description: -browser, chrome|firefox, provider=vk only
+        description: -browser, provider=vk only
+        enum:
+        - chrome
+        - firefox
+        - safari
         type: string
       clientId:
         description: -client-id, auto-generated if empty
@@ -6562,6 +6635,11 @@ definitions:
         type: string
       binaryPresent:
         type: boolean
+      dtlsConnections:
+        description: |-
+          DtlsConnections is the number of freeturn streams with an established
+          DTLS session in the current log tail (0 when not running).
+        type: integer
       lastError:
         description: |-
           LastError holds the tail of stderr from the most recent exit, only
@@ -8370,6 +8448,18 @@ paths:
       summary: Adopt external tunnel
       tags:
       - tunnels
+  /freeturn/captcha/status:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.FreeTurnCaptchaStatusResponse'
+      summary: Get FreeTurn VK captcha queue and per-client status
+      tags:
+      - freeturn
   /freeturn/client/config:
     put:
       responses:
@@ -9153,6 +9243,13 @@ paths:
     post:
       consumes:
       - application/json
+      parameters:
+      - description: Config content and optional metadata
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/api.ImportConfRequest'
       produces:
       - application/json
       responses:

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -159,6 +159,8 @@ func (s *Server) buildRouteHandlers() *routeHandlers {
 	if s.ndmsQueries != nil {
 		h.freeturnHandler.SetNDMSQueries(s.ndmsQueries)
 	}
+	h.freeturnHandler.SetLinkedTunnelCleanup(s.tunnels, s.tunnelService)
+	h.freeturnHandler.SetTunnelsHandler(h.tunnelsHandler)
 
 	// Auth middleware helper
 	h.guarded = s.authMiddleware.RequireAuthFunc
@@ -375,6 +377,7 @@ func (s *Server) registerSettingsRoutes(mux *http.ServeMux, h *routeHandlers) {
 	mux.HandleFunc("/api/freeturn/client/config", h.guarded(h.freeturnHandler.UpdateClientConfig))
 	mux.HandleFunc("/api/freeturn/server/config", h.guarded(h.freeturnHandler.UpdateServerConfig))
 	mux.HandleFunc("/api/freeturn/status", h.guarded(h.freeturnHandler.GetStatus))
+	mux.HandleFunc("/api/freeturn/captcha/status", h.guarded(h.freeturnHandler.GetCaptchaStatus))
 	mux.HandleFunc("/api/freeturn/client/start", h.guarded(h.freeturnHandler.StartClient))
 	mux.HandleFunc("/api/freeturn/client/stop", h.guarded(h.freeturnHandler.StopClient))
 	mux.HandleFunc("/api/freeturn/server/start", h.guarded(h.freeturnHandler.StartServer))

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -370,6 +370,7 @@ type AWGTunnel struct {
 	ActiveWAN          string                   `json:"activeWAN,omitempty"`          // Persisted resolved WAN for WAN event matching
 	StartedAt          string                   `json:"startedAt,omitempty"`          // RFC3339 timestamp of last successful start
 	Backend            string                   `json:"backend,omitempty"`            // "nativewg" | "kernel" | "" (legacy=kernel)
+	FreeTurnClientID   string                   `json:"freeTurnClientId,omitempty"`   // set when AWG tunnel is auto-created from freeturn:// import
 	NWGIndex           int                      `json:"nwgIndex"`                     // Wireguard{N} index, nativewg only (0 is valid!)
 	CreatedAt          string                   `json:"createdAt"`
 	Interface          AWGInterface             `json:"interface"`

--- a/internal/sys/routerclock/routerclock.go
+++ b/internal/sys/routerclock/routerclock.go
@@ -68,16 +68,39 @@ func InstallAsLocal() bool {
 // environment does not already define it. Child processes do not inherit
 // Go's time.Local — they need TZ in the environment for local timestamps.
 func AppendTZFromRouter(env []string) []string {
+	if envTZDefined(env) {
+		return env
+	}
+	return appendTZFromRouter(env)
+}
+
+// WithTZFromRouter sets router TZ for a child process, replacing any existing
+// TZ (Entware often exports TZ=UTC, which makes freeturn logs lag MSK by 3h).
+func WithTZFromRouter(env []string) []string {
+	return appendTZFromRouter(env)
+}
+
+func envTZDefined(env []string) bool {
 	for _, item := range env {
 		if strings.HasPrefix(item, "TZ=") {
-			return env
+			return true
 		}
 	}
+	return false
+}
+
+func appendTZFromRouter(env []string) []string {
 	info := Get()
 	if info.RawTZ == "" {
 		return env
 	}
-	out := append([]string(nil), env...)
+	out := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if strings.HasPrefix(item, "TZ=") {
+			continue
+		}
+		out = append(out, item)
+	}
 	return append(out, "TZ="+info.RawTZ)
 }
 

--- a/internal/sys/routerclock/routerclock_test.go
+++ b/internal/sys/routerclock/routerclock_test.go
@@ -145,6 +145,21 @@ func TestAppendTZFromRouter(t *testing.T) {
 	}
 }
 
+func TestWithTZFromRouter_ReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	tzFile := filepath.Join(dir, "TZ")
+	if err := os.WriteFile(tzFile, []byte("MSK-3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	restore := setTZCandidatesForTest([]string{tzFile})
+	defer restore()
+
+	got := WithTZFromRouter([]string{"TZ=UTC0", "PATH=/bin"})
+	if len(got) != 2 || got[0] != "PATH=/bin" || got[1] != "TZ=MSK-3" {
+		t.Fatalf("WithTZFromRouter() = %#v, want router TZ replacing UTC", got)
+	}
+}
+
 func TestInstallAsLocal_NoRouterTZ_NoOp(t *testing.T) {
 	restore := setTZCandidatesForTest([]string{"/nonexistent/TZ"})
 	defer restore()


### PR DESCRIPTION
Add in-app VK captcha via reverse proxy and modal auto-open, a simplified client setup wizard, and valid -browser values. Allocate client -listen ports against AWG endpoints, patch WG Endpoint on freeturn:// import, tag tunnels with freeTurnClientId, and remove only tagged tunnels when a freeturn client is deleted.