### PR TITLE
fix(dns): снять требование «exclude внутри include» и класть excludes…

### DIFF
--- a/internal/dnsroute/impl.go
+++ b/internal/dnsroute/impl.go
@@ -3,7 +3,6 @@ package dnsroute
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -165,60 +164,6 @@ func (s *ServiceImpl) LookupAffectedLists(tunnelID string, action string) []Affe
 	return result
 }
 
-// validateExcludes checks that every Excludes entry has a matching
-// include in the same list. Domain-style excludes must be subdomains
-// of one of list.Domains (or equal to one); CIDR-style excludes must
-// lie inside one of list.Subnets (or equal one).
-//
-// Returns the first error found.
-func validateExcludes(domains, subnets, exclDomains, exclSubnets []string) error {
-	for _, e := range exclDomains {
-		ne := normalizeDomain(e)
-		if ne == "" {
-			continue
-		}
-		ok := false
-		for _, d := range domains {
-			nd := normalizeDomain(d)
-			if nd == "" {
-				continue
-			}
-			if ne == nd {
-				ok = true
-				break
-			}
-			if strings.HasSuffix(ne, "."+nd) {
-				ok = true
-				break
-			}
-		}
-		if !ok {
-			return fmt.Errorf("exclude %q has no matching include in this list", e)
-		}
-	}
-	for _, e := range exclSubnets {
-		_, en, err := net.ParseCIDR(e)
-		if err != nil {
-			return fmt.Errorf("exclude subnet %q is not a valid CIDR", e)
-		}
-		ok := false
-		for _, s := range subnets {
-			_, sn, err := net.ParseCIDR(s)
-			if err != nil {
-				continue
-			}
-			if cidrCovers(sn, en) {
-				ok = true
-				break
-			}
-		}
-		if !ok {
-			return fmt.Errorf("exclude subnet %q has no matching include in this list", e)
-		}
-	}
-	return nil
-}
-
 // Create adds a new domain list, persists it, and reconciles router state.
 func (s *ServiceImpl) Create(ctx context.Context, list DomainList) (*DomainList, error) {
 	s.opMu.Lock()
@@ -258,10 +203,6 @@ func (s *ServiceImpl) Create(ctx context.Context, list DomainList) (*DomainList,
 	// Split user-input excludes into domain-form and CIDR-form, mirroring
 	// the same handling used for ManualDomains → Domains/Subnets.
 	list.Excludes, list.ExcludeSubnets = splitDomainsAndSubnets(deduplicateDomains(list.Excludes))
-
-	if err := validateExcludes(list.Domains, list.Subnets, list.Excludes, list.ExcludeSubnets); err != nil {
-		return nil, err
-	}
 
 	// Resolve tunnel IDs to NDMS interface names for RCI commands.
 	if err := s.resolveRouteInterfaces(ctx, list.Routes); err != nil {
@@ -464,10 +405,6 @@ func (s *ServiceImpl) Update(ctx context.Context, list DomainList) (*DomainList,
 	}
 
 	list.Excludes, list.ExcludeSubnets = splitDomainsAndSubnets(deduplicateDomains(list.Excludes))
-
-	if err := validateExcludes(list.Domains, list.Subnets, list.Excludes, list.ExcludeSubnets); err != nil {
-		return nil, err
-	}
 
 	// Resolve tunnel IDs to NDMS interface names for RCI commands.
 	if err := s.resolveRouteInterfaces(ctx, list.Routes); err != nil {

--- a/internal/dnsroute/impl_test.go
+++ b/internal/dnsroute/impl_test.go
@@ -357,6 +357,57 @@ func TestServiceImpl_UpdatePartialPreservesExcludesTextSubnets(t *testing.T) {
 	}
 }
 
+// Excludes no longer have to match an include: NDMS matches domains by
+// suffix without a dot boundary (x.com also matches yandex.com), so an
+// exclude for an unrelated domain is a legitimate workaround. Whether the
+// entry makes sense is the router's call — we just pass it through.
+func TestServiceImpl_CreateAcceptsUnrelatedExclude(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, DomainList{
+		Name:          "unrelated exclude",
+		ManualDomains: []string{"x.com"},
+		Excludes:      []string{"yandex.com", "192.168.0.0/24"},
+		Routes:        []RouteTarget{{Interface: "OpkgTun0", TunnelID: "t1"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(created.Excludes) != 1 || created.Excludes[0] != "yandex.com" {
+		t.Errorf("Excludes = %#v, want [yandex.com]", created.Excludes)
+	}
+	if len(created.ExcludeSubnets) != 1 || created.ExcludeSubnets[0] != "192.168.0.0/24" {
+		t.Errorf("ExcludeSubnets = %#v, want [192.168.0.0/24]", created.ExcludeSubnets)
+	}
+}
+
+func TestServiceImpl_UpdateAcceptsUnrelatedExclude(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, DomainList{
+		Name:          "unrelated exclude",
+		ManualDomains: []string{"x.com"},
+		Routes:        []RouteTarget{{Interface: "OpkgTun0", TunnelID: "t1"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	excludesText := "yandex.com"
+	updated, err := svc.Update(ctx, DomainList{
+		ID:           created.ID,
+		ExcludesText: &excludesText,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updated.Excludes) != 1 || updated.Excludes[0] != "yandex.com" {
+		t.Errorf("Excludes = %#v, want [yandex.com]", updated.Excludes)
+	}
+}
+
 func TestServiceImpl_NotFound(t *testing.T) {
 	dir := t.TempDir()
 	store := NewStore(dir)
@@ -537,77 +588,21 @@ func TestServiceImpl_LookupAffectedLists_RestoredAction(t *testing.T) {
 	}
 }
 
-func TestValidateExcludes_DomainNeedsInclude(t *testing.T) {
-	err := validateExcludes(
-		[]string{"google.com"},
-		nil,
-		[]string{"yandex.ru"},
-		nil,
-	)
-	if err == nil {
-		t.Fatal("expected error: yandex.ru has no matching include")
-	}
-}
-
-func TestValidateExcludes_SubdomainOK(t *testing.T) {
-	err := validateExcludes(
-		[]string{"google.com"},
-		nil,
-		[]string{"gemini.google.com"},
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateExcludes_SubnetNeedsInclude(t *testing.T) {
-	err := validateExcludes(
-		nil,
-		[]string{"10.0.0.0/8"},
-		nil,
-		[]string{"192.168.0.0/24"},
-	)
-	if err == nil {
-		t.Fatal("expected error: 192.168/24 not inside any include subnet")
-	}
-}
-
-func TestValidateExcludes_SubnetInsideOK(t *testing.T) {
-	err := validateExcludes(
-		nil,
-		[]string{"10.0.0.0/8"},
-		nil,
-		[]string{"10.0.0.0/24"},
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateExcludes_InvalidCIDR(t *testing.T) {
-	err := validateExcludes(nil, nil, nil, []string{"not-a-cidr"})
-	if err == nil {
-		t.Fatal("expected error for invalid CIDR")
-	}
-}
-
 // TestServiceCreate_SplitsAndDedupsMixedExcludes is an integration test
 // of the full Create pipeline: user typed mixed domains + CIDRs into
-// the Excludes field, server splits them, validates, persists, dedup
-// runs, and another list's parent doesn't claim the holed subdomain.
+// the Excludes field, server splits them, persists, dedup runs, and
+// another list's parent doesn't claim the holed subdomain.
 func TestServiceCreate_SplitsAndDedupsMixedExcludes(t *testing.T) {
 	// Skip if integration scaffold isn't available — these tests need a
 	// fully-wired ServiceImpl with a Store and resolveRouteInterfaces.
-	// We intentionally exercise validateExcludes + splitDomainsAndSubnets
-	// without going through real RCI: callers in unit tests build
-	// DomainList directly and check the dedup output, not the Service.
+	// We intentionally exercise splitDomainsAndSubnets without going
+	// through real RCI: callers in unit tests build DomainList directly
+	// and check the dedup output, not the Service.
 	//
 	// This test verifies the standalone helpers compose correctly:
 	// 1. splitDomainsAndSubnets routes CIDRs out of mixed input.
-	// 2. validateExcludes accepts the resulting halves.
-	// 3. BuildIndex registers domain-form excludes as holes.
-	// 4. dedupSubnets respects the CIDR-form excludes.
+	// 2. BuildIndex registers domain-form excludes as holes.
+	// 3. dedupSubnets respects the CIDR-form excludes.
 
 	rawExcludes := []string{"gemini.google.com", "10.0.0.0/24"}
 	rawDomains := []string{"google.com", "10.0.0.0/16"}
@@ -626,10 +621,6 @@ func TestServiceCreate_SplitsAndDedupsMixedExcludes(t *testing.T) {
 	}
 	if len(exclSubnets) != 1 || exclSubnets[0] != "10.0.0.0/24" {
 		t.Fatalf("exclSubnets: %v", exclSubnets)
-	}
-
-	if err := validateExcludes(domains, subnets, exclDomains, exclSubnets); err != nil {
-		t.Fatalf("validateExcludes: %v", err)
 	}
 
 	// Now build a list with the classified data and verify dedup carves

--- a/internal/dnsroute/sync.go
+++ b/internal/dnsroute/sync.go
@@ -227,9 +227,10 @@ func buildTargetState(data *StoreData, failedTunnels map[string]struct{}) target
 		items = append(items, list.Domains...)
 		items = append(items, list.Subnets...)
 
-		// Excludes live in the first group only and also count against
-		// the group's capacity; shrink the first chunk's budget accordingly.
-		chunks := chunkWithFirstBudget(items, MaxDomainsPerGroup, len(list.Excludes))
+		// NDMS applies an exclude only inside its own object-group, so the
+		// full exclude set goes into every chunk. Excludes also count
+		// against the group's capacity — shrink each chunk's budget.
+		chunks := chunkWithReserve(items, MaxDomainsPerGroup, len(list.Excludes))
 
 		for i, chunk := range chunks {
 			groupName := buildGroupName(list.ID, list.Name, i+1)
@@ -237,10 +238,7 @@ func buildTargetState(data *StoreData, failedTunnels map[string]struct{}) target
 			g := targetGroup{
 				name:     groupName,
 				includes: chunk,
-			}
-
-			if i == 0 {
-				g.excludes = list.Excludes
+				excludes: list.Excludes,
 			}
 
 			ts.groups = append(ts.groups, g)
@@ -287,29 +285,23 @@ func materializedFallback(f string) string {
 	return ""
 }
 
-// chunkWithFirstBudget splits items into chunks of at most maxPerChunk, where
-// the first chunk is shrunk by firstReserved slots so the caller can inject
-// extra elements (excludes) into that group without overflowing NDMS's limit.
+// chunkWithReserve splits items into chunks of at most maxPerChunk, where
+// every chunk is shrunk by reserved slots so the caller can inject extra
+// elements (excludes) into each group without overflowing NDMS's limit.
 //
-// The returned slice always has len == ceil-ish of items size; if firstReserved
-// consumes all of the first chunk's capacity, chunks[0] is empty (caller still
-// needs a group for the excludes) and items start in chunks[1].
-func chunkWithFirstBudget(items []string, maxPerChunk, firstReserved int) [][]string {
+// If reserved swallows the whole budget the chunk size falls back to 1 — the
+// group will overflow and NDMS will say so, which beats looping forever.
+func chunkWithReserve(items []string, maxPerChunk, reserved int) [][]string {
 	if maxPerChunk <= 0 || len(items) == 0 {
 		return nil
 	}
-	firstBudget := maxPerChunk - firstReserved
-	if firstBudget < 0 {
-		firstBudget = 0
+	budget := maxPerChunk - reserved
+	if budget < 1 {
+		budget = 1
 	}
 	var chunks [][]string
-	end := firstBudget
-	if end > len(items) {
-		end = len(items)
-	}
-	chunks = append(chunks, items[:end])
-	for i := end; i < len(items); i += maxPerChunk {
-		j := i + maxPerChunk
+	for i := 0; i < len(items); i += budget {
+		j := i + budget
 		if j > len(items) {
 			j = len(items)
 		}

--- a/internal/dnsroute/sync_test.go
+++ b/internal/dnsroute/sync_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/ndms"
 )
 
-func TestChunkWithFirstBudget(t *testing.T) {
+func TestChunkWithReserve(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		got := chunkWithFirstBudget(nil, 300, 0)
+		got := chunkWithReserve(nil, 300, 0)
 		if got != nil {
 			t.Errorf("expected nil, got %v", got)
 		}
@@ -16,7 +16,7 @@ func TestChunkWithFirstBudget(t *testing.T) {
 
 	t.Run("under limit no reserve", func(t *testing.T) {
 		items := []string{"a", "b"}
-		got := chunkWithFirstBudget(items, 300, 0)
+		got := chunkWithReserve(items, 300, 0)
 		if len(got) != 1 || len(got[0]) != 2 {
 			t.Errorf("expected 1 chunk of 2, got %v", got)
 		}
@@ -24,7 +24,7 @@ func TestChunkWithFirstBudget(t *testing.T) {
 
 	t.Run("exact limit no reserve", func(t *testing.T) {
 		items := make([]string, 300)
-		got := chunkWithFirstBudget(items, 300, 0)
+		got := chunkWithReserve(items, 300, 0)
 		if len(got) != 1 || len(got[0]) != 300 {
 			t.Errorf("expected 1 chunk of 300, got %d chunks", len(got))
 		}
@@ -32,7 +32,7 @@ func TestChunkWithFirstBudget(t *testing.T) {
 
 	t.Run("over limit splits no reserve", func(t *testing.T) {
 		items := make([]string, 500)
-		got := chunkWithFirstBudget(items, 300, 0)
+		got := chunkWithReserve(items, 300, 0)
 		if len(got) != 2 {
 			t.Fatalf("expected 2 chunks, got %d", len(got))
 		}
@@ -41,34 +41,28 @@ func TestChunkWithFirstBudget(t *testing.T) {
 		}
 	})
 
-	t.Run("first chunk shrunk by reserve", func(t *testing.T) {
-		items := make([]string, 400)
-		got := chunkWithFirstBudget(items, 300, 10)
-		if len(got) != 2 {
-			t.Fatalf("expected 2 chunks, got %d", len(got))
+	t.Run("every chunk shrunk by reserve", func(t *testing.T) {
+		items := make([]string, 700)
+		got := chunkWithReserve(items, 300, 10)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 chunks, got %d", len(got))
 		}
-		if len(got[0]) != 290 || len(got[1]) != 110 {
-			t.Errorf("chunk sizes = %d,%d; want 290,110", len(got[0]), len(got[1]))
+		if len(got[0]) != 290 || len(got[1]) != 290 || len(got[2]) != 120 {
+			t.Errorf("chunk sizes = %d,%d,%d; want 290,290,120", len(got[0]), len(got[1]), len(got[2]))
 		}
 	})
 
-	t.Run("reserve exceeds max leaves empty first chunk", func(t *testing.T) {
-		items := make([]string, 100)
-		got := chunkWithFirstBudget(items, 300, 500)
-		if len(got) != 2 {
-			t.Fatalf("expected 2 chunks, got %d", len(got))
-		}
-		if len(got[0]) != 0 {
-			t.Errorf("chunk 0 should be empty, got %d", len(got[0]))
-		}
-		if len(got[1]) != 100 {
-			t.Errorf("chunk 1 size = %d, want 100", len(got[1]))
+	t.Run("reserve exceeds max still makes progress", func(t *testing.T) {
+		items := make([]string, 3)
+		got := chunkWithReserve(items, 300, 500)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 chunks of 1, got %d", len(got))
 		}
 	})
 
 	t.Run("1200 items splits into four groups", func(t *testing.T) {
 		items := make([]string, 1200)
-		got := chunkWithFirstBudget(items, 300, 0)
+		got := chunkWithReserve(items, 300, 0)
 		if len(got) != 4 {
 			t.Fatalf("expected 4 chunks, got %d", len(got))
 		}
@@ -202,11 +196,12 @@ func TestBuildTargetState(t *testing.T) {
 		if len(ts.groups) != 2 {
 			t.Fatalf("expected 2 groups, got %d", len(ts.groups))
 		}
-		if len(ts.groups[0].excludes) != 1 {
-			t.Errorf("group 0 excludes = %d, want 1", len(ts.groups[0].excludes))
-		}
-		if len(ts.groups[1].excludes) != 0 {
-			t.Errorf("group 1 excludes = %d, want 0", len(ts.groups[1].excludes))
+		// NDMS applies an exclude only inside its own object-group, so every
+		// chunk needs the full exclude set.
+		for i, g := range ts.groups {
+			if len(g.excludes) != 1 {
+				t.Errorf("group %d excludes = %d, want 1", i, len(g.excludes))
+			}
 		}
 		if len(ts.routes) != 2 {
 			t.Errorf("expected 2 routes, got %d", len(ts.routes))
@@ -292,26 +287,20 @@ func TestBuildTargetState(t *testing.T) {
 			},
 		}}
 		ts := buildTargetState(data, nil)
-		// 600 items, first chunk budget = 300 - 10 excludes = 290; remainder 310 -> 300 + 10.
+		// 600 items, every chunk budget = 300 - 10 excludes = 290 -> 290 + 290 + 20.
 		if len(ts.groups) != 3 {
 			t.Fatalf("expected 3 groups, got %d: sizes=%d,%d,%d",
 				len(ts.groups),
 				safeLen(ts.groups, 0), safeLen(ts.groups, 1), safeLen(ts.groups, 2))
 		}
-		if len(ts.groups[0].includes) != 290 {
-			t.Errorf("group[0].includes = %d, want 290", len(ts.groups[0].includes))
-		}
-		if len(ts.groups[0].excludes) != 10 {
-			t.Errorf("group[0].excludes = %d, want 10", len(ts.groups[0].excludes))
-		}
-		if len(ts.groups[1].includes) != 300 {
-			t.Errorf("group[1].includes = %d, want 300", len(ts.groups[1].includes))
-		}
-		if len(ts.groups[1].excludes) != 0 {
-			t.Errorf("group[1] must not carry excludes, got %d", len(ts.groups[1].excludes))
-		}
-		if len(ts.groups[2].includes) != 10 {
-			t.Errorf("group[2].includes = %d, want 10", len(ts.groups[2].includes))
+		wantIncludes := []int{290, 290, 20}
+		for i, want := range wantIncludes {
+			if len(ts.groups[i].includes) != want {
+				t.Errorf("group[%d].includes = %d, want %d", i, len(ts.groups[i].includes), want)
+			}
+			if len(ts.groups[i].excludes) != 10 {
+				t.Errorf("group[%d].excludes = %d, want 10", i, len(ts.groups[i].excludes))
+			}
 		}
 	})
 }


### PR DESCRIPTION
… во все группы

NDMS сопоставляет домены по суффиксу без границы по точке (x.com ловит и yandex.com), поэтому exclude на посторонний домен — законный обход. Валидацию убрали, решение за роутером.

Заодно: exclude действует только внутри своей object-group, а мы клали его лишь в _p1 — для списков больше 300 доменов он не работал.