### PR TITLE
fix(subscription): различать эндпоинты одного сервера по транспорту

### DIFF
--- a/internal/singbox/subscription/diff.go
+++ b/internal/singbox/subscription/diff.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/vlink"
 )
@@ -87,6 +88,51 @@ func extendedKey(p vlink.ParsedOutbound) string {
 	return identityKey(p) + "|" + sni + "|" + sid
 }
 
+// transportKey collects the transport fields that make two endpoints on one
+// server:port:credential:SNI genuinely different routes: ws/httpupgrade/xhttp
+// path and Host, gRPC service_name, xhttp mode (issue #625). Empty when the
+// outbound carries no transport block (plain TCP).
+//
+// Field shapes differ per transport type (host is a string for httpupgrade and
+// xhttp but a []string for http/h2, and ws puts it in headers.Host), so every
+// spelling is read here rather than branching on the transport type.
+func transportKey(ob map[string]any) string {
+	tr, ok := ob["transport"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	host := ""
+	switch h := tr["host"].(type) {
+	case string:
+		host = h
+	case []any:
+		parts := make([]string, 0, len(h))
+		for _, v := range h {
+			if s, ok := v.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		host = strings.Join(parts, ",")
+	}
+	if host == "" {
+		if headers, ok := tr["headers"].(map[string]any); ok {
+			host, _ = headers["Host"].(string)
+		}
+	}
+	typ, _ := tr["type"].(string)
+	path, _ := tr["path"].(string)
+	service, _ := tr["service_name"].(string)
+	mode, _ := tr["mode"].(string)
+	return typ + "|" + path + "|" + host + "|" + service + "|" + mode
+}
+
+// fullKey is the widest identity: extendedKey plus the transport fields.
+func fullKey(p vlink.ParsedOutbound) string {
+	var ob map[string]any
+	json.Unmarshal(p.Outbound, &ob)
+	return extendedKey(p) + "|" + transportKey(ob)
+}
+
 func itoa(p uint16) string {
 	if p == 0 {
 		return "0"
@@ -111,20 +157,34 @@ func itoa(p uint16) string {
 // (preview) and the final tag (refresh) agree.
 func chooseKeys(parsed []vlink.ParsedOutbound) []string {
 	distinctExt := make(map[string]map[string]struct{}, len(parsed))
+	distinctFull := make(map[string]map[string]struct{}, len(parsed))
 	for _, p := range parsed {
 		nk := identityKey(p)
 		if distinctExt[nk] == nil {
 			distinctExt[nk] = make(map[string]struct{})
+			distinctFull[nk] = make(map[string]struct{})
 		}
 		distinctExt[nk][extendedKey(p)] = struct{}{}
+		distinctFull[nk][fullKey(p)] = struct{}{}
 	}
 	keys := make([]string, len(parsed))
 	for i, p := range parsed {
 		nk := identityKey(p)
-		if len(distinctExt[nk]) > 1 {
-			keys[i] = extendedKey(p)
-		} else {
+		switch {
+		case len(distinctFull[nk]) <= 1:
+			// Byte-identical duplicates: narrow key keeps the tag stable
+			// across refreshes and matches previously stored narrow tags.
 			keys[i] = nk
+		case len(distinctExt[nk]) == len(distinctFull[nk]):
+			// Masking alone tells them apart (issue #373). Staying on the
+			// extended key keeps tags of already-widened groups unchanged —
+			// widening further would re-tag subscriptions that never had the
+			// bug.
+			keys[i] = extendedKey(p)
+		default:
+			// Endpoints share masking and differ only by transport
+			// (issue #625): only the full key separates them.
+			keys[i] = fullKey(p)
 		}
 	}
 	return keys

--- a/internal/singbox/subscription/diff_test.go
+++ b/internal/singbox/subscription/diff_test.go
@@ -211,3 +211,88 @@ func TestPreviewSuffixMatchesRefreshTag(t *testing.T) {
 		}
 	}
 }
+
+// mkParsedWS строит vless-сервер с ws-транспортом: те же server/port/uuid,
+// но своя пара path+Host — ровно случай issue #625.
+func mkParsedWS(server string, port uint16, sni, path, host string) vlink.ParsedOutbound {
+	ob := map[string]any{
+		"type": "vless", "server": server, "server_port": port,
+		"uuid": "00000000-0000-0000-0000-000000000000",
+		"tls":  map[string]any{"enabled": true, "server_name": sni},
+		"transport": map[string]any{
+			"type": "ws", "path": path,
+			"headers": map[string]any{"Host": host},
+		},
+	}
+	raw, _ := json.Marshal(ob)
+	return vlink.ParsedOutbound{
+		Tag: "tmp", Protocol: "vless", Server: server, Port: port, Outbound: raw,
+	}
+}
+
+// mkParsedReality — различие только в маскировке (issue #373): тег обязан
+// остаться тем же, что и до правки, иначе у существующих подписок разъедутся
+// все теги, а не только сломанные.
+func mkParsedReality(server string, port uint16, sni, shortID string) vlink.ParsedOutbound {
+	ob := map[string]any{
+		"type": "vless", "server": server, "server_port": port,
+		"uuid": "00000000-0000-0000-0000-000000000000",
+		"tls": map[string]any{
+			"enabled": true, "server_name": sni,
+			"reality": map[string]any{"enabled": true, "short_id": shortID},
+		},
+	}
+	raw, _ := json.Marshal(ob)
+	return vlink.ParsedOutbound{
+		Tag: "tmp", Protocol: "vless", Server: server, Port: port, Outbound: raw,
+	}
+}
+
+// Issue #625: серверы на одном server:port:uuid:SNI, различающиеся только
+// ws-путём и Host-заголовком, — разные эндпоинты, а не дубликаты.
+func TestApplyDiff_TransportDistinguishesMembers(t *testing.T) {
+	parsed := []vlink.ParsedOutbound{
+		mkParsedWS("1.2.3.4", 443, "cdn.example.com", "/path1", "host1"),
+		mkParsedWS("1.2.3.4", 443, "cdn.example.com", "/path2", "host2"),
+	}
+	got := ApplyDiff("sub", nil, parsed)
+	if got.SkippedDuplicate != 0 {
+		t.Errorf("SkippedDuplicate = %d, want 0", got.SkippedDuplicate)
+	}
+	if len(got.New) != 2 {
+		t.Fatalf("len(New) = %d, want 2", len(got.New))
+	}
+	if got.New[0].Tag == got.New[1].Tag {
+		t.Errorf("both endpoints got the same tag %q", got.New[0].Tag)
+	}
+}
+
+// Байт-идентичные записи остаются дубликатами и держат УЗКИЙ ключ —
+// иначе теги существующих подписок поедут без причины.
+func TestApplyDiff_TrueDuplicatesKeepNarrowTag(t *testing.T) {
+	p := mkParsedWS("1.2.3.4", 443, "cdn.example.com", "/p", "h")
+	got := ApplyDiff("sub", nil, []vlink.ParsedOutbound{p, p})
+	if got.SkippedDuplicate != 1 {
+		t.Errorf("SkippedDuplicate = %d, want 1", got.SkippedDuplicate)
+	}
+	if len(got.New) != 1 {
+		t.Fatalf("len(New) = %d, want 1", len(got.New))
+	}
+	if want := stableTagFromKey("sub", identityKey(p)); got.New[0].Tag != want {
+		t.Errorf("tag = %q, want narrow-key tag %q", got.New[0].Tag, want)
+	}
+}
+
+// Регрессия на радиус поражения: когда серверы различает ОДНА маскировка,
+// ключ обязан остаться расширенным (как до правки), а не поехать на полный.
+func TestApplyDiff_RealityOnlyKeepsExtendedTag(t *testing.T) {
+	a := mkParsedReality("1.2.3.4", 443, "a.example.com", "aa")
+	b := mkParsedReality("1.2.3.4", 443, "b.example.com", "bb")
+	got := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b})
+	if len(got.New) != 2 {
+		t.Fatalf("len(New) = %d, want 2", len(got.New))
+	}
+	if want := stableTagFromKey("sub", extendedKey(a)); got.New[0].Tag != want {
+		t.Errorf("tag = %q, want extended-key tag %q (masking alone must not widen further)", got.New[0].Tag, want)
+	}
+}

--- a/internal/singbox/subscription/migrate_tags.go
+++ b/internal/singbox/subscription/migrate_tags.go
@@ -1,0 +1,110 @@
+package subscription
+
+// Перенос исключений на новую схему тегов (issues #614/#625).
+//
+// Тег члена выводится из ключа идентичности, а ключ расширился полями
+// транспорта. У групп, где раньше разные эндпоинты схлопывались в один тег,
+// теги изменились — и сохранённые ExcludedTags перестали бы совпадать. Это
+// данные пользователя: без переноса исключённые серверы молча вернулись бы в
+// строй.
+//
+// Сопоставление идёт по метаданным (MemberInfo), а не пересчётом прежних
+// ключей: иначе в коде пришлось бы вечно держать копию старой схемы. Побочная
+// выгода — механизм переживёт и следующую смену ключей.
+
+// remapStaleTags переносит исключения и активного члена на текущую схему тегов.
+// Возвращает новый список исключённых, нового активного и признак изменения.
+//
+// known — источник метаданных для протухших тегов: ExcludedMembers + Members.
+func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, active string) ([]string, string, bool) {
+	all := make([]TaggedOutbound, 0, len(diff.New)+len(diff.Existing))
+	all = append(all, diff.New...)
+	all = append(all, diff.Existing...)
+
+	current := make(map[string]bool, len(all))
+	for _, t := range all {
+		current[t.Tag] = true
+	}
+	infoByTag := make(map[string]MemberInfo, len(known))
+	for _, m := range known {
+		infoByTag[m.Tag] = m
+	}
+
+	// matches ищет в текущем фиде серверы, отвечающие метаданным протухшего
+	// тега. Сравнение заведомо широкое: в MemberInfo нет ни credential, ни
+	// reality short_id, поэтому под один старый тег может попасть больше
+	// серверов, чем стояло за ним раньше. Направление выбрано сознательно —
+	// лучше оставить исключённым лишнее, чем самовольно включить то, что
+	// пользователь выключил.
+	matches := func(mi MemberInfo) []string {
+		var out []string
+		for _, t := range all {
+			c := toMemberInfo(t.Tag, t.Out)
+			if c.Protocol == mi.Protocol && c.Server == mi.Server &&
+				c.Port == mi.Port && c.SNI == mi.SNI && c.Transport == mi.Transport {
+				out = append(out, t.Tag)
+			}
+		}
+		return out
+	}
+
+	result := make([]string, 0, len(excluded))
+	seen := make(map[string]bool, len(excluded))
+	add := func(tag string) {
+		if !seen[tag] {
+			seen[tag] = true
+			result = append(result, tag)
+		}
+	}
+
+	changed := false
+	for _, tag := range excluded {
+		if current[tag] {
+			add(tag)
+			continue
+		}
+		mi, ok := infoByTag[tag]
+		if !ok {
+			add(tag) // нет метаданных — судить не о чем
+			continue
+		}
+		found := matches(mi)
+		if len(found) == 0 {
+			// Обычный случай «сервер ушёл от провайдера». Тег обязан
+			// сохраниться: когда сервер вернётся, он останется исключённым.
+			add(tag)
+			continue
+		}
+		for _, t := range found {
+			add(t)
+		}
+		changed = true
+	}
+
+	// Guard: расширение «один тег → N» способно исключить вообще всех.
+	// Ручной путь такое запрещает (ErrAllMembersExcluded), значит refresh не
+	// имеет права создавать это состояние сам — откатываемся к исходному.
+	if changed {
+		remaining := 0
+		for _, t := range all {
+			if !seen[t.Tag] {
+				remaining++
+			}
+		}
+		if remaining == 0 {
+			return excluded, active, false
+		}
+	}
+
+	newActive := active
+	if active != "" && !current[active] {
+		if mi, ok := infoByTag[active]; ok {
+			if found := matches(mi); len(found) > 0 {
+				newActive = found[0]
+				changed = true
+			}
+		}
+	}
+
+	return result, newActive, changed
+}

--- a/internal/singbox/subscription/migrate_tags.go
+++ b/internal/singbox/subscription/migrate_tags.go
@@ -16,7 +16,13 @@ package subscription
 // Возвращает новый список исключённых, нового активного и признак изменения.
 //
 // known — источник метаданных для протухших тегов: ExcludedMembers + Members.
-func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, active string) ([]string, string, bool) {
+// allows — предикат regex-фильтра по имени сервера (flt.Allows). Guard обязан
+// его учитывать: applyDiff скрывает члена по «исключён ИЛИ отфильтрован» и на
+// пустом наборе возвращает ErrAllMembersFiltered (service.go:689,709).
+func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, active string, allows func(label string) bool) ([]string, string, bool) {
+	if allows == nil {
+		allows = func(string) bool { return true }
+	}
 	all := make([]TaggedOutbound, 0, len(diff.New)+len(diff.Existing))
 	all = append(all, diff.New...)
 	all = append(all, diff.Existing...)
@@ -31,19 +37,31 @@ func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, acti
 	}
 
 	// matches ищет в текущем фиде серверы, отвечающие метаданным протухшего
-	// тега. Сравнение заведомо широкое: в MemberInfo нет ни credential, ни
-	// reality short_id, поэтому под один старый тег может попасть больше
-	// серверов, чем стояло за ним раньше. Направление выбрано сознательно —
-	// лучше оставить исключённым лишнее, чем самовольно включить то, что
-	// пользователь выключил.
+	// тега.
+	//
+	// TransportKey сравнивается, когда он есть: без этого исключение одного
+	// эндпоинта расползалось бы на соседние. Тег мог протухнуть не только от
+	// смены схемы — уровень ключа зависит от состава фида, поэтому группа
+	// схлопывается и расширяется обратно по мере того, как провайдер убирает
+	// и возвращает эндпоинты. В такой момент широкое сравнение исключило бы и
+	// тот эндпоинт, которого пользователь не трогал.
+	//
+	// У записей, сделанных до появления поля, оно пустое — для них остаётся
+	// прежнее грубое сравнение (credential и reality short_id в MemberInfo нет
+	// в любом случае). Направление выбрано сознательно: лучше оставить
+	// исключённым лишнее, чем самовольно включить то, что пользователь выключил.
 	matches := func(mi MemberInfo) []string {
 		var out []string
 		for _, t := range all {
 			c := toMemberInfo(t.Tag, t.Out)
-			if c.Protocol == mi.Protocol && c.Server == mi.Server &&
-				c.Port == mi.Port && c.SNI == mi.SNI && c.Transport == mi.Transport {
-				out = append(out, t.Tag)
+			if c.Protocol != mi.Protocol || c.Server != mi.Server ||
+				c.Port != mi.Port || c.SNI != mi.SNI || c.Transport != mi.Transport {
+				continue
 			}
+			if mi.TransportKey != "" && c.TransportKey != mi.TransportKey {
+				continue
+			}
+			out = append(out, t.Tag)
 		}
 		return out
 	}
@@ -70,8 +88,14 @@ func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, acti
 		}
 		found := matches(mi)
 		if len(found) == 0 {
-			// Обычный случай «сервер ушёл от провайдера». Тег обязан
-			// сохраниться: когда сервер вернётся, он останется исключённым.
+			// Обычный случай «сервер ушёл от провайдера»: тег сохраняем.
+			//
+			// Оговорка: он защищает только пока схема тегов не менялась.
+			// MemberInfo исключённых пересобирается из фида (SetMembersExtras),
+			// поэтому у сервера, отсутствовавшего в момент refresh, метаданных
+			// не остаётся — вернувшись уже с новой схемой, он получит другой
+			// тег, сопоставить будет не по чему, и он материализуется активным.
+			// Данных для более точного поведения на диске просто нет.
 			add(tag)
 			continue
 		}
@@ -81,13 +105,16 @@ func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, acti
 		changed = true
 	}
 
