### PR TITLE
fix(pingcheck): не выдавать «не измерено» за время отклика

### DIFF
--- a/cmd/awg-manager/wiring_tunnels.go
+++ b/cmd/awg-manager/wiring_tunnels.go
@@ -208,12 +208,9 @@ func (a *app) setupServices() {
 
 	// Unified facade: kernel → custom loop, NativeWG → NDMS native
 	a.pingCheckFacade = pingcheck.NewFacade(a.pingCheckService, a.awgStore, a.nwgOp)
-	a.pingCheckFacade.SetNativeWGLatencyProbe(func(ctx context.Context, tunnelID string) int {
+	a.pingCheckFacade.SetNativeWGLatencyProbe(func(ctx context.Context, tunnelID string) (int, string) {
 		res, err := a.testService.CheckConnectivity(ctx, tunnelID)
-		if err != nil || res == nil || !res.Connected || res.Latency == nil {
-			return pingcheck.LatencyNotAvailable
-		}
-		return *res.Latency
+		return pingcheck.LatencyFromConnectivity(res, err)
 	})
 
 	// monitoringService is constructed below after systemTunnelSvc is wired,

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -2126,6 +2126,7 @@ const api_TunnelPingStatusDTO: v.GenericSchema = v.looseObject({
 	failCount: v.optional(v.nullable(v.number())),
 	failThreshold: v.optional(v.nullable(v.number())),
 	lastLatency: v.optional(v.nullable(v.number())),
+	latencyNote: v.optional(v.nullable(v.string())),
 	method: v.optional(v.nullable(v.string())),
 	restartCount: v.optional(v.nullable(v.number())),
 	status: v.optional(v.nullable(v.string())),

--- a/frontend/src/lib/components/pingcheck/MonitoringTab.svelte
+++ b/frontend/src/lib/components/pingcheck/MonitoringTab.svelte
@@ -87,6 +87,7 @@
 				configured: isWatchdog || !!cfg,
 				configLine: configLine(cfg, s.method, s.failThreshold),
 				stats: computeCardStats(logsByTunnel.get(s.tunnelId) ?? [], s),
+				latencyNote: s.latencyNote,
 			};
 		});
 		const noPc = tunnelMeta
@@ -201,6 +202,7 @@
 					isWatchdog={c.isWatchdog}
 					configLine={c.configLine}
 					stats={c.stats}
+					latencyNote={c.latencyNote}
 					onConfigure={() => openConfig(c.id, c.name, c.backend)}
 					onCheckNow={checkNow}
 					onDisable={() => disablePingcheck(c.id, c.name, c.backend)}

--- a/frontend/src/lib/components/pingcheck/WatchdogCard.svelte
+++ b/frontend/src/lib/components/pingcheck/WatchdogCard.svelte
@@ -15,13 +15,15 @@
 		isWatchdog: boolean;
 		configLine: string;
 		stats: CardStats | null;
+		/** Почему время отклика не измерено; пусто — измеряется нормально. */
+		latencyNote?: string;
 		onConfigure: () => void;
 		onCheckNow: () => void;
 		onDisable: () => void;
 		onEnable: () => void;
 	}
 
-	let { name, backend, awgVersion, statusKind, hasPingcheck, isWatchdog, configLine, stats, onConfigure, onCheckNow, onDisable, onEnable }: Props =
+	let { name, backend, awgVersion, statusKind, hasPingcheck, isWatchdog, configLine, stats, latencyNote, onConfigure, onCheckNow, onDisable, onEnable }: Props =
 		$props();
 
 	const STATUS: Record<Props['statusKind'], { dot: StatusDotVariant; pulse: boolean; label: string; badge: BadgeVariant }> = {
@@ -33,6 +35,9 @@
 	};
 	const st = $derived(STATUS[statusKind]);
 	const fmt = (v: number | null) => (v === null ? '—' : `${v}ms`);
+	// latency <= 0 у успешной проверки означает «не измерено» (issue #629):
+	// печатать «-1ms» нельзя, причина показана отдельной строкой ниже.
+	const fmtLat = (v: number) => (v > 0 ? `${v}ms` : '—');
 </script>
 
 <div class="wd-card" class:recovering={statusKind === 'recovering'}>
@@ -62,6 +67,12 @@
 			<div class="wd-stat"><span class="v" class:loss={stats.lossPct > 0}>{stats.lossPct}%</span><span class="k">loss</span></div>
 		</div>
 
+		<!-- Почему нет цифр: причина одна на туннель, поэтому показывается
+		     один раз, а не в каждой строке проверки (issue #629). -->
+		{#if latencyNote}
+			<div class="wd-latency-note"><Info size={13} />{latencyNote}</div>
+		{/if}
+
 		<!-- Last checks -->
 		<div class="wd-checks">
 			<div class="wd-checks-head">
@@ -80,7 +91,7 @@
 						<span class="ico" class:ok={e.success} class:bad={!e.success}>
 							{#if e.success}<Check size={13} />{:else}<X size={13} />{/if}
 						</span>
-						<span class="lat">{e.success ? `${e.latency}ms` : '—'}</span>
+						<span class="lat">{e.success ? fmtLat(e.latency) : '—'}</span>
 						<span class="note">{e.error}</span>
 					</div>
 				{/each}
@@ -196,6 +207,22 @@
 		line-height: 1.6;
 		color: var(--color-text-muted);
 		border-bottom: 1px solid var(--color-border);
+	}
+
+	.wd-latency-note {
+		display: flex;
+		align-items: flex-start;
+		gap: 6px;
+		padding: 8px 14px;
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--color-text-muted);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.wd-latency-note :global(svg) {
+		flex-shrink: 0;
+		margin-top: 1px;
 	}
 
 	/* Stats grid */

--- a/frontend/src/lib/components/tunnels/TunnelDelaySparkBars.svelte
+++ b/frontend/src/lib/components/tunnels/TunnelDelaySparkBars.svelte
@@ -50,9 +50,13 @@
 		{/each}
 	{:else}
 		{#each bars as d, i (i)}
+			<!-- d > 0 — измерено, 0 — проверка провалилась, < 0 — проверка прошла,
+			     но время не измерено (issue #629): такой столбец приглушённый,
+			     а не красный, иначе успешная проверка читается как сбой. -->
 			<div
 				class="bar"
-				class:fail={colorPerBar && (d <= 0 || latencyTier(d) === 'error')}
+				class:fail={colorPerBar && (d === 0 || (d > 0 && latencyTier(d) === 'error'))}
+				class:unmeasured={colorPerBar && d < 0}
 				class:slow={colorPerBar && d > 0 && latencyTier(d) === 'warning'}
 				style="height: {Math.max((d <= 0 ? max : d) / max, 0.08) * 100}%;"
 			></div>

--- a/frontend/src/lib/styles/tunnel-layout.css
+++ b/frontend/src/lib/styles/tunnel-layout.css
@@ -786,7 +786,8 @@ button.tunnel-list-traffic-cell:focus-visible {
 }
 
 .tunnel-delay-spark.unknown .bar,
-.tunnel-delay-spark .bar.empty {
+.tunnel-delay-spark .bar.empty,
+.tunnel-delay-spark .bar.unmeasured {
 	background: color-mix(in srgb, var(--color-text-muted) 35%, transparent);
 }
 

--- a/frontend/src/lib/types/tunnels.ts
+++ b/frontend/src/lib/types/tunnels.ts
@@ -256,7 +256,10 @@ export interface TunnelPingStatus {
 	status: 'alive' | 'recovering' | 'disabled' | 'stopped' | 'warming';
 	method: string;
 	lastCheck?: string;
+	/** ms; -1 — проверка прошла, но время не измерено (см. latencyNote). */
 	lastLatency: number;
+	/** Почему время отклика не измерено; пусто — измеряется нормально. */
+	latencyNote?: string;
 	failCount: number;
 	successCount?: number;
 	failThreshold: number;

--- a/frontend/src/lib/utils/pingStats.test.ts
+++ b/frontend/src/lib/utils/pingStats.test.ts
@@ -66,7 +66,7 @@ describe('unknown latency (-1)', () => {
 		tunnelId: 't', tunnelName: 't', enabled: true, backend: 'nativewg',
 		status: 'alive', method: 'handshake', lastLatency: -1,
 		failCount: 0, failThreshold: 3, restartCount: 0,
-	} as TunnelPingStatus;
+	};
 
 	it('не учитывает неизмеренные проверки в avg/min/max', () => {
 		const s = computeCardStats([log('t', true, -1), log('t', true, -1)], status);

--- a/frontend/src/lib/utils/pingStats.test.ts
+++ b/frontend/src/lib/utils/pingStats.test.ts
@@ -57,3 +57,39 @@ describe('computeCardStats', () => {
 		expect(s.history).toEqual([0, 0]);
 	});
 });
+
+// Issue #629: латентность -1 означает «не измерено», а не «0 мс».
+// Раньше она попадала в avg/min/max и в полоску, из-за чего успешные
+// проверки рисовались красными, а средняя показывала -1.
+describe('unknown latency (-1)', () => {
+	const status: TunnelPingStatus = {
+		tunnelId: 't', tunnelName: 't', enabled: true, backend: 'nativewg',
+		status: 'alive', method: 'handshake', lastLatency: -1,
+		failCount: 0, failThreshold: 3, restartCount: 0,
+	} as TunnelPingStatus;
+
+	it('не учитывает неизмеренные проверки в avg/min/max', () => {
+		const s = computeCardStats([log('t', true, -1), log('t', true, -1)], status);
+		expect(s.avgMs).toBeNull();
+		expect(s.minMs).toBeNull();
+		expect(s.maxMs).toBeNull();
+	});
+
+	it('считает статистику по измеренным, игнорируя неизмеренные', () => {
+		const s = computeCardStats([log('t', true, 10), log('t', true, -1), log('t', true, 30)], status);
+		expect(s.avgMs).toBe(20);
+		expect(s.minMs).toBe(10);
+		expect(s.maxMs).toBe(30);
+	});
+
+	it('не считает неизмеренную проверку потерей', () => {
+		const s = computeCardStats([log('t', true, -1), log('t', false, 0)], status);
+		expect(s.lossPct).toBe(50);
+	});
+
+	it('различает в history неизмеренную проверку (-1) и провал (0)', () => {
+		const s = computeCardStats([log('t', false, 0), log('t', true, -1)], status);
+		// history — хронологический, oldest→newest
+		expect(s.history).toEqual([-1, 0]);
+	});
+});

--- a/frontend/src/lib/utils/pingStats.ts
+++ b/frontend/src/lib/utils/pingStats.ts
@@ -31,7 +31,11 @@ export function groupLogsByTunnel(logs: PingLogEntry[]): Map<string, PingLogEntr
 export function computeCardStats(entries: PingLogEntry[], status: TunnelPingStatus): CardStats {
 	const window = entries.slice(0, STAT_WINDOW);
 	const ok = window.filter((e) => e.success);
-	const okLat = ok.map((e) => e.latency);
+	// latency <= 0 у успешной проверки означает «не измерено» (NativeWG:
+	// NDMS не отдаёт время, а методы handshake/disabled его не меряют).
+	// В avg/min/max такие записи не входят, но остаются успешными
+	// проверками — в lossPct и в полоске они учитываются.
+	const okLat = ok.map((e) => e.latency).filter((v) => v > 0);
 
 	const avgMs = okLat.length ? Math.round(okLat.reduce((s, v) => s + v, 0) / okLat.length) : null;
 	const minMs = okLat.length ? Math.min(...okLat) : null;

--- a/internal/api/pingcheck.go
+++ b/internal/api/pingcheck.go
@@ -25,6 +25,7 @@ type TunnelPingStatusDTO struct {
 	Status        string `json:"status" example:"alive"`
 	Method        string `json:"method" example:"http"`
 	LastLatency   int    `json:"lastLatency" example:"35"`
+	LatencyNote   string `json:"latencyNote,omitempty" example:"метод проверки не измеряет время отклика"`
 	FailCount     int    `json:"failCount" example:"0"`
 	FailThreshold int    `json:"failThreshold" example:"3"`
 	RestartCount  int    `json:"restartCount" example:"0"`

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -5813,6 +5813,9 @@ definitions:
       lastLatency:
         example: 35
         type: integer
+      latencyNote:
+        example: метод проверки не измеряет время отклика
+        type: string
       method:
         example: http
         type: string

--- a/internal/pingcheck/facade.go
+++ b/internal/pingcheck/facade.go
@@ -38,7 +38,7 @@ type Facade struct {
 	nwgSource       nwgPollSource // nil when nwgOp is nil; overridable for tests
 	nwgMonMu        sync.RWMutex
 	nwgMonitors     map[string]*nwgMonitor
-	nwgLatencyProbe func(context.Context, string) int // returns latency in ms, <=0 when unavailable
+	nwgLatencyProbe func(context.Context, string) (int, string) // latency in ms, plus a note when unavailable
 	ctx             context.Context
 	cancel          context.CancelFunc
 }
@@ -63,8 +63,10 @@ func NewFacade(custom *Service, tunnels *storage.AWGTunnelStore, nwgOp *nwg.Oper
 
 // SetNativeWGLatencyProbe sets an optional probe used by NativeWG monitors
 // to obtain real latency values (for example, via testing connectivity checks).
-// Probe should return latency in milliseconds, or <=0 when unavailable.
-func (f *Facade) SetNativeWGLatencyProbe(fn func(context.Context, string) int) {
+// The probe returns latency in milliseconds, or LatencyNotAvailable plus a
+// user-facing note explaining why nothing was measured — see
+// LatencyFromConnectivity.
+func (f *Facade) SetNativeWGLatencyProbe(fn func(context.Context, string) (int, string)) {
 	f.nwgLatencyProbe = fn
 }
 
@@ -195,6 +197,7 @@ func (f *Facade) getNativeWGStatuses() []TunnelStatus {
 			if ts.Status == "recovering" {
 				ts.RestartCount = 1
 			}
+			ts.LatencyNote = f.nwgLatencyNote(t.ID)
 		}
 
 		result = append(result, ts)
@@ -248,6 +251,18 @@ func (f *Facade) isNwgRestartDetected(tunnelID string) bool {
 		return false
 	}
 	return mon.restartDetected
+}
+
+// nwgLatencyNote returns the monitor's explanation for an absent latency
+// measurement, or "" when the last check produced a real number.
+func (f *Facade) nwgLatencyNote(tunnelID string) string {
+	f.nwgMonMu.RLock()
+	mon, ok := f.nwgMonitors[tunnelID]
+	f.nwgMonMu.RUnlock()
+	if !ok {
+		return ""
+	}
+	return mon.lastLatencyNote
 }
 
 // startNwgMonitor creates and starts a poll-based nwgMonitor for the given tunnel.

--- a/internal/pingcheck/nwg_latency.go
+++ b/internal/pingcheck/nwg_latency.go
@@ -1,0 +1,40 @@
+package pingcheck
+
+import (
+	testingsvc "github.com/hoaxisr/awg-manager/internal/testing"
+)
+
+// reasonCheckDisabled duplicates the literal returned by
+// testing.Service.CheckConnectivity for method "disabled"
+// (internal/testing/connectivity.go:46). It is a plain string there, not a
+// constant, so this copy is the coupling point — keep them in sync.
+const reasonCheckDisabled = "check disabled"
+
+// LatencyFromConnectivity converts a connectivity-check result into the latency
+// value stored in the ping log and a note explaining an absent measurement.
+//
+// Only the "http" and "ping" methods measure time (connectivity.go:101 and
+// :133); "handshake" and "disabled" report success with no latency at all, so
+// an absent value is normal rather than a failure. Collapsing every case into
+// LatencyNotAvailable without a note is what made the UI render a successful
+// check as "-1 ms" with a red bar (issue #629).
+func LatencyFromConnectivity(res *testingsvc.ConnectivityResult, err error) (int, string) {
+	switch {
+	case err != nil:
+		return LatencyNotAvailable, "проверка связности не выполнилась: " + err.Error()
+	case res == nil:
+		return LatencyNotAvailable, "проверка связности не вернула результат"
+	case !res.Connected:
+		note := "проверка связности не прошла"
+		if res.Reason != "" {
+			note += ": " + res.Reason
+		}
+		return LatencyNotAvailable, note
+	case res.Latency == nil:
+		if res.Reason == reasonCheckDisabled {
+			return LatencyNotAvailable, "проверка связности выключена — время отклика не измеряется"
+		}
+		return LatencyNotAvailable, "метод проверки не измеряет время отклика — выберите «ping» или «http», чтобы видеть числа"
+	}
+	return *res.Latency, ""
+}

--- a/internal/pingcheck/nwg_latency_test.go
+++ b/internal/pingcheck/nwg_latency_test.go
@@ -1,0 +1,81 @@
+package pingcheck
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	testingsvc "github.com/hoaxisr/awg-manager/internal/testing"
+)
+
+// Issue #629. NDMS не отдаёт латентность по каждой проверке NativeWG, поэтому
+// её измеряет отдельная проба. Все её неудачи раньше схлопывались в -1 без
+// причины, и UI показывал успешную проверку как «-1 ms» и красный квадрат.
+// Каждая ветка обязана давать своё объяснение.
+func TestLatencyFromConnectivity(t *testing.T) {
+	ms := func(v int) *int { return &v }
+
+	cases := []struct {
+		name     string
+		res      *testingsvc.ConnectivityResult
+		err      error
+		wantMS   int
+		wantNote string // подстрока
+	}{
+		{
+			name:   "измерено",
+			res:    &testingsvc.ConnectivityResult{Connected: true, Latency: ms(42)},
+			wantMS: 42,
+		},
+		{
+			name:     "проба не выполнилась",
+			err:      errors.New("boom"),
+			wantMS:   LatencyNotAvailable,
+			wantNote: "не выполнилась",
+		},
+		{
+			name:     "пустой результат",
+			wantMS:   LatencyNotAvailable,
+			wantNote: "не вернула результат",
+		},
+		{
+			name:     "связности нет — причина известна",
+			res:      &testingsvc.ConnectivityResult{Connected: false, Reason: "handshake stale: 5 minutes"},
+			wantMS:   LatencyNotAvailable,
+			wantNote: "handshake stale: 5 minutes",
+		},
+		{
+			name:     "метод не измеряет время",
+			res:      &testingsvc.ConnectivityResult{Connected: true},
+			wantMS:   LatencyNotAvailable,
+			wantNote: "не измеряет время",
+		},
+		{
+			name:     "проверка выключена",
+			res:      &testingsvc.ConnectivityResult{Connected: true, Reason: "check disabled"},
+			wantMS:   LatencyNotAvailable,
+			wantNote: "выключена",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMS, gotNote := LatencyFromConnectivity(tc.res, tc.err)
+			if gotMS != tc.wantMS {
+				t.Errorf("latency = %d, want %d", gotMS, tc.wantMS)
+			}
+			if tc.wantNote == "" {
+				if gotNote != "" {
+					t.Errorf("note = %q, want empty for a measured latency", gotNote)
+				}
+				return
+			}
+			if gotNote == "" {
+				t.Fatalf("note is empty, want an explanation containing %q", tc.wantNote)
+			}
+			if !strings.Contains(gotNote, tc.wantNote) {
+				t.Errorf("note = %q, want it to mention %q", gotNote, tc.wantNote)
+			}
+		})
+	}
+}

--- a/internal/pingcheck/nwg_monitor.go
+++ b/internal/pingcheck/nwg_monitor.go
@@ -9,8 +9,12 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/ndms"
 )
 
-// LatencyNotAvailable is used for NativeWG log entries where NDMS
-// does not provide per-check latency data. Frontend hides the value.
+// LatencyNotAvailable marks a NativeWG log entry whose latency could not be
+// measured: NDMS gives no per-check timing, and the fallback probe either
+// failed or ran a method that does not measure time at all. It is a sentinel,
+// NOT a value — the UI must render it as "unknown" and keep it out of
+// avg/min/max (issue #629). The reason travels separately, in
+// TunnelStatus.LatencyNote.
 const LatencyNotAvailable = -1
 
 // nwgPollSource abstracts NDMS polling for testability.
@@ -27,7 +31,7 @@ type nwgMonitor struct {
 	threshold    int
 	logBuffer    *LogBuffer
 	source       nwgPollSource
-	latencyProbe func(context.Context, string) int
+	latencyProbe func(context.Context, string) (int, string)
 	bus          *events.Bus
 
 	stopCh    chan struct{}
@@ -41,7 +45,9 @@ type nwgMonitor struct {
 	prevStatus   string
 	prevBound    bool
 	lastLatency  int
-	startupPhase bool
+	// lastLatencyNote explains an absent measurement; empty when measured.
+	lastLatencyNote string
+	startupPhase    bool
 
 	// restartDetected is set when nwgMonitor detects that NDMS restarted
 	// the tunnel interface (counters reset after failure). Cleared on first
@@ -278,9 +284,10 @@ func (m *nwgMonitor) pollOnce(ctx context.Context) {
 		return // skip this poll, retry next interval
 	}
 	if m.latencyProbe != nil {
-		m.lastLatency = m.latencyProbe(ctx, m.tunnelID)
+		m.lastLatency, m.lastLatencyNote = m.latencyProbe(ctx, m.tunnelID)
 	} else {
 		m.lastLatency = LatencyNotAvailable
+		m.lastLatencyNote = "проба времени отклика не настроена"
 	}
 
 	// Sync poll interval with actual NDMS check interval on first poll.

--- a/internal/pingcheck/types.go
+++ b/internal/pingcheck/types.go
@@ -25,19 +25,23 @@ type LogEntry struct {
 
 // TunnelStatus represents the current ping check status of a tunnel.
 type TunnelStatus struct {
-	TunnelID      string     `json:"tunnelId"`
-	TunnelName    string     `json:"tunnelName"`
-	Enabled       bool       `json:"enabled"`
-	Backend       string     `json:"backend"` // "kernel" or "nativewg"
-	Status        string     `json:"status"`  // "alive", "recovering", "disabled", "stopped"
-	Method        string     `json:"method"`  // "http", "icmp", "connect", "tls", "uri"
-	LastCheck     *time.Time `json:"lastCheck"`
-	LastLatency   int        `json:"lastLatency"` // ms
-	FailCount     int        `json:"failCount"`
-	SuccessCount  int        `json:"successCount,omitempty"` // NDMS native only
-	FailThreshold int        `json:"failThreshold"`
-	RestartCount  int        `json:"restartCount"`
-	TunnelRunning bool       `json:"tunnelRunning"` // whether the tunnel interface is actually up
+	TunnelID    string     `json:"tunnelId"`
+	TunnelName  string     `json:"tunnelName"`
+	Enabled     bool       `json:"enabled"`
+	Backend     string     `json:"backend"` // "kernel" or "nativewg"
+	Status      string     `json:"status"`  // "alive", "recovering", "disabled", "stopped"
+	Method      string     `json:"method"`  // "http", "icmp", "connect", "tls", "uri"
+	LastCheck   *time.Time `json:"lastCheck"`
+	LastLatency int        `json:"lastLatency"` // ms; LatencyNotAvailable (-1) = не измерено
+	// LatencyNote explains an absent measurement (empty when latency is real).
+	// NativeWG only: NDMS gives no per-check timing, and the fallback probe
+	// may run a method that does not measure time at all.
+	LatencyNote   string `json:"latencyNote,omitempty"`
+	FailCount     int    `json:"failCount"`
+	SuccessCount  int    `json:"successCount,omitempty"` // NDMS native only
+	FailThreshold int    `json:"failThreshold"`
+	RestartCount  int    `json:"restartCount"`
+	TunnelRunning bool   `json:"tunnelRunning"` // whether the tunnel interface is actually up
 }
 
 // TunnelPingInfo is a lightweight status for embedding in tunnel list responses.


### PR DESCRIPTION
NDMS не отдаёт латентность по каждой проверке NativeWG, её меряет отдельная проба. Все её неудачи схлопывались в -1 без причины, а UI считал -1 значением: успешная проверка показывалась как «-1 ms», квадрат красился в красный, и та же -1 попадала в avg/min/max.

Теперь -1 везде трактуется как «неизвестно»: в строках проверок прочерк, в полоске приглушённый столбец вместо красного, в статистике не учитывается. Причина едет отдельным полем и показывается один раз в карточке — методы handshake и disabled время не измеряют вовсе, и это не сбой.

Closes #629