### PR TITLE
fix(sb-router): переход в tun-режим перезапускал движок дважды

### DIFF
--- a/internal/singbox/orchestrator/orchestrator.go
+++ b/internal/singbox/orchestrator/orchestrator.go
@@ -56,6 +56,15 @@ type Orchestrator struct {
 	reloadTimer *time.Timer
 	reloading   bool
 
+	// holds > 0 подавляет debounce-reload: продюсер, записавший слот во время
+	// перехода режима, не должен дёргать движок посреди чужой транзакции (при
+	// живом tun каждый такой reload — полный Stop+Start). Подавленная запись
+	// помечается в pendingReload и применяется одним reload'ом на release.
+	// ReloadNow под hold НЕ подавляется: он явный и сам применяет всё
+	// накопленное, поэтому сбрасывает pendingReload.
+	holds         int
+	pendingReload bool
+
 	// prevHasTun records whether the LAST applied config had a tun
 	// inbound. Reload compares it against the new config's tun presence:
 	// a toggle (added or removed) forces a restart because sing-box
@@ -359,6 +368,38 @@ func (o *Orchestrator) saveLocked(slot Slot, jsonBytes []byte) error {
 		return fmt.Errorf("save %s: %w", slot, err)
 	}
 	return nil
+}
+
+// HoldReloads подавляет debounce-reload'ы до вызова возвращённой функции.
+// Нужен на время перехода режима: teardown и провижининг пишут слоты по
+// нескольку раз и дольше окна debounce, и без hold чужой reload прилетает
+// посреди транзакции. Возвращённый release идемпотентен; когда снят последний
+// hold, накопленная запись применяется одним отложенным reload'ом.
+func (o *Orchestrator) HoldReloads() func() {
+	o.mu.Lock()
+	o.holds++
+	if o.reloadTimer != nil {
+		o.reloadTimer.Stop()
+		o.reloadTimer = nil
+		o.pendingReload = true
+	}
+	o.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			o.mu.Lock()
+			if o.holds > 0 {
+				o.holds--
+			}
+			resume := o.holds == 0 && o.pendingReload
+			if resume {
+				o.pendingReload = false
+				o.scheduleReload()
+			}
+			o.mu.Unlock()
+		})
+	}
 }
 
 // SetEnabled toggles slot activity by renaming the file between

