### PR TITLE
fix(wdtt): пароль сервера пишется в panel.db синхронно

### DIFF
--- a/internal/wdtt/server.go
+++ b/internal/wdtt/server.go
@@ -46,11 +46,17 @@ func (s *Service) UpdateServerInstance(id string, cfg ServerConfig) (ServerConfi
 	if saveErr != nil {
 		return ServerConfig{}, saveErr
 	}
+	// Синхронно: пароль обязан лежать в panel.db к моменту ответа, иначе
+	// пользователь успевает нажать «Запустить» с ещё не записанным паролем и
+	// клиенты не аутентифицируются. Запись мелкая — одна строка в локальном
+	// SQLite. Раньше это была fire-and-forget горутина с проглоченной
+	// ошибкой: провал записи оставался невидимым, а в тестах она дописывала
+	// panel.db в уже удаляемый t.TempDir().
 	if pwd := strings.TrimSpace(savedCfg.Password); pwd != "" {
 		if cfgDir, dirErr := s.serverConfigDir(id, savedCfg); dirErr == nil {
-			go func(dir, pass string) {
-				_ = syncPanelMainPassword(dir, pass)
-			}(cfgDir, pwd)
+			if err := syncPanelMainPassword(cfgDir, pwd); err != nil && s.appLog != nil {
+				s.appLog.Warn("panel", id, "пароль сервера не записан в panel.db: "+err.Error())
+			}
 		}
 	}
 	if running {


### PR DESCRIPTION
CI на develop падал: TestUpdateServerInstance_ReturnsSaved не мог удалить t.TempDir() — «directory not empty». Причина не в тесте, а в fire-and-forget горутине: UpdateServerInstance отпускала syncPanelMainPassword, та создавала panel.db уже в удаляемом каталоге. Локально при -count=100 воспроизводится стабильно, на CI выстрелило из-за замедления от -covermode=atomic.

Запись стала синхронной: она мелкая (одна строка в локальном SQLite), а пароль обязан лежать в БД к моменту ответа — иначе пользователь успевает нажать «Запустить» с ещё не записанным паролем и клиенты не проходят аутентификацию. Ошибка больше не глотается, а уходит в журнал.

Проверено: -count=200 на этом тесте, три прогона командой CI с coverage, go test ./... целиком, vitest 1480 тестов, кросс-сборка трёх арок.