### PR TITLE
awg31: бейдж AWG 3.1 и параметры 3.1 только на просмотр

### DIFF
--- a/frontend/src/lib/components/asc/ASCEditor.svelte
+++ b/frontend/src/lib/components/asc/ASCEditor.svelte
@@ -6,7 +6,7 @@
 	import { AWG_PARAM_HINTS } from '$lib/utils/awgParamHints';
 	import { notifications } from '$lib/stores/notifications';
 	import { SettingsSectionLabel } from '$lib/components/settings';
-	import { Button, Dropdown, FieldHint, Toggle, type DropdownOption } from '$lib/components/ui';
+	import { Badge, Button, Dropdown, FieldHint, type DropdownOption } from '$lib/components/ui';
 	import { Fingerprint, Hash, MoveHorizontal, Shredder, ShieldCheck, Shuffle } from 'lucide-svelte';
 
 	const MAX_SIGNATURE_BYTES = 4096;
@@ -20,7 +20,6 @@
 		params = $bindable(),
 		extended = undefined,
 		awg3 = false,
-		awg31 = false,
 		mtu = 1280,
 		errors = {},
 		hints = AWG_PARAM_HINTS,
@@ -31,7 +30,6 @@
 		params: ASCParams;
 		extended?: boolean;
 		awg3?: boolean;
-		awg31?: boolean;
 		mtu?: number;
 		errors?: ASCErrorFields;
 		hints?: Record<string, string>;
@@ -51,6 +49,24 @@
 		{ key: 'maxHandshakeAttempts', label: 'MaxHandshakeAttempts' },
 		{ key: 'contentPaddingAddition', label: 'ContentPaddingAddition' },
 	];
+
+	// AWG 3.1 device flags. Read-only: they arrive with an imported .conf and
+	// switching RandomTrailers off on one end alone kills the tunnel.
+	const AWG31_FLAGS: { key: 'randomTrailers' | 'disableCookies'; label: string; note: string }[] = [
+		{
+			key: 'randomTrailers',
+			label: 'RandomTrailers',
+			note: 'Добивает пакеты случайным числом лишних байт. Согласования по проводу нет: параметр обязан стоять на обоих концах, иначе туннель молча не поднимется.',
+		},
+		{
+			key: 'disableCookies',
+			label: 'DisableCookies',
+			note: 'Не отвечать служебным пакетом-подтверждением под нагрузкой. Односторонний, совместимость не ломает.',
+		},
+	];
+	const ext31Flags = $derived(
+		AWG31_FLAGS.filter((f) => (params as ASCParamsExtended)[f.key]),
+	);
 
 	let selectedProtocol = $state<ProtocolKey>('quic_initial');
 	let generateMode = $state<GenerateMode>('protocol');
@@ -374,38 +390,25 @@
 		</section>
 	{/if}
 
