### PR TITLE
fix(system): пустые списки opkg ломали вкладку «Обновления»

### DIFF
--- a/internal/api/system_opkg.go
+++ b/internal/api/system_opkg.go
@@ -86,6 +86,16 @@ func (h *SystemToolsHandler) OpkgSearch(w http.ResponseWriter, r *http.Request) 
 	response.Success(w, pkgs)
 }
 
+// opkgOutcome помечает исход в журнале: SSE-подписчиков у события нет,
+// строка в app-логе — единственный след операции, и она не должна врать,
+// будто пакет установлен, когда opkg упал.
+func opkgOutcome(cmd string, err error) string {
+	if err != nil {
+		return cmd + ": ошибка"
+	}
+	return cmd
+}
+
 type opkgPackagesRequest struct {
 	Packages []string `json:"packages"`
 }
@@ -108,7 +118,7 @@ func (h *SystemToolsHandler) OpkgUpdate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	out, err := h.opkg.Update()
-	h.emitEvent("update", "", "opkg update")
+	h.emitEvent("update", "", opkgOutcome("opkg update", err))
 	if err != nil {
 		response.Error(w, out+"\n"+err.Error(), "OPKG_ERROR")
 		return
@@ -144,7 +154,7 @@ func (h *SystemToolsHandler) OpkgUpgrade(w http.ResponseWriter, r *http.Request)
 	} else {
 		out, err = h.opkg.UpgradePackages(req.Packages)
 	}
