### PR TITLE
Удалены мёртвые ручки enable/disable, кнопка перезапуска перестала молчать

### DIFF
--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -3027,7 +3027,6 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /singbox/router/bypass-set/install-deps": v.intersect([v.lazy(() => api_APIEnvelope), v.looseObject({
 	data: v.optional(v.nullable(v.lazy(() => api_BypassSetStatusData))),
 })]),
-	"POST /singbox/router/disable": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/dns/chain-preset": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/dns/globals": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/dns/rewrites/add": v.lazy(() => api_OkResponse),
@@ -3042,7 +3041,6 @@ export const RESPONSE_SCHEMAS: Record<string, v.GenericSchema> = {
 	"POST /singbox/router/dns/servers/delete": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/dns/servers/move": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/dns/servers/update": v.lazy(() => api_OkResponse),
-	"POST /singbox/router/enable": v.lazy(() => api_OkResponse),
 	"POST /singbox/router/inspect": v.lazy(() => api_SingboxRouterInspectResponse),
 	"POST /singbox/router/inspect-dns": v.lazy(() => api_SingboxRouterInspectDNSResponse),
 	"POST /singbox/router/mode": v.lazy(() => api_OkResponse),

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -87,6 +87,7 @@
 
   let wanInterfaces = $state<SingboxRouterWANInterface[]>([]);
   let saving = $state(false);
+  let restarting = $state(false);
   let lastError = $state<string | null>(null);
   let wanAutoOverride = $state<WanAutoOverride>(null);
   let wanAuto = $derived(resolveWanAuto(wanAutoOverride, cfg?.wanAutoDetect));
@@ -183,11 +184,16 @@
     if (activeMode !== null) modeSwitch.request(m);
   }
   async function restartEngine(_e: MouseEvent) {
+    if (restarting) return;
+    restarting = true;
     try {
       await api.singboxControl('restart');
       await singboxRouterStore.reloadStatus();
+      notifications.success('Движок перезапущен');
     } catch (e) {
-      console.error('restart failed', e);
+      notifications.error(`Не удалось перезапустить: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      restarting = false;
     }
   }
 
@@ -469,7 +475,7 @@
         <Button variant={captureOn ? 'danger' : 'primary'} size="sm" fullWidth disabled={switchBusy} onclick={handleToggleClick}>
           {captureOn ? 'Выключить' : 'Включить'}
         </Button>
-        <Button variant="ghost" size="sm" fullWidth onclick={restartEngine}>Перезапустить</Button>
+        <Button variant="ghost" size="sm" fullWidth loading={restarting} onclick={restartEngine}>Перезапустить</Button>
       </div>
       {#if isExpert}
         <span class="save-status" class:err={lastError}>

--- a/internal/api/singbox_router.go
+++ b/internal/api/singbox_router.go
@@ -63,68 +63,6 @@ func (h *SingboxRouterHandler) GetStatus(w http.ResponseWriter, r *http.Request)
 	response.Success(w, st)
 }
 
-// Enable starts the singbox-router engine and installs iptables/policy rules.
-//
-//	@Summary		Enable singbox-router
-//	@Description	Starts the singbox-router engine and installs iptables/policy rules. Returns 400 with code POLICY_NOT_CONFIGURED or POLICY_MISSING when the router policy mode is incomplete. Returns 503 SINGBOX_NOT_READY when sing-box did not become ready within the boot-wait window — iptables install is deliberately skipped to avoid orphaning DNS:53 redirects (issue #221).
-//	@Tags			singbox-router
-//	@Produce		json
-//	@Security		CookieAuth
-//	@Success		200	{object}	OkResponse
-//	@Failure		400	{object}	APIErrorEnvelope
-//	@Failure		405	{object}	APIErrorEnvelope
-//	@Failure		500	{object}	APIErrorEnvelope
-//	@Failure		503	{object}	APIErrorEnvelope	"sing-box did not come up in time"
-//	@Router			/singbox/router/enable [post]
-func (h *SingboxRouterHandler) Enable(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		response.MethodNotAllowed(w)
-		return
-	}
-	if err := h.svc.Enable(r.Context()); err != nil {
-		if errors.Is(err, router.ErrPolicyNotConfigured) {
-			response.ErrorWithStatus(w, http.StatusBadRequest, err.Error(), "POLICY_NOT_CONFIGURED")
-			return
-		}
-		if errors.Is(err, router.ErrPolicyMissing) {
-			response.ErrorWithStatus(w, http.StatusBadRequest, err.Error(), "POLICY_MISSING")
-			return
-		}
-		if errors.Is(err, router.ErrSingboxNotReady) {
-			response.ErrorWithStatus(w, http.StatusServiceUnavailable, err.Error(), "SINGBOX_NOT_READY")
-			return
-		}
-		h.handleErr(w, "request", err)
-		return
-	}
-	h.log.Info("enable", "", "Sing-box router enabled")
-	response.Success(w, map[string]bool{"ok": true})
-}
-
-// Disable stops the singbox-router engine and uninstalls iptables/policy rules.
-//
-//	@Summary		Disable singbox-router
-//	@Description	Stops the singbox-router engine and uninstalls iptables/policy rules. Idempotent.
-//	@Tags			singbox-router
-//	@Produce		json
-//	@Security		CookieAuth
-//	@Success		200	{object}	OkResponse
-//	@Failure		405	{object}	APIErrorEnvelope
-//	@Failure		500	{object}	APIErrorEnvelope
-//	@Router			/singbox/router/disable [post]
-func (h *SingboxRouterHandler) Disable(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		response.MethodNotAllowed(w)
-		return
-	}
-	if err := h.svc.Disable(r.Context()); err != nil {
-		response.InternalError(w, err.Error())
-		return
-	}
-	h.log.Info("disable", "", "Sing-box router disabled")
-	response.Success(w, map[string]bool{"ok": true})
-}
-
 // SwitchMode orchestrates a routing-mode transition (off↔tproxy↔fakeip-tun↔policy-tun)
 // with directional fail-closed rollback. Progress is reported out-of-band as
 // "singbox-router:transition" events on the existing events SSE stream

--- a/internal/api/singbox_router_test.go
+++ b/internal/api/singbox_router_test.go
@@ -22,7 +22,6 @@ import (
 
 // mockRouterSvc satisfies router.Service with controllable return values.
 type mockRouterSvc struct {
-	enableErr     error
 	bindMAC       string
 	bindPolicy    string
 	bindErr       error
@@ -54,8 +53,6 @@ type mockRouterSvc struct {
 	natPreviewErr error
 }
 
-func (m *mockRouterSvc) Enable(ctx context.Context) error    { return m.enableErr }
-func (m *mockRouterSvc) Disable(ctx context.Context) error   { return nil }
 func (m *mockRouterSvc) Reconcile(ctx context.Context) error { return nil }
 func (m *mockRouterSvc) SwitchRoutingMode(ctx context.Context, target string) error {
 	m.switchMu.Lock()
@@ -249,28 +246,6 @@ func TestRouterDeleteOutbound_ReferencedByProxy_Returns409(t *testing.T) {
 	}
 }
 
-func TestRouterEnable_PolicyNotConfigured_Returns400(t *testing.T) {
-	svc := &mockRouterSvc{enableErr: router.ErrPolicyNotConfigured}
-	h := newMockRouterHandler(svc)
-	req := httptest.NewRequest(http.MethodPost, "/api/singbox/router/enable", nil)
-	rr := httptest.NewRecorder()
-	h.Enable(rr, req)
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("want 400, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-func TestRouterEnable_PolicyMissing_Returns400(t *testing.T) {
-	svc := &mockRouterSvc{enableErr: router.ErrPolicyMissing}
-	h := newMockRouterHandler(svc)
-	req := httptest.NewRequest(http.MethodPost, "/api/singbox/router/enable", nil)
-	rr := httptest.NewRecorder()
-	h.Enable(rr, req)
-	if rr.Code != http.StatusBadRequest {
-		t.Errorf("want 400, got %d", rr.Code)
-	}
-}
-
 func TestRouterPutSettings_QoSClassesInvalid_Returns400(t *testing.T) {
 	svc := &mockRouterSvc{updateSettingsErr: fmt.Errorf("%w: qosClasses[0]: DSCP должен быть 0-63 (получено 99)", router.ErrQoSClassesInvalid)}
 	h := newMockRouterHandler(svc)
@@ -406,16 +381,6 @@ func TestRouterSwitchMode_MethodNotAllowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/singbox/router/mode", nil)
 	rr := httptest.NewRecorder()
 	h.SwitchMode(rr, req)
-	if rr.Code != http.StatusMethodNotAllowed {
-		t.Errorf("want 405, got %d", rr.Code)
-	}
-}
-
-func TestRouterEnable_MethodNotAllowed(t *testing.T) {
-	h := newMockRouterHandler(&mockRouterSvc{})
-	req := httptest.NewRequest(http.MethodGet, "/api/singbox/router/enable", nil)
-	rr := httptest.NewRecorder()
-	h.Enable(rr, req)
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("want 405, got %d", rr.Code)
 	}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -13879,30 +13879,6 @@ paths:
       summary: Geoip bypass-set status
       tags:
       - singbox-router
-  /singbox/router/disable:
-    post:
-      description: Stops the singbox-router engine and uninstalls iptables/policy
-        rules. Idempotent.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/api.OkResponse'
-        "405":
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-      security:
-      - CookieAuth: []
-      summary: Disable singbox-router
-      tags:
-      - singbox-router
   /singbox/router/dns/chain-preset:
     get:
       description: 'Returns the DNS-chain preset (sing-box 1.14 evaluate/match_response):
@@ -14562,41 +14538,6 @@ paths:
       security:
       - CookieAuth: []
       summary: Update singbox-router DNS server
-      tags:
-      - singbox-router
-  /singbox/router/enable:
-    post:
-      description: 'Starts the singbox-router engine and installs iptables/policy
-        rules. Returns 400 with code POLICY_NOT_CONFIGURED or POLICY_MISSING when
-        the router policy mode is incomplete. Returns 503 SINGBOX_NOT_READY when sing-box
-        did not become ready within the boot-wait window — iptables install is deliberately
-        skipped to avoid orphaning DNS:53 redirects (issue #221).'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/api.OkResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-        "405":
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-        "503":
-          description: sing-box did not come up in time
-          schema:
-            $ref: '#/definitions/api.APIErrorEnvelope'
-      security:
-      - CookieAuth: []
-      summary: Enable singbox-router
       tags:
       - singbox-router
   /singbox/router/geosites/list:

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -814,8 +814,6 @@ func (s *Server) registerSingboxRoutes(mux *http.ServeMux, h *routeHandlers) {
 	if s.singboxRouterHandler != nil {
 		rh := s.singboxRouterHandler
 		mux.HandleFunc("/api/singbox/router/status", h.guarded(rh.GetStatus))
-		mux.HandleFunc("/api/singbox/router/enable", h.guarded(rh.Enable))
-		mux.HandleFunc("/api/singbox/router/disable", h.guarded(rh.Disable))
 		mux.HandleFunc("/api/singbox/router/mode", h.guarded(rh.SwitchMode))
 		mux.HandleFunc("/api/singbox/router/settings", h.guarded(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -23,8 +23,6 @@ import (
 )
 
 type Service interface {
-	Enable(ctx context.Context) error
-	Disable(ctx context.Context) error
 	Reconcile(ctx context.Context) error
 	// SwitchRoutingMode orchestrates a routing-mode transition (off↔tproxy↔
 	// fakeip-tun) with directional fail-closed rollback and progress events.
@@ -443,15 +441,33 @@ type ServiceImpl struct {
 	// transitionReadinessProgress emits readiness heartbeats during
 	// waitForSingbox while SwitchRoutingMode is in flight (nil otherwise).
 	transitionReadinessProgress func(message string)
-	currentMark                 string              // last-installed iptables mark; used by Reconcile to detect change
-	currentWANIPs               []string            // last-collected WAN IPs; used by Reconcile to detect change
-	currentLANBridges           []LANBridgeDNSRedir // last-discovered LAN-bridge (name, ndnproxy port) pairs; reconcile triggers re-install when this changes (e.g. NDMS hotspot reconfigured, bridge added/removed, port reassigned)
-	currentBypassPresets        []string
-	currentBypassExtraPorts     string
-	currentBypassExtraSubnets   string
-	currentBypassGeoIPTags      []string // last-installed geoip-теги обхода; их смена = переустановка правил
-	currentKeenDNSCIDRs         []string // last-installed CIDR обхода пресета keendns (адрес с роутера, не из настроек)
-	currentIngress              []string // last-installed резолвленные ingress kernel-имена
+
+	// ─── Применённое состояние netfilter ────────────────────────────────────
+	// Поля current* ниже плюс netfilterStateKnown, blackholeActive и
+	// currentQoSClasses описывают то, что РЕАЛЬНО установлено в netfilter.
+	//
+	// ИНВАРИАНТ: все они читаются и пишутся только под transitionMu.
+	// Писатели: enableLocked, Disable, enablePolicyTun, reconcileInstalled,
+	// reconcilePolicyTunQoS. Читатели: reconcileInstalled,
+	// reconcilePolicyTunQoS. Каждый достижим ровно двумя путями — Reconcile
+	// (берёт transitionMu через TryLock) и SwitchRoutingMode (через Lock);
+	// s.mu, который берут Enable/Disable, ЭТИ поля не защищает, потому что
+	// reconcileInstalled читает их вне s.mu.
+	//
+	// Пока путей два, гонки нет по построению. Третий путь (например новая
+	// публичная ручка, зовущая Enable/Disable мимо transitionMu) её вернёт —
+	// раньше такой путь давали ручки POST /singbox/router/{enable,disable},
+	// и они удалены именно поэтому. Новый вызывающий обязан заходить через
+	// Reconcile или SwitchRoutingMode.
+	currentMark               string              // last-installed iptables mark; used by Reconcile to detect change
+	currentWANIPs             []string            // last-collected WAN IPs; used by Reconcile to detect change
+	currentLANBridges         []LANBridgeDNSRedir // last-discovered LAN-bridge (name, ndnproxy port) pairs; reconcile triggers re-install when this changes (e.g. NDMS hotspot reconfigured, bridge added/removed, port reassigned)
+	currentBypassPresets      []string
+	currentBypassExtraPorts   string
+	currentBypassExtraSubnets string
+	currentBypassGeoIPTags    []string // last-installed geoip-теги обхода; их смена = переустановка правил
+	currentKeenDNSCIDRs       []string // last-installed CIDR обхода пресета keendns (адрес с роутера, не из настроек)
+	currentIngress            []string // last-installed резолвленные ingress kernel-имена
 
 	// bypassPopulating — single-flight наполнения AWGM-BYPASS: пока идёт
 	// пересборка, повторные триггеры (Enable, reconcile, смена .dat) только
@@ -507,7 +523,8 @@ type ServiceImpl struct {
 	// blackholeActive tracks whether the fail-closed DROP chain is currently
 	// engaged (installed by reconcileInstalled while sing-box is dead and the
 	// PREROUTING interception jumps were wiped). It is removed the moment the
-	// engine recovers. Guarded by s.mu, like the other current* install state.
+	// engine recovers. Под transitionMu, как остальное применённое состояние
+	// netfilter (см. инвариант у current*): s.mu его не защищает.
 	blackholeActive bool
 
 	// currentQoSClasses is the last-installed QoS-DSCP dispatch set (DSCP +


### PR DESCRIPTION
Удаление мёртвой пары ручек и починка кнопки, которая молчала.

## Почему ручки мёртвые

`POST /singbox/router/enable` и `/disable` не зовёт никто. Фронт управляет
включением и выключением через `POST /singbox/router/mode`, где `off` — такая
же цель, как режим; это осознанное решение, зафиксированное комментарием в
`StatusDrawer.svelte`: «тумблер управляет режимом через общий modeSwitch, а не
enable/disable текущего режима». Потребителей API кроме собственного фронта у
проекта нет.

Внутри репозитория `svc.Enable`/`svc.Disable` вызывались только этими двумя
хендлерами: `SwitchRoutingMode` и `Reconcile` ходят к реализации напрямую.

Удалены хендлеры, маршруты, методы из интерфейса `router.Service` и их
swagger-описания. Методы на `ServiceImpl` остались — у них есть внутренние
вызывающие.

## Побочный эффект: исчезает гонка

Двенадцать полей применённого состояния netfilter читались в `reconcileInstalled`
без `s.mu`, пока публичные `Enable`/`Disable` их писали. Это был **единственный**
путь, не бравший `transitionMu`: `Reconcile` берёт его через `TryLock`,
`SwitchRoutingMode` — через `Lock`.

После удаления все писатели и читатели этих полей достижимы ровно двумя путями,
и оба под мьютексом. Гонка исчезает **по построению**, а не прикрывается ещё
одним локом.

Инвариант записан комментарием у объявления полей: перечислены писатели,
читатели и оба корня, отмечено, что `s.mu` эти поля не защищает, и что третий
путь вернёт гонку — с указанием, что удалённые ручки таким путём и были.

Попутно исправлен комментарий, противоречивший коду: `blackholeActive` был
помечен как «guarded by s.mu», хотя `reconcileInstalled` пишет его вне этого
лока.

## Кнопка «Перезапустить»

Ошибка перезапуска движка уходила в `console.error` и никуда больше: ни
уведомления, ни состояния. При этом успех выглядел так же — статус после
перезапуска тот же «работает», движок поднимается за доли секунды. То есть
кнопка была неотличима от неработающей независимо от того, работала она или нет.

Теперь она показывает ход (кнопка занята, спиннер) и результат — уведомление об
успехе или об ошибке. Механизмы взяты существующие, из соседней функции того же
файла.

## Проверка

- `go vet ./cmd/... ./internal/...` — чисто
- `go test ./cmd/... ./internal/... -count=1` — все пакеты ok; в `internal/api`
  435 → 432 тестов, ровно на три удалённых вместе с ручками
- `npm run check` — 0 ошибок; `npx eslint src` — чисто; vitest — 1612 тестов
- swagger перегенерирован двухшагово, ссылок на удалённые пути не осталось

Регресс-теста нет намеренно: это удаление, сеткой служит существующий корпус, а
исчезновение гонки — свойство конструкции, а не поведения, которое можно
проверить тестом.

## Чего НЕ проверено

Стенд-e2e не проводился. Кнопка «Перезапустить» визуально не проверялась —
поведение выведено из контракта примитива `Button` (`loading` гасит кнопку,
ставит `aria-busy` и рисует спиннер).

## Отклонённое

Рассматривался вариант заодно переименовать `Disable` в `disableLocked` и
свернуть `Enable` в `enableLocked` для симметрии с внутренними вызовами. Отклонён:
задело бы 132 вызова в тестах ради косметики.
