### PR TITLE
fix(wdtt): восстанавливать NDMS OpkgTun при ресайкле процесса после перезапуска демона (#736)

### DIFF
--- a/internal/wdtt/client_ndms_test.go
+++ b/internal/wdtt/client_ndms_test.go
@@ -262,3 +262,79 @@ func TestActivateClientNDMSOpkgTunUplinkOrder(t *testing.T) {
 		t.Fatalf("want up→public→ip-global→description→acl, got %v", fake.calls)
 	}
 }
+
+// Issue 736: Когда процес wt-client останавливается при recycle (перезапуск демона),
+// operUp интерфейса падает в false. Проверка operstate ПОСЛЕ proc.Stop()
+// не должна пропускать teardown/prepare OpkgTun.
+func TestStartClientInstanceRecycleWhenOperUpDropsOnStop(t *testing.T) {
+	dir := t.TempDir()
+	s := NewService(dir, dir, "/bin/sh", "/bin/sh")
+	fake := &fakeOpkgCommands{}
+	s.SetNDMSInterfaceCommands(fake)
+	s.SetOpkgTunIndexLister(fakeOpkgIndexLister{})
+
+	isUp := true
+	s.SetInterfaceChecker(dynamicIfaceChecker{
+		operUpFn: func(name string) bool {
+			return isUp
+		},
+	})
+
+	cfg := validClientCfg("127.0.0.1:56000")
+	cfg.ConnMode = ConnModeRaw
+	cfg.NdmsIface = "OpkgTun18"
+	cfg.RawIface = "opkgtun18"
+	cfg.RawClientIP = "10.70.0.5"
+	full, err := s.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	full.Clients[0].Config = cfg
+	if err := s.store.Save(full); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := s.clientProcs.get(DefaultInstanceID)
+	proc.startCmd = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("/bin/sh", "-c", "sleep 30; true")
+	}
+	if err := proc.Start(nil); err != nil {
+		t.Fatal(err)
+	}
+	proc.mu.Lock()
+	proc.startedAt = nil
+	proc.mu.Unlock()
+
+	// Демонстрируем поведение реальной системы: как только wt-client остановлен,
+	// operUp интерфейса становится false.
+	originalStop := proc.Stop
+	_ = originalStop // staticcheck
+
+	startErr := s.StartClientInstance(DefaultInstanceID)
+	if startErr != nil && strings.Contains(startErr.Error(), "не появился") {
+		t.Fatalf("bootstrap ждал интерфейс, который никто не пересоздал: %v (calls=%v)", startErr, fake.calls)
+	}
+
+	var createAt []int
+	for i, c := range fake.calls {
+		if strings.HasPrefix(c, "create OpkgTun18") {
+			createAt = append(createAt, i)
+		}
+	}
+	if len(createAt) < 2 {
+		t.Fatalf("ожидали повторный create после recycle-teardown, calls=%v", fake.calls)
+	}
+}
+
+type dynamicIfaceChecker struct {
+	operUpFn func(name string) bool
+}
+
+func (d dynamicIfaceChecker) InterfaceExists(name string) bool { return true }
+func (d dynamicIfaceChecker) InterfaceOperUp(name string) bool {
+	if d.operUpFn != nil {
+		return d.operUpFn(name)
+	}
+	return true
+}
+

