### PR TITLE
fix(ui): номера route-правил везде 0-based (#386)

### DIFF
--- a/frontend/src/lib/components/fakeip/routes/RoutesTab.svelte
+++ b/frontend/src/lib/components/fakeip/routes/RoutesTab.svelte
@@ -302,8 +302,8 @@
 	let deleteBusy = $state(false);
 
 	function ruleSummary(card: RuleCardData | undefined, idx: number): string {
-		if (!card) return `правило #${idx + 1}`;
-		return `правило #${idx + 1}: ${card.title}`;
+		if (!card) return `правило #${idx}`;
+		return `правило #${idx}: ${card.title}`;
 	}
 
 	// ── Handlers ─────────────────────────────────────────────────────────────
@@ -387,7 +387,7 @@
 				type="button"
 				class="grip"
 				class:is-busy={drag.busy || selectMode}
-				aria-label={`Перетащить правило #${i + 1}`}
+				aria-label={`Перетащить правило #${i}`}
 				title="Перетащить для изменения порядка"
 				onpointerdown={drag.busy || selectMode ? undefined : (e) => drag.handlePointerDown(i, e)}
 			>
@@ -401,10 +401,10 @@
 					class="rule-checkbox"
 					checked={selected.has(i)}
 					onchange={() => toggleSelect(i)}
-					aria-label={`Выбрать правило #${i + 1}`}
+					aria-label={`Выбрать правило #${i}`}
 				/>
 			{:else}
-				{i + 1}
+				{i}
 			{/if}
 		</span>
 		<div class="match">
@@ -441,8 +441,8 @@
 					type="button"
 					class="ib"
 					onclick={() => (ruleEditIdx = i)}
-					aria-label={`Редактировать правило #${i + 1}`}
-					title={`Редактировать правило #${i + 1}`}
+					aria-label={`Редактировать правило #${i}`}
+					title={`Редактировать правило #${i}`}
 				>
 					<Pencil size={15} strokeWidth={2} />
 				</button>
@@ -450,8 +450,8 @@
 					type="button"
 					class="ib danger"
 					onclick={() => (deleteIdx = i)}
-					aria-label={`Удалить правило #${i + 1}`}
-					title={`Удалить правило #${i + 1}`}
+					aria-label={`Удалить правило #${i}`}
+					title={`Удалить правило #${i}`}
 				>
 					<Trash2 size={15} strokeWidth={2} />
 				</button>
@@ -534,7 +534,7 @@
 				{/if}
 				<div class="rrow final-row">
 					<span class="grip grip-fixed" aria-hidden="true"></span>
-					<span class="num">{$storeRules.length + 1}</span>
+					<span class="num">{$storeRules.length}</span>
 					<span class="match-final">final</span>
 					<div class="outbound">
 						{#if finalEditing}

--- a/frontend/src/lib/components/fakeip/rulesets/RuleSetsTab.svelte
+++ b/frontend/src/lib/components/fakeip/rulesets/RuleSetsTab.svelte
@@ -86,7 +86,7 @@
 		{ k: 'inline', l: 'inline' },
 	];
 
-	// ── «используется в» (DNS #n · Route #m), 1-based по правилам ─────────
+	// ── «используется в» (DNS #n · Route #m): DNS с 1, route с 0 ─────────
 	const usageRefs = $derived(computeRuleSetUsageRefs($storeDnsRules, $storeRules));
 
 	// Каталог: суммарные счётчики (DNS + route) для различения «добавлено» /

--- a/frontend/src/lib/components/fakeip/rulesets/ruleSetUsageRefs.test.ts
+++ b/frontend/src/lib/components/fakeip/rulesets/ruleSetUsageRefs.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { computeRuleSetUsageRefs } from './ruleSetUsageRefs';
 
 describe('computeRuleSetUsageRefs', () => {
-	it('собирает 1-based номера DNS- и route-правил по тегу', () => {
+	it('нумерует DNS-правила с 1, route-правила с 0 — как их таблицы', () => {
 		const dns = [{ rule_set: ['a'] }, { rule_set: ['b', 'a'] }, {}];
 		const route = [{ rule_set: ['a'] }, {}, { rule_set: ['b'] }];
 		const m = computeRuleSetUsageRefs(dns, route);
 
-		expect(m.get('a')).toEqual({ dns: [1, 2], route: [1] });
-		expect(m.get('b')).toEqual({ dns: [2], route: [3] });
+		expect(m.get('a')).toEqual({ dns: [1, 2], route: [0] });
+		expect(m.get('b')).toEqual({ dns: [2], route: [2] });
 	});
 
 	it('игнорирует правила без rule_set', () => {

--- a/frontend/src/lib/components/fakeip/rulesets/ruleSetUsageRefs.ts
+++ b/frontend/src/lib/components/fakeip/rulesets/ruleSetUsageRefs.ts
@@ -1,6 +1,7 @@
 // «используется в» (мокап page-rulesets-v3): для каждого rule-set тега —
-// в каких DNS-правилах и route-правилах он упомянут (1-based номера, как в UI:
-// «DNS #1 · Route #3»). computeRuleSetUsage из routing/singboxRouter даёт только
+// в каких DNS-правилах и route-правилах он упомянут (номера как в самих
+// таблицах: DNS с 1, route с 0 — «DNS #1 · Route #2»).
+// computeRuleSetUsage из routing/singboxRouter даёт только
 // СУММУ ссылок; здесь нужен СПИСОК ссылок с разбивкой DNS/Route → отдельный
 // чистый хелпер.
 //
@@ -15,13 +16,13 @@ type WithRuleSet = { rule_set?: string[] };
 export interface RuleSetUsageRef {
 	/** 1-based номера DNS-правил, ссылающихся на тег. */
 	dns: number[];
-	/** 1-based номера route-правил, ссылающихся на тег. */
+	/** 0-based номера route-правил, ссылающихся на тег. */
 	route: number[];
 }
 
 /**
  * Строит карту tag → { dns:[…], route:[…] } из списков DNS- и route-правил.
- * Номера 1-based и в порядке появления правил. Тег учитывается один раз на
+ * Номера в порядке появления правил. Тег учитывается один раз на
  * правило (если правило ссылается на один rule_set дважды — номер не дублируется).
  */
 export function computeRuleSetUsageRefs(
@@ -42,6 +43,7 @@ export function computeRuleSetUsageRefs(
 	const collect = (
 		rules: readonly WithRuleSet[],
 		pick: (ref: RuleSetUsageRef) => number[],
+		base: number,
 	): void => {
 		for (let i = 0; i < rules.length; i++) {
 			const tags = rules[i].rule_set;
@@ -51,13 +53,13 @@ export function computeRuleSetUsageRefs(
 				const tag = displayRuleSetTag(raw);
 				if (seen.has(tag)) continue;
 				seen.add(tag);
-				pick(ensure(tag)).push(i + 1);
+				pick(ensure(tag)).push(i + base);
 			}
 		}
 	};
 
-	collect(dnsRules, (ref) => ref.dns);
-	collect(routeRules, (ref) => ref.route);
+	collect(dnsRules, (ref) => ref.dns, 1);
+	collect(routeRules, (ref) => ref.route, 0);
 
 	return m;
 }

--- a/frontend/src/lib/components/sb-router/RuleCard.svelte
+++ b/frontend/src/lib/components/sb-router/RuleCard.svelte
@@ -80,7 +80,7 @@
   }
 
   function ruleActionTarget(cardData: RuleCardData, idx: number): string {
-    const n = String(idx + 1).padStart(2, '0');
+    const n = String(idx).padStart(2, '0');
     return `правило #${n}: ${cardData.title} → ${outboundLabel(cardData)}`;
   }
 

--- a/frontend/src/lib/components/singbox-routing/RouteInspector.svelte
+++ b/frontend/src/lib/components/singbox-routing/RouteInspector.svelte
@@ -133,7 +133,7 @@
 		const ruleIndex = typeof progress.ruleIndex === 'number' ? progress.ruleIndex : undefined;
 		const ruleTotal = typeof progress.ruleTotal === 'number' ? progress.ruleTotal : undefined;
 		const ruleSetTag = progress.ruleSetTag || undefined;
-		let label = progress.message || formatProgressFallback(progress);
+		let label = progress.message || progress.phase;
 		let meta = '';
 		if (typeof ruleIndex === 'number' && ruleTotal) {
 			meta = `Правило #${ruleIndex} из ${ruleTotal}`;
@@ -184,7 +184,6 @@
 	}
 
 	function buildNextStep(): InspectorStep | null {
-		if (currentProgressMessage === 'Инспектор завершил проверку') return null;
 		if (totalRules <= 0) {
 			return {
 				id: `next:config:${Date.now()}`,
@@ -197,7 +196,7 @@
 			if (activeRuleSetTag) {
 				return {
 					id: `next:ruleset:${Date.now()}`,
-					label: `Завершить проверку rule_set и перейти к результату правила #${currentRule + 1}`,
+					label: `Завершить проверку rule_set и перейти к результату правила #${currentRule}`,
 					status: 'next',
 					meta: activeRuleSetTag ? `rule_set: ${activeRuleSetTag}` : '',
 				};
@@ -205,7 +204,7 @@
 			if (currentRule + 1 < totalRules) {
 				return {
 					id: `next:rule:${Date.now()}`,
-					label: `Далее: правило #${currentRule + 2} из ${totalRules}`,
+					label: `Далее: правило #${currentRule + 1} из ${totalRules}`,
 					status: 'next',
 					meta: '',
 				};
@@ -227,7 +226,7 @@
 
 	function handleProgress(progress: SingboxRouterInspectProgress): void {
 		const now = Date.now();
-		currentProgressMessage = progress.message || formatProgressFallback(progress);
+		currentProgressMessage = progress.message || progress.phase;
 		const ruleIndex = typeof progress.ruleIndex === 'number' ? progress.ruleIndex : undefined;
 		const ruleTotal = typeof progress.ruleTotal === 'number' ? progress.ruleTotal : undefined;
 		const ruleSetTag = progress.ruleSetTag || undefined;
@@ -323,21 +322,6 @@
 			slowestSteps,
 			ruleSetSteps,
 		};
-	}
-
-	function formatProgressFallback(progress: SingboxRouterInspectProgress): string {
-		switch (progress.phase) {
-			case 'rule_start':
-				return `Проверяем правило #${progress.ruleIndex ?? 0} из ${progress.ruleTotal ?? 0}`;
-			case 'rule_done':
-				return `Проверка правила #${(progress.ruleIndex ?? 0) + 1} завершена`;
-			case 'rule_set_start':
-				return `Проверяем rule_set ${progress.ruleSetTag ?? ''}`.trim();
-			case 'rule_set_match_start':
-				return `Проверяем rule_set ${progress.ruleSetTag ?? ''} через sing-box…`.trim();
-			default:
-				return progress.phase;
-		}
 	}
 
 	const currentRuleIndex = $derived(currentRule);

--- a/frontend/src/lib/components/tunnels/TunnelReferencedModal.svelte
+++ b/frontend/src/lib/components/tunnels/TunnelReferencedModal.svelte
@@ -27,7 +27,7 @@
 				<li>
 					Используется в правилах sing-box router:
 					<span class="rule-indices">
-						{details.routerRules.map((i) => `#${i + 1}`).join(', ')}
+						{details.routerRules.map((i) => `#${i}`).join(', ')}
 					</span>
 				</li>
 			{/if}

--- a/frontend/src/lib/utils/tunnelRefs.test.ts
+++ b/frontend/src/lib/utils/tunnelRefs.test.ts
@@ -44,6 +44,20 @@ describe('describeRouterReference', () => {
 		});
 	});
 
+	it('describes a fakeip rule with the 0-based number its table shows', () => {
+		expect(describeRouterReference('[fakeip] route.rules[9]')).toEqual({
+			text: 'FakeIP → Используется в правиле #9',
+			known: true
+		});
+	});
+
+	it('describes a fakeip non-rule location', () => {
+		expect(describeRouterReference('[fakeip] route.final')).toEqual({
+			text: 'FakeIP → Назначен маршрутом по умолчанию',
+			known: true
+		});
+	});
+
 	it('falls back to the raw path for unknown formats', () => {
 		expect(describeRouterReference('something.unexpected[5]')).toEqual({
 			text: 'something.unexpected[5]',

--- a/frontend/src/lib/utils/tunnelRefs.ts
+++ b/frontend/src/lib/utils/tunnelRefs.ts
@@ -12,14 +12,23 @@ export interface RouterReference {
 	known: boolean;
 }
 
-const PATTERNS: Array<{ re: RegExp; label: (name: string) => string }> = [
+const PATTERNS: Array<{ re: RegExp; label: (captured: string) => string }> = [
 	{ re: /^outbounds\[\d+="(.*)"\]\.outbounds\[\d+\]$/, label: (n) => `Входит в группу маршрутов «${n}»` },
 	{ re: /^outbounds\[\d+="(.*)"\]\.default$/, label: (n) => `Выбран по умолчанию в группе «${n}»` },
 	{ re: /^dns\.servers\[\d+="(.*)"\]\.detour$/, label: (n) => `Используется DNS-сервером «${n}»` },
-	{ re: /^route\.rule_set\[\d+="(.*)"\]\.download_detour$/, label: (n) => `Через него скачивается список «${n}»` }
+	{ re: /^route\.rule_set\[\d+="(.*)"\]\.download_detour$/, label: (n) => `Через него скачивается список «${n}»` },
+	// Приходит только от fakeip-слота: router-слот отдаёт свои правила
+	// отдельным списком индексов (RouterRules). Номер 0-based, как в таблице.
+	{ re: /^route\.rules\[(\d+)\]$/, label: (n) => `Используется в правиле #${n}` }
 ];
 
+const FAKEIP_PREFIX = '[fakeip] ';
+
 export function describeRouterReference(loc: string): RouterReference {
+	if (loc.startsWith(FAKEIP_PREFIX)) {
+		const ref = describeRouterReference(loc.slice(FAKEIP_PREFIX.length));
+		return { text: `FakeIP → ${ref.text}`, known: ref.known };
+	}
 	if (loc === 'route.final') {
 		return { text: 'Назначен маршрутом по умолчанию', known: true };
 	}

--- a/internal/singbox/router/fakeip_members_test.go
+++ b/internal/singbox/router/fakeip_members_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -135,20 +136,16 @@ func TestOutboundReferenceLocations_IncludesFakeIPSlot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Точные строки, а не Contains: формат — контракт с фронтом.
+	// frontend/src/lib/utils/tunnelRefs.ts разбирает префикс слота и
+	// route.rules[N] регулярками, молча падая в raw-путь при расхождении.
 	locs := svc.OutboundReferenceLocations("tun-x")
-	var composite, rule bool
-	for _, l := range locs {
-		if strings.Contains(l, "[fakeip]") {
-			if strings.Contains(l, "FI+LV") {
-				composite = true
-			}
-			if strings.Contains(l, "rules") {
-				rule = true
-			}
-		}
+	want := []string{
+		`[fakeip] route.rules[0]`,
+		`[fakeip] outbounds[0="FI+LV"].outbounds[0]`,
 	}
-	if !composite || !rule {
-		t.Fatalf("fakeip references missing (composite=%v rule=%v): %v", composite, rule, locs)
+	if !slices.Equal(locs, want) {
+		t.Fatalf("fakeip references = %q, want %q", locs, want)
 	}
 	if locs := svc.OutboundReferenceLocations("absent-tag"); len(locs) != 0 {
 		t.Fatalf("unreferenced tag must give no locations, got %v", locs)


### PR DESCRIPTION
Инспектор в 09b8ed9b привели к 0-based, но остались места, где номер показывался +1: модалка «Удаление невозможно» (о ней и репорт в issue), подписи шагов инспектора, тултипы карточек router-слота, таблица fakeip-роутов вместе с итоговой строкой final и «используется в» на вкладке наборов.

Теперь route-правила нумеруются с 0 во всех слотах (как в сыром sing-box-конфиге), DNS-правила остаются с 1 — их UI 1-based целиком.

Заодно: fakeip-ссылки в модалке стали человекочитаемыми через общий PATTERNS вместо сырого пути; удалён мёртвый formatProgressFallback (бэкенд шлёт Message для каждого события инспектора) и недостижимая проверка завершения по русской строке; Go-тест фиксирует точный формат fakeip-ссылок, который парсит фронт.