-	{#if awg31}
-		{@const ext31 = params as ASCParamsExtended}
+	{#if ext31Flags.length > 0}
 		<section class="card param-section">
 			<SettingsSectionLabel label="AmneziaWG 3.1" icon={Shuffle} tone="purple" header />
 			<p class="group-desc">
-				Параметры версии 3.1. Требуют модуля ядра 3.1 и на этом роутере, и на стороне сервера.
+				Параметры версии 3.1 включены в конфигурационном файле туннеля. Отсюда их не
+				поменять: они требуют модуля ядра 3.1 и на этом роутере, и на стороне сервера,
+				а снятие RandomTrailers на одной стороне рвёт туннель.
 			</p>
 
 			<div class="toggle-stack">
-				<div class="toggle-item">
-					<Toggle
-						checked={ext31.randomTrailers ?? false}
-						onchange={(v) => (ext31.randomTrailers = v)}
-						label="RandomTrailers — случайные хвосты"
-						hint="Добивает пакеты случайным числом лишних байт"
-					/>
-					<p class="toggle-note">
-						Включать обязательно на обоих концах: согласования по проводу у этого параметра
-						нет, и при включении на одной стороне туннель молча не поднимется. Заметно
-						увеличивает исходящий трафик и снижает скорость.
-					</p>
-				</div>
-
-				<div class="toggle-item">
-					<Toggle
-						checked={ext31.disableCookies ?? false}
-						onchange={(v) => (ext31.disableCookies = v)}
-						label="DisableCookies — не отвечать cookie"
-						hint="Не отвечать служебным пакетом-подтверждением под нагрузкой"
-					/>
-					<p class="toggle-note">Односторонний, совместимость не ломает.</p>
-				</div>
+				{#each ext31Flags as f}
+					<div>
+						<div class="flag-row">
+							<Badge variant="purple" size="xs" mono>{f.label}</Badge>
+							<span class="flag-state">включён</span>
+						</div>
+						<p class="toggle-note">{f.note}</p>
+					</div>
+				{/each}
 			</div>
 		</section>
 	{/if}
@@ -427,6 +430,17 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.25rem;
+	}
+
+	.flag-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.flag-state {
+		font-size: 0.8125rem;
+		color: var(--color-text-muted, #6b7280);
 	}
 
 	.toggle-note {

--- a/frontend/src/lib/components/diagnostics/ChecksGroup.svelte
+++ b/frontend/src/lib/components/diagnostics/ChecksGroup.svelte
@@ -14,6 +14,7 @@
 		'awg1.5': { label: 'AWG 1.5', color: '#7dcfff', bg: 'rgba(125,207,255,0.14)' },
 		'awg2.0': { label: 'AWG 2.0', color: '#7dcfff', bg: 'rgba(125,207,255,0.14)' },
 		'awg3':   { label: 'AWG 3.0', color: '#bb9af7', bg: 'rgba(187,154,247,0.14)' },
+		'awg3.1': { label: 'AWG 3.1', color: '#bb9af7', bg: 'rgba(187,154,247,0.14)' },
 		'xray':   { label: 'XRAY',    color: '#bb9af7', bg: 'rgba(187,154,247,0.14)' },
 		'vless':  { label: 'VLESS',   color: '#bb9af7', bg: 'rgba(187,154,247,0.14)' },
 		'hy2':    { label: 'HY2',     color: '#f7768e', bg: 'rgba(247,118,142,0.14)' },

--- a/frontend/src/lib/components/tunnels/AWGAdvancedParams.svelte
+++ b/frontend/src/lib/components/tunnels/AWGAdvancedParams.svelte
@@ -55,14 +55,12 @@
 		hints = undefined,
 		compact = false,
 		awg3 = false,
-		awg31 = false,
 	}: {
 		form: AWGFormFields;
 		errors: AWGErrorFields;
 		hints?: Record<string, string>;
 		compact?: boolean;
 		awg3?: boolean;
-		awg31?: boolean;
 	} = $props();
 </script>
 
@@ -70,7 +68,6 @@
 	bind:params={form}
 	extended
 	{awg3}
-	{awg31}
 	mtu={form.mtu}
 	{errors}
 	{hints}

--- a/frontend/src/lib/components/ui/VersionBadge.svelte
+++ b/frontend/src/lib/components/ui/VersionBadge.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export type VersionBadgeKind = 'backend' | 'awg';
   export type BackendValue = 'kernel' | 'nativewg' | string;
-  export type AwgValue = 'awg3' | 'awg2.0' | 'awg1.5' | 'awg1.0' | 'wg' | string;
+  export type AwgValue = 'awg3.1' | 'awg3' | 'awg2.0' | 'awg1.5' | 'awg1.0' | 'wg' | string;
 </script>
 
 <script lang="ts">
@@ -19,6 +19,7 @@
       return 'Kernel';
     }
     return ({
+      'awg3.1': 'AWG 3.1',
       'awg3': 'AWG 3.0',
       'awg2.0': 'AWG 2.0',
       'awg1.5': 'AWG 1.5',

--- a/frontend/src/lib/schemas/tunnel.ts
+++ b/frontend/src/lib/schemas/tunnel.ts
@@ -90,6 +90,9 @@ export const editTunnelSchema = z.object({
     rejectAfterTime: u16RangeField(),
     keepaliveTimeout: u16RangeField(),
     maxHandshakeAttempts: u16RangeField(),
+    // AWG 3.1 device flags — read-only, set only by an imported .conf.
+    randomTrailers: z.boolean().default(false),
+    disableCookies: z.boolean().default(false),
 }).refine(data => {
     const total = calcByteSize(data.i1) + calcByteSize(data.i2) +
         calcByteSize(data.i3) + calcByteSize(data.i4) + calcByteSize(data.i5);

--- a/frontend/src/lib/types/tunnels.ts
+++ b/frontend/src/lib/types/tunnels.ts
@@ -119,7 +119,7 @@ export interface TunnelListItem {
 	rxBytes?: number;
 	txBytes?: number;
 	lastHandshake?: string;
-	awgVersion?: 'wg' | 'awg1.0' | 'awg1.5' | 'awg2.0' | 'awg3';
+	awgVersion?: 'wg' | 'awg1.0' | 'awg1.5' | 'awg2.0' | 'awg3' | 'awg3.1';
 	mtu?: number;
 	startedAt?: string;
 	backend?: 'nativewg' | 'kernel';

--- a/frontend/src/lib/utils/backendAvailability.test.ts
+++ b/frontend/src/lib/utils/backendAvailability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { nativewgUnavailableHint, supportsAwg3, supportsAwg31 } from './backendAvailability';
+import { nativewgUnavailableHint, supportsAwg3 } from './backendAvailability';
 
 describe('nativewgUnavailableHint', () => {
 	it('explains the missing WireGuard component', () => {
@@ -29,22 +29,3 @@ describe('supportsAwg3', () => {
 	});
 });
 
-describe('supportsAwg31', () => {
-	it('rejects 3.0, which supportsAwg3 accepts', () => {
-		expect(supportsAwg3('3.0.20260805')).toBe(true);
-		expect(supportsAwg31('3.0.20260805')).toBe(false);
-	});
-
-	it('accepts 3.1 and above', () => {
-		expect(supportsAwg31('3.1.20260812')).toBe(true);
-		expect(supportsAwg31('3.2.20270101')).toBe(true);
-		expect(supportsAwg31('4.0.20270101')).toBe(true);
-	});
-
-	it('rejects older modules, a missing one and garbage', () => {
-		expect(supportsAwg31('1.0.20251009')).toBe(false);
-		expect(supportsAwg31('')).toBe(false);
-		expect(supportsAwg31(undefined)).toBe(false);
-		expect(supportsAwg31('unknown')).toBe(false);
-	});
-});

--- a/frontend/src/lib/utils/backendAvailability.ts
+++ b/frontend/src/lib/utils/backendAvailability.ts
@@ -5,17 +5,6 @@ export function supportsAwg3(kernelModuleLoadedVersion: string | undefined): boo
 	return /^3\./.test(kernelModuleLoadedVersion ?? '');
 }
 
-// AWG 3.1 added two device flags (RandomTrailers, DisableCookies) that a 3.0
-// module ignores without an error, exactly the way a 2.x module ignores the 3.0
-// params — so they need a floor of their own rather than reusing supportsAwg3.
-export function supportsAwg31(kernelModuleLoadedVersion: string | undefined): boolean {
-	const m = /^(\d+)\.(\d+)\./.exec(kernelModuleLoadedVersion ?? '');
-	if (!m) return false;
-	const major = Number(m[1]);
-	const minor = Number(m[2]);
-	return major > 3 || (major === 3 && minor >= 1);
-}
-
 // Maps the backend's `nativewgReason` (from system/info) to a user-facing
 // explanation shown next to the disabled NativeWG option, so it no longer
 // greys out silently. Empty reason → no hint (NativeWG is available).

--- a/frontend/src/lib/utils/classifyAwgVersion.test.ts
+++ b/frontend/src/lib/utils/classifyAwgVersion.test.ts
@@ -63,6 +63,26 @@ describe('classifyAwgVersionFromAsc', () => {
 			params: { h1: '100-200', h2: '2', h3: '3', h4: '4', i1: 'sig', maxHandshakeAttempts: '5' } as ASCParams,
 			want: 'awg3',
 		},
+		{
+			name: 'AWG 3.1 — RandomTrailers',
+			params: { randomTrailers: true } as ASCParams,
+			want: 'awg3.1',
+		},
+		{
+			name: 'AWG 3.1 — DisableCookies',
+			params: { disableCookies: true } as ASCParams,
+			want: 'awg3.1',
+		},
+		{
+			name: 'AWG 3.1 takes priority over AWG 3.0',
+			params: { headerProtectionKey: 'a2V5', randomTrailers: true } as ASCParams,
+			want: 'awg3.1',
+		},
+		{
+			name: 'both flags off stay out of the way',
+			params: { h1: '1', h2: '2', h3: '3', h4: '4', randomTrailers: false, disableCookies: false } as ASCParams,
+			want: 'awg1.0',
+		},
 	])('$name → $want', ({ params, want }) => {
 		expect(classifyAwgVersionFromAsc(params)).toBe(want);
 	});

--- a/frontend/src/lib/utils/classifyAwgVersion.ts
+++ b/frontend/src/lib/utils/classifyAwgVersion.ts
@@ -21,10 +21,19 @@ function hasAnyAwg3Param(params: ASCParams): boolean {
 	);
 }
 
-/** Mirrors backend config.ClassifyAWGVersion — AWG 3.0 → 2.0 → 1.5 → 1.0 → WG. */
+function hasAnyAwg31Param(params: ASCParams): boolean {
+	const ext = params as ASCParamsExtended;
+	return !!(ext.randomTrailers || ext.disableCookies);
+}
+
+/** Mirrors backend config.ClassifyAWGVersion — AWG 3.1 → 3.0 → 2.0 → 1.5 → 1.0 → WG. */
 export function classifyAwgVersionFromAsc(params: ASCParams | null | undefined): AwgValue {
 	if (!params) return 'wg';
 
+	// AWG 3.1 is a superset of 3.0, so its flags outrank the 3.0 device params.
+	if (hasAnyAwg31Param(params)) {
+		return 'awg3.1';
+	}
 	// AWG 3.0 outranks the rest — its device params sit on top of the obfuscation.
 	if (hasAnyAwg3Param(params)) {
 		return 'awg3';

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	import AwgConfigAnalyzer from '$lib/components/diagnostics/AwgConfigAnalyzer.svelte';
 	import { SettingsSectionLabel } from '$lib/components/settings';
 	import { AWG_PARAM_HINTS } from '$lib/utils/awgParamHints';
-	import { supportsAwg3, supportsAwg31 } from '$lib/utils/backendAvailability';
+	import { supportsAwg3 } from '$lib/utils/backendAvailability';
 	import { Network, Route, Router, Server, Tag } from 'lucide-svelte';
 
 	let { data } = $props();
@@ -175,6 +175,10 @@
 		$form.rejectAfterTime = tunnel.interface.rejectAfterTime || '';
 		$form.keepaliveTimeout = tunnel.interface.keepaliveTimeout || '';
 		$form.maxHandshakeAttempts = tunnel.interface.maxHandshakeAttempts || '';
+		// AWG 3.1 flags: read-only in the editor, shown only when the imported
+		// config carries them. buildUpdatePayload keeps them via the interface spread.
+		$form.randomTrailers = tunnel.interface.randomTrailers ?? false;
+		$form.disableCookies = tunnel.interface.disableCookies ?? false;
 		publicKey = tunnel.peer.publicKey;
 		$form.endpoint = tunnel.peer.endpoint;
 		$form.allowedIPs = tunnel.peer.allowedIPs.join(', ');
@@ -423,7 +427,6 @@
 						errors={$errors}
 						{hints}
 						awg3={tunnel?.backend !== 'nativewg' && supportsAwg3(systemInfo?.kernelModuleLoadedVersion)}
-						awg31={tunnel?.backend !== 'nativewg' && supportsAwg31(systemInfo?.kernelModuleLoadedVersion)}
 					/>
 				</div>
 

--- a/internal/api/tunnels_dto.go
+++ b/internal/api/tunnels_dto.go
@@ -25,7 +25,7 @@ type TunnelListItemDTO struct {
 	InterfaceName             string                `json:"interfaceName,omitempty" example:"nwg0"`
 	NdmsName                  string                `json:"ndmsName,omitempty" example:"Wireguard0"`
 	Backend                   string                `json:"backend,omitempty" example:"nativewg" enums:"nativewg,kernel"`
-	AWGVersion                string                `json:"awgVersion,omitempty" example:"awg2.0" enums:"wg,awg1.0,awg1.5,awg2.0,awg3"`
+	AWGVersion                string                `json:"awgVersion,omitempty" example:"awg2.0" enums:"wg,awg1.0,awg1.5,awg2.0,awg3,awg3.1"`
 	MTU                       int                   `json:"mtu,omitempty" example:"1420"`
 	IspInterface              string                `json:"ispInterface,omitempty" example:"PPPoE0"`
 	IspInterfaceLabel         string                `json:"ispInterfaceLabel,omitempty" example:"WAN"`

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -5827,6 +5827,7 @@ definitions:
         - awg1.5
         - awg2.0
         - awg3
+        - awg3.1
         example: awg2.0
         type: string
       backend:

--- a/internal/tunnel/config/classify.go
+++ b/internal/tunnel/config/classify.go
@@ -14,9 +14,14 @@ func ClassifyAWGVersion(iface *storage.AWGInterface) string {
 	if iface == nil {
 		return "wg"
 	}
+	// AWG 3.1: the two device flags. Checked before awg3 — 3.1 is a superset,
+	// so a config carrying both a 3.0 param and a flag is a 3.1 config.
+	if hasAnyAWG31Param(iface) {
+		return "awg3.1"
+	}
 	// AWG 3.0: any awg3 device param (header protection / content padding /
-	// timing range). Checked first — awg3 builds on top of the AWG 1.x/2.0
-	// obfuscation, so its presence outranks H-ranges and signature packets.
+	// timing range). awg3 builds on top of the AWG 1.x/2.0 obfuscation, so its
+	// presence outranks H-ranges and signature packets.
 	if hasAnyAWG3Param(iface) {
 		return "awg3"
 	}
@@ -62,6 +67,13 @@ func hasAnyAWG3Param(iface *storage.AWGInterface) bool {
 	return iface.HeaderProtectionKey != "" || iface.ContentPaddingAddition != "" ||
 		iface.RekeyAfterTime != "" || iface.RekeyTimeout != "" ||
 		iface.RejectAfterTime != "" || iface.KeepaliveTimeout != "" ||
-		iface.MaxHandshakeAttempts != "" ||
-		iface.RandomTrailers || iface.DisableCookies
+		iface.MaxHandshakeAttempts != ""
+}
+
+// hasAnyAWG31Param reports whether one of the AmneziaWG 3.1 device flags is set.
+func hasAnyAWG31Param(iface *storage.AWGInterface) bool {
+	if iface == nil {
+		return false
+	}
+	return iface.RandomTrailers || iface.DisableCookies
 }

--- a/internal/tunnel/config/config_test.go
+++ b/internal/tunnel/config/config_test.go
@@ -1223,13 +1223,28 @@ func TestParse_AWG31DisableCookies(t *testing.T) {
 // tunnel classified as plain: both flags printed as off must leave it alone.
 func TestClassifyAWGVersion_AWG31Flags(t *testing.T) {
 	plain := &storage.AWGInterface{}
-	if got := ClassifyAWGVersion(plain); got == "awg3" {
+	if got := ClassifyAWGVersion(plain); got != "wg" {
 		t.Fatalf("an interface with both flags off classified as %q", got)
 	}
 	withFlag := &storage.AWGInterface{
 		AWGObfuscation: storage.AWGObfuscation{RandomTrailers: true},
 	}
-	if got := ClassifyAWGVersion(withFlag); got != "awg3" {
-		t.Fatalf("RandomTrailers on classified as %q, want awg3", got)
+	if got := ClassifyAWGVersion(withFlag); got != "awg3.1" {
+		t.Fatalf("RandomTrailers on classified as %q, want awg3.1", got)
+	}
+	withCookies := &storage.AWGInterface{
+		AWGObfuscation: storage.AWGObfuscation{DisableCookies: true},
+	}
+	if got := ClassifyAWGVersion(withCookies); got != "awg3.1" {
+		t.Fatalf("DisableCookies on classified as %q, want awg3.1", got)
+	}
+	// A 3.0 param alongside a flag is still a 3.1 config: 3.1 is a superset.
+	mixed := &storage.AWGInterface{
+		AWGObfuscation: storage.AWGObfuscation{
+			HeaderProtectionKey: "aKey=", RandomTrailers: true,
+		},
+	}
+	if got := ClassifyAWGVersion(mixed); got != "awg3.1" {
+		t.Fatalf("HeaderProtectionKey + RandomTrailers classified as %q, want awg3.1", got)
 	}
 }

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -1214,7 +1214,7 @@ func buildASCJSON(iface *storage.AWGInterface) (json.RawMessage, error) {
 	// awg3 is included here so the extended block (S3/S4, I1-I5) still reaches
 	// NDMS. Firmware ASC does not model the awg3-specific device params, so
 	// those are simply not sent — the kernel backend (awg setconf) applies them.
-	if ver == "awg1.5" || ver == "awg2.0" || ver == "awg3" {
+	if ver == "awg1.5" || ver == "awg2.0" || ver == "awg3" || ver == "awg3.1" {
 		params := ndms.ASCParamsExtended{
 			ASCParams: ndms.ASCParams{
 				Jc: iface.Jc, Jmin: iface.Jmin, Jmax: iface.Jmax,


### PR DESCRIPTION
Классификация awg3.1, бейдж в VersionBadge и в диагностике, тумблеры 3.1 заменены индикацией по факту наличия в конфиге. Гейт supportsAwg31 удалён за ненадобностью.