### PR TITLE
fix(kmod): писать в журнал, когда для модели нет модуля в поставке

### DIFF
--- a/cmd/awg-manager/wiring_core.go
+++ b/cmd/awg-manager/wiring_core.go
@@ -103,6 +103,7 @@ func (a *app) setupNDMS() {
 	// Load kernel module if available (before backend detection).
 	// kmod.New() reads model/SoC from ndmsinfo, so it must run after Init above.
 	a.kmodLoader = kmod.New()
+	a.kmodLoader.Warn = func(msg string) { a.bootLog.Warn("kmod", "", msg) }
 
 	// Clean up old SoC-based module directories from previous IPK versions
 	a.kmodLoader.CleanupLegacyModules()

--- a/internal/sys/kmod/loader.go
+++ b/internal/sys/kmod/loader.go
@@ -40,6 +40,9 @@ type Loader struct {
 	model      string // e.g. "KN-1010"
 	soc        SoC    // kept for backward compatibility
 	modulePath string
+
+	// Warn reports a condition worth surfacing in the app journal. nil = silent.
+	Warn func(msg string)
 }
 
 // New creates a new kernel module loader.
@@ -327,7 +330,13 @@ func (l *Loader) selectBundledModule() {
 	}
 
 	if found == "" {
-		// No match for this model — clean up bundled dir anyway
+		// No match for this model — clean up bundled dir anyway.
+		// Worth a line in the journal: the models dropped from the shipped set
+		// land here, and without it the router silently keeps whatever module
+		// it already has (or none at all on a fresh install).
+		if l.Warn != nil {
+			l.Warn(fmt.Sprintf("no bundled kernel module for model %s — kernel mode works only if a module is already installed", l.model))
+		}
 		os.RemoveAll(BundledDir)
 		return
 	}

--- a/internal/sys/kmod/loader_test.go
+++ b/internal/sys/kmod/loader_test.go
@@ -1,0 +1,62 @@
+package kmod
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Модель вне поставки: bundled сносится, и без этой записи в журнале роутер
+// молча остаётся на том модуле, что уже стоит (или вовсе без него).
+func TestSelectBundledModuleWarnsOnUnknownModel(t *testing.T) {
+	dir := t.TempDir()
+	setModulesDir(t, dir)
+	if err := os.MkdirAll(BundledDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(BundledDir, "amneziawg-KN-1810.ko"), []byte("ko"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warned []string
+	l := &Loader{model: "KN-1613", Warn: func(m string) { warned = append(warned, m) }}
+	l.selectBundledModule()
+
+	if len(warned) != 1 || !strings.Contains(warned[0], "KN-1613") {
+		t.Errorf("ожидали одну запись с моделью, получили %v", warned)
+	}
+	if _, err := os.Stat(BundledDir); !os.IsNotExist(err) {
+		t.Error("bundled должен быть снесён")
+	}
+}
+
+// Совпадение по алиасу — не повод для предупреждения.
+func TestSelectBundledModuleSilentOnAliasHit(t *testing.T) {
+	dir := t.TempDir()
+	setModulesDir(t, dir)
+	if err := os.MkdirAll(BundledDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(BundledDir, "amneziawg-KN-1810.ko"), []byte("ko"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warned []string
+	l := &Loader{model: "KN-2910", Warn: func(m string) { warned = append(warned, m) }}
+	l.selectBundledModule()
+
+	if len(warned) != 0 {
+		t.Errorf("предупреждений быть не должно, получили %v", warned)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "amneziawg.ko")); err != nil {
+		t.Errorf("модуль алиаса не скопирован: %v", err)
+	}
+}
+
+func setModulesDir(t *testing.T, dir string) {
+	t.Helper()
+	oldModules, oldBundled := ModulesDir, BundledDir
+	ModulesDir, BundledDir = dir, filepath.Join(dir, "bundled")
+	t.Cleanup(func() { ModulesDir, BundledDir = oldModules, oldBundled })
+}


### PR DESCRIPTION
selectBundledModule при промахе по имени сносил bundled/ и молчал. На моделях, убранных из поставки, роутер оставался на уже установленном модуле (или без модуля вовсе), и в журнале не было ни строчки о причине.