### PR TITLE
fix(routing): убрать гейты с вкладки «Политики доступа»

### DIFF
--- a/frontend/src/lib/types/usageLevel.test.ts
+++ b/frontend/src/lib/types/usageLevel.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { isRoutingSubTabVisible } from './usageLevel';
+
+describe('isRoutingSubTabVisible', () => {
+	// Политики доступа — базовая функция роутера, а не экспертная настройка:
+	// вкладка видна на всех уровнях.
+	it('shows accessPolicies on the basic level', () => {
+		expect(isRoutingSubTabVisible('basic', 'accessPolicies')).toBe(true);
+	});
+});

--- a/frontend/src/lib/types/usageLevel.ts
+++ b/frontend/src/lib/types/usageLevel.ts
@@ -51,7 +51,7 @@ const SECTION_MIN_LEVEL: Record<Section, UsageLevel> = {
 };
 
 const ROUTING_SUBTAB_MIN_LEVEL: Record<RoutingSubTab, UsageLevel> = {
-	accessPolicies: 'advanced',
+	accessPolicies: 'basic',
 	clientRoutes: 'basic',
 	dnsRoutes: 'basic',
 	ipRoutes: 'advanced',

--- a/frontend/src/routes/routing/+page.svelte
+++ b/frontend/src/routes/routing/+page.svelte
@@ -242,7 +242,7 @@
             isOS5 ? { id: 'dns', label: 'NDMS', badge: dnsActiveCount } : null,
             { id: 'ip', label: 'IP-адреса', badge: ipActiveCount },
             { id: 'clientvpn', label: 'VPN для устройств', badge: clientActiveCount },
-            isOS5 ? { id: 'policy', label: 'Политики доступа', badge: policyCount } : null,
+            { id: 'policy', label: 'Политики доступа', badge: policyCount },
             // Visual gap separates the NDMS-stack tabs above from the
             // sing-box / hydraroute stack below. TProxy + FakeIP are the two
             // mutually-exclusive sing-box routing modes — kept adjacent (no
@@ -282,8 +282,8 @@
 
     // Пока список вкладок меняется (systemInfo, HR, уровень), не держим
     // active на id, которого ещё нет в tabItems — иначе пустой контент.
-    // Не сбрасываем NDMS/политики/sing-box до прихода systemInfo: до fetch
-    // isOS5=false и вкладки dns|policy ещё нет в списке — иначе F5 с NDMS
+    // Не сбрасываем NDMS/sing-box до прихода systemInfo: до fetch
+    // isOS5=false и вкладки dns ещё нет в списке — иначе F5 с NDMS
     // уводил на IP. Аналогично HR Neo — ждём hydraroute-status.
     $effect(() => {
         const items = tabItems;
@@ -296,7 +296,7 @@
 
         if (
             !systemKnown &&
-            (activeTab === 'dns' || activeTab === 'policy' || activeTab === 'singbox') &&
+            (activeTab === 'dns' || activeTab === 'singbox') &&
             !items.some((it) => it.id === activeTab)
         ) {
             return;


### PR DESCRIPTION
Вкладка скрывалась при isOS5=false и на уровнях ниже «Расширенного». Версионного основания нет: гейт по OS5 обоснован только для соседней вкладки NDMS (dns-proxy с object-group fqdn), а политики на OS4 такие же и работают одинаково — бэкенд их не гейтит и даже держит фолбэк для прошивок до 5.01 (accesspolicy/impl.go).