### PR TITLE
fakeip: не разбирать rule-set заново на каждом тике

### DIFF
--- a/internal/singbox/router/fakeip_cidr_remote.go
+++ b/internal/singbox/router/fakeip_cidr_remote.go
@@ -107,6 +107,68 @@ func (s *ServiceImpl) singboxBinary() string {
 	return ""
 }
 
+// ruleSetFileFacts — всё, что Tier-2 берёт из СОДЕРЖИМОГО скачанного набора:
+// пригоден ли он к merged matching и какие CIDR несёт. Обе величины следуют
+// только из файла, поэтому запоминаются вместе с его mtime+размером.
+type ruleSetFileFacts struct {
+	mod       time.Time
+	size      int64
+	mergeable bool
+	cidrs     []string
+}
+
+// ruleSetFactsByPath помнит разбор каждого скачанного набора. Без него каждый
+// 30-секундный тик reconcile спавнил `sing-box rule-set decompile` на КАЖДЫЙ
+// remote-набор (issue #756) — на 580МГц MIPS это секунды CPU в тик, вечно, при
+// том что файл в кэше живёт час. Ключ — путь файла; запись самозаменяется на
+// перекачке, так что карта не растёт сверх числа наборов.
+var (
+	ruleSetFactsMu     sync.Mutex
+	ruleSetFactsByPath = map[string]ruleSetFileFacts{}
+)
+
+// factsForRuleSetFile разбирает скачанный набор, пропуская decompile, когда
+// файл не менялся с прошлого раза. Провал stat (файла нет) отключает память
+// для этого вызова — fail-open: разбираем как раньше.
+func (s *ServiceImpl) factsForRuleSetFile(ctx context.Context, path, format string) (ruleSetFileFacts, error) {
+	st, statErr := os.Stat(path)
+	if statErr == nil {
+		ruleSetFactsMu.Lock()
+		f, ok := ruleSetFactsByPath[path]
+		ruleSetFactsMu.Unlock()
+		if ok && f.size == st.Size() && f.mod.Equal(st.ModTime()) {
+			return f, nil
+		}
+	}
+
+	var raw []byte
+	var err error
+	if strings.HasSuffix(path, ".json") || format == "source" {
+		raw, err = os.ReadFile(path)
+	} else {
+		raw, err = ruleSetDecompileExec(ctx, s.singboxBinary(), path)
+	}
+	if err != nil {
+		return ruleSetFileFacts{}, fmt.Errorf("read/decompile: %w", err)
+	}
+	var src inlineRuleSetSource
+	if e := json.Unmarshal(raw, &src); e != nil {
+		return ruleSetFileFacts{}, fmt.Errorf("parse: %w", e)
+	}
+
+	facts := ruleSetFileFacts{
+		mergeable: mergeableRuleSetRule(RuleSet{Rules: src.Rules}) != nil,
+		cidrs:     ruleSetCIDRs(RuleSet{Rules: src.Rules}),
+	}
+	if statErr == nil {
+		facts.mod, facts.size = st.ModTime(), st.Size()
+		ruleSetFactsMu.Lock()
+		ruleSetFactsByPath[path] = facts
+		ruleSetFactsMu.Unlock()
+	}
+	return facts, nil
+}
+
 // remoteTunCIDRs downloads + decompiles each remote rule-set referenced by a
 // LOOP-SAFE proxy route-rule and returns the normalized v4/v6 ip_cidr it contains.
 // Gating on loopSafeProxyRule (not just isProxyRoute) is the loop-safety contract:
@@ -168,19 +230,9 @@ func (s *ServiceImpl) remoteTunCIDRs(ctx context.Context, cfg *RouterConfig) (v4
 			s.appLog.Warn("fakeip-cidr-remote", rs.Tag, "download: "+err.Error())
 			continue
 		}
-		var raw []byte
-		if strings.HasSuffix(path, ".json") || rs.Format == "source" {
-			raw, err = os.ReadFile(path)
-		} else {
-			raw, err = ruleSetDecompileExec(ctx, s.singboxBinary(), path)
-		}
+		facts, err := s.factsForRuleSetFile(ctx, path, rs.Format)
 		if err != nil {
-			s.appLog.Warn("fakeip-cidr-remote", rs.Tag, "read/decompile: "+err.Error())
-			continue
-		}
-		var src inlineRuleSetSource
-		if e := json.Unmarshal(raw, &src); e != nil {
-			s.appLog.Warn("fakeip-cidr-remote", rs.Tag, "parse: "+e.Error())
+			s.appLog.Warn("fakeip-cidr-remote", rs.Tag, err.Error())
 			continue
 		}
 		// Тот же beta.1-гейт merged matching, что в desiredTunCIDRs, но по