-	// Guard: расширение «один тег → N» способно исключить вообще всех.
-	// Ручной путь такое запрещает (ErrAllMembersExcluded), значит refresh не
-	// имеет права создавать это состояние сам — откатываемся к исходному.
+	// Guard: расширение «один тег → N» способно не оставить ни одного живого
+	// члена. Ручной путь такое запрещает (ErrAllMembersExcluded), а applyDiff
+	// на пустом наборе валит весь refresh (ErrAllMembersFiltered) — и валил бы
+	// его на каждом тике, потому что remap пересчитывается заново. Считаем
+	// оставшихся так же, как applyDiff: член жив, если не исключён И не срезан
+	// фильтром.
 	if changed {
 		remaining := 0
 		for _, t := range all {
-			if !seen[t.Tag] {
+			if !seen[t.Tag] && allows(t.Out.Label) {
 				remaining++
 			}
 		}
@@ -96,15 +123,30 @@ func remapStaleTags(excluded []string, known []MemberInfo, diff DiffResult, acti
 		}
 	}
 
+	// Активный член не может оказаться исключённым: seen к этому моменту
+	// содержит итоговый набор исключений.
 	newActive := active
 	if active != "" && !current[active] {
 		if mi, ok := infoByTag[active]; ok {
-			if found := matches(mi); len(found) > 0 {
-				newActive = found[0]
-				changed = true
+			for _, candidate := range matches(mi) {
+				if !seen[candidate] && allows(labelOf(all, candidate)) {
+					newActive = candidate
+					changed = true
+					break
+				}
 			}
 		}
 	}
 
 	return result, newActive, changed
+}
+
+// labelOf возвращает имя сервера по тегу — для проверки его фильтром.
+func labelOf(all []TaggedOutbound, tag string) string {
+	for _, t := range all {
+		if t.Tag == tag {
+			return t.Out.Label
+		}
+	}
+	return ""
 }

--- a/internal/singbox/subscription/migrate_tags_test.go
+++ b/internal/singbox/subscription/migrate_tags_test.go
@@ -1,0 +1,123 @@
+package subscription
+
+import (
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox/vlink"
+)
+
+// Issue #614/#625. Расширение ключа меняет теги ровно у тех групп, где раньше
+// разные серверы схлопывались в один. Исключения пользователя хранятся тегами,
+// поэтому без переноса они молча перестали бы совпадать, и исключённые серверы
+// вернулись бы в строй.
+
+// wsFeed: два эндпоинта, различающиеся только транспортом, плюс независимый
+// третий сервер (нужен, чтобы не срабатывал guard «исключены все»).
+func wsFeed() (a, b, other vlink.ParsedOutbound) {
+	return mkParsedWS("1.2.3.4", 443, "cdn.example.com", "/path1", "host1"),
+		mkParsedWS("1.2.3.4", 443, "cdn.example.com", "/path2", "host2"),
+		mkParsed("other.example.com", 443, "vless")
+}
+
+// narrowInfo — метаданные того единственного члена, который существовал до
+// правки: узкий тег и общие для группы протокол/сервер/порт/SNI.
+func narrowInfo(p vlink.ParsedOutbound) MemberInfo {
+	mi := toMemberInfo(stableTagFromKey("sub", identityKey(p)), p)
+	return mi
+}
+
+func TestRemapStaleTags_ExpandsCollapsedGroup(t *testing.T) {
+	a, b, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	old := narrowInfo(a)
+
+	got, active, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if active != "" {
+		t.Errorf("active = %q, want empty (was not set)", active)
+	}
+	for _, tag := range got {
+		if tag == old.Tag {
+			t.Errorf("stale tag %q survived the remap: %v", old.Tag, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want both endpoints of the collapsed group", got)
+	}
+}
+
+// Сервер ушёл от провайдера — тег протух не из-за схемы ключей. Трогать его
+// нельзя: когда сервер вернётся, он обязан остаться исключённым.
+func TestRemapStaleTags_KeepsTagWithoutMatchInFeed(t *testing.T) {
+	_, _, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{other})
+	gone := MemberInfo{Tag: "sub-x-deadbeef", Protocol: "vless", Server: "gone.example.com", Port: 443}
+
+	got, _, changed := remapStaleTags([]string{gone.Tag}, []MemberInfo{gone}, diff, "")
+	if changed {
+		t.Error("changed = true, want false")
+	}
+	if len(got) != 1 || got[0] != gone.Tag {
+		t.Fatalf("got %v, want the tag preserved", got)
+	}
+}
+
+func TestRemapStaleTags_Idempotent(t *testing.T) {
+	a, b, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	old := narrowInfo(a)
+
+	first, _, _ := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
+	second, _, changed := remapStaleTags(first, []MemberInfo{old}, diff, "")
+	if changed {
+		t.Error("second pass reported a change, want no-op")
+	}
+	if len(second) != len(first) {
+		t.Fatalf("second = %v, first = %v", second, first)
+	}
+}
+
+// Протухший ActiveMember обязан переехать: BuildSelector подставляет
+// memberTags[0] только когда default пустой, а принадлежность набору не
+// проверяет — иначе в конфиг уедет ссылка на несуществующий outbound.
+func TestRemapStaleTags_RemapsActiveMember(t *testing.T) {
+	a, b, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	old := narrowInfo(a)
+
+	_, active, changed := remapStaleTags(nil, []MemberInfo{old}, diff, old.Tag)
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if active == old.Tag || active == "" {
+		t.Fatalf("active = %q, want one of the new tags", active)
+	}
+	found := false
+	for _, tg := range append(append([]TaggedOutbound{}, diff.New...), diff.Existing...) {
+		if tg.Tag == active {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("active %q is not a current member tag", active)
+	}
+}
+
+// Расширение «один тег → N» способно исключить вообще всех. Ручной путь такое
+// запрещает (ErrAllMembersExcluded), значит refresh не имеет права создавать
+// это состояние сам.
+func TestRemapStaleTags_GuardAgainstExcludingEveryone(t *testing.T) {
+	a, b, _ := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b})
+	old := narrowInfo(a)
+
+	got, _, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
+	if changed {
+		t.Error("changed = true, want the expansion skipped")
+	}
+	if len(got) != 1 || got[0] != old.Tag {
+		t.Fatalf("got %v, want the original tag untouched", got)
+	}
+}

--- a/internal/singbox/subscription/migrate_tags_test.go
+++ b/internal/singbox/subscription/migrate_tags_test.go
@@ -20,10 +20,20 @@ func wsFeed() (a, b, other vlink.ParsedOutbound) {
 }
 
 // narrowInfo — метаданные того единственного члена, который существовал до
-// правки: узкий тег и общие для группы протокол/сервер/порт/SNI.
+// правки: узкий тег и общие для группы протокол/сервер/порт/SNI. TransportKey
+// у таких записей ПУСТ: поле появилось вместе с этой правкой, и на диске у
+// пользователя его нет. Заполнить его здесь означало бы тестировать
+// несуществующие данные и скрыть поведение грубого сравнения.
 func narrowInfo(p vlink.ParsedOutbound) MemberInfo {
 	mi := toMemberInfo(stableTagFromKey("sub", identityKey(p)), p)
+	mi.TransportKey = ""
 	return mi
+}
+
+// currentInfo — запись, сделанная уже новым кодом: тег полного ключа и
+// заполненный TransportKey.
+func currentInfo(p vlink.ParsedOutbound) MemberInfo {
+	return toMemberInfo(stableTagFromKey("sub", fullKey(p)), p)
 }
 
 func TestRemapStaleTags_ExpandsCollapsedGroup(t *testing.T) {
@@ -31,7 +41,7 @@ func TestRemapStaleTags_ExpandsCollapsedGroup(t *testing.T) {
 	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
 	old := narrowInfo(a)
 
-	got, active, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
+	got, active, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "", nil)
 	if !changed {
 		t.Fatal("changed = false, want true")
 	}
@@ -55,7 +65,7 @@ func TestRemapStaleTags_KeepsTagWithoutMatchInFeed(t *testing.T) {
 	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{other})
 	gone := MemberInfo{Tag: "sub-x-deadbeef", Protocol: "vless", Server: "gone.example.com", Port: 443}
 
-	got, _, changed := remapStaleTags([]string{gone.Tag}, []MemberInfo{gone}, diff, "")
+	got, _, changed := remapStaleTags([]string{gone.Tag}, []MemberInfo{gone}, diff, "", nil)
 	if changed {
 		t.Error("changed = true, want false")
 	}
@@ -69,8 +79,8 @@ func TestRemapStaleTags_Idempotent(t *testing.T) {
 	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
 	old := narrowInfo(a)
 
-	first, _, _ := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
-	second, _, changed := remapStaleTags(first, []MemberInfo{old}, diff, "")
+	first, _, _ := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "", nil)
+	second, _, changed := remapStaleTags(first, []MemberInfo{old}, diff, "", nil)
 	if changed {
 		t.Error("second pass reported a change, want no-op")
 	}
@@ -87,7 +97,7 @@ func TestRemapStaleTags_RemapsActiveMember(t *testing.T) {
 	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
 	old := narrowInfo(a)
 
-	_, active, changed := remapStaleTags(nil, []MemberInfo{old}, diff, old.Tag)
+	_, active, changed := remapStaleTags(nil, []MemberInfo{old}, diff, old.Tag, nil)
 	if !changed {
 		t.Fatal("changed = false, want true")
 	}
@@ -113,11 +123,71 @@ func TestRemapStaleTags_GuardAgainstExcludingEveryone(t *testing.T) {
 	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b})
 	old := narrowInfo(a)
 
-	got, _, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "")
+	got, _, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "", nil)
 	if changed {
 		t.Error("changed = true, want the expansion skipped")
 	}
 	if len(got) != 1 || got[0] != old.Tag {
 		t.Fatalf("got %v, want the original tag untouched", got)
+	}
+}
+
+// Тег протухает не только от смены схемы: уровень ключа зависит от состава
+// фида, поэтому группа схлопывается и расширяется обратно, когда провайдер
+// убирает и возвращает эндпоинт. В такой момент грубое сравнение исключило бы
+// и соседний эндпоинт, которого пользователь не трогал.
+func TestRemapStaleTags_NoContagionWhenTransportKnown(t *testing.T) {
+	a, b, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	// Запись сделана новым кодом, но её тег протух (группа успела схлопнуться).
+	stale := currentInfo(a)
+	stale.Tag = stableTagFromKey("sub", identityKey(a))
+
+	got, _, changed := remapStaleTags([]string{stale.Tag}, []MemberInfo{stale}, diff, "", nil)
+	if !changed {
+		t.Fatal("changed = false, want the tag remapped")
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %v, want exactly the endpoint the user excluded", got)
+	}
+	if want := stableTagFromKey("sub", fullKey(a)); got[0] != want {
+		t.Errorf("got %q, want %q (/path1)", got[0], want)
+	}
+}
+
+// Guard обязан считать оставшихся так же, как applyDiff: член жив, только если
+// не исключён И не срезан regex-фильтром. Иначе refresh валился бы с
+// ErrAllMembersFiltered на каждом тике.
+func TestRemapStaleTags_GuardCountsFilteredOut(t *testing.T) {
+	a, b, other := wsFeed()
+	// Имена обязаны различаться: без этого предикат резал бы всех подряд и
+	// тест проходил бы независимо от guard'а.
+	a.Label, b.Label, other.Label = "A", "B", "OTHER"
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	old := narrowInfo(a)
+	// Единственный член вне расширяемой группы срезан фильтром по имени.
+	allows := func(label string) bool { return label != "OTHER" }
+
+	got, _, changed := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, "", allows)
+	if changed {
+		t.Error("changed = true, want the expansion skipped: nothing would stay alive")
+	}
+	if len(got) != 1 || got[0] != old.Tag {
+		t.Fatalf("got %v, want the original tag untouched", got)
+	}
+}
+
+// Активный член не может переехать на тег, который этой же миграцией
+// исключён.
+func TestRemapStaleTags_ActiveNeverLandsOnExcluded(t *testing.T) {
+	a, b, other := wsFeed()
+	diff := ApplyDiff("sub", nil, []vlink.ParsedOutbound{a, b, other})
+	old := narrowInfo(a)
+
+	excluded, active, _ := remapStaleTags([]string{old.Tag}, []MemberInfo{old}, diff, old.Tag, nil)
+	for _, e := range excluded {
+		if e == active {
+			t.Fatalf("active %q is also excluded: %v", active, excluded)
+		}
 	}
 }

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -530,18 +530,15 @@ func (s *Service) refreshLockedOpts(ctx context.Context, id string, forceInlineR
 	known := make([]MemberInfo, 0, len(sub.ExcludedMembers)+len(sub.Members))
 	known = append(known, sub.ExcludedMembers...)
 	known = append(known, sub.Members...)
-	if tags, active, changed := remapStaleTags(sub.ExcludedTags, known, diff, sub.ActiveMember); changed {
-		if err := s.store.SetExcludedTags(id, tags, sub.ExcludedMembers); err != nil {
-			return nil, err
-		}
+	prevActive := sub.ActiveMember
+	tags, active, migrated := remapStaleTags(sub.ExcludedTags, known, diff, sub.ActiveMember, flt.Allows)
+	if migrated {
+		// В память — сразу (applyDiff читает sub.ExcludedTags), в стор — только
+		// после успешного applyDiff: иначе упавший refresh оставил бы на диске
+		// новые теги со старыми ExcludedMembers, и вкладка «исключённые»
+		// потеряла бы строку восстановления.
 		sub.ExcludedTags = tags
-		if active != sub.ActiveMember {
-			if err := s.store.SetActiveMember(id, active); err != nil {
-				return nil, err
-			}
-			sub.ActiveMember = active
-		}
-		s.logInfo("subscription-refresh", id, fmt.Sprintf("migrated %d excluded tag(s) to the current identity scheme", len(tags)))
+		sub.ActiveMember = active
 	}
 
 	// applyDiff (stage → Reload) и Rollback-компенсация выполняются одной
@@ -608,6 +605,20 @@ func (s *Service) refreshLockedOpts(ctx context.Context, id string, forceInlineR
 	info := mergeInfoItems(sub.InfoItems, filterDismissedInfo(parts.Info, sub.DismissedInfoIDs))
 	if len(prunedTags) > 0 {
 		s.logWarn("subscription-refresh", id, fmt.Sprintf("pruned %d member(s) not materialized (dropped by validation): %s", len(prunedTags), strings.Join(prunedTags, ", ")))
+	}
+	// Миграция тегов фиксируется здесь — после успешного applyDiff и вместе с
+	// пересобранными excludedMembers, чтобы теги и метаданные исключённых
+	// уехали на диск согласованными.
+	if migrated {
+		if err := s.store.SetExcludedTags(id, sub.ExcludedTags, excludedMembers); err != nil {
+			return nil, err
+		}
+		if active != prevActive {
+			if err := s.store.SetActiveMember(id, active); err != nil {
+				return nil, err
+			}
+		}
+		s.logInfo("subscription-refresh", id, fmt.Sprintf("migrated %d excluded tag(s) to the current identity scheme", len(sub.ExcludedTags)))
 	}
 	if err := s.store.SetMembersExtras(id, newMembers, diff.Orphan, rejected, info, excludedMembers, filteredMembers); err != nil {
 		return nil, err

--- a/internal/singbox/subscription/service.go
+++ b/internal/singbox/subscription/service.go
@@ -522,6 +522,28 @@ func (s *Service) refreshLockedOpts(ctx context.Context, id string, forceInlineR
 
 	diff := ApplyDiff(id, sub.MemberTags, parts.Valid)
 
+	// Перенос исключений на текущую схему тегов (issues #614/#625). Обязан
+	// идти ДО applyDiff: тот читает sub.ExcludedTags (см. ниже) и без переноса
+	// применил бы протухшие теги, вернув исключённые серверы в строй.
+	// Метаданные берём и у исключённых, и у активных членов — активный член
+	// тоже мог протухнуть, а BuildSelector принадлежность набору не проверяет.
+	known := make([]MemberInfo, 0, len(sub.ExcludedMembers)+len(sub.Members))
+	known = append(known, sub.ExcludedMembers...)
+	known = append(known, sub.Members...)
+	if tags, active, changed := remapStaleTags(sub.ExcludedTags, known, diff, sub.ActiveMember); changed {
+		if err := s.store.SetExcludedTags(id, tags, sub.ExcludedMembers); err != nil {
+			return nil, err
+		}
+		sub.ExcludedTags = tags
+		if active != sub.ActiveMember {
+			if err := s.store.SetActiveMember(id, active); err != nil {
+				return nil, err
+			}
+			sub.ActiveMember = active
+		}
+		s.logInfo("subscription-refresh", id, fmt.Sprintf("migrated %d excluded tag(s) to the current identity scheme", len(tags)))
+	}
+
 	// applyDiff (stage → Reload) и Rollback-компенсация выполняются одной
 	// txMu-секцией: между staged-мутациями и их коммитом/откатом не может
 	// вклиниться Reload/Rollback параллельной операции (общий батч слота).
@@ -825,6 +847,7 @@ func toMemberInfo(tag string, p vlink.ParsedOutbound) MemberInfo {
 			mi.Transport = t
 		}
 	}
+	mi.TransportKey = transportKey(ob)
 	if tls, ok := ob["tls"].(map[string]any); ok {
 		if serverName, ok := tls["server_name"].(string); ok {
 			mi.SNI = strings.TrimSpace(serverName)
@@ -1125,17 +1148,28 @@ func (s *Service) AddManualMember(ctx context.Context, id, shareLink string) (*S
 	}
 	out := parts.Valid[0]
 	// Набор для chooseKeys недоступен (credential существующих членов не
-	// хранится), поэтому тег нового члена считаем по расширенному ключу, а
-	// точный повтор ловим по метаданным MemberInfo (server+port+protocol+SNI).
-	// ponytail: short_id/uuid в MemberInfo нет — два сервера на одном
-	// server:port:SNI с разным short_id/uuid дадут ложный отказ; редкий край.
-	tag := stableTagFromKey(sub.ID, extendedKey(out))
+	// хранится), поэтому тег считаем по полному ключу: два эндпоинта одного
+	// сервера, различающиеся
+	// только транспортом, обязаны получить РАЗНЫЕ теги, иначе второй outbound
+	// перезаписал бы первый (issue #625).
+	//
+	// Повтор по-прежнему ловим по метаданным: точного ключа существующих
+	// членов взять неоткуда (мутатор не отдаёт тела outbound'ов), а их теги
+	// могли быть посчитаны на любом уровне ключа. TransportKey закрывает ту
+	// дыру, из-за которой разные ws-пути считались одним сервером; у записей,
+	// сделанных до появления поля, он пуст — для них остаётся прежнее грубое
+	// сравнение, иначе точный повтор проскочил бы под тем же тегом.
+	tag := stableTagFromKey(sub.ID, fullKey(out))
 	mi := toMemberInfo(tag, out)
 	for _, existing := range sub.Members {
-		if existing.Server == mi.Server && existing.Port == mi.Port &&
-			existing.Protocol == mi.Protocol && existing.SNI == mi.SNI {
-			return nil, ErrMemberDuplicate
+		if existing.Server != mi.Server || existing.Port != mi.Port ||
+			existing.Protocol != mi.Protocol || existing.SNI != mi.SNI {
+			continue
 		}
+		if existing.TransportKey != "" && existing.TransportKey != mi.TransportKey {
+			continue
+		}
+		return nil, ErrMemberDuplicate
 	}
 
 	// Fail-closed write order: mutate sing-box config (idempotent

--- a/internal/singbox/subscription/service_test.go
+++ b/internal/singbox/subscription/service_test.go
@@ -1946,3 +1946,26 @@ func TestCreate_InlineUnrecognizedJSON(t *testing.T) {
 		t.Fatalf("error must mention both supported JSON formats, got: %v", err)
 	}
 }
+
+// Issue #625: тот же host:port:uuid и тот же SNI, но другой ws-путь и Host —
+// это другой эндпоинт, а не повтор. Раньше проверка сравнивала только
+// server+port+protocol+SNI и отвергала такое добавление.
+func TestAddManualMember_TransportDiffersIsNotDuplicate(t *testing.T) {
+	svc, _ := newTestService(t)
+	sub, err := svc.Create(context.Background(), CreateInput{
+		Label:   "manual",
+		Inline:  "vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@h.example:443?security=tls&sni=a.sni&type=ws&path=/p1&host=h1#A",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := svc.AddManualMember(context.Background(), sub.ID,
+		"vless://3a3b1c2e-9999-4321-aaaa-1234567890ab@h.example:443?security=tls&sni=a.sni&type=ws&path=/p2&host=h2#B")
+	if err != nil {
+		t.Fatalf("different ws path/host must add, got %v", err)
+	}
+	if len(updated.MemberTags) != 2 {
+		t.Errorf("MemberTags=%d want 2", len(updated.MemberTags))
+	}
+}

--- a/internal/singbox/subscription/types.go
+++ b/internal/singbox/subscription/types.go
@@ -14,6 +14,12 @@ type MemberInfo struct {
 	SNI       string `json:"sni,omitempty"`
 	Transport string `json:"transport,omitempty"` // "tcp" | "ws" | "grpc" | "http" — empty if N/A
 	Security  string `json:"security,omitempty"`  // "tls" | "reality" | "" (none/Hy2 always tls)
+	// TransportKey is the canonical transport fingerprint (path, Host,
+	// service_name, mode). Two endpoints of one server:port:credential:SNI
+	// differ only here, and without it a manual add rejects them as duplicates
+	// (issue #625). Empty on records written before this field existed —
+	// consumers must fall back to the coarse comparison for those.
+	TransportKey string `json:"transportKey,omitempty"`
 }
 
 // SubscriptionMode picks which sing-box outbound type wraps the


### PR DESCRIPTION
Идентичность сервера считалась по протоколу, адресу, порту и credential, а расширялась только маскировкой — SNI и reality short_id. Записи, отличающиеся ws-путём и Host-заголовком, давали один тег: при импорте подписки второй такой сервер отбрасывался как дубликат, при ручном добавлении — отклонялся.

Ключ расширен полями транспорта, но только там, где маскировки для различения не хватает: у групп, которые и раньше разводились по SNI или short_id, теги не меняются. Исключения пользователя хранятся тегами, поэтому у затронутых групп они переносятся на новую схему по метаданным члена; сервер, ушедший из фида, остаётся исключённым, а расширение, исключающее вообще всех, не применяется.

Closes #625
Closes #614