### PR TITLE
fix(ndms): пустой элемент в set ipv6 address валил переход в policy-tun

### DIFF
--- a/internal/ndms/command/interfaces.go
+++ b/internal/ndms/command/interfaces.go
@@ -148,14 +148,20 @@ func (c *InterfaceCommands) ClearAddress(ctx context.Context, name string) error
 }
 
 // SetIPv6Address sets a single IPv6 address on the interface, clearing
-// any existing IPv6 assignments in the same call.
+// any existing IPv6 assignments in the same call. The clearing element is
+// `no:true` — an empty element clears nothing and NDMS answers it with
+// `no input [http/rci 127.0.0.1]` (Command::Root refusing an argument-less
+// command), which since the response check landed fails the whole call even
+// though the address itself was applied. Both forms verified on the stand
+// (KeeneticOS 5.01): `no:true` answers "cleared addresses" and is idempotent
+// on an interface with no addresses.
 func (c *InterfaceCommands) SetIPv6Address(ctx context.Context, name, address string) error {
 	payload := map[string]any{
 		"interface": map[string]any{
 			name: map[string]any{
 				"ipv6": map[string]any{
 					"address": []any{
-						map[string]any{},
+						map[string]any{"no": true},
 						map[string]any{"block": address + "/128"},
 					},
 				},

--- a/internal/ndms/command/interfaces_payload_test.go
+++ b/internal/ndms/command/interfaces_payload_test.go
@@ -79,7 +79,7 @@ func TestInterfaceCommandsPayloads_AddressAndIPv6(t *testing.T) {
 		t.Fatalf("SetIPv6Address: %v", err)
 	}
 	requireJSONEqual(t, poster.Payloads()[2], `{
-		"interface":{"OpkgTun10":{"ipv6":{"address":[{},{"block":"fd00::1/128"}]}}}
+		"interface":{"OpkgTun10":{"ipv6":{"address":[{"no":true},{"block":"fd00::1/128"}]}}}
 	}`)
 
 	if err := cmds.ClearIPv6Address(context.Background(), "OpkgTun10"); err != nil {


### PR DESCRIPTION
Регресс #775: NDMS отвечает на элемент без аргументов no input [http/rci], проверка ответа сделала ложный отказ фатальным. Пустой элемент к тому же не чистил адреса — накапливались. Формы проверены на стенде KeeneticOS 5.01. Радиус: policy-tun, fakeip-tun, создание/синк туннелей с IPv6