### PR TITLE
fix(iptables): грузить xt_comment перед правилом с -m comment

### DIFF
--- a/internal/sys/iptables/iptables.go
+++ b/internal/sys/iptables/iptables.go
@@ -3,10 +3,14 @@ package iptables
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hoaxisr/awg-manager/internal/sys/exec"
+	"github.com/hoaxisr/awg-manager/internal/sys/osdetect"
 )
 
 const (
@@ -21,12 +25,90 @@ const (
 // отсутствующего модуля или отвергнутой ядром спеки — тот же довод, что уже
 // записан у RestoreNoflush ниже.
 func Run(ctx context.Context, args ...string) error {
+	comment := usesCommentMatch(args)
+	if comment {
+		ensureCommentModuleFn(ctx)
+	}
 	full := append([]string{"-w"}, args...)
 	res, err := exec.Run(ctx, Binary, full...)
 	if err != nil {
+		if comment && !commentModuleLoaded() {
+			return fmt.Errorf("%w (модуль ядра xt_comment не загружен)", exec.FormatError(res, err))
+		}
 		return exec.FormatError(res, err)
 	}
 	return nil
+}
+
+// xt_comment грузится лениво здесь, в единственной точке, через которую
+// проходят все наши правила. Причина: на части прошивок (Keenetic/Netcraze
+// OS 5.x EA, NC-1812) NDMS сам `-m comment` нигде не использует, поэтому
+// модуль не подгружается на старте; если ещё и sing-box не установлен —
+// его router-преflight тоже не отрабатывает, и первое же правило с нашим
+// маркером ядро отвергает: «iptables: No chain/target/match by that name»
+// (issue #666; тот же корень, что #130 для sb-router). Место выбрано не у
+// вызывающих — их уже трое (WDTT NAT, WDTT LAN, listen-firewall), и ровно
+// «забыли позвать preflight» и есть баг.
+//
+// Soft-fail: отсутствующий .ko означает либо вкомпилен в ядро, либо реально
+// нет — вердикт в обоих случаях выносит сам iptables, а не мы.
+var (
+	commentMu     sync.Mutex
+	commentLoaded bool
+)
+
+// ensureCommentModuleFn — точка подмены для тестов.
+var ensureCommentModuleFn = ensureCommentModule
+
+func usesCommentMatch(args []string) bool {
+	for i, a := range args {
+		if a == "comment" && i > 0 && args[i-1] == "-m" {
+			return true
+		}
+	}
+	return false
+}
+
+func commentModuleLoaded() bool {
+	commentMu.Lock()
+	defer commentMu.Unlock()
+	return commentLoaded
+}
+
+func ensureCommentModule(ctx context.Context) {
+	commentMu.Lock()
+	defer commentMu.Unlock()
+	if commentLoaded {
+		return
+	}
+	if moduleLoaded("xt_comment") {
+		commentLoaded = true
+		return
+	}
+	kernel := osdetect.KernelRelease()
+	if kernel == "" {
+		return
+	}
+	path := filepath.Join("/lib/modules", kernel, "xt_comment.ko")
+	if _, err := os.Stat(path); err != nil {
+		return
+	}
+	if _, err := exec.Run(ctx, "insmod", path); err == nil {
+		commentLoaded = true
+	}
+}
+
+func moduleLoaded(name string) bool {
+	data, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, name+" ") {
+			return true
+		}
+	}
+	return false
 }
 
 // RunOutput runs iptables and returns its stdout. Used by read-only queries

--- a/internal/sys/iptables/iptables_test.go
+++ b/internal/sys/iptables/iptables_test.go
@@ -1,0 +1,65 @@
+package iptables
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Правило с `-m comment` обязано пройти через ленивую подгрузку xt_comment:
+// на прошивках, где NDMS сам комменты не использует и sing-box не установлен,
+// модуль никем не грузится и ядро отвергает правило с «No chain/target/match
+// by that name» (issue #666).
+func TestRunEnsuresCommentModuleOnlyForCommentRules(t *testing.T) {
+	orig := ensureCommentModuleFn
+	t.Cleanup(func() { ensureCommentModuleFn = orig })
+	calls := 0
+	ensureCommentModuleFn = func(context.Context) { calls++ }
+
+	_ = Run(context.Background(), "-t", "nat", "-S", "POSTROUTING")
+	if calls != 0 {
+		t.Fatalf("правило без -m comment не должно трогать модуль, вызовов: %d", calls)
+	}
+
+	_ = Run(context.Background(), "-t", "nat", "-I", "POSTROUTING", "1",
+		"-s", "10.66.66.0/24", "-o", "eth3",
+		"-m", "comment", "--comment", "AWGM_WDTT", "-j", "MASQUERADE")
+	if calls != 1 {
+		t.Fatalf("правило с -m comment должно подгрузить xt_comment, вызовов: %d", calls)
+	}
+}
+
+// Ошибка правила с комментом при незагруженном модуле должна прямо называть
+// причину: голое «No chain/target/match by that name» стоило репортёру #666
+// целого раунда переписки.
+func TestRunHintsMissingCommentModule(t *testing.T) {
+	origEnsure := ensureCommentModuleFn
+	origLoaded := commentLoaded
+	t.Cleanup(func() {
+		ensureCommentModuleFn = origEnsure
+		commentLoaded = origLoaded
+	})
+	ensureCommentModuleFn = func(context.Context) {}
+	commentLoaded = false
+
+	// Бинарь /opt/sbin/iptables в тестовой среде отсутствует — Run вернёт
+	// ошибку запуска, нам важен только хвост подсказки.
+	err := Run(context.Background(), "-t", "nat", "-I", "POSTROUTING", "1",
+		"-m", "comment", "--comment", "AWGM_WDTT", "-j", "MASQUERADE")
+	if err == nil {
+		t.Fatal("ожидалась ошибка")
+	}
+	if !strings.Contains(err.Error(), "xt_comment") {
+		t.Fatalf("нет подсказки про xt_comment: %v", err)
+	}
+
+	commentLoaded = true
+	err = Run(context.Background(), "-t", "nat", "-I", "POSTROUTING", "1",
+		"-m", "comment", "--comment", "AWGM_WDTT", "-j", "MASQUERADE")
+	if err == nil {
+		t.Fatal("ожидалась ошибка")
+	}
+	if strings.Contains(err.Error(), "xt_comment") {
+		t.Fatalf("модуль загружен — подсказка лишняя: %v", err)
+	}
+}


### PR DESCRIPTION
WDTT на Netcraze Ultra (NC-1812, OS 5.01 EA) не мог поставить NAT: «MASQUERADE 10.66.66.0/24 via eth3: No chain/target/match by that name». Ручное правило без коммента проходило, с -m comment — нет: модуль xt_comment не загружен. NDMS на этих прошивках комментов не использует, а sing-box, чей preflight грузил модуль раньше, не установлен.

Грузим лениво в iptables.Run — единственной точке, через которую идут все правила; забыть позвать preflight у нового вызывающего теперь нельзя. Если .ko нет (вкомпилен в ядро либо отсутствует) — молча идём дальше, вердикт выносит сам iptables, но в ошибку добавляется, что модуль не загружен.

Closes #666