### PR TITLE
feat(freeturn,wdtt): instance switcher in log header and client mode/transport UI

### DIFF
--- a/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnClientSimple.svelte
@@ -4,7 +4,8 @@
 	import WizardStep from '$lib/components/sb-router/WizardStep.svelte';
 	import ProcessLogBox from './ProcessLogBox.svelte';
 	import LinkParamsSummary from './LinkParamsSummary.svelte';
-	import { browserOptions } from './options';
+	import type { LogInstanceItem } from './LogInstanceSwitcher.svelte';
+	import { browserOptions, modeOptions, transportOptions } from './options';
 	import { api } from '$lib/api/client';
 	import type { FreeTurnClientConfig, FreeTurnLinkPayload, FreeTurnProcessStatus } from '$lib/types';
 
@@ -17,6 +18,9 @@
 		onSave: (cfg: FreeTurnClientConfig) => void | Promise<void>;
 		onToggle: (on: boolean) => void | Promise<void>;
 		onImportLink: (link: string) => void | Promise<void>;
+		instances?: LogInstanceItem[];
+		selectedInstanceId?: string;
+		onSelectInstance?: (id: string) => void;
 	}
 
 	let {
@@ -27,7 +31,10 @@
 		routerClock,
 		onSave,
 		onToggle,
-		onImportLink
+		onImportLink,
+		instances = [],
+		selectedInstanceId = '',
+		onSelectInstance
 	}: Props = $props();
 
 	let importLink = $state('');
@@ -142,7 +149,7 @@
 	<WizardStep
 		n={3}
 		title="Потоки и браузер"
-		hint="-n, -streams-per-cred, -browser"
+		hint="-n, -streams-per-cred, -mode, -transport, -browser"
 		active={step2Done}
 	>
 		<div class="ft-simple-grid">
@@ -163,6 +170,18 @@
 			Суммарно до {linksCount * client.streamsPerCred || client.streamsPerCred} потоков на все
 			ссылки (×{linksCount || 1} кред{linksCount === 1 ? '' : 'а'}). Каждый поток может
 			потребовать отдельную VK-капчу.
+		</p>
+
+		<div class="ft-simple-grid">
+			<Dropdown label="Режим (-mode)" bind:value={client.mode} options={modeOptions} />
+			<Dropdown
+				label="Транспорт до TURN (-transport)"
+				bind:value={client.transport}
+				options={transportOptions}
+			/>
+		</div>
+		<p class="ft-hint">
+			<code>-mode</code> — режим туннеля (udp/tcp). <code>-transport</code> — протокол до TURN-relay.
 		</p>
 
 		<Dropdown
@@ -198,7 +217,15 @@
 		</div>
 	</WizardStep>
 
-	<ProcessLogBox log={status?.log} {routerClock} bind:debug={client.debug} showDebugToggle />
+	<ProcessLogBox
+		log={status?.log}
+		{routerClock}
+		bind:debug={client.debug}
+		showDebugToggle
+		{instances}
+		{selectedInstanceId}
+		{onSelectInstance}
+	/>
 </div>
 
 <style>

--- a/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnServerSimple.svelte
@@ -8,6 +8,7 @@
 	import ServerWgBind from './ServerWgBind.svelte';
 	import ProcessLogBox from './ProcessLogBox.svelte';
 	import LinkParamsSummary from './LinkParamsSummary.svelte';
+	import type { LogInstanceItem } from './LogInstanceSwitcher.svelte';
 	import ServerAllowlist from './ServerAllowlist.svelte';
 	import { obfOptions } from './options';
 	import { obfProfileHints, randomObfKeyHex } from './obfHints';
@@ -40,6 +41,9 @@
 			name: string
 		) => Promise<import('$lib/types').FreeTurnGenerateLinkResult | null>;
 		onCopy: (text: string) => void;
+		instances?: LogInstanceItem[];
+		selectedInstanceId?: string;
+		onSelectInstance?: (id: string) => void;
 	}
 
 	let {
@@ -61,7 +65,10 @@
 		onSave,
 		onToggle,
 		onGenerate,
-		onCopy
+		onCopy,
+		instances = [],
+		selectedInstanceId = '',
+		onSelectInstance
 	}: Props = $props();
 
 	let starting = $state(false);
@@ -314,7 +321,14 @@
 		<ServerAllowlist bind:this={allowlistPanel} serverInstanceId={serverInstanceId} {server} />
 	</WizardStep>
 
-	<ProcessLogBox log={status?.log} bind:debug={server.debug} showDebugToggle />
+	<ProcessLogBox
+		log={status?.log}
+		bind:debug={server.debug}
+		showDebugToggle
+		{instances}
+		{selectedInstanceId}
+		{onSelectInstance}
+	/>
 </div>
 
 <style>

