### PR TITLE
fix(freeturn): do not auto-generate client ID when generating server link

### DIFF
--- a/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
@@ -149,25 +149,16 @@
 	}
 
 	async function generateLinkNow() {
-		if (!genClientId.trim()) {
-			randomClientId();
-		}
 		let peerParam = genPeer.trim();
 		if (peerParam && !peerParam.includes(':')) {
 			peerParam = `${peerParam}:${listenPort}`;
 		}
 		const result = await onGenerate(genProvider, peerParam, genMTU, genWG, genClientId, genName);
-		if (result?.clientId) {
-			genClientId = result.clientId;
-		}
 		if (result?.link) {
 			try {
 				linkParams = await api.decodeFreeTurnLink(result.link);
 			} catch {
 				linkParams = null;
-			}
-			if (genClientId.trim()) {
-				await saveClientToAllowlist(true);
 			}
 		}
 	}
@@ -312,9 +303,9 @@
 				<div class="ft-link-box">{generatedLink}</div>
 				<Button variant="ghost" size="sm" onclick={() => onCopy(generatedLink)}>Скопировать</Button>
 				<LinkParamsSummary payload={linkParams} peer={generatedPeer} />
-				{#if genClientId.trim()}
+				{#if genClientId.trim() && server.clientsFile}
 					<p class="ft-hint">
-						Client ID <code>{genClientId}</code> добавлен в allowlist (или уже был в списке).
+						Если allowlist включён — добавьте Client ID <code>{genClientId}</code> кнопкой «В список».
 					</p>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -371,6 +371,12 @@
 		}
 	}
 
+	function freeturnTunnelName(instanceName?: string): string {
+		const base = instanceName?.trim() || 'FreeTurn';
+		if (base.toLowerCase().endsWith(' ft')) return base.slice(0, 60);
+		return `${base} FT`.slice(0, 60);
+	}
+
 	async function applyImportLink(link: string) {
 		if (!link.trim() || !selectedClient || !config) return;
 		importing = true;
@@ -404,7 +410,7 @@
 					const wgForImport = patchWgConfEndpoint(wg, listenPort);
 					const tunnel = await api.importConfig(
 						wgForImport,
-						`FreeTurn ${payload.peer}`.slice(0, 60),
+						freeturnTunnelName(selectedClient.name),
 						undefined,
 						selectedClientId
 					);


### PR DESCRIPTION
## Summary
- Stop auto-generating Client ID when clicking «Только сгенерировать ссылку» or «Сохранить, запустить и получить ссылку» in the FreeTurn server simple wizard.
- Stop silently adding the ID to allowlist during link generation.
- Client ID generation stays on the refresh button; allowlist updates stay on «В список».

## Test plan
- [ ] Open FreeTurn server simple wizard with empty Client ID field.
- [ ] Click «Только сгенерировать ссылку» — link is generated, Client ID field stays empty, allowlist unchanged.
- [ ] Click refresh (↻) — Client ID appears in the field.
- [ ] Click «В список» — ID is added to allowlist only then.
- [ ] Click «Сохранить, запустить и получить ссылку» with empty Client ID — no auto ID, no allowlist write.