### PR TITLE
feat(sb-router): прямой переход в редактирование политики sing-box (#…

### DIFF
--- a/frontend/src/lib/components/sb-router/TrafficSourceSettings.svelte
+++ b/frontend/src/lib/components/sb-router/TrafficSourceSettings.svelte
@@ -77,11 +77,13 @@
           Привязку MAC-адресов настраивайте на странице политик.
         {/if}
       </p>
-      {#if variant === 'beginner'}
-        <Button variant="ghost" size="sm" href="/routing?tab=policy">
-          Управление устройствами →
-        </Button>
-      {/if}
+      <Button
+        variant="ghost"
+        size="sm"
+        href="/routing?tab=policy&policy={encodeURIComponent(cfg.policyName)}"
+      >
+        Управление устройствами →
+      </Button>
     {:else}
       <p class="hint">Выберите или создайте политику — без неё sing-box не обработает трафик устройств.</p>
     {/if}

--- a/frontend/src/routes/routing/+page.svelte
+++ b/frontend/src/routes/routing/+page.svelte
@@ -64,6 +64,10 @@
 
     let activeTab = $state<'hrneo' | 'geodata' | 'dns' | 'ip' | 'policy' | 'clientvpn' | 'singbox' | 'fakeip'>('dns');
 
+    // ?policy=Policy1 — прямой переход из настроек sing-box в редактор
+    // конкретной политики (#573).
+    let deepLinkPolicy = $derived($page.url.searchParams.get('policy'));
+
     let isOS5 = $derived($systemInfo.data?.isOS5 ?? false);
     let hydrarouteInstalled = $derived($routing.hydrarouteStatus?.installed ?? false);
     let hasDnsEngine = $derived(isOS5 || hydrarouteInstalled);
@@ -386,6 +390,7 @@
                 {policyDevices}
                 {policyInterfaces}
                 missing={missing.includes('accessPolicies')}
+                openPolicy={deepLinkPolicy}
             />
     {:else if activeTab === 'clientvpn'}
         <ClientRoutesTab

--- a/frontend/src/routes/routing/AccessPoliciesTab.svelte
+++ b/frontend/src/routes/routing/AccessPoliciesTab.svelte
@@ -14,9 +14,11 @@
         policyDevices: PolicyDevice[];
         policyInterfaces: PolicyGlobalInterface[];
         missing?: boolean;
+        /** Deep-link из настроек sing-box: открыть редактор этой политики (#573). */
+        openPolicy?: string | null;
     }
 
-    let { accessPolicies, policyDevices, policyInterfaces, missing = false }: Props = $props();
+    let { accessPolicies, policyDevices, policyInterfaces, missing = false, openPolicy = null }: Props = $props();
 
     let policyCreateOpen = $state(false);
     let policyCreating = $state(false);
@@ -37,6 +39,19 @@
         if (editingPolicy) {
             editingPolicyData = accessPolicies.find(p => p.name === editingPolicy) ?? null;
         }
+    });
+
+    // Одноразовое открытие по deep-link: политики приезжают из стора, поэтому
+    // ждём появления нужной. Отмечаем имя обработанным, иначе «Назад» из
+    // редактора тут же открывал бы его снова.
+    let appliedOpenPolicy = $state<string | null>(null);
+    $effect(() => {
+        if (!openPolicy || openPolicy === appliedOpenPolicy) return;
+        const target = accessPolicies.find(p => p.name === openPolicy);
+        if (!target) return;
+        appliedOpenPolicy = openPolicy;
+        editingPolicy = target.name;
+        editingPolicyData = target;
     });
 
     async function createPolicy(description: string) {


### PR DESCRIPTION
…573)

Кнопка «Управление устройствами» была только в простом режиме и вела на список политик. Теперь она есть и в экспертной панели движка, а ссылка несёт имя текущей политики — вкладка сразу открывает её редактор.