### PR TITLE
fix(diagnostics): в окружении показывать правила VPN для устройств

### DIFF
--- a/frontend/src/lib/utils/about-device.test.ts
+++ b/frontend/src/lib/utils/about-device.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildAwgmServicesSnapshot, awgmServicesRows } from './about-device';
+
+// #663: прокси (SOCKS5/HTTP) и client routes — разные строки отчёта.
+describe('awgmServicesRows', () => {
+	const snap = buildAwgmServicesSnapshot({
+		level: 'advanced',
+		theme: null,
+		settings: null,
+		authDisabled: true,
+		authenticated: false,
+		login: null,
+		singbox: null,
+		hydra: null,
+		deviceProxy: { enabled: false, port: 1080, selectedOutbound: '' } as never,
+		deviceProxyRuntime: null,
+		clientRoutesTotal: 1,
+		clientRoutesEnabled: 1,
+		clientRoutesLoaded: true,
+		dnsRoutesTotal: 0,
+		dnsRoutesEnabled: 0,
+		awgRunning: 0,
+		awgTotal: 0,
+		subscriptionsEnabled: 0,
+		subscriptionsTotal: 0,
+	});
+
+	const value = (label: string) => awgmServicesRows(snap).find((r) => r.label === label)?.value;
+
+	it('показывает правила client routes под «VPN для устройств»', () => {
+		expect(value('VPN для устройств')).toBe('1 вкл / 1 всего');
+	});
+
+	it('показывает прокси отдельной строкой', () => {
+		expect(value('Прокси для устройств')).toBe('выкл');
+	});
+});