-	h.emitEvent("upgrade", strings.Join(req.Packages, ","), "opkg upgrade")
+	h.emitEvent("upgrade", strings.Join(req.Packages, ","), opkgOutcome("opkg upgrade", err))
 	if err != nil {
 		response.Error(w, out+"\n"+err.Error(), "OPKG_ERROR")
 		return
@@ -175,7 +185,7 @@ func (h *SystemToolsHandler) OpkgInstall(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	out, err := h.opkg.Install(req.Packages)
-	h.emitEvent("install", strings.Join(req.Packages, ","), "opkg install")
+	h.emitEvent("install", strings.Join(req.Packages, ","), opkgOutcome("opkg install", err))
 	if err != nil {
 		response.Error(w, out+"\n"+err.Error(), "OPKG_ERROR")
 		return
@@ -234,7 +244,7 @@ func (h *SystemToolsHandler) OpkgRemove(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	out, err := h.opkg.Remove(req.Packages)
-	h.emitEvent("remove", strings.Join(req.Packages, ","), "opkg remove")
+	h.emitEvent("remove", strings.Join(req.Packages, ","), opkgOutcome("opkg remove", err))
 	if err != nil {
 		response.Error(w, out+"\n"+err.Error(), "OPKG_ERROR")
 		return

--- a/internal/api/system_opkg_test.go
+++ b/internal/api/system_opkg_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/sys/opkg"
+)
+
+// newOpkgHandler подсовывает вместо opkg скрипт с заданным поведением.
+func newOpkgHandler(t *testing.T, script string) *SystemToolsHandler {
+	t.Helper()
+	h, _ := newSystemToolsForTest(t, "expert")
+	bin := filepath.Join(t.TempDir(), "opkg")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h.opkg = opkg.NewClient()
+	h.opkg.Bin = bin
+	return h
+}
+
+// Роутер, где обновлять нечего, отдаёт пустой вывод и exit 0. Пустой список
+// обязан приехать массивом: `data: null` роняет рендер вкладки «Обновления».
+func TestOpkgEmptyListsAreArrays(t *testing.T) {
+	h := newOpkgHandler(t, "#!/bin/sh\nexit 0\n")
+
+	cases := []struct {
+		name string
+		url  string
+		call func(*httptest.ResponseRecorder, string)
+		want string
+	}{
+		{"upgradable", "/api/system/opkg/upgradable", func(w *httptest.ResponseRecorder, u string) {
+			h.OpkgUpgradable(w, httptest.NewRequest("GET", u, nil))
+		}, `{"success":true,"data":[]}`},
+		{"installed", "/api/system/opkg/installed", func(w *httptest.ResponseRecorder, u string) {
+			h.OpkgInstalled(w, httptest.NewRequest("GET", u, nil))
+		}, `{"success":true,"data":[]}`},
+		{"search", "/api/system/opkg/search?q=curl", func(w *httptest.ResponseRecorder, u string) {
+			h.OpkgSearch(w, httptest.NewRequest("GET", u, nil))
+		}, `{"success":true,"data":[]}`},
+		{"available", "/api/system/opkg/available?limit=50", func(w *httptest.ResponseRecorder, u string) {
+			h.OpkgAvailable(w, httptest.NewRequest("GET", u, nil))
+		}, `{"success":true,"data":{"items":[],"total":0,"offset":0,"limit":50}}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			c.call(rr, c.url)
+			got := strings.TrimSpace(rr.Body.String())
+			if got != c.want {
+				t.Errorf("тело ответа = %s, ожидалось %s", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/api/system_tools_test.go
+++ b/internal/api/system_tools_test.go
@@ -14,6 +14,7 @@ import (
 	sysfiles "github.com/hoaxisr/awg-manager/internal/sys/files"
 	"github.com/hoaxisr/awg-manager/internal/sys/opkg"
 	sysports "github.com/hoaxisr/awg-manager/internal/sys/ports"
+	"github.com/hoaxisr/awg-manager/internal/sys/procmon"
 	"github.com/hoaxisr/awg-manager/internal/sys/services"
 )
 
@@ -47,6 +48,7 @@ func newSystemToolsForTest(t *testing.T, level string) (*SystemToolsHandler, str
 		services: services.NewScanner(),
 		opkg:     opkg.NewClient(),
 		ports:    sysports.NewScanner(),
+		procmon:  procmon.NewSampler(),
 	}
 	return h, root
 }

--- a/internal/sys/opkg/opkg.go
+++ b/internal/sys/opkg/opkg.go
@@ -90,6 +90,11 @@ func (c *Client) run(args ...string) (stdout string, exitCode int, err error) {
 // наши вызовы.
 var ErrLocked = errors.New("opkg занят другим процессом: дождитесь окончания его работы")
 
+// ErrBusy — работает наша же долгая операция (update/upgrade/install).
+// Чтения не встают в её очередь: ожидание до пяти минут неотличимо от
+// зависшей страницы, а отказ виден сразу.
+var ErrBusy = errors.New("выполняется другая операция opkg: дождитесь её окончания")
+
 // lockedByOther распознаёт занятую базу по сообщению opkg.
 func lockedByOther(out string) bool {
 	low := strings.ToLower(out)
@@ -101,6 +106,20 @@ func lockedByOther(out string) bool {
 func (c *Client) runLocked(args ...string) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.runHeld(args...)
+}
+
+// runLockedRead — то же, но без ожидания: занятый клиент отвечает ErrBusy.
+func (c *Client) runLockedRead(args ...string) (string, error) {
+	if !c.mu.TryLock() {
+		return "", ErrBusy
+	}
+	defer c.mu.Unlock()
+	return c.runHeld(args...)
+}
+
+// runHeld выполняет opkg; вызывается с уже взятым мьютексом.
+func (c *Client) runHeld(args ...string) (string, error) {
 	out, code, err := c.run(args...)
 	if err != nil {
 		if lockedByOther(out) {
@@ -134,7 +153,7 @@ func isBenignEmptyList(args []string, out string, code int) bool {
 
 // ListInstalled returns installed packages enriched from opkg status.
 func (c *Client) ListInstalled() ([]Package, error) {
-	text, err := c.runLocked("list-installed")
+	text, err := c.runLockedRead("list-installed")
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +172,7 @@ func (c *Client) ListInstalled() ([]Package, error) {
 
 // ListUpgradable returns packages with available upgrades.
 func (c *Client) ListUpgradable() ([]Package, error) {
-	text, err := c.runLocked("list-upgradable")
+	text, err := c.runLockedRead("list-upgradable")
 	if err != nil {
 		return nil, err
 	}
@@ -195,10 +214,12 @@ func (c *Client) ListAvailable(query string, offset, limit int) (items []Package
 }
 
 func (c *Client) allAvailable() ([]Package, error) {
-	c.mu.Lock()
+	if !c.mu.TryLock() {
+		return nil, ErrBusy
+	}
 	defer c.mu.Unlock()
 	if len(c.listCache) > 0 && time.Since(c.listCached) < listCacheTTL {
-		return append([]Package(nil), c.listCache...), nil
+		return append([]Package{}, c.listCache...), nil
 	}
 	text, _, err := c.run("list")
 	if err != nil && strings.TrimSpace(text) == "" {
@@ -207,7 +228,7 @@ func (c *Client) allAvailable() ([]Package, error) {
 	pkgs := parseList(text)
 	c.listCache = pkgs
 	c.listCached = time.Now()
-	return append([]Package(nil), pkgs...), nil
+	return append([]Package{}, pkgs...), nil
 }
 
 // Search finds installable packages by query (opkg find).
@@ -221,7 +242,7 @@ func (c *Client) Search(query string) ([]Package, error) {
 	if err := validatePkgNames([]string{query}); err != nil {
 		return nil, err
 	}
-	text, err := c.runLocked("find", query)
+	text, err := c.runLockedRead("find", query)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +380,7 @@ func readStatusMeta() map[string]statusMeta {
 }
 
 func parseList(text string) []Package {
-	var out []Package
+	out := []Package{}
 	sc := bufio.NewScanner(strings.NewReader(text))
 	n := 0
 	for sc.Scan() {
@@ -386,7 +407,7 @@ func parseList(text string) []Package {
 }
 
 func parseInstalled(text string) []Package {
-	var out []Package
+	out := []Package{}
 	sc := bufio.NewScanner(strings.NewReader(text))
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -404,7 +425,7 @@ func parseInstalled(text string) []Package {
 }
 
 func parseUpgradable(text string) []Package {
-	var out []Package
+	out := []Package{}
 	sc := bufio.NewScanner(strings.NewReader(text))
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())

--- a/internal/sys/opkg/opkg_busy_test.go
+++ b/internal/sys/opkg/opkg_busy_test.go
@@ -1,0 +1,46 @@
+package opkg
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Долгий opkg update держит мьютекс до пяти минут. Чтения не должны молча
+// стоять в этой очереди: страница висит без единого признака жизни.
+func TestReadsDoNotQueueBehindLongOperation(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "opkg")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{Bin: bin}
+
+	c.mu.Lock() // имитируем идущий update
+	defer c.mu.Unlock()
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"ListInstalled", func() error { _, err := c.ListInstalled(); return err }},
+		{"ListUpgradable", func() error { _, err := c.ListUpgradable(); return err }},
+		{"Search", func() error { _, err := c.Search("curl"); return err }},
+		{"ListAvailable", func() error { _, _, err := c.ListAvailable("", 0, 50); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan error, 1)
+			go func() { done <- tc.call() }()
+			select {
+			case err := <-done:
+				if !errors.Is(err, ErrBusy) {
+					t.Errorf("ошибка = %v, ожидалась ErrBusy", err)
+				}
+			case <-time.After(time.Second):
+				t.Error("чтение встало в очередь за долгой операцией")
+			}
+		})
+	}
+}

--- a/internal/sys/ports/ports.go
+++ b/internal/sys/ports/ports.go
@@ -52,7 +52,7 @@ func (s *Scanner) List() ([]Binding, error) {
 		procDir = "/proc"
 	}
 
-	var bindings []Binding
+	bindings := []Binding{}
 
 	// 1. Collect sockets from /proc/net/{tcp,tcp6,udp,udp6}
 	tcp4, _ := s.parseNetFile(filepath.Join(procDir, "net", "tcp"), "tcp", true)
@@ -102,7 +102,7 @@ func (s *Scanner) InspectPort(port int, proto string) ([]Binding, error) {
 		return nil, err
 	}
 	proto = strings.ToLower(strings.TrimSpace(proto))
-	var matches []Binding
+	matches := []Binding{}
 	for _, b := range all {
 		if b.Port == port {
 			if proto == "" || strings.HasPrefix(b.Proto, proto) {


### PR DESCRIPTION
opkg на роутере, где обновлять нечего, отдаёт пустой вывод и exit 0. Парсер возвращал nil-срез, он уезжал на фронт как data: null, и рендер падал на upgradable.length — вкладка навсегда застревала на «Загрузка…», а дальнейшие действия, включая opkg update, уже не перерисовывались. Пустой список теперь всегда массив: то же касается «Установленных», «Доступных», поиска и списка портов.

Заодно: чтения opkg не встают в очередь за долгим update — вместо ожидания до пяти минут сразу отвечают, что opkg занят; журнал больше не пишет «opkg install», когда установка провалилась.