### PR TITLE
fix(vlink): не отдавать sing-box поле encryption у VLESS

### DIFF
--- a/internal/singbox/vlink/clash_vless_test.go
+++ b/internal/singbox/vlink/clash_vless_test.go
@@ -128,8 +128,9 @@ func TestMapClashVless_PortAsString(t *testing.T) {
 }
 
 // TestMapClashVless_FlowNormalizedAndEncryption verifies the Clash mapper goes
-// through the shared buildVlessOutbound: flow loses the -udp443 suffix and
-// encryption is carried — both previously diverged from the share-link path.
+// through the shared buildVlessOutbound: flow loses the -udp443 suffix, and
+// encryption never reaches the outbound — sing-box has no such field on VLESS
+// and rejects the whole config when it appears (issue #603).
 func TestMapClashVless_FlowNormalizedAndEncryption(t *testing.T) {
 	in := map[string]any{
 		"name":       "n",
@@ -138,7 +139,7 @@ func TestMapClashVless_FlowNormalizedAndEncryption(t *testing.T) {
 		"port":       443,
 		"uuid":       "3a3b1c2e-9999-4321-aaaa-1234567890ab",
 		"flow":       "xtls-rprx-vision-udp443",
-		"encryption": "xtls-rprx",
+		"encryption": "auto",
 		"tls":        true,
 		"servername": "h",
 	}
@@ -153,8 +154,24 @@ func TestMapClashVless_FlowNormalizedAndEncryption(t *testing.T) {
 	if ob["flow"] != "xtls-rprx-vision" {
 		t.Errorf("flow not normalized: got %v, want xtls-rprx-vision (stripped -udp443)", ob["flow"])
 	}
-	if ob["encryption"] != "xtls-rprx" {
-		t.Errorf("encryption dropped: got %v, want xtls-rprx", ob["encryption"])
+	if _, present := ob["encryption"]; present {
+		t.Errorf("encryption reached the sing-box outbound: %s", got.Outbound)
+	}
+}
+
+// Clash-путь обязан отказывать так же, как share-link: настоящий VLESS
+// Encryption sing-box не умеет, и сервер не заработает.
+func TestMapClashVless_RealEncryptionRejected(t *testing.T) {
+	in := map[string]any{
+		"name":       "n",
+		"type":       "vless",
+		"server":     "ex.com",
+		"port":       443,
+		"uuid":       "3a3b1c2e-9999-4321-aaaa-1234567890ab",
+		"encryption": "mlkem768x25519plus.native.600s.AAAA",
+	}
+	if _, err := mapClashVless(in); err == nil {
+		t.Fatal("expected rejection: sing-box cannot carry VLESS Encryption")
 	}
 }
 

--- a/internal/singbox/vlink/encode.go
+++ b/internal/singbox/vlink/encode.go
@@ -69,9 +69,6 @@ func encodeVless(ob map[string]any, label string) (string, error) {
 	if flow, _ := ob["flow"].(string); flow != "" {
 		q.Set("flow", flow)
 	}
-	if enc, _ := ob["encryption"].(string); enc != "" && !strings.EqualFold(enc, "none") {
-		q.Set("encryption", enc)
-	}
 	u.RawQuery = q.Encode()
 	if label != "" {
 		u.Fragment = label

--- a/internal/singbox/vlink/vless.go
+++ b/internal/singbox/vlink/vless.go
@@ -41,12 +41,44 @@ func parseVless(input string) (*ParsedOutbound, error) {
 	return buildVlessOutbound(host, uint16(port), uuid, q.Get("flow"), q.Get("encryption"), stream, u.Fragment, u.Fragment)
 }
 
+// meaninglessEncryption lists encryption values that carry no meaning for
+// VLESS: "none" from the spec itself, plus VMess ciphers that keep travelling
+// through public subscriptions by copy-paste. They are dropped silently.
+var meaninglessEncryption = map[string]bool{
+	"":                  true,
+	"none":              true,
+	"auto":              true,
+	"zero":              true,
+	"aes-128-gcm":       true,
+	"aes-256-gcm":       true,
+	"aes-128-cfb":       true,
+	"chacha20-poly1305": true,
+}
+
+// checkVlessEncryption rejects links that need real VLESS Encryption (issue
+// #603). sing-box has no encryption field on a VLESS outbound at all
+// (option.VLESSOutboundOptions) and decodes strictly, so passing the value
+// through poisons the whole config with `json: unknown field "encryption"`.
+// Dropping it silently would instead hand the user a server that cannot
+// connect, so anything outside the meaningless set fails here — the list is a
+// whitelist of junk on purpose: an unknown value is more likely a new
+// encryption spec than new junk, and a visible refusal beats a silent break.
+func checkVlessEncryption(encryption string) error {
+	if meaninglessEncryption[strings.ToLower(strings.TrimSpace(encryption))] {
+		return nil
+	}
+	return fmt.Errorf("vless: encryption=%q не поддерживается sing-box (VLESS Encryption) — сервер пропущен", encryption)
+}
+
 // buildVlessOutbound assembles the vless outbound shared by the share-link
 // parser (parseVless) and the Clash mapper (mapClashVless), so flow
 // normalization and encryption handling stay identical across both entry
 // formats — previously the Clash path took flow raw and ignored encryption.
 // tag falls back to vless-<host>-<port> when empty.
 func buildVlessOutbound(host string, port uint16, uuid, flow, encryption string, stream *StreamBuilder, tag, label string) (*ParsedOutbound, error) {
+	if err := checkVlessEncryption(encryption); err != nil {
+		return nil, err
+	}
 	out := map[string]any{
 		"type":        "vless",
 		"server":      host,
@@ -55,9 +87,6 @@ func buildVlessOutbound(host string, port uint16, uuid, flow, encryption string,
 	}
 	if f := normalizeFlow(flow); f != "" {
 		out["flow"] = f
-	}
-	if encryption != "" && encryption != "none" {
-		out["encryption"] = encryption
 	}
 	stream.MergeIntoOutbound(out)
 

--- a/internal/singbox/vlink/vless_test.go
+++ b/internal/singbox/vlink/vless_test.go
@@ -209,3 +209,42 @@ func TestParseVless_NoFragmentLabelEmpty(t *testing.T) {
 		t.Errorf("Label=%q want empty", got.Label)
 	}
 }
+
+// Issue #603. sing-box не имеет поля encryption у VLESS-outbound'а
+// (option.VLESSOutboundOptions), а декодер строгий, поэтому конфиг с ним
+// падает целиком: `outbounds[N].encryption: json: unknown field`. Значения
+// вроде auto/aes-128-gcm для VLESS ничего не значат (наследие VMess) —
+// такие ссылки обязаны парситься, просто без поля.
+func TestParseVless_MeaninglessEncryptionIgnored(t *testing.T) {
+	for _, enc := range []string{"none", "auto", "zero", "aes-128-gcm", "chacha20-poly1305"} {
+		t.Run(enc, func(t *testing.T) {
+			link := "vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@example.com:443?security=tls&type=tcp&encryption=" + enc + "#n"
+			got, err := ParseLink(link)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			var ob map[string]any
+			if err := json.Unmarshal(got.Outbound, &ob); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if _, present := ob["encryption"]; present {
+				t.Fatalf("encryption reached the sing-box outbound: %s", got.Outbound)
+			}
+		})
+	}
+}
+
+// Настоящий VLESS Encryption (фича Xray) sing-box не умеет вовсе, поэтому
+// сервер не заработает никак. Молча выкинуть параметр — значит отдать
+// пользователю нерабочий сервер без объяснения; отказываем с внятным текстом,
+// он доезжает до UI через BatchResult.Errors.
+func TestParseVless_RealEncryptionRejected(t *testing.T) {
+	link := "vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@example.com:443?security=tls&type=tcp&encryption=mlkem768x25519plus.native.600s.AAAA#n"
+	_, err := ParseLink(link)
+	if err == nil {
+		t.Fatal("expected rejection: sing-box cannot carry VLESS Encryption")
+	}
+	if !strings.Contains(err.Error(), "encryption") {
+		t.Fatalf("error must name the culprit, got: %v", err)
+	}
+}


### PR DESCRIPTION
sing-box не имеет encryption в VLESS-outbound и декодирует строго, поэтому одна ссылка с этим полем роняла разбор всего конфига. На больших подписках каждый такой сервер стоил отдельного запуска sing-box check, дренаж упирался в бюджет, и пользователь видел «слишком много неподдерживаемых серверов».

Мусорные значения (auto, zero, шифры от VMess) молча игнорируются, настоящий VLESS Encryption отбраковывается с объяснением — sing-box его не умеет, и сервер всё равно не заработает. Экспорт ссылки этот параметр больше не несёт.

Closes #603

не нужно использовать постквант шифрование в панелке 3xui если вы планируете использовать singbox