--- a/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
+++ b/frontend/src/lib/components/freeturn/FreeTurnTab.svelte
@@ -557,6 +557,11 @@
 				status={clientStatus}
 				routerClock={status?.routerClock}
 				{saving}
+				instances={clientBarItems}
+				selectedInstanceId={selectedClientId}
+				onSelectInstance={(id) => {
+					selectedClientId = id;
+				}}
 				onSave={saveClientConfig}
 				onToggle={(on) => toggleClientInstance(selectedClientId, on)}
 				onImportLink={applyImportLink}
@@ -588,6 +593,11 @@
 				defaultClientListenPort={defaultClientListenPort}
 				{generatedLink}
 				{generatedPeer}
+				instances={serverBarItems}
+				selectedInstanceId={selectedServerId}
+				onSelectInstance={(id) => {
+					selectedServerId = id;
+				}}
 				bind:genProvider
 				bind:genPeer
 				bind:genMTU

--- a/frontend/src/lib/components/freeturn/LogInstanceSwitcher.svelte
+++ b/frontend/src/lib/components/freeturn/LogInstanceSwitcher.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	export interface LogInstanceItem {
+		id: string;
+		name: string;
+		running?: boolean;
+	}
+
+	interface Props {
+		items: LogInstanceItem[];
+		selectedId: string;
+		onSelect: (id: string) => void;
+	}
+
+	let { items, selectedId, onSelect }: Props = $props();
+</script>
+
+{#if items.length > 1}
+	<div class="ft-log-instances" role="tablist" aria-label="Переключение инстанса">
+		{#each items as item (item.id)}
+			<button
+				type="button"
+				role="tab"
+				class="ft-log-instance"
+				class:active={item.id === selectedId}
+				aria-selected={item.id === selectedId}
+				title={item.running ? `${item.name} — запущен` : `${item.name} — остановлен`}
+				onclick={() => onSelect(item.id)}
+			>
+				<span class="ft-log-instance-dot" class:running={item.running}></span>
+				<span class="ft-log-instance-name">{item.name}</span>
+			</button>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.ft-log-instances {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		flex: 1;
+		min-width: 0;
+		margin: 0 0.5rem;
+		overflow-x: auto;
+		scrollbar-width: thin;
+	}
+
+	.ft-log-instance {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.2rem 0.625rem;
+		border: 1px solid var(--color-border);
+		border-radius: 999px;
+		background: var(--color-bg-primary);
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition:
+			border-color 0.15s,
+			background 0.15s;
+	}
+
+	.ft-log-instance:hover {
+		border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+	}
+
+	.ft-log-instance.active {
+		border-color: var(--color-accent);
+		background: var(--color-bg-secondary);
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 25%, transparent);
+	}
+
+	.ft-log-instance-dot {
+		width: 0.4375rem;
+		height: 0.4375rem;
+		border-radius: 50%;
+		background: var(--color-text-muted);
+		flex-shrink: 0;
+	}
+
+	.ft-log-instance-dot.running {
+		background: var(--color-success);
+	}
+
+	.ft-log-instance-name {
+		font-size: 0.75rem;
+		font-weight: 600;
+		max-width: 8rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+</style>

--- a/frontend/src/lib/components/freeturn/LogInstanceSwitcher.svelte
+++ b/frontend/src/lib/components/freeturn/LogInstanceSwitcher.svelte
@@ -15,14 +15,13 @@
 </script>
 
 {#if items.length > 1}
-	<div class="ft-log-instances" role="tablist" aria-label="Переключение инстанса">
+	<div class="ft-log-instances" role="group" aria-label="Переключение инстанса">
 		{#each items as item (item.id)}
 			<button
 				type="button"
-				role="tab"
 				class="ft-log-instance"
 				class:active={item.id === selectedId}
-				aria-selected={item.id === selectedId}
+				aria-pressed={item.id === selectedId}
 				title={item.running ? `${item.name} — запущен` : `${item.name} — остановлен`}
 				onclick={() => onSelect(item.id)}
 			>

--- a/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
+++ b/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
@@ -3,6 +3,7 @@
 	import { ChevronRight, ChevronDown, ArrowDown } from 'lucide-svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { notifications } from '$lib/stores/notifications';
+	import LogInstanceSwitcher, { type LogInstanceItem } from './LogInstanceSwitcher.svelte';
 
 	interface Props {
 		log?: string;
@@ -17,6 +18,10 @@
 		debug?: boolean;
 		/** Свёрнут ли лог по умолчанию. */
 		defaultCollapsed?: boolean;
+		/** Компактный переключатель клиентов/серверов в шапке лога. */
+		instances?: LogInstanceItem[];
+		selectedInstanceId?: string;
+		onSelectInstance?: (id: string) => void;
 	}
 
 	let {
@@ -27,7 +32,10 @@
 		embedded = false,
 		showDebugToggle = false,
 		debug = $bindable(false),
-		defaultCollapsed = false
+		defaultCollapsed = false,
+		instances = [],
+		selectedInstanceId = '',
+		onSelectInstance
 	}: Props = $props();
 
 	let collapsed = $state(defaultCollapsed);
@@ -84,6 +92,9 @@
 					<span class="ft-log-meta">({lineCount} строк)</span>
 				{/if}
 			</button>
+		{/if}
+		{#if instances.length > 1 && onSelectInstance}
+			<LogInstanceSwitcher items={instances} selectedId={selectedInstanceId} onSelect={onSelectInstance} />
 		{/if}
 		<div class="ft-log-toolbar-actions">
 			{#if !stickToBottom}
@@ -188,12 +199,18 @@
 	}
 
 	.ft-log-toolbar--header {
-		justify-content: space-between;
+		justify-content: flex-start;
+		flex-wrap: nowrap;
 		margin-bottom: 0.5rem;
+	}
+
+	.ft-log-toolbar--header .ft-log-toggle {
+		flex-shrink: 0;
 	}
 
 	.ft-log-toolbar--header .ft-log-toolbar-actions {
 		width: auto;
+		margin-left: auto;
 	}
 
 	.ft-log-debug {

--- a/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
+++ b/frontend/src/lib/components/freeturn/ProcessLogBox.svelte
@@ -93,7 +93,7 @@
 				{/if}
 			</button>
 		{/if}
-		{#if instances.length > 1 && onSelectInstance}
+		{#if onSelectInstance}
 			<LogInstanceSwitcher items={instances} selectedId={selectedInstanceId} onSelect={onSelectInstance} />
 		{/if}
 		<div class="ft-log-toolbar-actions">

--- a/frontend/src/lib/components/wdtt/WdttClientSimple.svelte
+++ b/frontend/src/lib/components/wdtt/WdttClientSimple.svelte
@@ -3,6 +3,7 @@
 	import StepPill from '$lib/components/sb-router/StepPill.svelte';
 	import WizardStep from '$lib/components/sb-router/WizardStep.svelte';
 	import ProcessLogBox from '../freeturn/ProcessLogBox.svelte';
+	import type { LogInstanceItem } from '../freeturn/LogInstanceSwitcher.svelte';
 	import { api } from '$lib/api/client';
 	import { notifications } from '$lib/stores/notifications';
 	import { peersEqual } from '$lib/utils/wdttPeer';
@@ -30,6 +31,9 @@
 		subscriptionTick?: number;
 		onEnsureWg?: () => void | Promise<void>;
 		ensuringWg?: boolean;
+		instances?: LogInstanceItem[];
+		selectedInstanceId?: string;
+		onSelectInstance?: (id: string) => void;
 	}
 
 	let {
@@ -47,7 +51,10 @@
 		refreshingSub = false,
 		subscriptionTick = 0,
 		onEnsureWg,
-		ensuringWg = false
+		ensuringWg = false,
+		instances = [],
+		selectedInstanceId = '',
+		onSelectInstance
 	}: Props = $props();
 
 	let importLink = $state('');
@@ -379,7 +386,13 @@
 				Процесс помечен как запущенный, но лог пуст — нажмите «Остановить», затем «Сохранить и запустить».
 			</p>
 		{/if}
-		<ProcessLogBox log={status?.log} {routerClock} />
+		<ProcessLogBox
+			log={status?.log}
+			{routerClock}
+			{instances}
+			{selectedInstanceId}
+			{onSelectInstance}
+		/>
 	</WizardStep>
 </div>
 

--- a/frontend/src/lib/components/wdtt/WdttTab.svelte
+++ b/frontend/src/lib/components/wdtt/WdttTab.svelte
@@ -455,6 +455,12 @@
 				routerClock={status?.routerClock}
 				{saving}
 				{importing}
+				instances={clientBarItems}
+				selectedInstanceId={selectedClientId}
+				onSelectInstance={(id) => {
+					selectedClientId = id;
+					wgEnsureSettled.delete(id);
+				}}
 				onSave={saveClientConfig}
 				onRevert={revertClient}
 				onToggle={(on) => toggleClientInstance(selectedClientId, on)}


### PR DESCRIPTION
## Summary
- Add compact client/server switcher pills in the process log header (FreeTurn and WDTT) so users can change the active instance without scrolling back to the top InstanceBar.
- Show a green/gray activity dot and highlight the selected instance; switcher appears only when there are 2+ instances.
- Restore -mode and -transport controls in the FreeTurn client wizard step «Потоки и браузер».

## Test plan
- [ ] Open FreeTurn with 2+ clients, scroll to the log, switch instances from the log header and verify log/status updates.
- [ ] Repeat on the WDTT tab with 2+ clients.
- [ ] Confirm switcher is hidden with a single instance.
- [ ] In FreeTurn client wizard step 3, set mode/transport, save, restart client, and verify CLI flags.