### PR TITLE
feat(wdtt): ссылки wdtt://connect от WDTT Plus

### DIFF
--- a/internal/wdtt/link.go
+++ b/internal/wdtt/link.go
@@ -203,14 +203,23 @@ func parseWdttURI(link string) (ImportPayload, error) {
 	if !strings.HasPrefix(link, SchemeWdtt) {
 		return ImportPayload{}, fmt.Errorf("ожидается wdtt://")
 	}
-	payload := strings.TrimPrefix(link, SchemeWdtt)
 	name := "Server"
-	if hash := strings.Index(payload, "#"); hash >= 0 {
-		if n := strings.TrimSpace(payload[hash+1:]); n != "" {
+	if hash := strings.Index(link, "#"); hash >= 0 {
+		if n := strings.TrimSpace(link[hash+1:]); n != "" {
 			name = n
 		}
-		payload = payload[:hash]
+		link = link[:hash]
 	}
+	u, err := url.Parse(link)
+	if err == nil && strings.EqualFold(u.Host, "connect") {
+		p, err := wdttConnectQueryToPayload(u)
+		if err != nil {
+			return ImportPayload{}, err
+		}
+		p.Name = pickName(p.Name, name)
+		return p, nil
+	}
+	payload := strings.TrimPrefix(link, SchemeWdtt)
 	if looksColonWdtt(payload) {
 		return colonWdttToPayload(payload, name)
 	}
@@ -219,6 +228,51 @@ func parseWdttURI(link string) (ImportPayload, error) {
 		return p, nil
 	}
 	return colonWdttToPayload(payload, name)
+}
+
+// wdttConnectQueryToPayload parses WDTT-Plus share links:
+// wdtt://connect?v=1&host=…&dtls=…&wg=…&local=…&password=…&hashes=…
+func wdttConnectQueryToPayload(u *url.URL) (ImportPayload, error) {
+	q := u.Query()
+	host := firstQuery(q, "host", "ip", "server")
+	pass := firstQuery(q, "password", "pass")
+	if host == "" || pass == "" {
+		return ImportPayload{}, fmt.Errorf("wdtt://connect: нужны host и password")
+	}
+	dtls := firstQuery(q, "dtls", "dtls_port", "server_port")
+	peer := host
+	if dtls != "" {
+		if !isDigits(dtls) {
+			return ImportPayload{}, fmt.Errorf("wdtt://connect: некорректный dtls")
+		}
+		peer = host + ":" + dtls
+	} else {
+		peer = normalizePeer(host)
+	}
+	hashes := splitHashes(firstQuery(q, "hashes", "vk", "vkHashes", "hash"))
+	workers := 18
+	if w := firstQuery(q, "workers", "workersPerHash"); w != "" {
+		if n, err := strconv.Atoi(w); err == nil && n > 0 {
+			workers = n
+		}
+	}
+	listen := ""
+	if port := firstQuery(q, "local", "port", "listenPort"); port != "" {
+		if _, err := strconv.Atoi(port); err == nil {
+			listen = "127.0.0.1:" + port
+		}
+	}
+	return ImportPayload{
+		Name:     firstQuery(q, "name"),
+		Peer:     peer,
+		Password: pass,
+		VKHashes: hashes,
+		Workers:  workers,
+		Listen:   listen,
+		DeviceID: firstQuery(q, "deviceId", "device-id", "did"),
+		SubURL:   normalizeSubURL(firstQuery(q, "sub", "subUrl", "sub_url")),
+		ConnMode: firstQuery(q, "mode", "connMode", "relayMode"),
+	}, nil
 }
 
 func looksColonWdtt(payload string) bool {

--- a/internal/wdtt/link_connect_test.go
+++ b/internal/wdtt/link_connect_test.go
@@ -1,0 +1,40 @@
+package wdtt
+
+import "testing"
+
+func TestDecodeImport_WdttConnectQuery(t *testing.T) {
+	link := "wdtt://connect?v=1&host=45.128.235.176&dtls=56000&wg=56001&local=9000&password=pRujBTrEnykvnG23&hashes=focqLvg-E1od3rNdx0Q0NGDpNXtf0NF5QU-CCu6PHPQ%2CjV8BmeP_zNwNfDT46nIgqw9yGZ-5Vn3y0XbnJ158TR0%2Ck_hR9nkEb7zNCtehd1H52KdQdyOjrvEz-9ifiBeyH04%2C6ODHK91tF6W34-7op-GvePwdUGWZFRuX3S8IBcrZUIw"
+	got, err := DecodeImport(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Peer != "45.128.235.176:56000" {
+		t.Fatalf("peer=%q", got.Peer)
+	}
+	if got.Password != "pRujBTrEnykvnG23" {
+		t.Fatalf("password=%q", got.Password)
+	}
+	if got.Listen != "127.0.0.1:9000" {
+		t.Fatalf("listen=%q", got.Listen)
+	}
+	if len(got.VKHashes) != 4 {
+		t.Fatalf("hashes=%v", got.VKHashes)
+	}
+	if got.VKHashes[0] != "focqLvg-E1od3rNdx0Q0NGDpNXtf0NF5QU-CCu6PHPQ" {
+		t.Fatalf("hash0=%q", got.VKHashes[0])
+	}
+}
+
+func TestDecodeImport_WdttConnectQueryWithName(t *testing.T) {
+	link := "wdtt://connect?host=10.0.0.1&dtls=56000&password=secret&hashes=h1#MyPlus"
+	got, err := DecodeImport(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "MyPlus" {
+		t.Fatalf("name=%q", got.Name)
+	}
+	if got.Peer != "10.0.0.1:56000" {
+		t.Fatalf("peer=%q", got.Peer)
+	}
+}


### PR DESCRIPTION
## Summary
- Парсинг формата \wdtt://connect?v=1&host=…&dtls=…&local=…&password=…&hashes=…\ (WDTT Plus)
- Поля host/dtls → peer, local → listen, hashes URL-decode

## Test plan
- [ ] Импорт ссылки из WDTT Plus в WDTT-клиент awg-manager
- [ ] Старые wdtt:// и qwdtt:// ссылки без регрессий

Made with [Cursor](https://cursor.com)