--- a/internal/singbox/orchestrator/orchestrator_test.go
+++ b/internal/singbox/orchestrator/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -812,6 +813,122 @@ func TestReload_SighupWhenTunStillPresent(t *testing.T) {
 	}
 	if fp.startsN() != 0 || fp.stopsN() != 0 {
 		t.Errorf("must not restart when tun unchanged; starts=%d stops=%d", fp.startsN(), fp.stopsN())
+	}
+}
+
+// TestHoldReloads_SuppressesUntilRelease: пока держится hold, записи слотов не
+// дёргают процесс — иначе чужой продюсер перезапускал бы движок посреди
+// перехода режима (при живом tun любой reload это Stop+Start). На release
+// накопленное применяется одним reload'ом.
+func TestHoldReloads_SuppressesUntilRelease(t *testing.T) {
+	fp := &fakeProc{running: true}
+	dir := t.TempDir()
+	o := newFakeOrch(t, dir, fp)
+	_ = o.Register(SlotMeta{Slot: SlotRouter, Filename: "20-router.json"})
+	if err := o.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+
+	release := o.HoldReloads()
+	if err := o.Save(SlotRouter, []byte(tunInboundConfig)); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.SetEnabled(SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(3 * reloadDebounce)
+	if got := fp.calls(); len(got) != 0 {
+		t.Fatalf("под hold процесс трогать нельзя, получено %v", got)
+	}
+
+	release()
+	deadline := time.Now().Add(2 * time.Second)
+	for len(fp.calls()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := fp.calls(); len(got) == 0 {
+		t.Fatal("после release накопленная запись обязана примениться")
+	}
+	// Ровно одно применение: старт (процесс уже жив → SIGHUP или restart по
+	// toggle tun), а не по одному на каждую подавленную запись.
+	time.Sleep(3 * reloadDebounce)
+	if got := fp.calls(); len(got) > 2 {
+		t.Errorf("ожидалось одно применение, получено %v", got)
+	}
+}
+
+// TestHoldReloads_ReloadNowClearsPending: явный ReloadNow под hold применяет всё
+// накопленное, поэтому release не обязан стрелять вторым reload'ом — иначе
+// переход режима заканчивался бы лишним перезапуском движка.
+func TestHoldReloads_ReloadNowClearsPending(t *testing.T) {
+	fp := &fakeProc{running: true}
+	dir := t.TempDir()
+	o := newFakeOrch(t, dir, fp)
+	_ = o.Register(SlotMeta{Slot: SlotRouter, Filename: "20-router.json"})
+	if err := o.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+
+	release := o.HoldReloads()
+	if err := o.Save(SlotRouter, []byte(tunInboundConfig)); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.SetEnabled(SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.ReloadNow(); err != nil {
+		t.Fatalf("reload now: %v", err)
+	}
+	applied := len(fp.calls())
+	if applied == 0 {
+		t.Fatal("ReloadNow под hold обязан применить конфиг")
+	}
+
+	// Процесс на лишнем прогоне не пострадал бы — его съел бы skip-gate по
+	// хешу, — поэтому ловим сам факт прогона по журналу оркестратора.
+	var after []string
+	o.SetLogger(func(_, msg string) { after = append(after, msg) })
+	release()
+	time.Sleep(3 * reloadDebounce)
+	if len(after) != 0 {
+		t.Errorf("release после ReloadNow не должен запускать reload повторно, журнал: %v", after)
+	}
+	if got := fp.calls(); len(got) != applied {
+		t.Errorf("release после ReloadNow не должен применять повторно: было %d, стало %v", applied, got)
+	}
+}
+
+// TestReload_LogNamesRestartWhenTunActive: при живом tun proc.Reload делает
+// Stop+Start (SIGHUP пересоздал бы tun под удерживаемым fd → FATAL), поэтому
+// строка журнала обязана называть рестарт. Прежняя формулировка «SIGHUP»
+// сбивала с толку при разборе простоя: в журнале стоял SIGHUP, а движок в
+// этот момент перезапускался.
+func TestReload_LogNamesRestartWhenTunActive(t *testing.T) {
+	fp := &fakeProc{running: true}
+	dir := t.TempDir()
+	o := newFakeOrch(t, dir, fp)
+	var lines []string
+	o.SetLogger(func(_, msg string) { lines = append(lines, msg) })
+	_ = o.Register(SlotMeta{Slot: SlotRouter, Filename: "20-router.json"})
+	if err := o.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Save(SlotRouter, []byte(tunInboundConfig)); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.SetEnabled(SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	o.prevHasTun = true // tun уже жив — реального SIGHUP не будет
+	if err := o.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "restarting sing-box (config changed, tun active)") {
+		t.Errorf("журнал обязан назвать рестарт; строки: %v", lines)
+	}
+	if strings.Contains(joined, "SIGHUP") {
+		t.Errorf("при живом tun строка SIGHUP лжёт; строки: %v", lines)
 	}
 }
 

--- a/internal/singbox/orchestrator/reload.go
+++ b/internal/singbox/orchestrator/reload.go
@@ -19,6 +19,9 @@ func (o *Orchestrator) ReloadNow() error {
 		o.reloadTimer.Stop()
 		o.reloadTimer = nil
 	}
+	// Явное применение накрывает и то, что подавил hold, — иначе release
+	// выстрелил бы вторым, уже ненужным reload'ом.
+	o.pendingReload = false
 	o.mu.Unlock()
 	return o.Reload()
 }
@@ -27,6 +30,10 @@ func (o *Orchestrator) ReloadNow() error {
 // hold o.mu. Calling repeatedly within the window coalesces into one
 // reload.
 func (o *Orchestrator) scheduleReload() {
+	if o.holds > 0 {
+		o.pendingReload = true
+		return
+	}
 	if o.reloadTimer != nil {
 		o.reloadTimer.Reset(reloadDebounce)
 		return
@@ -155,7 +162,15 @@ func (o *Orchestrator) Reload() error {
 				}
 				err = proc.Start()
 			} else {
-				o.log("info", "orchestrator: SIGHUP sing-box (config changed)")
+				// При живом tun proc.Reload делает Stop+Start (SIGHUP пересоздал
+				// бы tun под удерживаемым fd → FATAL, см. process.go), поэтому
+				// строка обязана называть то, что произойдёт на самом деле:
+				// «SIGHUP» здесь сбивал с толку при разборе простоя.
+				if prevHasTun {
+					o.log("info", "orchestrator: restarting sing-box (config changed, tun active)")
+				} else {
+					o.log("info", "orchestrator: SIGHUP sing-box (config changed)")
+				}
 				err = proc.Reload()
 			}
 			if err == nil {

--- a/internal/singbox/router/fakeip_enable.go
+++ b/internal/singbox/router/fakeip_enable.go
@@ -349,7 +349,7 @@ func (s *ServiceImpl) enableFakeIPTun(ctx context.Context, settings *storage.Set
 	// Slot XOR выше поменял видимость композитов (20 припаркован, 21 активен) —
 	// зависимый слот 30 device-proxy перегенерируется ДО reload ниже (issue #465).
 	s.notifyRoutingSlotsChanged()
-	if err = s.orchestratorApplyNow(); err != nil {
+	if err = s.applyConfigNow(); err != nil {
 		return fmt.Errorf("enable fakeip-tun: orchestrator reload: %w", err)
 	}
 

--- a/internal/singbox/router/fakeip_transition.go
+++ b/internal/singbox/router/fakeip_transition.go
@@ -133,6 +133,16 @@ func (s *ServiceImpl) SwitchRoutingMode(ctx context.Context, target string) erro
 	s.transitionMu.Lock()
 	defer s.transitionMu.Unlock()
 
+	// Переход пишет слоты по нескольку раз (teardown, провижининг, примирение
+	// базы на выходе из Disable/Enable) и длится дольше окна debounce, поэтому
+	// без hold чужой reload прилетает посреди транзакции — а при живом tun
+	// каждый reload это полный Stop+Start движка. Явные applyConfigNow внутри
+	// Enable/Disable под hold работают как раньше; накопленное применяется
+	// одним reload'ом на выходе.
+	if s.deps.Orch != nil {
+		defer s.deps.Orch.HoldReloads()()
+	}
+
 	id := nextTransitionID()
 
 	source, err := s.currentState()

--- a/internal/singbox/router/policytun_enable.go
+++ b/internal/singbox/router/policytun_enable.go
@@ -316,7 +316,7 @@ func (s *ServiceImpl) enablePolicyTun(ctx context.Context, settings *storage.Set
 	// Слот 20 снова активен — зависимые продюсеры (device-proxy) перегенерируют
 	// свои слоты ДО reload.
 	s.notifyRoutingSlotsChanged()
-	if err = s.orchestratorApplyNow(); err != nil {
+	if err = s.applyConfigNow(); err != nil {
 		return fmt.Errorf("enable policy-tun: orchestrator reload: %w", err)
 	}
 

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -814,6 +814,20 @@ func (s *ServiceImpl) orchestratorApplyNow() error {
 	return s.deps.Orch.ReloadNow()
 }
 
+// applyConfigNow примиряет скаляры 00-base и сразу применяет config.d. Порядок
+// обязателен: база владеет dns.strategy, пока routing-слот запаркован, и
+// уступает его при перепарковке. Если примирять после применения (так делает
+// хвостовой defer в enableLocked/Disable), запись базы прилетает уже ПОСЛЕ
+// reload — а reload при живом tun это Stop+Start, то есть второй перезапуск
+// движка вне гейта готовности, когда дефолт клиентов уже припаркован на tun
+// (стенд 2026-08-20: pid менялся дважды за переход). Хвостовой defer при этом
+// остаётся страховкой для путей, уходящих через ошибку: mutateBase не пишет,
+// когда менять нечего.
+func (s *ServiceImpl) applyConfigNow() error {
+	s.reconcileBaseOwnedScalars()
+	return s.orchestratorApplyNow()
+}
+
 func (s *ServiceImpl) persistConfig(ctx context.Context, cfg *RouterConfig) error {
 	materialized, err := s.ruleSetMaterializer().materializeConfig(cfg)
 	if err != nil {

--- a/internal/singbox/router/service_dns_globals_reconcile_test.go
+++ b/internal/singbox/router/service_dns_globals_reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
@@ -110,3 +111,64 @@ func TestFakeIPSetDNSGlobals_CallsReconcileBaseDNSStrategy(t *testing.T) {
 		t.Fatalf("ReconcileBaseDNSStrategy вызовов = %d, want 1", calls)
 	}
 }
+
+// applyConfigNow обязан примирить базу ДО применения config.d: 00-base владеет
+// dns.strategy, пока routing-слот запаркован, и запись базы после reload
+// означала бы ещё один reload — при живом tun это полный перезапуск движка
+// (стенд 2026-08-20: pid менялся дважды за один переход в policy-tun).
+func TestApplyConfigNow_ReconcilesBaseBeforeApply(t *testing.T) {
+	svc, dir := newOrchedTestService(t)
+
+	// Живой процесс нужен, чтобы применение конфига дошло до ProcessController:
+	// с nil-контроллером оркестратор молчит и порядок вызовов не наблюдаем.
+	proc := &orderProc{}
+	orch := orchestrator.New(dir, proc)
+	if err := orch.Register(orchestrator.SlotMeta{Slot: orchestrator.SlotRouter, Filename: "20-router.json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Save(orchestrator.SlotRouter, []byte(`{"outbounds":[{"tag":"direct","type":"direct"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.SetEnabled(orchestrator.SlotRouter, true); err != nil {
+		t.Fatal(err)
+	}
+	svc.deps.Orch = orch
+	svc.deps.ReconcileBaseOwnedScalars = func() error {
+		proc.record("reconcile")
+		return nil
+	}
+
+	if err := svc.applyConfigNow(); err != nil {
+		t.Fatalf("applyConfigNow: %v", err)
+	}
+	got := proc.calls()
+	if len(got) < 2 || got[0] != "reconcile" {
+		t.Fatalf("примирение базы обязано идти ДО применения, порядок: %v", got)
+	}
+}
+
+// orderProc — ProcessController, записывающий порядок обращений к процессу.
+type orderProc struct {
+	mu    sync.Mutex
+	order []string
+}
+
+func (p *orderProc) record(what string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.order = append(p.order, what)
+}
+
+func (p *orderProc) calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.order...)
+}
+
+func (p *orderProc) IsRunning() (bool, int) { return true, 4242 }
+func (p *orderProc) Start() error           { p.record("start"); return nil }
+func (p *orderProc) Stop() error            { p.record("stop"); return nil }
+func (p *orderProc) Reload() error          { p.record("reload"); return nil }

--- a/internal/singbox/router/service_lifecycle.go
+++ b/internal/singbox/router/service_lifecycle.go
@@ -645,7 +645,7 @@ func (s *ServiceImpl) enableLocked(ctx context.Context, clearManualStop bool) er
 	// Слот 20 снова активен — зависимые продюсеры (device-proxy) должны
 	// перегенерировать свои слоты (вернуть ссылки на композиты) ДО reload.
 	s.notifyRoutingSlotsChanged()
-	if err := s.orchestratorApplyNow(); err != nil {
+	if err := s.applyConfigNow(); err != nil {
 		return fmt.Errorf("orchestrator reload after enable: %w", err)
 	}
 


### PR DESCRIPTION
Примирение 00-base висело на хвостовом defer и переписывало базу после применения — reload при живом tun это Stop+Start, то есть второй перезапуск движка вне гейта готовности. Доказано наблюдателем на железе: pid менялся дважды за переход. Примирение стало частью общей точки applyConfigNow (инвариант держится и в tproxy), переход держит hold на reload'ы, строка журнала перестала лгать про SIGHUP.