### PR TITLE
fix(wdtt,freeturn): не держать s.mu во время Stop() при удалении инстанса

### DIFF
--- a/internal/freeturn/service.go
+++ b/internal/freeturn/service.go
@@ -180,34 +180,44 @@ func (s *Service) CreateServer(in CreateServerInput) (ServerInstance, error) {
 
 func (s *Service) DeleteClient(id string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	full, err := s.store.Load()
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
 	idx := findClientIndex(full.Clients, id)
 	if idx < 0 {
+		s.mu.Unlock()
 		return fmt.Errorf("клиент %q не найден", id)
 	}
-	_ = s.clientProcs.get(id).Stop()
 	full.Clients = append(full.Clients[:idx], full.Clients[idx+1:]...)
-	return s.store.Save(full)
+	saveErr := s.store.Save(full)
+	s.mu.Unlock()
+	// Блокирующий Stop (kill до ~3с) — вне s.mu, чтобы не сериализовать
+	// прочие RMW-методы и boot-ResumeEnabled на время убийства процесса.
+	_ = s.clientProcs.get(id).Stop()
+	return saveErr
 }
 
 func (s *Service) DeleteServer(id string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	full, err := s.store.Load()
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
 	idx := findServerIndex(full.Servers, id)
 	if idx < 0 {
+		s.mu.Unlock()
 		return fmt.Errorf("сервер %q не найден", id)
 	}
-	_ = s.serverProcs.get(id).Stop()
 	full.Servers = append(full.Servers[:idx], full.Servers[idx+1:]...)
-	return s.store.Save(full)
+	saveErr := s.store.Save(full)
+	s.mu.Unlock()
+	// Блокирующий Stop (kill до ~3с) — вне s.mu, чтобы не сериализовать
+	// прочие RMW-методы и boot-ResumeEnabled на время убийства процесса.
+	_ = s.serverProcs.get(id).Stop()
+	return saveErr
 }
 
 func (s *Service) RenameClient(id, name string) error {

--- a/internal/wdtt/delete_test.go
+++ b/internal/wdtt/delete_test.go
@@ -1,0 +1,31 @@
+package wdtt
+
+import "testing"
+
+// TestService_DeleteClient проверяет семантику удаления: id уходит из конфига,
+// повторное удаление даёт «не найден». Регрессия к выносу Stop() из-под s.mu.
+func TestService_DeleteClient(t *testing.T) {
+	dir := t.TempDir()
+	s := NewService(dir, dir, "/bin/sh")
+
+	inst, err := s.CreateClient(CreateClientInput{Name: "A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DeleteClient(inst.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	cfg, err := s.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findClientIndex(cfg.Clients, inst.ID) >= 0 {
+		t.Fatalf("клиент %q остался в конфиге после удаления", inst.ID)
+	}
+
+	if err := s.DeleteClient(inst.ID); err == nil {
+		t.Fatal("повторное удаление должно вернуть «не найден»")
+	}
+}

--- a/internal/wdtt/service.go
+++ b/internal/wdtt/service.go
@@ -123,18 +123,23 @@ func (s *Service) CreateClient(in CreateClientInput) (ClientInstance, error) {
 
 func (s *Service) DeleteClient(id string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	full, err := s.store.Load()
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
 	idx := findClientIndex(full.Clients, id)
 	if idx < 0 {
+		s.mu.Unlock()
 		return fmt.Errorf("клиент %q не найден", id)
 	}
-	_ = s.procs.get(id).Stop()
 	full.Clients = append(full.Clients[:idx], full.Clients[idx+1:]...)
-	return s.store.Save(full)
+	saveErr := s.store.Save(full)
+	s.mu.Unlock()
+	// Блокирующий Stop (kill до ~3с) — вне s.mu, чтобы не сериализовать
+	// прочие RMW-методы и boot-ResumeEnabled на время убийства процесса.
+	_ = s.procs.get(id).Stop()
+	return saveErr
 }
 
 func (s *Service) RenameClient(id, name string) error {


### PR DESCRIPTION
DeleteClient/DeleteServer убивали процесс (kill до ~3с) под сервисным s.mu, сериализуя все RMW-методы и boot-ResumeEnabled. Load-modify-Save под локом, блокирующий Stop() после release (best-effort, как и был).