### PR TITLE
fix(routing): политики доступа работают на KeeneticOS 4.x

### DIFF
--- a/internal/api/accesspolicy.go
+++ b/internal/api/accesspolicy.go
@@ -138,7 +138,7 @@ func NewAccessPolicyHandler(svc accesspolicy.Service) *AccessPolicyHandler {
 // GET /api/access-policies
 //
 //	@Summary		List access policies
-//	@Description	KeeneticOS 5 only when route is registered.
+//	@Description	Works on both KeeneticOS 4.x and 5.x: `ip policy` exists since firmware 2.12.
 //	@Tags			access-policy
 //	@Produce		json
 //	@Security		CookieAuth

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -7247,7 +7247,8 @@ info:
 paths:
   /access-policies:
     get:
-      description: KeeneticOS 5 only when route is registered.
+      description: 'Works on both KeeneticOS 4.x and 5.x: `ip policy` exists since
+        firmware 2.12.'
       parameters:
       - description: Pass 'true' to bypass NDMS cache
         in: query
@@ -11175,7 +11176,8 @@ paths:
       - device-proxy
   /routing/access-policies:
     get:
-      description: KeeneticOS 5 only when route is registered.
+      description: 'Works on both KeeneticOS 4.x and 5.x: `ip policy` exists since
+        firmware 2.12.'
       parameters:
       - description: Pass 'true' to bypass NDMS cache
         in: query

--- a/internal/server/policy_routes_test.go
+++ b/internal/server/policy_routes_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Политики доступа существуют и на KeeneticOS 4.x: команда `ip policy` есть с
+// прошивки 2.12, `ip policy standalone` с 4.02, а `/rci/show/rc/ip/policy` на
+// живом 4.x роутере отдаёт конфиг политик. Регистрация ручек по версии
+// прошивки прятала вкладку целиком, поэтому маршруты не должны зависеть от
+// версии вовсе.
+//
+// Отдельно это защищает от второй ловушки: osdetect.Get() отдаёт Version4x,
+// пока не заполнен ndmsinfo, а маршруты регистрируются один раз при старте.
+// Медленный NDMS на загрузке молча выключал бы политики и на 5.x до
+// перезапуска демона. В тесте ndmsinfo пуст, то есть проверка идёт ровно в
+// том состоянии, в котором ручки пропадали.
+func TestPolicyRoutesRegisteredRegardlessOfFirmware(t *testing.T) {
+	mux := http.NewServeMux()
+	s := &Server{}
+	h := &routeHandlers{guarded: func(f http.HandlerFunc) http.HandlerFunc { return f }}
+
+	s.registerPolicyRoutes(mux, h)
+
+	paths := []string{
+		"/api/access-policies",
+		"/api/access-policies/create",
+		"/api/access-policies/delete",
+		"/api/access-policies/description",
+		"/api/access-policies/standalone",
+		"/api/access-policies/permit",
+		"/api/access-policies/assign",
+		"/api/access-policies/interfaces",
+		"/api/access-policies/interface-up",
+		"/api/access-policies/devices",
+		"/api/routing/access-policies",
+		"/api/routing/policy-interfaces",
+		"/api/routing/policy-devices",
+	}
+
+	for _, path := range paths {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if _, pattern := mux.Handler(req); pattern == "" {
+			t.Errorf("%s не зарегистрирован", path)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -595,6 +595,17 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 // spaHandler serves static files with SPA fallback to index.html.
 func spaHandler(staticFS fs.FS) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Незарегистрированная ручка под /api/ — это ошибка маршрутизации, а
+		// не путь SPA. Отдав index.html с кодом 200, мы заставляли клиент
+		// разбирать HTML как JSON, и он показывал «Некорректный ответ сервера
+		// (200)» вместо внятного сообщения.
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":true,"message":"эндпоинт не найден","code":"NOT_FOUND"}`))
+			return
+		}
+
 		name := strings.TrimPrefix(path.Clean("/"+r.URL.Path), "/")
 		if name == "" {
 			name = "index.html"

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/response"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
-	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
 )
 
 // routeHandlers держит handlers, разделяемые секциями registerRoutes.
@@ -565,18 +564,20 @@ func (s *Server) registerPolicyRoutes(mux *http.ServeMux, h *routeHandlers) {
 	// Devices endpoint uses hotspot RCI — works on both OS4 and OS5
 	mux.HandleFunc("/api/access-policies/devices", h.guarded(h.accessPolicyHandler.ListDevices))
 
-	// Access policies (protected + boot guarded) — OS5 only
-	if osdetect.Is5() {
-		mux.HandleFunc("/api/access-policies", h.guarded(h.accessPolicyHandler.List))
-		mux.HandleFunc("/api/access-policies/create", h.guarded(h.accessPolicyHandler.Create))
-		mux.HandleFunc("/api/access-policies/delete", h.guarded(h.accessPolicyHandler.Delete))
-		mux.HandleFunc("/api/access-policies/description", h.guarded(h.accessPolicyHandler.SetDescription))
-		mux.HandleFunc("/api/access-policies/standalone", h.guarded(h.accessPolicyHandler.SetStandalone))
-		mux.HandleFunc("/api/access-policies/permit", h.guarded(h.accessPolicyHandler.PermitInterface))
-		mux.HandleFunc("/api/access-policies/assign", h.guarded(h.accessPolicyHandler.AssignDevice))
-		mux.HandleFunc("/api/access-policies/interfaces", h.guarded(h.accessPolicyHandler.ListGlobalInterfaces))
-		mux.HandleFunc("/api/access-policies/interface-up", h.guarded(h.accessPolicyHandler.SetInterfaceUp))
-	}
+	// Политики доступа работают на обеих ветках прошивки: `ip policy` есть с
+	// 2.12, `ip policy standalone` с 4.02, а `/show/rc/ip/policy` отдаёт
+	// конфиг и на 4.x. Гейта по версии здесь быть не должно ещё и потому, что
+	// osdetect отдаёт 4.x, пока не заполнен ndmsinfo: маршруты регистрируются
+	// один раз при старте, и медленный NDMS выключал бы вкладку и на 5.x.
+	mux.HandleFunc("/api/access-policies", h.guarded(h.accessPolicyHandler.List))
+	mux.HandleFunc("/api/access-policies/create", h.guarded(h.accessPolicyHandler.Create))
+	mux.HandleFunc("/api/access-policies/delete", h.guarded(h.accessPolicyHandler.Delete))
+	mux.HandleFunc("/api/access-policies/description", h.guarded(h.accessPolicyHandler.SetDescription))
+	mux.HandleFunc("/api/access-policies/standalone", h.guarded(h.accessPolicyHandler.SetStandalone))
+	mux.HandleFunc("/api/access-policies/permit", h.guarded(h.accessPolicyHandler.PermitInterface))
+	mux.HandleFunc("/api/access-policies/assign", h.guarded(h.accessPolicyHandler.AssignDevice))
+	mux.HandleFunc("/api/access-policies/interfaces", h.guarded(h.accessPolicyHandler.ListGlobalInterfaces))
+	mux.HandleFunc("/api/access-policies/interface-up", h.guarded(h.accessPolicyHandler.SetInterfaceUp))
 
 	// Client routes (per-device VPN routing) — works on both OS4 and OS5
 	h.crHandler = api.NewClientRouteHandler(s.clientRouteService)
@@ -591,24 +592,8 @@ func (s *Server) registerPolicyRoutes(mux *http.ServeMux, h *routeHandlers) {
 	mux.HandleFunc("/api/routing/client-routes", h.guarded(h.crHandler.HandleList))
 	// Policy devices endpoint is unconditional (hotspot RCI works on both OSes).
 	mux.HandleFunc("/api/routing/policy-devices", h.guarded(h.accessPolicyHandler.ListDevices))
-	if osdetect.Is5() {
-		mux.HandleFunc("/api/routing/access-policies", h.guarded(h.accessPolicyHandler.List))
-		mux.HandleFunc("/api/routing/policy-interfaces", h.guarded(h.accessPolicyHandler.ListGlobalInterfaces))
-	} else {
-		// OS4: access policies + global-interfaces are NOT available.
-		// Return empty arrays so the polling stores stay in the 'fresh'
-		// state instead of erroring and showing a badge.
-		emptyArr := func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodGet {
-				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":[]}`))
-		}
-		mux.HandleFunc("/api/routing/access-policies", h.guarded(emptyArr))
-		mux.HandleFunc("/api/routing/policy-interfaces", h.guarded(emptyArr))
-	}
+	mux.HandleFunc("/api/routing/access-policies", h.guarded(h.accessPolicyHandler.List))
+	mux.HandleFunc("/api/routing/policy-interfaces", h.guarded(h.accessPolicyHandler.ListGlobalInterfaces))
 
 }
 

--- a/internal/server/spa_handler_test.go
+++ b/internal/server/spa_handler_test.go
@@ -204,3 +204,28 @@ func TestSPAHandlerGzip(t *testing.T) {
 		}
 	})
 }
+
+// Неразрешённый путь под /api/ не должен получать index.html: клиент разбирает
+// ответ как JSON, спотыкается на HTML и показывает «Некорректный ответ сервера
+// (200)» вместо внятной ошибки. Именно так выглядела пропавшая ручка политик
+// доступа на KeeneticOS 4.x.
+func TestSPAHandlerDoesNotSwallowAPIPaths(t *testing.T) {
+	handler := spaHandler(fstest.MapFS{
+		"index.html": {Data: []byte("<!doctype html><div id=\"app\"></div>"), Mode: fs.ModePerm},
+	})
+
+	for _, path := range []string{"/api/no-such-endpoint", "/api/access-policies/create"} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: код %d, ожидался 404", path, rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Errorf("%s: Content-Type %q, ожидался application/json", path, ct)
+		}
+		if strings.Contains(rec.Body.String(), "<!doctype html>") {
+			t.Errorf("%s: отдан index.html вместо JSON", path)
+		}
+	}
+}


### PR DESCRIPTION
Ручки /api/access-policies* регистрировались только при osdetect.Is5(), а polling-алиас на 4.x отдавал заглушку с пустым списком. После снятия гейта с вкладки в 2.16.3 это дало пустую вкладку и «Некорректный ответ сервера (200)» на любом действии: запрос уходил в незарегистрированный путь и проваливался в SPA-хендлер, который отдаёт index.html с кодом 200.

Гейт был неверен по факту: команда "ip policy" есть с прошивки 2.12, "ip policy standalone" с 4.02, а /show/rc/ip/policy на живом 4.x роутере отдаёт конфиг политик. Устройства и глобальные интерфейсы там тоже читаются: для хостов без поля policy уже есть фолбэк через running-config.

Заодно условная регистрация была ловушкой сама по себе: osdetect отдаёт 4.x, пока не заполнен ndmsinfo, а маршруты ставятся один раз при старте, поэтому медленный NDMS на загрузке выключал бы вкладку и на 5.x.

Отдельно: незарегистрированный путь под /api/ теперь отвечает JSON 404, а не index.html. Раньше любая ошибка маршрутизации выглядела как загадочная «ошибка 200» на стороне клиента.