--- a/frontend/src/lib/utils/about-device.ts
+++ b/frontend/src/lib/utils/about-device.ts
@@ -77,6 +77,7 @@ export interface AwgmServicesSnapshot {
 	/** null — строка скрыта (ещё грузится). */
 	hydraRoute: string | null;
 	deviceProxy: string;
+	clientRoutes: string;
 	dnsRoutes: string;
 	awgTunnels: string;
 	subscriptions: string;
@@ -362,6 +363,9 @@ export function buildAwgmServicesSnapshot(input: {
 	showHydra?: boolean;
 	deviceProxy: DeviceProxyConfig | null;
 	deviceProxyRuntime: DeviceProxyRuntime | null;
+	clientRoutesTotal: number;
+	clientRoutesEnabled: number;
+	clientRoutesLoaded?: boolean;
 	dnsRoutesTotal: number;
 	dnsRoutesEnabled: number;
 	dnsRoutesLoaded?: boolean;
@@ -425,6 +429,10 @@ export function buildAwgmServicesSnapshot(input: {
 			: 'выкл';
 	}
 
+	const clientRoutes = input.clientRoutesLoaded
+		? `${input.clientRoutesEnabled} вкл / ${input.clientRoutesTotal} всего`
+		: '…';
+
 	const dnsRoutes =
 		!input.showDnsRoutes
 			? '—'
@@ -453,6 +461,7 @@ export function buildAwgmServicesSnapshot(input: {
 		singbox,
 		hydraRoute: hydra,
 		deviceProxy,
+		clientRoutes,
 		dnsRoutes,
 		awgTunnels,
 		subscriptions,
@@ -473,7 +482,10 @@ export function awgmServicesRows(s: AwgmServicesSnapshot): AboutInfoRow[] {
 		rows.push({ label: 'HydraRoute Neo', value: s.hydraRoute });
 	}
 	rows.push(
-		{ label: 'VPN для устройств', value: s.deviceProxy },
+		// Прокси (SOCKS5/HTTP) и «VPN для устройств» (client routes) — разные
+		// подсистемы; до #663 прокси показывался под именем вкладки client routes.
+		{ label: 'Прокси для устройств', value: s.deviceProxy },
+		{ label: 'VPN для устройств', value: s.clientRoutes },
 		{ label: 'DNS-маршруты', value: s.dnsRoutes },
 		{ label: 'AWG-туннели', value: s.awgTunnels },
 		{ label: 'SingBox подписки', value: s.subscriptions },

--- a/frontend/src/lib/utils/diagnostics-environment.ts
+++ b/frontend/src/lib/utils/diagnostics-environment.ts
@@ -61,6 +61,9 @@ type AwgmCounts = {
 	hydraLoaded?: boolean;
 	deviceProxy?: DeviceProxyConfig | null;
 	deviceProxyRuntime?: DeviceProxyRuntime | null;
+	clientRoutesTotal?: number;
+	clientRoutesEnabled?: number;
+	clientRoutesLoaded?: boolean;
 	dnsRoutesTotal?: number;
 	dnsRoutesEnabled?: number;
 	dnsRoutesLoaded?: boolean;
@@ -236,6 +239,25 @@ export async function collectDiagnosticsEnvironmentSnapshot(): Promise<Diagnosti
 	}
 
 	if (isRoutingSubTabVisible(level, 'clientRoutes')) {
+		await capture(
+			'clientRoutes',
+			async () => {
+				const res = await fetch('/api/routing/client-routes');
+				if (!res.ok) {
+					throw new Error(`client-routes ${res.status}`);
+				}
+				const body = await res.json();
+				const routes = (body.data ?? []) as { enabled?: boolean }[];
+				counts.clientRoutesTotal = routes.length;
+				counts.clientRoutesEnabled = routes.filter((r) => r.enabled).length;
+				counts.clientRoutesLoaded = true;
+				return true;
+			},
+			false,
+			errors,
+			markPartial,
+		);
+
 		const [cfg, rt] = await Promise.all([
 			capture('deviceProxy.config', () => api.getDeviceProxyConfig(), null as DeviceProxyConfig | null, errors, markPartial),
 			capture('deviceProxy.runtime', () => api.getDeviceProxyRuntime(), null as DeviceProxyRuntime | null, errors, markPartial),
@@ -272,6 +294,9 @@ export async function collectDiagnosticsEnvironmentSnapshot(): Promise<Diagnosti
 				showHydra: isRoutingSubTabVisible(level, 'hrNeo'),
 				deviceProxy: counts.deviceProxy ?? null,
 				deviceProxyRuntime: counts.deviceProxyRuntime ?? null,
+				clientRoutesTotal: counts.clientRoutesTotal ?? 0,
+				clientRoutesEnabled: counts.clientRoutesEnabled ?? 0,
+				clientRoutesLoaded: counts.clientRoutesLoaded ?? false,
 				dnsRoutesTotal: counts.dnsRoutesTotal ?? 0,
 				dnsRoutesEnabled: counts.dnsRoutesEnabled ?? 0,
 				dnsRoutesLoaded: counts.dnsRoutesLoaded ?? false,

--- a/frontend/src/routes/diagnostics/AboutDeviceTab.svelte
+++ b/frontend/src/routes/diagnostics/AboutDeviceTab.svelte
@@ -55,6 +55,9 @@
 		hydraLoaded?: boolean;
 		deviceProxy?: DeviceProxyConfig | null;
 		deviceProxyRuntime?: DeviceProxyRuntime | null;
+		clientRoutesTotal?: number;
+		clientRoutesEnabled?: number;
+		clientRoutesLoaded?: boolean;
 		dnsRoutesTotal?: number;
 		dnsRoutesEnabled?: number;
 		dnsRoutesLoaded?: boolean;
@@ -85,6 +88,9 @@
 			showHydra: isRoutingSubTabVisible(level, 'hrNeo'),
 			deviceProxy: c.deviceProxy ?? null,
 			deviceProxyRuntime: c.deviceProxyRuntime ?? null,
+			clientRoutesTotal: c.clientRoutesTotal ?? 0,
+			clientRoutesEnabled: c.clientRoutesEnabled ?? 0,
+			clientRoutesLoaded: c.clientRoutesLoaded ?? false,
 			dnsRoutesTotal: c.dnsRoutesTotal ?? 0,
 			dnsRoutesEnabled: c.dnsRoutesEnabled ?? 0,
 			dnsRoutesLoaded: c.dnsRoutesLoaded ?? false,
@@ -180,6 +186,19 @@
 		}
 
 		if (isRoutingSubTabVisible(level, 'clientRoutes')) {
+			void fetch('/api/routing/client-routes')
+				.then(async (res) => {
+					if (!res.ok) return;
+					const body = await res.json();
+					const routes = (body.data ?? []) as { enabled?: boolean }[];
+					patchAwgmFromStores({
+						clientRoutesTotal: routes.length,
+						clientRoutesEnabled: routes.filter((r) => r.enabled).length,
+						clientRoutesLoaded: true,
+					});
+				})
+				.catch(() => {});
+
 			void Promise.all([
 				api.getDeviceProxyConfig().catch(() => null),
 				api.getDeviceProxyRuntime().catch(() => null),


### PR DESCRIPTION
Closes #663

В отчёте «Инструменты → Окружение» строка «VPN для устройств» показывала
статус прокси-сервера (SOCKS5/HTTP, `deviceproxy`), а не правила client
routes — совпали имя вкладки «Маршрутизация → VPN для устройств» и имя
строки отчёта. Правила client routes не выводились нигде, поэтому при
существующих правилах отчёт показывал «выкл».

- строка прокси переименована в «Прокси для устройств»;
- добавлена строка «VPN для устройств: N вкл / M всего» по образцу
  «DNS-маршруты» — в UI-вкладке и в скачиваемом отчёте.

