### PR TITLE
freeturn,wdtt: Wait() после EOF drain — не терять stderr при раннем в…

### DIFF
--- a/internal/freeturn/freeturn_test.go
+++ b/internal/freeturn/freeturn_test.go
@@ -362,6 +362,18 @@ func TestProcess_StartupFailureCapturesStderr(t *testing.T) {
 	}
 }
 
+// TestProcess_StartupFailure_StderrCaptured_UnderDrainDelay детерминированно
+// воспроизводит гонку os/exec: если Wait() закрывает пайпы раньше, чем drain
+// успел прочитать stderr, «boom» теряется. drainStartDelay форсирует окно.
+func TestProcess_StartupFailure_StderrCaptured_UnderDrainDelay(t *testing.T) {
+	p := newTestProcess(t, "echo boom >&2; exit 1")
+	p.drainStartDelay = 50 * time.Millisecond
+	err := p.Start(nil)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("stderr должен быть в ошибке даже с задержкой drain, got: %v", err)
+	}
+}
+
 func TestProcess_StartStop(t *testing.T) {
 	p := newTestProcess(t, "sleep 30")
 	if err := p.Start(nil); err != nil {

--- a/internal/freeturn/process.go
+++ b/internal/freeturn/process.go
@@ -49,6 +49,11 @@ type process struct {
 
 	// Seam for tests.
 	startCmd func(bin string, args ...string) *exec.Cmd
+
+	// drainStartDelay искусственно задерживает старт чтения пайпа —
+	// тест-seam для форсирования окна гонки «Wait закрыл пайп раньше drain».
+	// В проде zero → без эффекта.
+	drainStartDelay time.Duration
 }
 
 func newProcess(name, binary, runtimeDir string) *process {
@@ -111,12 +116,16 @@ func (p *process) Start(args []string) error {
 
 	if err := p.writePID(cmd.Process.Pid); err != nil {
 		_ = childproc.Terminate(cmd.Process.Pid)
+		drainWG.Wait() // Terminate убил ребёнка → write-концы закрылись → drain EOF
 		_ = cmd.Wait()
 		return fmt.Errorf("freeturn %s: write pidfile: %w", p.name, err)
 	}
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- cmd.Wait() }()
+	go func() {
+		drainWG.Wait()      // drain'ы дочитали до EOF — Wait не уничтожит буфер пайпов
+		errCh <- cmd.Wait() // безопасно: читать больше нечего
+	}()
 
 	myPid := cmd.Process.Pid
 
@@ -124,9 +133,8 @@ func (p *process) Start(args []string) error {
 	case waitErr := <-errCh:
 		// Died before grace period — this is a startup failure.
 		p.cleanupPidIfOurs(myPid)
-		// cmd.Wait() закрыл пайпы; дождаться (ограниченно) завершения drain,
-		// чтобы хвост stderr успел попасть в logTail.
-		waitDrainGroup(&drainWG, 500*time.Millisecond)
+		// К моменту получения из errCh drain'ы гарантированно завершены (Wait
+		// вызывается после drainWG.Wait()), хвост stderr уже в logTail.
 		msg := strings.TrimSpace(p.logTail.LastLines(30))
 		if msg == "" && waitErr != nil {
 			msg = waitErr.Error()
@@ -160,7 +168,6 @@ func (p *process) Start(args []string) error {
 				// Unexpected exit. Only the last few lines, not the whole
 				// buffer — after a long run that buffer is mostly benign
 				// per-stream connect/disconnect noise, not the actual cause.
-				waitDrainGroup(&drainWG, 500*time.Millisecond)
 				tail := strings.TrimSpace(p.logTail.LastLines(10))
 				if tail == "" && waitErr != nil {
 					tail = waitErr.Error()
@@ -252,6 +259,9 @@ func freeturnRuntimeEnv(base []string) []string {
 }
 
 func (p *process) drain(r io.Reader) {
+	if p.drainStartDelay > 0 {
+		time.Sleep(p.drainStartDelay)
+	}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 4096), 64*1024)
 	for sc.Scan() {
@@ -263,17 +273,6 @@ func (p *process) setLastErr(s string) {
 	p.mu.Lock()
 	p.lastErr = s
 	p.mu.Unlock()
-}
-
-// waitDrainGroup ждёт завершения drain-горутин, но не дольше timeout —
-// гард от вечного зависания, если drain почему-то не закрылся.
-func waitDrainGroup(wg *sync.WaitGroup, timeout time.Duration) {
-	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-	}
 }
 
 // cleanupPidIfOurs removes the pidfile only if it still names myPid —

--- a/internal/wdtt/process.go
+++ b/internal/wdtt/process.go
@@ -32,6 +32,11 @@ type process struct {
 	lastWgConfig  string // last CONFIG event seen in drain; survives log ring-buffer eviction
 	logTail       *childproc.RingBuffer
 	startCmd      func(bin string, args ...string) *exec.Cmd
+
+	// drainStartDelay искусственно задерживает старт чтения пайпа —
+	// тест-seam для форсирования окна гонки «Wait закрыл пайп раньше drain».
+	// В проде zero → без эффекта.
+	drainStartDelay time.Duration
 }
 
 func newProcess(name, binary, runtimeDir string) *process {
@@ -99,20 +104,23 @@ func (p *process) Start(args []string) error {
 
 	if err := p.writePID(cmd.Process.Pid); err != nil {
 		_ = childproc.Terminate(cmd.Process.Pid)
+		drainWG.Wait() // Terminate убил ребёнка → write-концы закрылись → drain EOF
 		_ = cmd.Wait()
 		return fmt.Errorf("wdtt %s: pidfile: %w", p.name, err)
 	}
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- cmd.Wait() }()
+	go func() {
+		drainWG.Wait()      // drain'ы дочитали до EOF — Wait не уничтожит буфер пайпов
+		errCh <- cmd.Wait() // безопасно: читать больше нечего
+	}()
 	myPid := cmd.Process.Pid
 
 	select {
 	case waitErr := <-errCh:
 		p.cleanupPidIfOurs(myPid)
-		// cmd.Wait() закрыл пайпы; дождаться (ограниченно) завершения drain,
-		// чтобы хвост stderr успел попасть в logTail.
-		waitDrainGroup(&drainWG, 500*time.Millisecond)
+		// К моменту получения из errCh drain'ы гарантированно завершены (Wait
+		// вызывается после drainWG.Wait()), хвост stderr уже в logTail.
 		msg := strings.TrimSpace(p.logTail.LastLines(30))
 		if msg == "" && waitErr != nil {
 			msg = waitErr.Error()
@@ -135,7 +143,6 @@ func (p *process) Start(args []string) error {
 			if stopped {
 				p.setLastErr("")
 			} else {
-				waitDrainGroup(&drainWG, 500*time.Millisecond)
 				tail := strings.TrimSpace(p.logTail.LastLines(10))
 				if tail == "" && waitErr != nil {
 					tail = waitErr.Error()
@@ -237,6 +244,9 @@ func wdttRuntimeEnv(base []string) []string {
 }
 
 func (p *process) drain(r io.Reader) {
+	if p.drainStartDelay > 0 {
+		time.Sleep(p.drainStartDelay)
+	}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 4096), 64*1024)
 	for sc.Scan() {
@@ -254,17 +264,6 @@ func (p *process) setLastErr(s string) {
 	p.mu.Lock()
 	p.lastErr = s
 	p.mu.Unlock()
-}
-
-// waitDrainGroup ждёт завершения drain-горутин, но не дольше timeout —
-// гард от вечного зависания, если drain почему-то не закрылся.
-func waitDrainGroup(wg *sync.WaitGroup, timeout time.Duration) {
-	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-	}
 }
 
 func (p *process) cleanupPidIfOurs(myPid int) {

--- a/internal/wdtt/process_test.go
+++ b/internal/wdtt/process_test.go
@@ -1,9 +1,33 @@
 package wdtt
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
+
+// newTestProcess подменяет реальный бинарь shell-скриптом через seam startCmd;
+// p.binary=/bin/sh проходит binaryPresent, реальная команда — из script.
+func newTestProcess(t *testing.T, script string) *process {
+	t.Helper()
+	p := newProcess("client", "/bin/sh", t.TempDir())
+	p.startCmd = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("/bin/sh", "-c", script)
+	}
+	return p
+}
+
+// TestProcess_StartupFailure_StderrCaptured_UnderDrainDelay — детерминированный
+// регресс на гонку os/exec: Wait() не должен закрывать пайпы раньше drain.
+func TestProcess_StartupFailure_StderrCaptured_UnderDrainDelay(t *testing.T) {
+	p := newTestProcess(t, "echo boom >&2; exit 1")
+	p.drainStartDelay = 50 * time.Millisecond
+	err := p.Start(nil)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("stderr должен быть в ошибке даже с задержкой drain, got: %v", err)
+	}
+}
 
 // TestDrainCONFIGSurvivesEviction проверяет, что CONFIG-событие, пойманное в
 // drain, остаётся доступным через Status() даже после того как исходная строка


### PR DESCRIPTION
…ыходе (гонка os/exec)

Cmd.Wait() в конкурентной горутине закрывал read-концы StderrPipe при выходе процесса раньше, чем drain дочитывал буфер ядра → stderr терялся, ошибка старта откатывалась на «exit status 1». Восстановлен документированный порядок os/exec: Wait() вызывается только после drainWG.Wait() (оба drain достигли EOF). Убраны ненужные теперь waitDrainGroup-вызовы и хелпер. writePID error-путь тоже ждёт drainWG перед Wait(). Детерминированный регресс-тест через seam drainStartDelay.