@@ -188,10 +240,12 @@ func (s *ServiceImpl) remoteTunCIDRs(ctx context.Context, cfg *RouterConfig) (v4
 		// Если на набор ссылаются ТОЛЬКО правила с собственным ip_cidr, его
 		// CIDR безопасны лишь когда набор mergeable — иначе внешнее правило по
 		// такому пакету не совпадёт и он уйдёт в route.final=direct → петля.
-		if !standalone[rs.Tag] && mergeableRuleSetRule(RuleSet{Rules: src.Rules}) == nil {
+		// Гейт зависит от КОНФИГА, поэтому решается здесь, а не в памяти
+		// разбора: та помнит только то, что следует из самого файла.
+		if !standalone[rs.Tag] && !facts.mergeable {
 			continue
 		}
-		for _, c := range ruleSetCIDRs(RuleSet{Rules: src.Rules}) {
+		for _, c := range facts.cidrs {
 			add(c)
 		}
 	}

--- a/internal/singbox/router/fakeip_cidr_remote_test.go
+++ b/internal/singbox/router/fakeip_cidr_remote_test.go
@@ -2,6 +2,8 @@ package router
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -87,5 +89,98 @@ func TestRemoteTunCIDRs_NonMergeableSetUnderOwnIPCIDR(t *testing.T) {
 	cfg.Route.Rules = append(cfg.Route.Rules, Rule{Action: "route", Outbound: "proxy", RuleSet: []string{"r"}})
 	if v4, _ := s.remoteTunCIDRs(context.Background(), cfg); len(v4) != 1 || v4[0] != "149.154.160.0/20" {
 		t.Errorf("standalone reference must still yield the set cidr, got %v", v4)
+	}
+}
+
+// Tier-2 гоняется на КАЖДОМ тике планировщика (30 с). Пока результат разбора
+// набора не запоминался, каждый тик спавнил `sing-box rule-set decompile` на
+// каждый remote-набор — на MIPS это секунды CPU в тик, вечно (issue #756).
+// Файл в кэше меняется только при перекачке, поэтому разбор обязан случиться
+// один раз на файл.
+func TestRemoteTunCIDRs_DecompilesOncePerFile(t *testing.T) {
+	origDL, origDC := ruleSetDownload, ruleSetDecompileExec
+	t.Cleanup(func() { ruleSetDownload, ruleSetDecompileExec = origDL, origDC })
+
+	dir := t.TempDir()
+	paths := map[string]string{}
+	for _, tag := range []string{"a", "b"} {
+		p := filepath.Join(dir, tag+".srs")
+		if err := os.WriteFile(p, []byte("srs-"+tag), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths[tag] = p
+	}
+
+	calls := 0
+	ruleSetDownload = func(_ context.Context, url, _format string) (string, error) {
+		return paths[url], nil
+	}
+	ruleSetDecompileExec = func(_ context.Context, _binary, _srsPath string) ([]byte, error) {
+		calls++
+		return []byte(`{"version":3,"rules":[{"ip_cidr":["149.154.160.0/20"]}]}`), nil
+	}
+
+	cfg := &RouterConfig{Route: Route{
+		Rules: []Rule{
+			{Action: "route", Outbound: "proxy", RuleSet: []string{"a"}},
+			{Action: "route", Outbound: "proxy", RuleSet: []string{"b"}},
+		},
+		RuleSet: []RuleSet{
+			{Tag: "a", Type: "remote", URL: "a", Format: "binary"},
+			{Tag: "b", Type: "remote", URL: "b", Format: "binary"},
+		},
+	}}
+	s := newTestService(t, Deps{})
+
+	for i := 0; i < 3; i++ {
+		v4, _ := s.remoteTunCIDRs(context.Background(), cfg)
+		if len(v4) != 1 || v4[0] != "149.154.160.0/20" {
+			t.Fatalf("tick %d: v4 = %v, want [149.154.160.0/20]", i, v4)
+		}
+	}
+	if calls != 2 {
+		t.Errorf("decompile ran %d times over 3 ticks, want 2 (once per rule-set file)", calls)
+	}
+}
+
+// Перекачанный набор обязан быть разобран заново: ключ памяти — сам файл
+// (mtime+размер), а не URL.
+func TestRemoteTunCIDRs_RedecompilesWhenFileChanges(t *testing.T) {
+	origDL, origDC := ruleSetDownload, ruleSetDecompileExec
+	t.Cleanup(func() { ruleSetDownload, ruleSetDecompileExec = origDL, origDC })
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.srs")
+	if err := os.WriteFile(p, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	cidr := "149.154.160.0/20"
+	ruleSetDownload = func(_ context.Context, _url, _format string) (string, error) { return p, nil }
+	ruleSetDecompileExec = func(_ context.Context, _binary, _srsPath string) ([]byte, error) {
+		calls++
+		return []byte(`{"version":3,"rules":[{"ip_cidr":["` + cidr + `"]}]}`), nil
+	}
+
+	cfg := &RouterConfig{Route: Route{
+		Rules:   []Rule{{Action: "route", Outbound: "proxy", RuleSet: []string{"a"}}},
+		RuleSet: []RuleSet{{Tag: "a", Type: "remote", URL: "a", Format: "binary"}},
+	}}
+	s := newTestService(t, Deps{})
+	s.remoteTunCIDRs(context.Background(), cfg)
+
+	// Перекачка: другое содержимое (и размер) под тем же путём.
+	cidr = "203.0.113.0/24"
+	if err := os.WriteFile(p, []byte("version-two"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	v4, _ := s.remoteTunCIDRs(context.Background(), cfg)
+
+	if calls != 2 {
+		t.Errorf("decompile ran %d times, want 2 (once per file version)", calls)
+	}
+	if len(v4) != 1 || v4[0] != "203.0.113.0/24" {
+		t.Errorf("v4 = %v, want [203.0.113.0/24] from the re-downloaded set", v4)
 	}
 }


### PR DESCRIPTION
Tier-2 дрейф-хила спавнил `sing-box rule-set decompile` на каждый remote-набор каждые 30 секунд, хотя файл в кэше живёт час — работа повторялась впустую. На MIPS это секунды CPU в тик, и в `top` выглядит как нагрузка от sing-box.

Разбор набора запоминается по самому файлу (mtime+размер); гейт standalone/mergeable зависит от конфига и по-прежнему считается на каждом вызове.

Регрессия закрыта двумя тестами на шве `ruleSetDecompileExec`: три тика с неизменными файлами дают ровно один decompile на набор (до фикса — по одному на тик), перекачанный файл разбирается заново.

Связь с #756 не доказана: дефект измерен, но подтверждения, что репортёр видит именно его, нет — нужен его `top -b -n 3` с полной командной строкой и включён ли fakeip-tun. Чинится как самостоятельный баг.

Issue #756