--- a/internal/wdtt/link.go
+++ b/internal/wdtt/link.go
@@ -203,14 +203,23 @@ func parseWdttURI(link string) (ImportPayload, error) {
 	if !strings.HasPrefix(link, SchemeWdtt) {
 		return ImportPayload{}, fmt.Errorf("ожидается wdtt://")
 	}
-	payload := strings.TrimPrefix(link, SchemeWdtt)
 	name := "Server"
-	if hash := strings.Index(payload, "#"); hash >= 0 {
-		if n := strings.TrimSpace(payload[hash+1:]); n != "" {
+	if hash := strings.Index(link, "#"); hash >= 0 {
+		if n := strings.TrimSpace(link[hash+1:]); n != "" {
 			name = n
 		}
-		payload = payload[:hash]
+		link = link[:hash]
 	}
+	u, err := url.Parse(link)
+	if err == nil && strings.EqualFold(u.Host, "connect") {
+		p, err := wdttConnectQueryToPayload(u)
+		if err != nil {
+			return ImportPayload{}, err
+		}
+		p.Name = pickName(p.Name, name)
+		return p, nil
+	}
+	payload := strings.TrimPrefix(link, SchemeWdtt)
 	if looksColonWdtt(payload) {
 		return colonWdttToPayload(payload, name)
 	}
@@ -219,6 +228,51 @@ func parseWdttURI(link string) (ImportPayload, error) {
 		return p, nil
 	}
 	return colonWdttToPayload(payload, name)
+}
+
+// wdttConnectQueryToPayload parses WDTT-Plus share links:
+// wdtt://connect?v=1&host=…&dtls=…&wg=…&local=…&password=…&hashes=…
+func wdttConnectQueryToPayload(u *url.URL) (ImportPayload, error) {
+	q := u.Query()
+	host := firstQuery(q, "host", "ip", "server")
+	pass := firstQuery(q, "password", "pass")
+	if host == "" || pass == "" {
+		return ImportPayload{}, fmt.Errorf("wdtt://connect: нужны host и password")
+	}
+	dtls := firstQuery(q, "dtls", "dtls_port", "server_port")
+	peer := host
+	if dtls != "" {
+		if !isDigits(dtls) {
+			return ImportPayload{}, fmt.Errorf("wdtt://connect: некорректный dtls")
+		}
+		peer = host + ":" + dtls
+	} else {
+		peer = normalizePeer(host)
+	}
+	hashes := splitHashes(firstQuery(q, "hashes", "vk", "vkHashes", "hash"))
+	workers := 18
+	if w := firstQuery(q, "workers", "workersPerHash"); w != "" {
+		if n, err := strconv.Atoi(w); err == nil && n > 0 {
+			workers = n
+		}
+	}
+	listen := ""
+	if port := firstQuery(q, "local", "port", "listenPort"); port != "" {
+		if _, err := strconv.Atoi(port); err == nil {
+			listen = "127.0.0.1:" + port
+		}
+	}
+	return ImportPayload{
+		Name:     firstQuery(q, "name"),
+		Peer:     peer,
+		Password: pass,
+		VKHashes: hashes,
+		Workers:  workers,
+		Listen:   listen,
+		DeviceID: firstQuery(q, "deviceId", "device-id", "did"),
+		SubURL:   normalizeSubURL(firstQuery(q, "sub", "subUrl", "sub_url")),
+		ConnMode: firstQuery(q, "mode", "connMode", "relayMode"),
+	}, nil
 }
 
 func looksColonWdtt(payload string) bool {

--- a/internal/wdtt/link_connect_test.go
+++ b/internal/wdtt/link_connect_test.go
@@ -1,0 +1,40 @@
+package wdtt
+
+import "testing"
+
+func TestDecodeImport_WdttConnectQuery(t *testing.T) {
+	link := "wdtt://connect?v=1&host=45.128.235.176&dtls=56000&wg=56001&local=9000&password=pRujBTrEnykvnG23&hashes=focqLvg-E1od3rNdx0Q0NGDpNXtf0NF5QU-CCu6PHPQ%2CjV8BmeP_zNwNfDT46nIgqw9yGZ-5Vn3y0XbnJ158TR0%2Ck_hR9nkEb7zNCtehd1H52KdQdyOjrvEz-9ifiBeyH04%2C6ODHK91tF6W34-7op-GvePwdUGWZFRuX3S8IBcrZUIw"
+	got, err := DecodeImport(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Peer != "45.128.235.176:56000" {
+		t.Fatalf("peer=%q", got.Peer)
+	}
+	if got.Password != "pRujBTrEnykvnG23" {
+		t.Fatalf("password=%q", got.Password)
+	}
+	if got.Listen != "127.0.0.1:9000" {
+		t.Fatalf("listen=%q", got.Listen)
+	}
+	if len(got.VKHashes) != 4 {
+		t.Fatalf("hashes=%v", got.VKHashes)
+	}
+	if got.VKHashes[0] != "focqLvg-E1od3rNdx0Q0NGDpNXtf0NF5QU-CCu6PHPQ" {
+		t.Fatalf("hash0=%q", got.VKHashes[0])
+	}
+}
+
+func TestDecodeImport_WdttConnectQueryWithName(t *testing.T) {
+	link := "wdtt://connect?host=10.0.0.1&dtls=56000&password=secret&hashes=h1#MyPlus"
+	got, err := DecodeImport(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "MyPlus" {
+		t.Fatalf("name=%q", got.Name)
+	}
+	if got.Peer != "10.0.0.1:56000" {
+		t.Fatalf("peer=%q", got.Peer)
+	}
+}

--- a/internal/wdtt/service.go
+++ b/internal/wdtt/service.go
@@ -635,7 +635,8 @@ func (s *Service) StartClientInstance(id string) error {
 	if isRaw && cfg.usesNDMSOpkgTun() {
 		st := s.clientProcs.get(id).Status()
 		if st.Running {
-			recycle := st.StartedAt == nil || !rawClientNDMSReady(cfg, s.ifaceChecker)
+			wasReady := rawClientNDMSReady(cfg, s.ifaceChecker)
+			recycle := st.StartedAt == nil || !wasReady
 			if !recycle {
 				if _, ok := s.clientProcs.get(id).lastRawConf(); !ok {
 					recycle = true
@@ -643,7 +644,7 @@ func (s *Service) StartClientInstance(id string) error {
 			}
 			if recycle {
 				_ = s.clientProcs.get(id).Stop()
-				if rawClientNDMSReady(cfg, s.ifaceChecker) {
+				if wasReady || s.opkgTunExists(ctx, cfg.ndmsAccessIface()) {
 					_ = s.teardownClientOpkgTun(ctx, cfg)
 					// teardown снёс OpkgTun целиком; prepare выше отработал ДО
 					// него — без повторного вызова bootstrapRawClient ждёт


### PR DESCRIPTION
Исправляет проблему #736, при которой после перезапуска демона AWG manager конфигурация WDTT в RAW-режиме не поднимала маршрутизацию до тех пор, пока пользователь вручную не выключит и не включит тумблер.

### 🔍 Причина ошибки
При перезапуске демона awg-manager процесс wt-client продолжал работать в ОС (st.Running == true), но у демона не было сведений о времени старта (st.StartedAt == nil). Включалась логика ресайкла процесса:
1. Вызывался s.clientProcs.get(id).Stop(), который завершал wt-client.
2. После остановки процесса закрывался TUN-дескриптор и статус операционной готовности интерфейса (InterfaceOperUp) падал в false.
3. Код проверял if rawClientNDMSReady(cfg, s.ifaceChecker) уже после Stop(), что всегда возвращало false.
4. Из-за этого teardownClientOpkgTun и prepareClientNDMSOpkgTun пропускались, оставляя интерфейс OpkgTun в устаревшем/зависшем состоянии NDMS. Новый процесс запускался, но NDMS не перепривязывала маршруты.

### 🛠 Что сделано
1. Состояние готовности интерфейса (wasReady) теперь запоминается до остановки процесса Stop().
2. При ресайкле вызов teardownClientOpkgTun и prepareClientNDMSOpkgTun выполняется корректно, пересоздавая OpkgTun в NDMS и обеспечивая чистую инициализацию маршрутизации при старте нового процесса.
3. Добавлен юнит-тест TestStartClientInstanceRecycleWhenOperUpDropsOnStop.

Closes #736