### PR TITLE
fix(tunnels): тулбар дашборда занимает всю ширину (#607)

### DIFF
--- a/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
+++ b/frontend/src/lib/components/tunnels/DashboardFlatSection.svelte
@@ -545,6 +545,10 @@
 		justify-content: flex-end;
 		flex-wrap: wrap;
 		gap: 0.5rem;
+		/* Единственный ребёнок .tunnels-toolbar — без роста тулбар жался по
+		   содержимому влево, и справа оставалась пустота (#607). */
+		flex: 1 1 auto;
+		min-width: 0;
 	}
 
 	.toolbar-actions :global(.btn.size-md) {

--- a/frontend/src/lib/components/tunnels/DashboardToolbar.svelte
+++ b/frontend/src/lib/components/tunnels/DashboardToolbar.svelte
@@ -149,22 +149,24 @@
 		</div>
 	{/if}
 
-	{#if actions}
-		<div class="dashboard-toolbar-actions">
-			{@render actions()}
-		</div>
-	{/if}
+	<div class="dashboard-toolbar-right">
+		{#if actions}
+			<div class="dashboard-toolbar-actions">
+				{@render actions()}
+			</div>
+		{/if}
 
-	<div class="dashboard-toolbar-create">
-		<TunnelCreateMenu
-			onAwg={onCreateAwg}
-			onSingboxSingle={onCreateSingboxSingle}
-			onSingboxGroup={onCreateSingboxGroup}
-			onSingboxSubscription={onCreateSingboxSubscription}
-			onAwg3={onCreateAwg3}
-			showSingbox={showSingboxCreate}
-			triggerIcon={createIcon}
-		/>
+		<div class="dashboard-toolbar-create">
+			<TunnelCreateMenu
+				onAwg={onCreateAwg}
+				onSingboxSingle={onCreateSingboxSingle}
+				onSingboxGroup={onCreateSingboxGroup}
+				onSingboxSubscription={onCreateSingboxSubscription}
+				onAwg3={onCreateAwg3}
+				showSingbox={showSingboxCreate}
+				triggerIcon={createIcon}
+			/>
+		</div>
 	</div>
 </div>
 
@@ -175,6 +177,9 @@
 		gap: 0.5rem;
 		min-width: 0;
 		flex: 1 1 auto;
+		/* В 761–1000px всё в строку не влезает: переносим, а не сжимаем —
+		   иначе подписи сегмент-контролов схлопываются до «Сплошн». */
+		flex-wrap: wrap;
 	}
 
 	.tunnel-toolbar-search {
@@ -251,11 +256,27 @@
 		flex: 0 0 auto;
 	}
 
+	/* Свободное место уходит между фильтрами и действиями: кнопки прижаты к
+	   правому краю (#607). Обёртка нужна, чтобы при переносе строки правая
+	   группа уезжала целиком и оставалась справа. */
+	.dashboard-toolbar-right {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
 	/* Mobile: авторазмещение по order, компактно в ≤4 строки —
 	   row 1: layout + view 50/50; row 2: order + group 50/50;
 	   row 3: тег-фильтр + actions 50/50 (одиночный растягивается на всю
 	   строку); row 4: search + create 50/50 */
 	@media (max-width: 760px) {
+		/* Грид ниже раскладывает прямых детей по order — обёртка правой группы
+		   растворяется, иначе actions и create схлопнулись бы в одну ячейку. */
+		.dashboard-toolbar-right {
+			display: contents;
+		}
+
 		.dashboard-toolbar {
 			display: grid;
 			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);


### PR DESCRIPTION
Кнопки действий прижаты к правому краю, поиск и переключатели остаются слева — свободное место уходит в середину. Хост-контейнер не растягивался (единственный ребёнок без flex-grow), поэтому тулбар жался влево.

Заодно чинится переполнение на 761–1000px: там тулбар вылезал за правый край и «Создать» была недоступна. Теперь строка переносится, правая группа уезжает целиком.