### PR TITLE
fix(sb-router): порты инбаундов уходили эфемерным сокетам

### DIFF
--- a/cmd/awg-manager/wiring_server.go
+++ b/cmd/awg-manager/wiring_server.go
@@ -314,6 +314,13 @@ func (a *app) setupDeviceProxy() {
 // the geoip bypass set, subscription scheduler/handler and the remaining
 // sing-box HTTP handlers.
 func (a *app) setupRouter() {
+	// Порты инбаундов sb-router лежат внутри эфемерного диапазона ядра
+	// (49000-61001 на Keenetic), поэтому исходящее соединение может занять
+	// их в окно рестарта sing-box и уронить старт с EADDRINUSE (#762).
+	if err := router.ReserveListenPorts(); err != nil {
+		logging.NewScopedLogger(a.loggingService, logging.GroupRouting, logging.SubSingboxRouter).
+			Warn("reserve-ports", "", "зарезервировать порты инбаундов: "+err.Error())
+	}
 	bindableAdapter := &routerWANInterfaceAdapter{store: a.ndmsQueries.Interfaces, nativeProxies: a.singboxOp.ListNativeProxies}
 	routerSvc := router.NewService(router.Deps{
 		AppLog:                   a.loggingService,

--- a/internal/singbox/router/portreserve.go
+++ b/internal/singbox/router/portreserve.go
@@ -1,0 +1,108 @@
+package router
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// reservedPortsSysctl — список портов, которые ядро НЕ выдаёт эфемерным
+// (исходящим) сокетам.
+const reservedPortsSysctl = "/proc/sys/net/ipv4/ip_local_reserved_ports"
+
+// routerListenPorts перечисляет фиксированные порты инбаундов sb-router.
+// Источник — те же константы, что рендерят правила iptables и конфиг
+// sing-box, поэтому список не может разъехаться с реальными слушателями.
+func routerListenPorts() []int {
+	ports := []int{TPROXYPort, RedirectPort}
+	for slot := 0; slot < MaxQoSClasses; slot++ {
+		tp, rp := QoSClassPorts(slot)
+		ports = append(ports, tp, rp)
+	}
+	return ports
+}
+
+// ReserveListenPorts убирает порты инбаундов sb-router из эфемерного пула
+// ядра.
+//
+// На Keenetic ip_local_port_range = 49000-61001 (замер на роутере), то есть
+// 51271/51272 и QoS-диапазоны лежат ВНУТРИ него. Пока sing-box слушает, порт
+// защищён; но переключение режима с tun-инбаундом требует полного рестарта
+// процесса, и в это окно ядро вправе отдать порт локальным концом любого
+// исходящего соединения. Тогда старт падает с «bind: address already in use»,
+// а переключение режима откатывается (issue #762).
+//
+// Best-effort: отсутствующий sysctl (ядро без опции) — не ошибка.
+func ReserveListenPorts() error { return reserveListenPortsAt(reservedPortsSysctl) }
+
+func reserveListenPortsAt(path string) error {
+	ports := routerListenPorts()
+	cur, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if reservedSpecCovers(string(cur), ports) {
+		return nil
+	}
+	// Дописываем к текущему значению, а не заменяем: резерв могли ставить
+	// не мы. Ядро само схлопывает пересечения и дубли в диапазоны
+	// (проверено на роутере).
+	parts := make([]string, 0, len(ports)+1)
+	if s := strings.TrimSpace(string(cur)); s != "" {
+		parts = append(parts, s)
+	}
+	for _, p := range ports {
+		parts = append(parts, strconv.Itoa(p))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(parts, ",")), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// reservedSpecCovers сообщает, покрыты ли все ports значением sysctl —
+// списком через запятую из одиночных портов и диапазонов «от-до».
+func reservedSpecCovers(spec string, ports []int) bool {
+	reserved := make(map[int]bool)
+	for _, item := range strings.Split(spec, ",") {
+		lo, hi, ok := parseReservedItem(item)
+		if !ok {
+			continue
+		}
+		for p := lo; p <= hi; p++ {
+			reserved[p] = true
+		}
+	}
+	for _, p := range ports {
+		if !reserved[p] {
+			return false
+		}
+	}
+	return true
+}
+
+func parseReservedItem(item string) (lo, hi int, ok bool) {
+	item = strings.TrimSpace(item)
+	if item == "" {
+		return 0, 0, false
+	}
+	from, to, isRange := strings.Cut(item, "-")
+	lo, err := strconv.Atoi(strings.TrimSpace(from))
+	if err != nil {
+		return 0, 0, false
+	}
+	if !isRange {
+		return lo, lo, true
+	}
+	hi, err = strconv.Atoi(strings.TrimSpace(to))
+	if err != nil || hi < lo {
+		return 0, 0, false
+	}
+	return lo, hi, true
+}

--- a/internal/singbox/router/portreserve_test.go
+++ b/internal/singbox/router/portreserve_test.go
@@ -1,0 +1,93 @@
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRouterListenPortsCoversEveryInbound(t *testing.T) {
+	ports := routerListenPorts()
+	want := map[int]bool{TPROXYPort: false, RedirectPort: false}
+	for slot := 0; slot < MaxQoSClasses; slot++ {
+		tp, rp := QoSClassPorts(slot)
+		want[tp], want[rp] = false, false
+	}
+	for _, p := range ports {
+		if _, ok := want[p]; !ok {
+			t.Errorf("лишний порт %d", p)
+		}
+		want[p] = true
+	}
+	for p, seen := range want {
+		if !seen {
+			t.Errorf("порт %d не попал в список резервирования", p)
+		}
+	}
+}
+
+func TestReservedSpecCovers(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  string
+		ports []int
+		want  bool
+	}{
+		{"пусто", "", []int{51271}, false},
+		{"точное совпадение диапазоном", "51271-51272", []int{51271, 51272}, true},
+		{"одиночный порт", "51271", []int{51271}, true},
+		{"часть портов вне", "51271-51272", []int{51272, 51281}, false},
+		{"чужой резерв плюс наш", "1000-1010,51271-51272,51281-51288", []int{51271, 51288}, true},
+		{"мусор не считается покрытием", "abc,,-", []int{51271}, false},
+		{"граница диапазона", "51281-51288", []int{51289}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := reservedSpecCovers(c.spec, c.ports); got != c.want {
+				t.Errorf("reservedSpecCovers(%q, %v) = %v, ожидалось %v", c.spec, c.ports, got, c.want)
+			}
+		})
+	}
+}
+
+func TestReserveListenPortsWritesMergedSpec(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ip_local_reserved_ports")
+	if err := os.WriteFile(path, []byte("1000-1010\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := reserveListenPortsAt(path); err != nil {
+		t.Fatalf("резервирование: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reservedSpecCovers(string(got), routerListenPorts()) {
+		t.Errorf("после записи порты не покрыты: %q", got)
+	}
+	if !reservedSpecCovers(string(got), []int{1000, 1010}) {
+		t.Errorf("чужой резерв потерян: %q", got)
+	}
+}
+
+func TestReserveListenPortsSkipsWriteWhenCovered(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ip_local_reserved_ports")
+	covered := "51271-51272,51281-51288,51301-51308\n"
+	if err := os.WriteFile(path, []byte(covered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Файл только для чтения: повторный старт не должен в него писать.
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := reserveListenPortsAt(path); err != nil {
+		t.Fatalf("повторный вызов не должен ни писать, ни падать: %v", err)
+	}
+}
+
+// Отсутствующий sysctl (ядро без опции, не-Linux) — не ошибка запуска.
+func TestReserveListenPortsMissingSysctl(t *testing.T) {
+	if err := reserveListenPortsAt(filepath.Join(t.TempDir(), "нет-такого")); err != nil {
+		t.Errorf("отсутствие файла должно быть тихим, получено: %v", err)
+	}
+}


### PR DESCRIPTION
Порты redirect/tproxy (51271, 51272) и QoS-диапазоны лежат внутри ip_local_port_range роутера (49000-61001 на Keenetic) и не зарезервированы, поэтому ядро вправе отдать их локальным концом исходящего соединения. Пока sing-box слушает, порт защищён; но переключение режима с tun-инбаундом требует полного рестарта процесса, и в это окно порт успевает уйти на сторону — старт падает с «bind: address already in use», а переключение откатывается (#762).

Порты теперь добавляются в ip_local_reserved_ports при старте: ядро перестаёт выдавать их автоматически, а явный bind sing-box по-прежнему разрешён. Чужой резерв в sysctl сохраняется, повторный старт не пишет.

Проверено на роутере: с сужением диапазона до 51271-51272 ядро без резерва выдаёт эти порты исходящим, с резервом — не выдаёт.