### PR TITLE
feat(sb-router): лечить отцепившийся tun при живом движке

### DIFF
--- a/internal/singbox/router/fakeip_reconcile.go
+++ b/internal/singbox/router/fakeip_reconcile.go
@@ -91,6 +91,10 @@ func (s *ServiceImpl) reconcileFakeIPTun(ctx context.Context, sr storage.Singbox
 	// указывают в OpkgTun без читателя, трафик дропается, не утекает.
 	// SetEnabled — только при фактически запаркованном слоте, иначе каждый
 	// тик взводил бы debounced reload.
+	//
+	// Отдельно от слота: движок может быть жив, а его стек отцепиться от tun —
+	// это состояние тоже не лечил никто, см. healDetachedTun.
+	s.healDetachedTun(iface, "fakeip-reconcile")
 	if s.deps.Orch != nil {
 		if st, ok := s.slotSnapshot(orchestrator.SlotFakeIP); !ok || !st.Enabled {
 			if e := s.deps.Orch.SetEnabled(orchestrator.SlotFakeIP, true); e != nil {

--- a/internal/singbox/router/policytun_reconcile.go
+++ b/internal/singbox/router/policytun_reconcile.go
@@ -281,6 +281,10 @@ func (s *ServiceImpl) reconcilePolicyTun(ctx context.Context, sr storage.Singbox
 		return s.enableLocked(ctx, false)
 	}
 
+	// Движок жив, интерфейс наш и на месте — но стек мог отцепиться от tun.
+	// Это состояние не ловит ни один другой heal, см. healDetachedTun.
+	s.healDetachedTun(iface, "policy-tun-reconcile")
+
 	// Запаркованный слот 20 — дрейф независимо от жизни процесса: enable
 	// no-op'ится на provisioned+live и слот бы уже не вернул, а без него в
 	// merged-конфиге нет tun-инбаунда.

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -488,6 +488,11 @@ type ServiceImpl struct {
 	// пишут ещё Disable, disablePolicyTun и нулевая ветка reconcilePolicyTunQoS).
 	appliedSpec *RestoreInputSpec
 
+	// lastTunHealAt — когда healDetachedTun последний раз перезапускал движок
+	// из-за отцепившегося tun. Пишется и читается только из reconcile-тика,
+	// сериализованного transitionMu.
+	lastTunHealAt time.Time
+
 	// appliedBlackhole — такой же снимок ВТОРОГО ресурса: fail-closed DROP,
 	// который reconcileInstalled поднимает, пока sing-box мёртв, а
 	// PREROUTING-джампы снесены. nil = блокировки нет. Ресурс отдельный от

--- a/internal/singbox/router/service_lifecycle.go
+++ b/internal/singbox/router/service_lifecycle.go
@@ -362,6 +362,47 @@ func (s *ServiceImpl) fakeIPReadyInputs() (iface, dnsAddr string, fakeipNet neti
 	return iface, dnsAddr, fakeipNet, true
 }
 
+// healDetachedTunInterval — минимальный зазор между попытками оживить
+// отцепившийся tun. Тик реконсиляции идёт куда чаще, и без зазора интерфейс,
+// который не поднимается по другой причине, вогнал бы движок в цикл
+// перезапусков.
+const healDetachedTunInterval = time.Minute
+
+// healDetachedTun чинит состояние «процесс жив, tun не прицеплен»: sing-box
+// работает и отвечает, но carrier на tun нулевой — значит его стек к
+// устройству не привязан. Для клиентов это худший вид отказа: дефолт уже
+// припаркован на интерфейс, трафик уходит в никуда, а режим числится
+// включённым. Раньше это не лечил НИКТО — Operator.Reconcile реагирует только
+// на мёртвый процесс, а drift-heal режима смотрит на NDMS-ресурсы, не на
+// привязку стека (стенд 2026-08-20: помогал только ручной перезапуск движка).
+//
+// Лечение — Reload движка: при живом tun он выполняется как Stop+Start
+// (см. process.go) и пересоздаёт привязку. Через оркестратор идти нельзя —
+// его skip-gate по хешу увидит неизменный конфиг и не сделает ничего.
+//
+// Вызывается из reconcile-тика, сериализованного transitionMu, — им же
+// защищено поле lastTunHealAt.
+func (s *ServiceImpl) healDetachedTun(iface, scope string) {
+	if s.deps.Singbox == nil || iface == "" {
+		return
+	}
+	if running, _ := s.deps.Singbox.IsRunning(); !running {
+		return // мёртвый процесс — забота watchdog'а, не наша
+	}
+	if tunReadyProbe(iface) {
+		return
+	}
+	now := time.Now()
+	if !s.lastTunHealAt.IsZero() && now.Sub(s.lastTunHealAt) < healDetachedTunInterval {
+		return
+	}
+	s.lastTunHealAt = now
+	s.appLog.Warn(scope, iface, "движок жив, но tun не прицеплен (carrier=0) — перезапускаю движок")
+	if err := s.deps.Singbox.Reload(); err != nil {
+		s.appLog.Warn(scope, iface, "перезапуск движка не удался: "+err.Error())
+	}
+}
+
 func (s *ServiceImpl) waitForSingbox(ctx context.Context, timeout time.Duration) error {
 	if s.deps.Singbox == nil {
 		return nil

--- a/internal/singbox/router/service_test.go
+++ b/internal/singbox/router/service_test.go
@@ -156,6 +156,10 @@ type fakeSingbox struct {
 	// supplying their own callback.
 	autoRestartFn func() (bool, bool, error)
 
+	// reloadCalls считает Reload() — на нём healDetachedTun оживляет
+	// отцепившийся tun (при живом tun Reload выполняется как Stop+Start).
+	reloadCalls int
+
 	// crashStats seeds CrashStats() for status tests.
 	crashCount             int
 	lastCrashReason        string
@@ -175,7 +179,7 @@ func newReadyTestSingbox(t *testing.T) *fakeSingbox {
 	return sb
 }
 
-func (f *fakeSingbox) Reload() error { return nil }
+func (f *fakeSingbox) Reload() error { f.reloadCalls++; return nil }
 func (f *fakeSingbox) IsRunning() (bool, int) {
 	if f.isRunningFn != nil {
 		return f.isRunningFn()

--- a/internal/singbox/router/tun_healer_test.go
+++ b/internal/singbox/router/tun_healer_test.go
@@ -1,0 +1,73 @@
+package router
+
+import (
+	"testing"
+	"time"
+)
+
+// Движок жив, но стек отцепился от tun (carrier=0): дефолт клиентов уже
+// припаркован на интерфейс, трафик уходит в никуда, а режим числится
+// включённым. Единственное лечение — перезапуск движка; до healDetachedTun это
+// состояние не ловил никто.
+func TestHealDetachedTun_RestartsWhenCarrierDown(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc.deps.Singbox = sb
+	stubTunReadyProbe(t, func(string) bool { return false })
+
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	if sb.reloadCalls != 1 {
+		t.Fatalf("ожидался один перезапуск движка, получено %d", sb.reloadCalls)
+	}
+}
+
+// Тик реконсиляции идёт часто: без зазора интерфейс, который не поднимается по
+// другой причине, вогнал бы движок в цикл перезапусков.
+func TestHealDetachedTun_ThrottlesRepeats(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc.deps.Singbox = sb
+	stubTunReadyProbe(t, func(string) bool { return false })
+
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	if sb.reloadCalls != 1 {
+		t.Fatalf("повтор в пределах зазора не должен перезапускать движок, вызовов %d", sb.reloadCalls)
+	}
+
+	svc.lastTunHealAt = time.Now().Add(-2 * healDetachedTunInterval)
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	if sb.reloadCalls != 2 {
+		t.Fatalf("после зазора лечение обязано повториться, вызовов %d", sb.reloadCalls)
+	}
+}
+
+// Живой carrier — не наш случай: движок трогать нельзя.
+func TestHealDetachedTun_NoopWhenCarrierUp(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return true, 1234 }
+	svc.deps.Singbox = sb
+	stubTunReadyProbe(t, func(string) bool { return true })
+
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	if sb.reloadCalls != 0 {
+		t.Fatalf("при живом carrier перезапуск не нужен, вызовов %d", sb.reloadCalls)
+	}
+}
+
+// Мёртвый процесс — забота watchdog'а: healer не должен с ним конкурировать.
+func TestHealDetachedTun_NoopWhenProcessDead(t *testing.T) {
+	svc, _ := newOrchedTestService(t)
+	sb := newTestSingbox(t)
+	sb.isRunningFn = func() (bool, int) { return false, 0 }
+	svc.deps.Singbox = sb
+	stubTunReadyProbe(t, func(string) bool { return false })
+
+	svc.healDetachedTun("opkgtun0", "policy-tun-reconcile")
+	if sb.reloadCalls != 0 {
+		t.Fatalf("мёртвый процесс поднимает watchdog, вызовов %d", sb.reloadCalls)
+	}
+}


### PR DESCRIPTION
Состояние «sing-box работает, но carrier на tun нулевой» не лечил никто: Operator.Reconcile смотрит только на мёртвый процесс, drift-heal режима — на NDMS-ресурсы. Клиенты при этом без интернета, режим числится включённым, помогает только ручной перезапуск. Лечение — Reload движка с зазором в минуту, в обоих tun-режимах.