### PR TITLE
Убран гард ingressSeamsWired, тестовые заглушки заполнены полностью

### DIFF
--- a/internal/singbox/router/fakeip_ingress.go
+++ b/internal/singbox/router/fakeip_ingress.go
@@ -142,13 +142,6 @@ func (spec FakeIPIngressSpec) active() bool {
 
 func fakeIPIngressTableStr() string { return strconv.Itoa(fakeIPIngressTable) }
 
-// ingressSeamsWired — все четыре сида на месте. Частично собранный IPTables
-// встречается в тестах соседних путей (tproxy), и для них заворот — не их
-// предмет: молча ничего не делаем вместо nil-паники.
-func (it *IPTables) ingressSeamsWired() bool {
-	return it.runIPTables != nil && it.runIPTablesOut != nil && it.runIP != nil && it.runIPOut != nil
-}
-
 // fakeIPIngressDNATArgs собирает вставку правила перехвата DNS для одного
 // селектора. Вставка в позицию 1: правило обязано стоять выше DNS-редиректов
 // NDMS, иначе запрос уйдёт в ndnproxy.
@@ -298,9 +291,6 @@ func fakeIPIngressRuleDrift(dump string, spec FakeIPIngressSpec) bool {
 // мутации, только три чтения (дамп nat, ip rule, таблица маршрутов).
 // Пустой spec означает «заворота быть не должно» — тогда всё снимается.
 func (it *IPTables) EnsureFakeIPIngress(ctx context.Context, spec FakeIPIngressSpec) error {
-	if !it.ingressSeamsWired() {
-		return nil
-	}
 	// Хук: пишем при перехвате policy-tun, снимаем во всех прочих случаях
 	// (чужой режим, отключённый перехват, пустой спек). Решение зависит ТОЛЬКО
 	// от спека, поэтому стоит выше дампов: сбой чтения `iptables -S` не должен
@@ -398,9 +388,6 @@ func (it *IPTables) EnsureFakeIPIngress(ctx context.Context, spec FakeIPIngressS
 // RemoveFakeIPIngress снимает перехват и заворот целиком. Идемпотентно —
 // безопасно звать, когда ничего не установлено.
 func (it *IPTables) RemoveFakeIPIngress(ctx context.Context) {
-	if !it.ingressSeamsWired() {
-		return
-	}
 	// Кто снимает правила перехвата, тот снимает и файл, который их
 	// восстанавливает: иначе первое же событие nat вернуло бы DNAT.
 	if it.cleanupPolicyTunDNSHook != nil {
@@ -420,9 +407,6 @@ func (it *IPTables) RemoveFakeIPIngress(ctx context.Context) {
 // живёт (ip rule iif + таблица 700), а протухший DNAT прежнего fakeip обязан
 // уйти. Идемпотентно.
 func (it *IPTables) RemoveFakeIPIngressDNAT(ctx context.Context, tag string) {
-	if !it.ingressSeamsWired() {
-		return
-	}
 	dump, err := it.runIPTablesOut(ctx, "-t", "nat", "-S", "PREROUTING")
 	if err != nil || !strings.Contains(dump, tag) {
 		return

--- a/internal/singbox/router/iptables_test.go
+++ b/internal/singbox/router/iptables_test.go
@@ -67,6 +67,16 @@ func newFakeIPTables(fe *fakeExec) *IPTables {
 		runIPTables:    fe.runIPTables,
 		runIPTablesOut: func(_ context.Context, _ ...string) (string, error) { return jumpsPresentDump(), nil },
 		runIP:          fe.runIP,
+		runIPOut:       func(_ context.Context, _ ...string) (string, error) { return "", nil },
+		persistRules:   func(_, _, _ string) error { return nil },
+		persistHook:    func(bool) error { return nil },
+		cleanupHook:    func() {},
+
+		persistPolicyTunDNSHook: func(string) error { return nil },
+		cleanupPolicyTunDNSHook: func() {},
+		persistBlackhole:        func(string) error { return nil },
+		cleanupBlackhole:        func() {},
+		runCtClean:              func(context.Context) {},
 	}
 }
 

--- a/internal/singbox/router/qos_test.go
+++ b/internal/singbox/router/qos_test.go
@@ -1229,9 +1229,16 @@ func noopNotInstalledIPTables() *IPTables {
 		runIPTables:    func(_ context.Context, _ ...string) error { return errors.New("chain missing") },
 		runIPTablesOut: func(_ context.Context, _ ...string) (string, error) { return "", nil },
 		runIP:          func(_ context.Context, _ ...string) error { return nil },
+		runIPOut:       func(_ context.Context, _ ...string) (string, error) { return "", nil },
 		persistRules:   func(_, _, _ string) error { return nil },
 		persistHook:    func(bool) error { return nil },
 		cleanupHook:    func() {},
+
+		persistPolicyTunDNSHook: func(string) error { return nil },
+		cleanupPolicyTunDNSHook: func() {},
+		persistBlackhole:        func(string) error { return nil },
+		cleanupBlackhole:        func() {},
+		runCtClean:              func(context.Context) {},
 	}
 }
 

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -926,7 +926,9 @@ func TestReconcile_DisabledPartialInstall_CleansUp(t *testing.T) {
 			}
 			return nil
 		},
-		runIP: func(_ context.Context, args ...string) error { return nil },
+		runIPTablesOut: func(_ context.Context, _ ...string) (string, error) { return "", nil },
+		runIP:          func(_ context.Context, args ...string) error { return nil },
+		runIPOut:       func(_ context.Context, _ ...string) (string, error) { return "", nil },
 		cleanupHook: func() {
 			uninstallCalled = true
 		},

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -82,9 +82,16 @@ func newStubIPTables(restoreRecorder func(context.Context, string) error) *IPTab
 		runIPTables:    func(_ context.Context, _ ...string) error { return nil },
 		runIPTablesOut: func(_ context.Context, _ ...string) (string, error) { return jumpsPresentDump(), nil },
 		runIP:          func(_ context.Context, _ ...string) error { return nil },
+		runIPOut:       func(_ context.Context, _ ...string) (string, error) { return "", nil },
 		persistRules:   func(_, _, _ string) error { return nil },
 		persistHook:    func(bool) error { return nil },
 		cleanupHook:    func() {},
+
+		persistPolicyTunDNSHook: func(string) error { return nil },
+		cleanupPolicyTunDNSHook: func() {},
+		persistBlackhole:        func(string) error { return nil },
+		cleanupBlackhole:        func() {},
+		runCtClean:              func(context.Context) {},
 	}
 }
 


### PR DESCRIPTION
Убрана ветка продакшн-кода, форму которой задала тестовая обвязка.

## Что было

`*IPTables` имеет 13 приватных функциональных полей — швов, через которые тесты
подменяют вызовы `iptables` и `ip`. Продакшн-конструктор заполняет все 13, но
тестовые заглушки заполняли не все.

Ради этого в продакшне жил гард `ingressSeamsWired()`: он проверял, что четыре
поля не nil, и охранял три ранних возврата — в `EnsureFakeIPIngress`,
`RemoveFakeIPIngress` и `RemoveFakeIPIngressDNAT`. В реальной сборке условие
ложным быть не могло; ветка существовала исключительно потому, что тесты
собирали структуру частично.

Цена была не косметическая. Из-за незаполненного `runIPOut` гард возвращал false,
и весь ingress-путь в **24 тестах** исполнялся как no-op — тесты гоняли этот код
и не замечали, что он не работает.

## Что сделано

Заглушки дозаполнены до всех 13 полей, гард и три ранних возврата удалены.

Проверено инструментированием, а не предположением: после первого коммита
`runIPOut` вызывается 130 раз в 24 тестах, где раньше не вызывался ни разу.

Осмысленные особенности заглушек сохранены — например `fakeExec.runIP`
по-прежнему отдаёт ENOENT, чтобы слив правил не крутил все проходы до предела.

## Честная оговорка

**Зелёный прогон здесь не доказывает корректность ingress-пути.** Заглушки
выбрасывают вызовы, поэтому ни одно утверждение не в состоянии увидеть ни
пересборку заворота, ни её отсутствие. Эти 24 теста теперь исполняют код, но
по-прежнему ничего о нём не утверждают.

Записывающая заглушка с утверждениями на состав вызовов — отдельная задача.
Попутно установлено, что маршрутная половина заворота не покрыта ни одним
service-level тестом: в инструментированном прогоне `route show table 700` не
запрашивался ни разу.

## Проверка

- `go vet ./cmd/... ./internal/...` — чисто
- `go test ./cmd/... ./internal/... -count=1` — **5434 PASS до и после**, множества
  имён тестов совпадают побайтно
- `go test -race ./internal/singbox/router/` — ok

Регресс-теста нет намеренно: это удаление ветки, недостижимой в продакшне.

## Найдено попутно, не чинилось

При снятии гарда упали две заглушки, которые он прикрывал сверх ожидаемого —
общий хелпер `noopNotInstalledIPTables` и одноразовый литерал в тесте
`Reconcile`. Оба дозаполнены: первый до всех полей, второй ровно теми двумя,
которых не хватало его сценарию.

Замечен флейк вне зоны: `TestKillPIDFile_OwnProcess_KillsGroup`
(`internal/backup`) упал по таймингу в одном прогоне и прошёл в контрольном.

## Чего НЕ проверено

Стенд-e2e не проводился. Всё покрытие — юнит-тесты.
