### PR TITLE
feat(awg3.1): AmneziaWG 3.1 for NativeWG via awg_proxy (header protection + random trailers)

### DIFF
--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -2071,6 +2071,7 @@ const api_SystemInfoBackendAvailability: v.GenericSchema = v.looseObject({
 
 const api_SystemInfoData: v.GenericSchema = v.looseObject({
 	activeBackend: v.optional(v.nullable(v.string())),
+	awgProxyVersion: v.optional(v.nullable(v.string())),
 	backendAvailability: v.optional(v.nullable(v.lazy(() => api_SystemInfoBackendAvailability))),
 	bootInProgress: v.optional(v.nullable(v.boolean())),
 	disableMemorySaving: v.optional(v.nullable(v.boolean())),

--- a/frontend/src/lib/components/asc/ASCEditor.svelte
+++ b/frontend/src/lib/components/asc/ASCEditor.svelte
@@ -20,6 +20,7 @@
 		params = $bindable(),
 		extended = undefined,
 		awg3 = false,
+		awg3Limited = false,
 		mtu = 1280,
 		errors = {},
 		hints = AWG_PARAM_HINTS,
@@ -30,6 +31,9 @@
 		params: ASCParams;
 		extended?: boolean;
 		awg3?: boolean;
+		// NativeWG (awg_proxy) can only do header protection + random trailers —
+		// not the kernel-only timers / content padding. Hide those when true.
+		awg3Limited?: boolean;
 		mtu?: number;
 		errors?: ASCErrorFields;
 		hints?: Record<string, string>;
@@ -352,8 +356,13 @@
 		<section class="card param-section">
 			<SettingsSectionLabel label="AmneziaWG 3.0" icon={ShieldCheck} tone="purple" header />
 			<p class="group-desc">
-				Параметры ядра AWG 3.0 (только режим kernel). Таймеры — число или диапазон
-				<code>min-max</code> в секундах; пусто = значение по умолчанию.
+				{#if awg3Limited}
+					Через NativeWG (awg_proxy) доступна только защита заголовков. Таймеры и
+					content-padding работают лишь в режиме kernel.
+				{:else}
+					Параметры ядра AWG 3.0 (только режим kernel). Таймеры — число или диапазон
+					<code>min-max</code> в секундах; пусто = значение по умолчанию.
+				{/if}
 			</p>
 
 			<div class="form-group">
@@ -370,23 +379,25 @@
 				{/if}
 			</div>
 
-			<div class="inline-row inline-row-2">
+			{#if !awg3Limited}
+				<div class="inline-row inline-row-2">
+					{#each awg3RangeFields as f}
+						{@render paramLabel(f.key, f.label)}
+						<input
+							type="text"
+							id={fieldId(f.key)}
+							class="field-input"
+							bind:value={ext[f.key]}
+							placeholder="напр. 120 или 120-150"
+						/>
+					{/each}
+				</div>
 				{#each awg3RangeFields as f}
-					{@render paramLabel(f.key, f.label)}
-					<input
-						type="text"
-						id={fieldId(f.key)}
-						class="field-input"
-						bind:value={ext[f.key]}
-						placeholder="напр. 120 или 120-150"
-					/>
+					{#if errors[f.key]}
+						<p class="field-error">{f.label}: {errors[f.key]}</p>
+					{/if}
 				{/each}
-			</div>
-			{#each awg3RangeFields as f}
-				{#if errors[f.key]}
-					<p class="field-error">{f.label}: {errors[f.key]}</p>
-				{/if}
-			{/each}
+			{/if}
 		</section>
 	{/if}
 

--- a/frontend/src/lib/components/asc/ASCEditor.svelte
+++ b/frontend/src/lib/components/asc/ASCEditor.svelte
@@ -357,8 +357,8 @@
 			<SettingsSectionLabel label="AmneziaWG 3.0" icon={ShieldCheck} tone="purple" header />
 			<p class="group-desc">
 				{#if awg3Limited}
-					Через NativeWG (awg_proxy) доступна только защита заголовков. Таймеры и
-					content-padding работают лишь в режиме kernel.
+					Через NativeWG (awg_proxy) доступны защита заголовков и RandomTrailers (ниже).
+					Таймеры и content-padding работают лишь в режиме kernel.
 				{:else}
 					Параметры ядра AWG 3.0 (только режим kernel). Таймеры — число или диапазон
 					<code>min-max</code> в секундах; пусто = значение по умолчанию.

--- a/frontend/src/lib/components/tunnels/AWGAdvancedParams.svelte
+++ b/frontend/src/lib/components/tunnels/AWGAdvancedParams.svelte
@@ -55,12 +55,14 @@
 		hints = undefined,
 		compact = false,
 		awg3 = false,
+		awg3Limited = false,
 	}: {
 		form: AWGFormFields;
 		errors: AWGErrorFields;
 		hints?: Record<string, string>;
 		compact?: boolean;
 		awg3?: boolean;
+		awg3Limited?: boolean;
 	} = $props();
 </script>
 
@@ -68,6 +70,7 @@
 	bind:params={form}
 	extended
 	{awg3}
+	{awg3Limited}
 	mtu={form.mtu}
 	{errors}
 	{hints}

--- a/frontend/src/lib/types/system.ts
+++ b/frontend/src/lib/types/system.ts
@@ -101,6 +101,8 @@ export interface SystemInfo {
 	kernelModuleVersion: string;
 	/** Version reported by the module currently in the kernel, "" if not loaded. */
 	kernelModuleLoadedVersion?: string;
+	/** Loaded awg_proxy version (NativeWG); >= 1.4.0 supports AWG 3.1. */
+	awgProxyVersion?: string;
 	isAarch64: boolean;
 	activeBackend: string;
 	routerIP: string;

--- a/frontend/src/lib/utils/backendAvailability.test.ts
+++ b/frontend/src/lib/utils/backendAvailability.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { nativewgUnavailableHint, supportsAwg3 } from './backendAvailability';
+import { nativewgUnavailableHint, supportsAwg3, supportsAwg31Proxy } from './backendAvailability';
+
+describe('supportsAwg31Proxy', () => {
+	it('accepts awg_proxy >= 1.4.0 (header protection + random trailers)', () => {
+		expect(supportsAwg31Proxy('1.4.0')).toBe(true);
+		expect(supportsAwg31Proxy('1.4')).toBe(true);
+		expect(supportsAwg31Proxy('1.10.0')).toBe(true);
+		expect(supportsAwg31Proxy('2.0.0')).toBe(true);
+	});
+
+	it('rejects older proxies and a missing/dev one', () => {
+		expect(supportsAwg31Proxy('1.3.0')).toBe(false);
+		expect(supportsAwg31Proxy('1.2.5')).toBe(false);
+		expect(supportsAwg31Proxy('dev')).toBe(false);
+		expect(supportsAwg31Proxy('')).toBe(false);
+		expect(supportsAwg31Proxy(undefined)).toBe(false);
+	});
+});
 
 describe('nativewgUnavailableHint', () => {
 	it('explains the missing WireGuard component', () => {

--- a/frontend/src/lib/utils/backendAvailability.ts
+++ b/frontend/src/lib/utils/backendAvailability.ts
@@ -5,6 +5,18 @@ export function supportsAwg3(kernelModuleLoadedVersion: string | undefined): boo
 	return /^3\./.test(kernelModuleLoadedVersion ?? '');
 }
 
+// AWG 3.1 over NativeWG runs through awg_proxy, whose 1.4.0 build adds header
+// protection (HP_KEY) + random trailers (RT). Older proxies silently ignore
+// those tokens, so gate the NativeWG awg3 editor on the loaded proxy version —
+// the NativeWG analogue of supportsAwg3 for the kernel module.
+export function supportsAwg31Proxy(awgProxyVersion: string | undefined): boolean {
+	const m = /^(\d+)\.(\d+)/.exec(awgProxyVersion ?? '');
+	if (!m) return false;
+	const major = Number(m[1]);
+	const minor = Number(m[2]);
+	return major > 1 || (major === 1 && minor >= 4);
+}
+
 // Maps the backend's `nativewgReason` (from system/info) to a user-facing
 // explanation shown next to the disabled NativeWG option, so it no longer
 // greys out silently. Empty reason → no hint (NativeWG is available).

--- a/frontend/src/routes/tunnels/[id]/+page.svelte
+++ b/frontend/src/routes/tunnels/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	import AwgConfigAnalyzer from '$lib/components/diagnostics/AwgConfigAnalyzer.svelte';
 	import { SettingsSectionLabel } from '$lib/components/settings';
 	import { AWG_PARAM_HINTS } from '$lib/utils/awgParamHints';
-	import { supportsAwg3 } from '$lib/utils/backendAvailability';
+	import { supportsAwg3, supportsAwg31Proxy } from '$lib/utils/backendAvailability';
 	import { Network, Route, Router, Server, Tag } from 'lucide-svelte';
 
 	let { data } = $props();
@@ -426,7 +426,9 @@
 						bind:form={$form}
 						errors={$errors}
 						{hints}
-						awg3={tunnel?.backend !== 'nativewg' && supportsAwg3(systemInfo?.kernelModuleLoadedVersion)}
+						awg3={(tunnel?.backend !== 'nativewg' && supportsAwg3(systemInfo?.kernelModuleLoadedVersion)) ||
+							(tunnel?.backend === 'nativewg' && supportsAwg31Proxy(systemInfo?.awgProxyVersion))}
+						awg3Limited={tunnel?.backend === 'nativewg'}
 					/>
 				</div>
 

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -61,6 +62,7 @@ type SystemInfoData struct {
 	KernelModuleModel           string                        `json:"kernelModuleModel" example:"MT7981"`
 	KernelModuleVersion         string                        `json:"kernelModuleVersion" example:""`
 	KernelModuleLoadedVersion   string                        `json:"kernelModuleLoadedVersion" example:"3.1.20260812"`
+	AwgProxyVersion             string                        `json:"awgProxyVersion" example:"1.4.0"`
 	IsAarch64                   bool                          `json:"isAarch64" example:"true"`
 	ActiveBackend               string                        `json:"activeBackend" example:"nativewg"`
 	RouterIP                    string                        `json:"routerIP" example:"192.168.1.1"`
@@ -460,6 +462,7 @@ func (h *SystemHandler) buildSystemInfo(disableMemorySaving bool, gcMemLimit, go
 		"kernelModuleModel":           kernelModuleModel,
 		"kernelModuleVersion":         kernelModuleVersion,
 		"kernelModuleLoadedVersion":   kernelModuleLoadedVersion,
+		"awgProxyVersion":             awgProxyLoadedVersion(),
 		"isAarch64":                   isAarch64,
 		"activeBackend":               activeBackendType,
 		"routerIP":                    routerIP,
@@ -633,6 +636,18 @@ func evalNativewg(hasWireguardComponent, supportsASC, awgProxyLoaded bool) (avai
 func nativewgStatus() (available bool, reason string) {
 	_, err := os.Stat("/proc/awg_proxy/version")
 	return evalNativewg(ndmsinfo.HasWireguardComponent(), ndmsinfo.SupportsWireguardASC(), err == nil)
+}
+
+// awgProxyLoadedVersion returns the loaded awg_proxy version, or "" if not
+// loaded. The frontend gates the NativeWG AWG 3.1 editor on this (>= 1.4.0 adds
+// header protection + random trailers), mirroring supportsAwg3 for the kernel
+// module.
+func awgProxyLoadedVersion() string {
+	data, err := os.ReadFile("/proc/awg_proxy/version")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // wanInterfaceJSON is the JSON response for a single WAN interface.

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -5747,6 +5747,9 @@ definitions:
       activeBackend:
         example: nativewg
         type: string
+      awgProxyVersion:
+        example: 1.4.0
+        type: string
       backendAvailability:
         $ref: '#/definitions/api.SystemInfoBackendAvailability'
       bootInProgress:

--- a/internal/tunnel/config/validate_awg3.go
+++ b/internal/tunnel/config/validate_awg3.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/hoaxisr/awg-manager/internal/storage"
@@ -20,6 +21,13 @@ const headerProtectionMinPadding = 12
 func ValidateAWG3(o *storage.AWGObfuscation) error {
 	if o == nil || o.HeaderProtectionKey == "" {
 		return nil
+	}
+	// The key must be a base64-encoded 32-byte ChaCha20 key. Otherwise
+	// pubKeyToHex silently drops it to "" downstream and the tunnel comes up
+	// with header protection OFF while the server expects it — every handshake
+	// is dropped with nothing logged. Reject it here with a clear message.
+	if b, err := base64.StdEncoding.DecodeString(o.HeaderProtectionKey); err != nil || len(b) != 32 {
+		return fmt.Errorf("HeaderProtectionKey должен быть base64-ключом из 32 байт")
 	}
 	for _, s := range []struct {
 		name  string

--- a/internal/tunnel/config/validate_awg3_test.go
+++ b/internal/tunnel/config/validate_awg3_test.go
@@ -39,6 +39,16 @@ func TestValidateAWG3(t *testing.T) {
 			},
 			wantErr: "S4 = 11",
 		},
+		{
+			name: "malformed header protection key — not a 32-byte base64 key",
+			obf: storage.AWGObfuscation{
+				HeaderProtectionKey: "dGVzdA==", // base64 "test" — 4 bytes, not 32
+				S1:                  12, S2: 12, S3: 12, S4: 12,
+			},
+			// Must be a hard error, else pubKeyToHex drops it to "" and the
+			// tunnel comes up with header protection silently OFF.
+			wantErr: "HeaderProtectionKey",
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,7 +113,7 @@ Endpoint = 192.0.2.1:51820
 // padding, and refusing them next to a key would be an invented restriction.
 func TestValidateAWG3FlagsAreIndependent(t *testing.T) {
 	o := &storage.AWGObfuscation{
-		HeaderProtectionKey: "dGVzdA==",
+		HeaderProtectionKey: "ceaFRw/bcsvnr9I5fmZqPY1HTuUhhdkYjSxgUH0ixRc=",
 		S1:                  12, S2: 12, S3: 12, S4: 12,
 		RandomTrailers: true,
 		DisableCookies: true,
@@ -117,7 +127,7 @@ func TestValidateAWG3FlagsAreIndependent(t *testing.T) {
 // reachable when the new flags are set, so adding them cannot shadow it.
 func TestValidateAWG3FlagsStillEnforceSxFloor(t *testing.T) {
 	o := &storage.AWGObfuscation{
-		HeaderProtectionKey: "dGVzdA==",
+		HeaderProtectionKey: "ceaFRw/bcsvnr9I5fmZqPY1HTuUhhdkYjSxgUH0ixRc=",
 		S1:                  11, S2: 12, S3: 12, S4: 12,
 		RandomTrailers: true,
 	}

--- a/internal/tunnel/nwg/kmod_manager.go
+++ b/internal/tunnel/nwg/kmod_manager.go
@@ -82,6 +82,9 @@ type KmodConfig struct {
 	PubClientHex       string // 64-char hex
 	I1, I2, I3, I4, I5 string // CPS template strings
 	BindIface          string // kernel iface for SO_BINDTODEVICE (e.g. "eth3")
+	// AWG 3.1 (awg_proxy >= header-protection build).
+	HeaderProtectionKeyHex string // 64-char hex; empty = no header protection
+	RandomTrailers         bool   // append/accept random handshake trailers
 }
 
 // KmodResult holds the result of adding a tunnel to the kernel module.
@@ -609,6 +612,15 @@ func buildProcLine(cfg KmodConfig) string {
 
 	if cfg.BindIface != "" {
 		fmt.Fprintf(&b, " BIND=%s", cfg.BindIface)
+	}
+
+	// AWG 3.1: header protection (HP_KEY) and random trailers (RT). Emitted
+	// only when set, so an AWG 1.x/2.0 line stays byte-identical.
+	if cfg.HeaderProtectionKeyHex != "" {
+		fmt.Fprintf(&b, " HP_KEY=%s", cfg.HeaderProtectionKeyHex)
+	}
+	if cfg.RandomTrailers {
+		b.WriteString(" RT=1")
 	}
 
 	return b.String()

--- a/internal/tunnel/nwg/kmod_manager_test.go
+++ b/internal/tunnel/nwg/kmod_manager_test.go
@@ -10,15 +10,16 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
-// buildKmodConfigResolved must carry the awg3.1 params from storage: the
-// base64 HeaderProtectionKey becomes 64-hex, RandomTrailers passes through, and
-// S1-S4 are clamped to the header-protection minimum (12 = ChaCha20 nonce).
+// buildKmodConfigResolved must carry the awg3.1 params from storage verbatim:
+// the base64 HeaderProtectionKey becomes 64-hex, RandomTrailers passes through,
+// and S1-S4 are NOT altered (they must byte-match the server; the S>=12 rule is
+// enforced fail-closed by config.ValidateAWG3 at create/update, not here).
 func TestBuildKmodConfig_AWG31(t *testing.T) {
 	keyBytes := bytes.Repeat([]byte{0x01}, 32)
 	stored := &storage.AWGTunnel{
 		Interface: storage.AWGInterface{
 			AWGObfuscation: storage.AWGObfuscation{
-				S1: 8, S2: 40, S3: 40, S4: 40, // S1 below the minimum
+				S1: 87, S2: 118, S3: 36, S4: 23,
 				HeaderProtectionKey: base64.StdEncoding.EncodeToString(keyBytes),
 				RandomTrailers:      true,
 			},
@@ -35,11 +36,9 @@ func TestBuildKmodConfig_AWG31(t *testing.T) {
 	if !cfg.RandomTrailers {
 		t.Error("RandomTrailers not carried through")
 	}
-	if cfg.S1 != 12 {
-		t.Errorf("S1 not clamped to 12: got %d", cfg.S1)
-	}
-	if cfg.S2 != 40 {
-		t.Errorf("S2 should be untouched (>=12): got %d", cfg.S2)
+	if cfg.S1 != 87 || cfg.S2 != 118 || cfg.S3 != 36 || cfg.S4 != 23 {
+		t.Errorf("S1-S4 must pass through unchanged: got %d/%d/%d/%d",
+			cfg.S1, cfg.S2, cfg.S3, cfg.S4)
 	}
 }
 

--- a/internal/tunnel/nwg/kmod_manager_test.go
+++ b/internal/tunnel/nwg/kmod_manager_test.go
@@ -1,9 +1,47 @@
 package nwg
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"strings"
 	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
+
+// buildKmodConfigResolved must carry the awg3.1 params from storage: the
+// base64 HeaderProtectionKey becomes 64-hex, RandomTrailers passes through, and
+// S1-S4 are clamped to the header-protection minimum (12 = ChaCha20 nonce).
+func TestBuildKmodConfig_AWG31(t *testing.T) {
+	keyBytes := bytes.Repeat([]byte{0x01}, 32)
+	stored := &storage.AWGTunnel{
+		Interface: storage.AWGInterface{
+			AWGObfuscation: storage.AWGObfuscation{
+				S1: 8, S2: 40, S3: 40, S4: 40, // S1 below the minimum
+				HeaderProtectionKey: base64.StdEncoding.EncodeToString(keyBytes),
+				RandomTrailers:      true,
+			},
+		},
+	}
+
+	cfg, err := buildKmodConfigResolved(stored, "1.2.3.4", 51820, "")
+	if err != nil {
+		t.Fatalf("buildKmodConfigResolved: %v", err)
+	}
+	if cfg.HeaderProtectionKeyHex != hex.EncodeToString(keyBytes) {
+		t.Errorf("HP key hex = %q", cfg.HeaderProtectionKeyHex)
+	}
+	if !cfg.RandomTrailers {
+		t.Error("RandomTrailers not carried through")
+	}
+	if cfg.S1 != 12 {
+		t.Errorf("S1 not clamped to 12: got %d", cfg.S1)
+	}
+	if cfg.S2 != 40 {
+		t.Errorf("S2 should be untouched (>=12): got %d", cfg.S2)
+	}
+}
 
 func TestPubKeyToHex(t *testing.T) {
 	key := "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY="
@@ -31,6 +69,36 @@ func TestBuildProcLine(t *testing.T) {
 	expected := "1.2.3.4:51820"
 	if len(line) < len(expected) || line[:len(expected)] != expected {
 		t.Errorf("buildProcLine prefix = %q, want prefix %q", line[:20], expected)
+	}
+}
+
+func TestBuildProcLine_AWG31(t *testing.T) {
+	cfg := KmodConfig{
+		EndpointIP:   "1.2.3.4",
+		EndpointPort: 51820,
+		H1:           "1", H2: "2", H3: "3", H4: "4",
+		S1: 12, S2: 12, S3: 12, S4: 12,
+		HeaderProtectionKeyHex: "01020304050607080910111213141516" +
+			"01020304050607080910111213141516",
+		RandomTrailers: true,
+	}
+	line := buildProcLine(cfg)
+	if !strings.Contains(line, " HP_KEY="+cfg.HeaderProtectionKeyHex) {
+		t.Errorf("missing HP_KEY in %q", line)
+	}
+	if !strings.Contains(line, " RT=1") {
+		t.Errorf("missing RT=1 in %q", line)
+	}
+}
+
+func TestBuildProcLine_NoAWG31WhenUnset(t *testing.T) {
+	cfg := KmodConfig{
+		EndpointIP: "1.2.3.4", EndpointPort: 51820,
+		H1: "1", H2: "2", H3: "3", H4: "4",
+	}
+	line := buildProcLine(cfg)
+	if strings.Contains(line, "HP_KEY=") || strings.Contains(line, "RT=") {
+		t.Errorf("awg3.1 tokens leaked into a non-awg3.1 line: %q", line)
 	}
 }
 

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -1013,40 +1013,26 @@ func (o *OperatorNativeWG) nextFreeIndex(ctx context.Context) (int, error) {
 // buildKmodConfigResolved builds a KmodConfig with a pre-resolved endpoint IP.
 // bindIface is the kernel interface name for SO_BINDTODEVICE (empty = no binding).
 func buildKmodConfigResolved(stored *storage.AWGTunnel, endpointIP string, endpointPort int, bindIface string) (KmodConfig, error) {
-	s1, s2, s3, s4 := stored.Interface.S1, stored.Interface.S2, stored.Interface.S3, stored.Interface.S4
-	hpKeyHex := pubKeyToHex(stored.Interface.HeaderProtectionKey)
-	// Header protection uses the first 12 padding bytes as the ChaCha20 nonce,
-	// so S1-S4 must be >= 12 or the kmod rejects the add. A real awg3.1 server
-	// config already satisfies this; clamp defensively so a stray S<12 doesn't
-	// break the tunnel (the server side sends >=12 regardless).
-	if hpKeyHex != "" {
-		s1, s2, s3, s4 = clampMinHP(s1), clampMinHP(s2), clampMinHP(s3), clampMinHP(s4)
-	}
+	// S1-S4 pass through verbatim: header protection needs them >= 12 (the
+	// ChaCha20 nonce length), but that is enforced fail-closed by
+	// config.ValidateAWG3 at create/update — and these bytes must byte-match
+	// the server config, so this is not the place to silently adjust them.
 	return KmodConfig{
 		EndpointIP:   endpointIP,
 		EndpointPort: endpointPort,
 		H1:           stored.Interface.H1, H2: stored.Interface.H2,
 		H3: stored.Interface.H3, H4: stored.Interface.H4,
-		S1: s1, S2: s2, S3: s3, S4: s4,
+		S1: stored.Interface.S1, S2: stored.Interface.S2,
+		S3: stored.Interface.S3, S4: stored.Interface.S4,
 		Jc: stored.Interface.Jc, Jmin: stored.Interface.Jmin, Jmax: stored.Interface.Jmax,
 		PubServerHex: pubKeyToHex(stored.Peer.PublicKey),
 		PubClientHex: pubKeyToHex(clientPubKeyFromPrivate(stored.Interface.PrivateKey)),
 		I1:           stored.Interface.I1, I2: stored.Interface.I2,
 		I3: stored.Interface.I3, I4: stored.Interface.I4, I5: stored.Interface.I5,
 		BindIface:              bindIface,
-		HeaderProtectionKeyHex: hpKeyHex,
+		HeaderProtectionKeyHex: pubKeyToHex(stored.Interface.HeaderProtectionKey),
 		RandomTrailers:         stored.Interface.RandomTrailers,
 	}, nil
-}
-
-// clampMinHP raises a padding size to the header-protection minimum (12, the
-// ChaCha20 nonce length) so the nonce is never truncated.
-func clampMinHP(s int) int {
-	const hpMinPadding = 12
-	if s < hpMinPadding {
-		return hpMinPadding
-	}
-	return s
 }
 
 // fallbackResolve uses the cached ResolvedEndpointIP from storage when DNS is unavailable

--- a/internal/tunnel/nwg/operator.go
+++ b/internal/tunnel/nwg/operator.go
@@ -1013,20 +1013,40 @@ func (o *OperatorNativeWG) nextFreeIndex(ctx context.Context) (int, error) {
 // buildKmodConfigResolved builds a KmodConfig with a pre-resolved endpoint IP.
 // bindIface is the kernel interface name for SO_BINDTODEVICE (empty = no binding).
 func buildKmodConfigResolved(stored *storage.AWGTunnel, endpointIP string, endpointPort int, bindIface string) (KmodConfig, error) {
+	s1, s2, s3, s4 := stored.Interface.S1, stored.Interface.S2, stored.Interface.S3, stored.Interface.S4
+	hpKeyHex := pubKeyToHex(stored.Interface.HeaderProtectionKey)
+	// Header protection uses the first 12 padding bytes as the ChaCha20 nonce,
+	// so S1-S4 must be >= 12 or the kmod rejects the add. A real awg3.1 server
+	// config already satisfies this; clamp defensively so a stray S<12 doesn't
+	// break the tunnel (the server side sends >=12 regardless).
+	if hpKeyHex != "" {
+		s1, s2, s3, s4 = clampMinHP(s1), clampMinHP(s2), clampMinHP(s3), clampMinHP(s4)
+	}
 	return KmodConfig{
 		EndpointIP:   endpointIP,
 		EndpointPort: endpointPort,
 		H1:           stored.Interface.H1, H2: stored.Interface.H2,
 		H3: stored.Interface.H3, H4: stored.Interface.H4,
-		S1: stored.Interface.S1, S2: stored.Interface.S2,
-		S3: stored.Interface.S3, S4: stored.Interface.S4,
+		S1: s1, S2: s2, S3: s3, S4: s4,
 		Jc: stored.Interface.Jc, Jmin: stored.Interface.Jmin, Jmax: stored.Interface.Jmax,
 		PubServerHex: pubKeyToHex(stored.Peer.PublicKey),
 		PubClientHex: pubKeyToHex(clientPubKeyFromPrivate(stored.Interface.PrivateKey)),
 		I1:           stored.Interface.I1, I2: stored.Interface.I2,
 		I3: stored.Interface.I3, I4: stored.Interface.I4, I5: stored.Interface.I5,
-		BindIface: bindIface,
+		BindIface:              bindIface,
+		HeaderProtectionKeyHex: hpKeyHex,
+		RandomTrailers:         stored.Interface.RandomTrailers,
 	}, nil
+}
+
+// clampMinHP raises a padding size to the header-protection minimum (12, the
+// ChaCha20 nonce length) so the nonce is never truncated.
+func clampMinHP(s int) int {
+	const hpMinPadding = 12
+	if s < hpMinPadding {
+		return hpMinPadding
+	}
+	return s
 }
 
 // fallbackResolve uses the cached ResolvedEndpointIP from storage when DNS is unavailable

--- a/kmod/awg-proxy/package/Makefile
+++ b/kmod/awg-proxy/package/Makefile
@@ -2,8 +2,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=awg-proxy
+# 1.4.0: AWG 3.1 — header protection (HP_KEY) + random trailers (RT).
 # 1.3.0: IPv6 endpoint support ("[v6]:port" procfs syntax, udp_tunnel6 TX).
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.0
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/kmod/awg-proxy/src/Makefile
+++ b/kmod/awg-proxy/src/Makefile
@@ -1,10 +1,11 @@
 # Standalone out-of-tree build (for development/testing on host)
 # For cross-compilation, use the SDK package or build.sh
 
+# 1.4.0: AWG 3.1 — header protection (HP_KEY) + random trailers (RT).
 # 1.3.0: IPv6 endpoint support — "[v6]:port" accepted by /proc add/del,
 # printed in /proc list; per-family remote socket + udp_tunnel6 TX path.
 # Keep in sync with package/Makefile PKG_VERSION.
-AWG_PROXY_VERSION ?= 1.3.0
+AWG_PROXY_VERSION ?= 1.4.0
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 

--- a/kmod/awg-proxy/src/cookie.c
+++ b/kmod/awg-proxy/src/cookie.c
@@ -96,10 +96,12 @@ static void hchacha20(u8 subkey[32], const u8 key[32], const u8 nonce[16])
 	memzero_explicit(x, sizeof(x));
 }
 
-/* Generate ChaCha20 keystream and XOR with data.
- * counter starts at the given value. Handles up to ~256 bytes (4 blocks). */
-static void chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
-			  u8 *data, size_t len)
+/* Generate ChaCha20 keystream and XOR with data (public: see cookie.h).
+ * counter starts at the given value. Handles multi-block spans. Used both for
+ * the XChaCha20-Poly1305 cookie AEAD below and AmneziaWG 3.0+ header protection
+ * (transform.c), so there is one vetted ChaCha20 core, not two. */
+void awg_chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
+		      u8 *data, size_t len)
 {
 	u32 state[16], block[16];
 	u8 keystream[64];
@@ -132,14 +134,6 @@ static void chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
 	memzero_explicit(state, sizeof(state));
 	memzero_explicit(block, sizeof(block));
 	memzero_explicit(keystream, sizeof(keystream));
-}
-
-/* Public entry point (see cookie.h): AmneziaWG 3.0+ header protection reuses
- * the vetted ChaCha20 core above rather than carrying a second copy. */
-void awg_chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
-		      u8 *data, size_t len)
-{
-	chacha20_xor(key, nonce, counter, data, len);
 }
 
 /* ---- Poly1305 (Donna32, RFC 8439 §2.5) ---- */
@@ -320,7 +314,7 @@ int awg_xchacha20p1305_encrypt(const u8 key[32], const u8 nonce[24],
 	}
 
 	/* Encrypt plaintext with counter starting at 1 */
-	chacha20_xor(subkey, subnonce, 1, pt_buf, pt_len);
+	awg_chacha20_xor(subkey, subnonce, 1, pt_buf, pt_len);
 
 	/* Compute tag: Poly1305(poly_key, pad16(AAD) || pad16(ct) || le64(aad_len) || le64(ct_len)) */
 	poly1305_init(&poly, poly_key_block);
@@ -427,7 +421,7 @@ int awg_xchacha20p1305_decrypt(const u8 key[32], const u8 nonce[24],
 	ret = memcmp(tag, ct_with_tag + ct_len, 16) ? -EBADMSG : 0;
 
 	if (!ret)
-		chacha20_xor(subkey, subnonce, 1, ct_with_tag, ct_len);
+		awg_chacha20_xor(subkey, subnonce, 1, ct_with_tag, ct_len);
 
 	memzero_explicit(subkey, sizeof(subkey));
 	memzero_explicit(poly_key_block, sizeof(poly_key_block));

--- a/kmod/awg-proxy/src/cookie.c
+++ b/kmod/awg-proxy/src/cookie.c
@@ -134,6 +134,14 @@ static void chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
 	memzero_explicit(keystream, sizeof(keystream));
 }
 
+/* Public entry point (see cookie.h): AmneziaWG 3.0+ header protection reuses
+ * the vetted ChaCha20 core above rather than carrying a second copy. */
+void awg_chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
+		      u8 *data, size_t len)
+{
+	chacha20_xor(key, nonce, counter, data, len);
+}
+
 /* ---- Poly1305 (Donna32, RFC 8439 §2.5) ---- */
 
 struct poly1305_state {

--- a/kmod/awg-proxy/src/cookie.h
+++ b/kmod/awg-proxy/src/cookie.h
@@ -12,4 +12,13 @@ int awg_xchacha20p1305_encrypt(const u8 key[32], const u8 nonce[24],
 			       const u8 *aad, size_t aad_len,
 			       u8 *pt_out_buf, size_t pt_len);
 
+/* Raw IETF/RFC-8439 ChaCha20 keystream XOR (in place), block counter starting
+ * at `counter`. Public entry point for AmneziaWG 3.0+ header protection, which
+ * XORs the WireGuard header with header_protection_key (used directly as the
+ * key) and nonce = the first 12 on-wire junk-padding bytes, counter 0. Handles
+ * multi-block spans (up to the largest handshake, 148 bytes = 3 blocks).
+ */
+void awg_chacha20_xor(const u8 key[32], const u8 nonce[12], u32 counter,
+		      u8 *data, size_t len);
+
 #endif /* _AWG_PROXY_COOKIE_H */

--- a/kmod/awg-proxy/src/proxy.c
+++ b/kmod/awg-proxy/src/proxy.c
@@ -925,11 +925,15 @@ static int s2c_thread_fn(void *data)
 
 		atomic_inc(&proxy->rx_packets);
 		atomic64_add(n, &proxy->rx_bytes);
-		/* Feed the adaptive window from real inbound datagram sizes. */
-		udp_window_observe(proxy, n);
 
 		/* Transform inbound AWG -> WG */
 		out = transform_inbound(buf, n, &proxy->cfg, &out_len);
+		/* Feed the adaptive window from the POST-strip size, not the raw
+		 * datagram: a server handshake may carry its own random trailer, and
+		 * observing that would bias the window off cosmetic padding. Matches
+		 * the egress path, which observes the pre-trailer out_len. */
+		if (out)
+			udp_window_observe(proxy, out_len);
 		if (out && out_len == WG_COOKIE_SIZE &&
 		    out[0] == WG_COOKIE_REPLY &&
 		    proxy->has_cookie_key &&

--- a/kmod/awg-proxy/src/proxy.c
+++ b/kmod/awg-proxy/src/proxy.c
@@ -710,6 +710,22 @@ static int c2s_thread_fn(void *data)
 		}
 
 		/*
+		 * AWG 3.0 header protection: encrypt the WG header LAST, after
+		 * MAC1/MAC2 are final — for handshakes HP wraps the whole message
+		 * including the MACs, so it must run after they are rewritten. The
+		 * nonce is the padding prefix (out[0..12)), so s_prefix >= 12
+		 * (enforced at config parse). Transport encrypts only the 16-byte
+		 * header. Ingress decrypt lives inside transform_inbound.
+		 */
+		if (proxy->cfg.hp_key_set &&
+		    msgType >= WG_HANDSHAKE_INIT && msgType <= WG_TRANSPORT_DATA) {
+			int s_prefix = out_len - n;
+
+			if (s_prefix >= AWG_HP_MIN_PADDING)
+				hp_crypt(&proxy->cfg, out, s_prefix, n, msgType);
+		}
+
+		/*
 		 * Send I1-I5 CPS packets before the handshake init whenever any
 		 * template is configured — independent of Jc, matching the
 		 * reference (src/send.c: the ispec loop is unconditional; only

--- a/kmod/awg-proxy/src/proxy.c
+++ b/kmod/awg-proxy/src/proxy.c
@@ -560,6 +560,21 @@ static void send_junk_packets(struct awg_proxy *proxy)
 /* ---- worker threads ---- */
 
 /*
+ * AWG 3.1 adaptive window: record the largest real datagram seen on the slot
+ * (clamped to AWG_UDP_WINDOW_MAX) so handshake trailer sizes track the traffic
+ * envelope. Observe pre-trailer sizes only — observing our own trailered
+ * handshakes would make the window run away. Racy by design: a slightly stale
+ * window only perturbs a cosmetic trailer length.
+ */
+static inline void udp_window_observe(struct awg_proxy *proxy, int size)
+{
+	if (size > AWG_UDP_WINDOW_MAX)
+		size = AWG_UDP_WINDOW_MAX;
+	if (size > atomic_read(&proxy->udp_window))
+		atomic_set(&proxy->udp_window, size);
+}
+
+/*
  * Client-to-server thread: reads WG packets from listen_sock,
  * transforms to AWG via transform_outbound(), sends to remote_sock.
  *
@@ -726,6 +741,30 @@ static int c2s_thread_fn(void *data)
 		}
 
 		/*
+		 * AWG 3.1 random trailer: append cleartext bytes to handshake
+		 * datagrams so their fixed size stops being a fingerprint. Observe
+		 * the pre-trailer size first (transport packets set the envelope),
+		 * then draw a trailer for handshakes only — transport padding would
+		 * have to live inside the AEAD, which a keyless proxy cannot do.
+		 */
+		udp_window_observe(proxy, out_len);
+		if (proxy->cfg.random_trailers &&
+		    (msgType == WG_HANDSHAKE_INIT ||
+		     msgType == WG_HANDSHAKE_RESPONSE ||
+		     msgType == WG_COOKIE_REPLY)) {
+			int tailroom = (raw_buf + headroom + bufsize) - (out + out_len);
+			int tlen = awg_trailer_len(atomic_read(&proxy->udp_window),
+						   out_len);
+
+			if (tlen > tailroom)
+				tlen = tailroom;
+			if (tlen > 0) {
+				get_random_bytes(out + out_len, tlen);
+				out_len += tlen;
+			}
+		}
+
+		/*
 		 * Send I1-I5 CPS packets before the handshake init whenever any
 		 * template is configured — independent of Jc, matching the
 		 * reference (src/send.c: the ispec loop is unconditional; only
@@ -886,6 +925,8 @@ static int s2c_thread_fn(void *data)
 
 		atomic_inc(&proxy->rx_packets);
 		atomic64_add(n, &proxy->rx_bytes);
+		/* Feed the adaptive window from real inbound datagram sizes. */
+		udp_window_observe(proxy, n);
 
 		/* Transform inbound AWG -> WG */
 		out = transform_inbound(buf, n, &proxy->cfg, &out_len);
@@ -1074,6 +1115,7 @@ int awg_proxy_add(const char *config_line)
 	atomic64_set(&p->tx_bytes, 0);
 	atomic_set(&p->rx_packets, 0);
 	atomic_set(&p->tx_packets, 0);
+	atomic_set(&p->udp_window, AWG_DEFAULT_UDP_WINDOW);
 
 	/* Create listen socket (127.0.0.1:auto) */
 	ret = create_listen_socket(&p->listen_sock, &p->listen_port);

--- a/kmod/awg-proxy/src/proxy.h
+++ b/kmod/awg-proxy/src/proxy.h
@@ -19,6 +19,12 @@
 #define AWG_BUF_SIZE    2048  /* per-packet buffer (MTU + headroom) */
 #define AWG_RX_QUEUE_MAX 1024 /* max server->client skbs queued by encap_rcv */
 
+/* AWG 3.1 random-trailer adaptive window: seeded to 500, grows to the largest
+ * datagram observed (clamped to 1500), so handshake trailer sizes track the
+ * connection's natural envelope. Mirrors amneziawg-go DefaultUdpWindow. */
+#define AWG_DEFAULT_UDP_WINDOW 500
+#define AWG_UDP_WINDOW_MAX     1500
+
 /*
  * Per-tunnel UDP proxy instance.
  *
@@ -55,6 +61,7 @@ struct awg_proxy {
 	atomic64_t tx_bytes;  /* bytes sent to server */
 	atomic_t rx_packets;  /* packets from server */
 	atomic_t tx_packets;  /* packets to server */
+	atomic_t udp_window;  /* AWG 3.1 random-trailer size envelope */
 
 	/* Sockets */
 	struct socket *listen_sock;     /* UDP, binds 127.0.0.1:0 (auto port) */

--- a/kmod/awg-proxy/src/transform.c
+++ b/kmod/awg-proxy/src/transform.c
@@ -12,6 +12,7 @@
 
 #include "transform.h"
 #include "blake2s.h"
+#include "cookie.h"	/* awg_chacha20_xor for header protection */
 
 void config_compute(awg_config_t *cfg)
 {
@@ -54,6 +55,39 @@ static inline void write32_le(u8 *p, u32 v)
 	__le32 le = cpu_to_le32(v);
 
 	memcpy(p, &le, 4);
+}
+
+/*
+ * AWG 3.0 header protection (see amneziawg-go device/send.go, receive.go).
+ * XOR the WireGuard header with a raw ChaCha20 keystream: key = cfg->hp_key
+ * used directly, nonce = pkt[0..12) (the first on-wire junk-padding bytes),
+ * counter 0. Handshakes (init/resp/cookie) encrypt the whole message; transport
+ * encrypts only the 16-byte header (type|receiver|counter), leaving the AEAD
+ * payload untouched. XOR is its own inverse, so the same call encrypts (egress,
+ * after mac1/mac2) and decrypts (ingress, before the type is trusted).
+ *
+ * Callers gate on cfg->hp_key_set and guarantee s_prefix >= AWG_HP_MIN_PADDING
+ * (enforced in awg_config_parse), so the 12-byte nonce is always present.
+ */
+void hp_crypt(const awg_config_t *cfg, u8 *pkt, int s_prefix, int n, u32 msgType)
+{
+	int len = (msgType == WG_TRANSPORT_DATA) ? AWG_HP_TRANSPORT_HDR : n;
+
+	awg_chacha20_xor(cfg->hp_key, pkt, 0, pkt + s_prefix, len);
+}
+
+/*
+ * Recover the plaintext WireGuard type of an encrypted candidate at
+ * pkt + s_prefix, WITHOUT mutating pkt: XOR the ciphertext type field with the
+ * first 4 keystream bytes. Used for size+H dispatch on ingress before deciding
+ * whether to decrypt the whole message.
+ */
+u32 hp_peek_type(const awg_config_t *cfg, const u8 *pkt, int s_prefix)
+{
+	u8 ks[4] = {0};
+
+	awg_chacha20_xor(cfg->hp_key, pkt, 0, ks, sizeof(ks));
+	return read32_le(pkt + s_prefix) ^ read32_le(ks);
 }
 
 u8 *transform_outbound(u8 *buf, int dataoff, int n,
@@ -156,8 +190,9 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 	if (n < 4)
 		return NULL;
 
-	/* Fast path: identity transport */
-	if (cfg->h4_noop) {
+	/* Fast path: identity transport. Never under header protection — the
+	 * type field is encrypted, and HP requires s4 >= 12 so h4_noop is false. */
+	if (cfg->h4_noop && !cfg->hp_key_set) {
 		if (read32_le(buf) == WG_TRANSPORT_DATA &&
 		    n >= WG_TRANSPORT_MIN) {
 			*out_len = n;
@@ -165,11 +200,18 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 		}
 	}
 
-	/* Size-based dispatch: handshake first, transport last */
+	/* Size-based dispatch: handshake first, transport last. Under header
+	 * protection the type is recovered via hp_peek_type (keystream XOR) and,
+	 * once a candidate matches its H-range, the message is decrypted in place
+	 * before the canonical WG type is written and MAC1 recomputed. */
 	if (n == cfg->init_total) {
-		u32 h = read32_le(buf + cfg->s1);
+		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s1)
+				       : read32_le(buf + cfg->s1);
 
 		if (hrange_contains(&cfg->h1, h)) {
+			if (cfg->hp_key_set)
+				hp_crypt(cfg, buf, cfg->s1, WG_INIT_SIZE,
+					 WG_HANDSHAKE_INIT);
 			write32_le(buf + cfg->s1, WG_HANDSHAKE_INIT);
 			if (cfg->has_client_pub)
 				recompute_mac1(buf + cfg->s1,
@@ -180,9 +222,13 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 	}
 
 	if (n == cfg->resp_total) {
-		u32 h = read32_le(buf + cfg->s2);
+		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s2)
+				       : read32_le(buf + cfg->s2);
 
 		if (hrange_contains(&cfg->h2, h)) {
+			if (cfg->hp_key_set)
+				hp_crypt(cfg, buf, cfg->s2, WG_RESP_SIZE,
+					 WG_HANDSHAKE_RESPONSE);
 			write32_le(buf + cfg->s2, WG_HANDSHAKE_RESPONSE);
 			if (cfg->has_client_pub)
 				recompute_mac1_response(buf + cfg->s2,
@@ -193,9 +239,13 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 	}
 
 	if (n == cfg->cookie_total) {
-		u32 h = read32_le(buf + cfg->s3);
+		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s3)
+				       : read32_le(buf + cfg->s3);
 
 		if (hrange_contains(&cfg->h3, h)) {
+			if (cfg->hp_key_set)
+				hp_crypt(cfg, buf, cfg->s3, WG_COOKIE_SIZE,
+					 WG_COOKIE_REPLY);
 			write32_le(buf + cfg->s3, WG_COOKIE_REPLY);
 			*out_len = n - cfg->s3;
 			return buf + cfg->s3;
@@ -204,9 +254,13 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 
 	/* Transport data: variable size, checked last */
 	if (n >= cfg->s4 + WG_TRANSPORT_MIN) {
-		u32 h = read32_le(buf + cfg->s4);
+		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s4)
+				       : read32_le(buf + cfg->s4);
 
 		if (hrange_contains(&cfg->h4, h)) {
+			if (cfg->hp_key_set)
+				hp_crypt(cfg, buf, cfg->s4, n - cfg->s4,
+					 WG_TRANSPORT_DATA);
 			write32_le(buf + cfg->s4, WG_TRANSPORT_DATA);
 			*out_len = n - cfg->s4;
 			return buf + cfg->s4;

--- a/kmod/awg-proxy/src/transform.c
+++ b/kmod/awg-proxy/src/transform.c
@@ -90,6 +90,24 @@ u32 hp_peek_type(const awg_config_t *cfg, const u8 *pkt, int s_prefix)
 	return read32_le(pkt + s_prefix) ^ read32_le(ks);
 }
 
+/*
+ * AWG 3.1 random-trailer length: a value in [0, udp_window - packet_size),
+ * or 0 when the window has not yet exceeded the packet. udp_window is the
+ * per-slot largest datagram observed (seeded to DefaultUdpWindow=500), so
+ * trailers track the connection's natural size envelope. Mirrors
+ * amneziawg-go Peer.randomTrailer / mikrotik trailer_len.
+ */
+int awg_trailer_len(u32 udp_window, int packet_size)
+{
+	u32 span, r;
+
+	if (packet_size < 0 || udp_window <= (u32)packet_size)
+		return 0;
+	span = udp_window - (u32)packet_size;
+	get_random_bytes(&r, sizeof(r));
+	return (int)(r % span);
+}
+
 u8 *transform_outbound(u8 *buf, int dataoff, int n,
 		       const awg_config_t *cfg, u64 rand_val,
 		       int *out_len, int *sendCps, int *sendJunk,
@@ -204,7 +222,10 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 	 * protection the type is recovered via hp_peek_type (keystream XOR) and,
 	 * once a candidate matches its H-range, the message is decrypted in place
 	 * before the canonical WG type is written and MAC1 recomputed. */
-	if (n == cfg->init_total) {
+	/* Handshakes: exact size, or (under random_trailers) longer — the extra
+	 * bytes are a cleartext trailer stripped by returning the fixed size. */
+	if (n == cfg->init_total ||
+	    (cfg->random_trailers && n > cfg->init_total)) {
 		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s1)
 				       : read32_le(buf + cfg->s1);
 
@@ -216,12 +237,13 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 			if (cfg->has_client_pub)
 				recompute_mac1(buf + cfg->s1,
 					       cfg->mac1key_client);
-			*out_len = n - cfg->s1;
+			*out_len = WG_INIT_SIZE;
 			return buf + cfg->s1;
 		}
 	}
 
-	if (n == cfg->resp_total) {
+	if (n == cfg->resp_total ||
+	    (cfg->random_trailers && n > cfg->resp_total)) {
 		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s2)
 				       : read32_le(buf + cfg->s2);
 
@@ -233,12 +255,13 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 			if (cfg->has_client_pub)
 				recompute_mac1_response(buf + cfg->s2,
 							cfg->mac1key_client);
-			*out_len = n - cfg->s2;
+			*out_len = WG_RESP_SIZE;
 			return buf + cfg->s2;
 		}
 	}
 
-	if (n == cfg->cookie_total) {
+	if (n == cfg->cookie_total ||
+	    (cfg->random_trailers && n > cfg->cookie_total)) {
 		u32 h = cfg->hp_key_set ? hp_peek_type(cfg, buf, cfg->s3)
 				       : read32_le(buf + cfg->s3);
 
@@ -247,7 +270,7 @@ u8 *transform_inbound(u8 *buf, int n, const awg_config_t *cfg, int *out_len)
 				hp_crypt(cfg, buf, cfg->s3, WG_COOKIE_SIZE,
 					 WG_COOKIE_REPLY);
 			write32_le(buf + cfg->s3, WG_COOKIE_REPLY);
-			*out_len = n - cfg->s3;
+			*out_len = WG_COOKIE_SIZE;
 			return buf + cfg->s3;
 		}
 	}

--- a/kmod/awg-proxy/src/transform.h
+++ b/kmod/awg-proxy/src/transform.h
@@ -127,6 +127,13 @@ typedef struct {
 /* Compute MAC1 keys and fast-path flags. Call after setting all fields. */
 void config_compute(awg_config_t *cfg);
 
+/* AWG 3.0 header protection (gated on cfg->hp_key_set). hp_crypt XORs the
+ * WG header with the ChaCha20 keystream (whole message for handshakes, 16-byte
+ * header for transport); it is its own inverse. hp_peek_type recovers a
+ * candidate's plaintext type on ingress without mutating the packet. */
+void hp_crypt(const awg_config_t *cfg, u8 *pkt, int s_prefix, int n, u32 msgType);
+u32 hp_peek_type(const awg_config_t *cfg, const u8 *pkt, int s_prefix);
+
 /*
  * Transform outbound WG->AWG.
  * buf has dataoff bytes of headroom before the packet data.

--- a/kmod/awg-proxy/src/transform.h
+++ b/kmod/awg-proxy/src/transform.h
@@ -29,6 +29,12 @@
 #define WG_COOKIE_SIZE    64
 #define WG_TRANSPORT_MIN  32
 
+/* AWG 3.0+ header protection: the ChaCha20 nonce is the first 12 on-wire
+ * padding bytes, so S1-S4 must each be >= this when a header-protection key
+ * is set. Matches HeaderCipherNonceSize in amneziawg-go. */
+#define AWG_HP_MIN_PADDING 12
+#define AWG_HP_TRANSPORT_HDR 16  /* transport: only type|receiver|counter is XORed */
+
 /* Max junk packet count (bounds sizes[] stack array) */
 #define AWG_MAX_JC       128
 
@@ -92,6 +98,15 @@ typedef struct {
 	u8 client_pub[32];
 	u8 mac1key_server[32];
 	u8 mac1key_client[32];
+
+	/* AWG 3.0+ header protection. hp_key is used directly as the ChaCha20
+	 * key (no KDF); the nonce is the first 12 on-wire padding bytes, counter
+	 * 0. Gated by hp_key_set — which requires S1-S4 >= 12 (nonce length). */
+	u8  hp_key[32];
+	int hp_key_set;
+	/* AWG 3.1: append a random cleartext trailer to handshake datagrams and
+	 * accept over-long handshakes on ingress. Must match the peer. */
+	int random_trailers;
 
 	u32 h4_fixed;
 	int h4_noop;        /* H4={4,4} && S4==0 */

--- a/kmod/awg-proxy/src/transform.h
+++ b/kmod/awg-proxy/src/transform.h
@@ -134,6 +134,9 @@ void config_compute(awg_config_t *cfg);
 void hp_crypt(const awg_config_t *cfg, u8 *pkt, int s_prefix, int n, u32 msgType);
 u32 hp_peek_type(const awg_config_t *cfg, const u8 *pkt, int s_prefix);
 
+/* AWG 3.1 random-trailer length in [0, udp_window - packet_size), else 0. */
+int awg_trailer_len(u32 udp_window, int packet_size);
+
 /*
  * Transform outbound WG->AWG.
  * buf has dataoff bytes of headroom before the packet data.

--- a/kmod/awg-proxy/src/tunnel.c
+++ b/kmod/awg-proxy/src/tunnel.c
@@ -238,6 +238,15 @@ int awg_config_parse(const char *config_line, awg_config_t *cfg)
 			}
 		} else if (strcmp(key, "BIND") == 0) {
 			strscpy(cfg->bind_iface, val, sizeof(cfg->bind_iface));
+		} else if (strcmp(key, "HP_KEY") == 0) {
+			if (parse_hex_exact(val, cfg->hp_key, 32)) {
+				pr_warn("awg_proxy: invalid HP_KEY\n");
+				kfree(val);
+				goto out_invalid;
+			}
+			cfg->hp_key_set = 1;
+		} else if (strcmp(key, "RT") == 0) {
+			bad = kstrtoint(val, 10, &cfg->random_trailers) != 0;
 		} else if (key[0] == 'I' && key[1] >= '1' && key[1] <= '5' &&
 			   key[2] == '\0') {
 			int idx = key[1] - '1';
@@ -269,6 +278,15 @@ int awg_config_parse(const char *config_line, awg_config_t *cfg)
 	    cfg->s3 + WG_COOKIE_SIZE > 1500 ||
 	    cfg->s4 > 1024) {
 		pr_warn("awg_proxy: S1-S4 out of range\n");
+		goto out_invalid;
+	}
+	/* Header protection uses the first AWG_HP_MIN_PADDING padding bytes as the
+	 * ChaCha20 nonce, so every message class must carry at least that much. */
+	if (cfg->hp_key_set &&
+	    (cfg->s1 < AWG_HP_MIN_PADDING || cfg->s2 < AWG_HP_MIN_PADDING ||
+	     cfg->s3 < AWG_HP_MIN_PADDING || cfg->s4 < AWG_HP_MIN_PADDING)) {
+		pr_warn("awg_proxy: S1-S4 must be >= %d with header protection\n",
+			AWG_HP_MIN_PADDING);
 		goto out_invalid;
 	}
 	if (cfg->jc < 0 || cfg->jc > AWG_MAX_JC) {

--- a/kmod/awg-proxy/tests/.gitignore
+++ b/kmod/awg-proxy/tests/.gitignore
@@ -4,3 +4,4 @@ test_tunnel
 test_proxy_recv
 test_proxy_loop
 *.dSYM
+test_hp

--- a/kmod/awg-proxy/tests/Makefile
+++ b/kmod/awg-proxy/tests/Makefile
@@ -45,8 +45,8 @@ test_hp: test_hp.c shim.c shim.h $(SRC)/cookie.c
 test_transform: test_transform.c shim.c shim.h $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c
 	$(CC) $(CFLAGS) -o $@ test_transform.c shim.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c $(LDFLAGS)
 
-test_tunnel: test_tunnel.c shim.c shim.h $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c
-	$(CC) $(CFLAGS) -o $@ test_tunnel.c shim.c $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(LDFLAGS)
+test_tunnel: test_tunnel.c shim.c shim.h $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c
+	$(CC) $(CFLAGS) -o $@ test_tunnel.c shim.c $(SRC)/tunnel.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c $(LDFLAGS)
 
 # test_proxy_recv covers src/proxy_recv.h — the dual-mode worker recv-loop
 # classifier — and src/endpoint.h — the pure RX source filter

--- a/kmod/awg-proxy/tests/Makefile
+++ b/kmod/awg-proxy/tests/Makefile
@@ -26,15 +26,21 @@ SRC     := ../src
 
 all: test
 
-test: test_cps test_transform test_tunnel test_proxy_recv test_proxy_loop
+test: test_cps test_transform test_tunnel test_proxy_recv test_proxy_loop test_hp
 	./test_cps
 	./test_transform
 	./test_tunnel
 	./test_proxy_recv
 	./test_proxy_loop
+	./test_hp
 
 test_cps: test_cps.c shim.c shim.h $(SRC)/cps.c
 	$(CC) $(CFLAGS) -o $@ test_cps.c shim.c $(SRC)/cps.c $(LDFLAGS)
+
+# test_hp covers the header-protection ChaCha20 primitive (awg_chacha20_xor
+# in cookie.c) against an independent OpenSSL-generated golden vector.
+test_hp: test_hp.c shim.c shim.h $(SRC)/cookie.c
+	$(CC) $(CFLAGS) -o $@ test_hp.c shim.c $(SRC)/cookie.c $(LDFLAGS)
 
 test_transform: test_transform.c shim.c shim.h $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c
 	$(CC) $(CFLAGS) -o $@ test_transform.c shim.c $(SRC)/transform.c $(SRC)/blake2s.c $(SRC)/cps.c $(SRC)/cookie.c $(LDFLAGS)
@@ -57,4 +63,4 @@ test_proxy_loop: test_proxy_loop.c shim.c shim.h $(SRC)/proxy_recv.h
 	$(CC) $(CFLAGS) -o $@ test_proxy_loop.c shim.c $(LDFLAGS)
 
 clean:
-	rm -f test_cps test_transform test_tunnel test_proxy_recv test_proxy_loop *.o
+	rm -f test_cps test_transform test_tunnel test_proxy_recv test_proxy_loop test_hp *.o

--- a/kmod/awg-proxy/tests/test_hp.c
+++ b/kmod/awg-proxy/tests/test_hp.c
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Userspace unit tests for the AmneziaWG 3.0+ header-protection ChaCha20
+ * primitive (awg_chacha20_xor in src/cookie.c).
+ *
+ * Header protection XORs the WireGuard header with a raw ChaCha20 keystream:
+ * IETF/RFC-8439 (32-byte key, 12-byte nonce, 32-bit block counter), counter
+ * starting at 0, keying = header_protection_key used directly, nonce = the
+ * first 12 on-wire junk-padding bytes. This must be byte-identical to
+ * amneziawg-go's chacha20.NewUnauthenticatedCipher(key, nonce).XORKeyStream.
+ *
+ * The 148-byte known-answer vector (KS148) was generated independently from
+ * the code under test via Python cryptography (OpenSSL ChaCha20), counter=0,
+ * key=00..1f, nonce=00 00 00 09 00 00 00 4a 00 00 00 00 — spanning 3 blocks so
+ * the counter-increment path is covered.
+ *
+ * Run via `make test`.
+ */
+
+#include "shim.h"
+#include "../src/cookie.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+static int tests_run, tests_failed;
+
+static void test_fail(const char *test, const char *fmt, ...)
+{
+	va_list ap;
+
+	fprintf(stderr, "FAIL %s: ", test);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+	tests_failed++;
+}
+
+static void hexdec(const char *hex, u8 *out, size_t n)
+{
+	for (size_t i = 0; i < n; i++) {
+		unsigned int b;
+		sscanf(hex + 2 * i, "%2x", &b);
+		out[i] = (u8)b;
+	}
+}
+
+/* Independent golden vector (Python cryptography, OpenSSL ChaCha20, ctr=0). */
+static const char KEY_HEX[] =
+	"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+static const char NONCE_HEX[] = "000000090000004a00000000";
+static const char KS148_HEX[] =
+	"8adc91fd9ff4f0f51b0fad50ff15d637e40efda206cc52c783a74200503c1582"
+	"cd9833367d0a54d57d3c9e998f490ee69ca34c1ff9e939a75584c52d690a35d4"
+	"10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4e"
+	"d2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e"
+	"0a88837739d7bf4ef8ccacb0ea2bb9d69d56c394";
+
+/* XOR against an all-zero buffer yields the raw keystream — compare to the
+ * independent 148-byte reference across 3 ChaCha20 blocks (counter 0,1,2). */
+static void test_keystream_kat(void)
+{
+	u8 key[32], nonce[12], want[148], buf[148] = {0};
+
+	tests_run++;
+	hexdec(KEY_HEX, key, 32);
+	hexdec(NONCE_HEX, nonce, 12);
+	hexdec(KS148_HEX, want, 148);
+
+	awg_chacha20_xor(key, nonce, 0, buf, sizeof(buf));
+
+	if (memcmp(buf, want, sizeof(buf)) != 0)
+		test_fail("keystream_kat", "multi-block keystream mismatch vs OpenSSL reference");
+}
+
+/* XOR is its own inverse: encrypt then decrypt returns the plaintext. */
+static void test_roundtrip_identity(void)
+{
+	u8 key[32], nonce[12], msg[148], orig[148];
+
+	tests_run++;
+	hexdec(KEY_HEX, key, 32);
+	hexdec(NONCE_HEX, nonce, 12);
+	for (int i = 0; i < 148; i++)
+		msg[i] = (u8)(0x40 + (i * 7));
+	memcpy(orig, msg, sizeof(msg));
+
+	awg_chacha20_xor(key, nonce, 0, msg, sizeof(msg));
+	if (memcmp(msg, orig, sizeof(msg)) == 0)
+		test_fail("roundtrip_identity", "ciphertext equals plaintext (no encryption happened)");
+	awg_chacha20_xor(key, nonce, 0, msg, sizeof(msg));
+	if (memcmp(msg, orig, sizeof(msg)) != 0)
+		test_fail("roundtrip_identity", "decrypt did not restore plaintext");
+}
+
+/* Keystream depends on the nonce (the first 12 padding bytes on the wire). */
+static void test_nonce_dependence(void)
+{
+	u8 key[32], n1[12], n2[12], b1[16] = {0}, b2[16] = {0};
+
+	tests_run++;
+	hexdec(KEY_HEX, key, 32);
+	hexdec(NONCE_HEX, n1, 12);
+	memcpy(n2, n1, 12);
+	n2[0] ^= 0x01;
+
+	awg_chacha20_xor(key, n1, 0, b1, sizeof(b1));
+	awg_chacha20_xor(key, n2, 0, b2, sizeof(b2));
+	if (memcmp(b1, b2, sizeof(b1)) == 0)
+		test_fail("nonce_dependence", "different nonces produced identical keystream");
+}
+
+int main(void)
+{
+	test_keystream_kat();
+	test_roundtrip_identity();
+	test_nonce_dependence();
+
+	if (tests_failed) {
+		fprintf(stderr, "test_hp: %d/%d FAILED\n", tests_failed, tests_run);
+		return 1;
+	}
+	printf("test_hp: %d tests passed\n", tests_run);
+	return 0;
+}

--- a/kmod/awg-proxy/tests/test_transform.c
+++ b/kmod/awg-proxy/tests/test_transform.c
@@ -69,6 +69,13 @@ static void write32_le_host(u8 *p, u32 v)
 	memcpy(p, &le, 4);
 }
 
+static u32 read32_le_host(const u8 *p)
+{
+	__le32 le;
+	memcpy(&le, p, 4);
+	return le32_to_cpu(le);
+}
+
 /* Build a minimal awg_config_t for tests.  Zero everything first. */
 static void cfg_init(awg_config_t *cfg)
 {
@@ -579,6 +586,113 @@ static void test_xchacha20p1305_bad_aad(void)
 
 /* ---------- Main ---------- */
 
+/* ---------- AWG 3.0 header protection (hp_crypt / hp_peek_type) ---------- */
+
+static void cfg_init_hp(awg_config_t *cfg)
+{
+	cfg_init(cfg);
+	for (int i = 0; i < 32; i++)
+		cfg->hp_key[i] = (u8)(0x10 + i);
+	cfg->hp_key_set = 1;
+}
+
+/* Encrypt then decrypt (XOR is its own inverse) restores the whole handshake
+ * message; the padding prefix (the nonce) is never touched. */
+static void test_hp_handshake_roundtrip(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + WG_INIT_SIZE], orig[12 + WG_INIT_SIZE];
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	for (unsigned i = 0; i < sizeof(pkt); i++)
+		pkt[i] = (u8)(0x30 + i);
+	memcpy(orig, pkt, sizeof(pkt));
+
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+	if (memcmp(pkt, orig, 12) != 0)
+		test_fail("hp_handshake_roundtrip", "padding/nonce was modified");
+	if (memcmp(pkt + 12, orig + 12, WG_INIT_SIZE) == 0)
+		test_fail("hp_handshake_roundtrip", "message was not encrypted");
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+	if (memcmp(pkt, orig, sizeof(pkt)) != 0)
+		test_fail("hp_handshake_roundtrip", "decrypt did not restore message");
+}
+
+/* Transport encrypts ONLY the 16-byte header; the AEAD payload stays cleartext. */
+static void test_hp_transport_scope(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + 60], orig[12 + 60];
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	for (unsigned i = 0; i < sizeof(pkt); i++)
+		pkt[i] = (u8)(0x30 + i);
+	memcpy(orig, pkt, sizeof(pkt));
+
+	hp_crypt(&cfg, pkt, 12, 60, WG_TRANSPORT_DATA);
+	if (memcmp(pkt + 12, orig + 12, 16) == 0)
+		test_fail("hp_transport_scope", "16-byte header not encrypted");
+	if (memcmp(pkt + 12 + 16, orig + 12 + 16, 60 - 16) != 0)
+		test_fail("hp_transport_scope", "payload past the header was modified");
+}
+
+/* hp_peek_type recovers the plaintext type of an encrypted candidate without
+ * mutating the packet (used for size+H dispatch on ingress). */
+static void test_hp_peek_type(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + WG_INIT_SIZE], before[12 + WG_INIT_SIZE];
+	const u32 htype = 0x000003e8; /* 1000 */
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	memset(pkt, 0, sizeof(pkt));
+	for (int i = 0; i < 12; i++)
+		pkt[i] = (u8)(0xA0 + i);
+	pkt[12] = 0xe8; pkt[13] = 0x03; /* type=1000 LE in the message */
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+	memcpy(before, pkt, sizeof(pkt));
+
+	if (hp_peek_type(&cfg, pkt, 12) != htype)
+		test_fail("hp_peek_type", "recovered type mismatch");
+	if (memcmp(pkt, before, sizeof(pkt)) != 0)
+		test_fail("hp_peek_type", "hp_peek_type mutated the packet");
+}
+
+/* End-to-end ingress: an encrypted init (H1-remapped type) is detected,
+ * decrypted, and restored to WG_HANDSHAKE_INIT by transform_inbound. */
+static void test_transform_inbound_hp(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + WG_INIT_SIZE];
+	int out_len = 0;
+	u8 *msg;
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	cfg.s1 = 12; cfg.s2 = 12; cfg.s3 = 12; cfg.s4 = 12;
+	cfg.h1.min = 1000; cfg.h1.max = 1000;
+	for (int i = 0; i < 32; i++)
+		cfg.client_pub[i] = (u8)(i + 1);
+	config_compute(&cfg);
+
+	memset(pkt, 0, sizeof(pkt));
+	for (int i = 0; i < 12; i++)
+		pkt[i] = (u8)(0xB0 + i);
+	write32_le_host(pkt + 12, 1000);        /* H1-remapped type on the wire */
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+
+	msg = transform_inbound(pkt, cfg.init_total, &cfg, &out_len);
+	if (!msg)
+		test_fail("transform_inbound_hp", "encrypted init not recognized");
+	else if (out_len != WG_INIT_SIZE)
+		test_fail("transform_inbound_hp", "wrong out_len %d", out_len);
+	else if (read32_le_host(msg) != WG_HANDSHAKE_INIT)
+		test_fail("transform_inbound_hp", "type not restored to WG init");
+}
+
 int main(void)
 {
 	test_s4_random_fill();
@@ -595,6 +709,10 @@ int main(void)
 	test_mac2_non_handshake_noop();
 	test_xchacha20p1305_known_answer();
 	test_xchacha20p1305_bad_aad();
+	test_hp_handshake_roundtrip();
+	test_hp_transport_scope();
+	test_hp_peek_type();
+	test_transform_inbound_hp();
 
 	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
 	return tests_failed == 0 ? 0 : 1;

--- a/kmod/awg-proxy/tests/test_transform.c
+++ b/kmod/awg-proxy/tests/test_transform.c
@@ -693,6 +693,83 @@ static void test_transform_inbound_hp(void)
 		test_fail("transform_inbound_hp", "type not restored to WG init");
 }
 
+/* ---------- AWG 3.1 random trailers ---------- */
+
+/* With random_trailers, transform_inbound accepts an over-long handshake
+ * (message + cleartext trailer) and strips the trailer back to the fixed size. */
+static void test_transform_inbound_rt_strips_trailer(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + WG_INIT_SIZE + 20];
+	int out_len = 0;
+	u8 *msg;
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	cfg.s1 = 12; cfg.s2 = 12; cfg.s3 = 12; cfg.s4 = 12;
+	cfg.h1.min = 1000; cfg.h1.max = 1000;
+	cfg.random_trailers = 1;
+	config_compute(&cfg);
+
+	memset(pkt, 0, sizeof(pkt));
+	for (int i = 0; i < 12; i++)
+		pkt[i] = (u8)(0xB0 + i);
+	write32_le_host(pkt + 12, 1000);
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+	for (int i = 0; i < 20; i++)            /* cleartext trailer */
+		pkt[12 + WG_INIT_SIZE + i] = (u8)(0xEE ^ i);
+
+	msg = transform_inbound(pkt, 12 + WG_INIT_SIZE + 20, &cfg, &out_len);
+	if (!msg)
+		test_fail("rt_strips_trailer", "over-long init not accepted under RT");
+	else if (out_len != WG_INIT_SIZE)
+		test_fail("rt_strips_trailer", "trailer not stripped: out_len=%d", out_len);
+	else if (read32_le_host(msg) != WG_HANDSHAKE_INIT)
+		test_fail("rt_strips_trailer", "type not restored");
+}
+
+/* Without random_trailers, an over-long handshake is NOT accepted as a
+ * handshake (exact-size dispatch), so the H1 candidate does not match. */
+static void test_transform_inbound_no_rt_rejects_trailer(void)
+{
+	awg_config_t cfg;
+	u8 pkt[12 + WG_INIT_SIZE + 20];
+	int out_len = 0;
+	u8 *msg;
+
+	tests_run++;
+	cfg_init_hp(&cfg);
+	cfg.s1 = 12; cfg.s2 = 12; cfg.s3 = 12; cfg.s4 = 12;
+	cfg.h1.min = 1000; cfg.h1.max = 1000;
+	cfg.random_trailers = 0;               /* RT disabled */
+	config_compute(&cfg);
+
+	memset(pkt, 0, sizeof(pkt));
+	write32_le_host(pkt + 12, 1000);
+	hp_crypt(&cfg, pkt, 12, WG_INIT_SIZE, WG_HANDSHAKE_INIT);
+
+	msg = transform_inbound(pkt, 12 + WG_INIT_SIZE + 20, &cfg, &out_len);
+	if (msg && out_len == WG_INIT_SIZE)
+		test_fail("no_rt_rejects_trailer", "over-long init accepted without RT");
+}
+
+static void test_trailer_len_bounds(void)
+{
+	int i, r;
+
+	tests_run++;
+	shim_set_random_seed(0x9911);
+	for (i = 0; i < 200; i++) {
+		r = awg_trailer_len(500, 160);
+		if (r < 0 || r >= 500 - 160)
+			test_fail("trailer_len_bounds", "out of [0,340): %d", r);
+	}
+	if (awg_trailer_len(100, 160) != 0)
+		test_fail("trailer_len_bounds", "window<=size must yield 0");
+	if (awg_trailer_len(160, 160) != 0)
+		test_fail("trailer_len_bounds", "window==size must yield 0");
+}
+
 int main(void)
 {
 	test_s4_random_fill();
@@ -713,6 +790,9 @@ int main(void)
 	test_hp_transport_scope();
 	test_hp_peek_type();
 	test_transform_inbound_hp();
+	test_transform_inbound_rt_strips_trailer();
+	test_transform_inbound_no_rt_rejects_trailer();
+	test_trailer_len_bounds();
 
 	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
 	return tests_failed == 0 ? 0 : 1;

--- a/kmod/awg-proxy/tests/test_tunnel.c
+++ b/kmod/awg-proxy/tests/test_tunnel.c
@@ -322,6 +322,49 @@ static void test_endpoint_parse_del_forms(void)
 		    "token without ':' must be rejected");
 }
 
+/* AWG 3.1: header-protection key (64-hex → 32 bytes) enables header protection;
+ * S1-S4 must be >= 12 (the first 12 padding bytes are the ChaCha20 nonce). */
+static void test_accepts_header_protection_key(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	memset(&cfg, 0, sizeof(cfg));
+	ret = awg_config_parse("203.0.113.1:51820 "
+		"HP_KEY=0102030405060708090a0b0c0d0e0f10"
+		"1112131415161718191a1b1c1d1e1f20 "
+		"S1=12 S2=12 S3=12 S4=12", &cfg);
+	ASSERT_TRUE("accepts_header_protection_key", ret == 0, "valid HP_KEY must parse");
+	ASSERT_TRUE("accepts_header_protection_key", cfg.hp_key_set, "hp_key_set must be true");
+	ASSERT_TRUE("accepts_header_protection_key", cfg.hp_key[0] == 0x01 && cfg.hp_key[31] == 0x20,
+		    "hp_key bytes must decode from hex");
+}
+
+static void test_accepts_random_trailers_flag(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	memset(&cfg, 0, sizeof(cfg));
+	ret = awg_config_parse("203.0.113.1:51820 RT=1", &cfg);
+	ASSERT_TRUE("accepts_random_trailers_flag", ret == 0, "RT=1 must parse");
+	ASSERT_TRUE("accepts_random_trailers_flag", cfg.random_trailers, "random_trailers must be set");
+}
+
+static void test_rejects_hp_with_short_padding(void)
+{
+	awg_config_t cfg;
+	int ret;
+
+	memset(&cfg, 0, sizeof(cfg));
+	ret = awg_config_parse("203.0.113.1:51820 "
+		"HP_KEY=0102030405060708090a0b0c0d0e0f10"
+		"1112131415161718191a1b1c1d1e1f20 "
+		"S1=8 S2=12 S3=12 S4=12", &cfg);
+	ASSERT_TRUE("rejects_hp_with_short_padding", ret != 0,
+		    "S1<12 with header protection must be rejected (nonce needs 12 bytes)");
+}
+
 int main(void)
 {
 	test_accepts_non_overlapping_h_ranges();
@@ -340,6 +383,9 @@ int main(void)
 	test_rejects_bare_ipv6_endpoint();
 	test_rejects_malformed_bracket_endpoints();
 	test_endpoint_parse_del_forms();
+	test_accepts_header_protection_key();
+	test_accepts_random_trailers_flag();
+	test_rejects_hp_with_short_padding();
 
 	printf("\n=== %d run, %d failed ===\n", tests_run, tests_failed);
 	return tests_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## AmneziaWG 3.1 for NativeWG (via awg_proxy)

Brings AWG 3.1 interop to **NativeWG** tunnels. NativeWG has two sub-paths: Keenetic's native ASC firmware (capped at AWG 2.0, not ours) and our own `awg_proxy.ko` packet transform. This PR extends **`awg_proxy`** — the only NativeWG path we control — so a NativeWG tunnel can talk to an AmneziaWG 3.1 server.

The AWG 3.1 delta over 2.0 is **header protection** (ChaCha20 over the WG header) + **random trailers**. Both are pure packet transforms a keyless proxy can do; the byte-level spec was cross-validated against `amneziawg-go` `v3.1.20260814` and matches `timbrs/amneziawg-mikrotik-c` (which ships 3.1 the same keyless-proxy way).

### What's included
**kmod (`awg_proxy` → 1.4.0)**
- `awg_chacha20_xor`: raw IETF ChaCha20 keystream, reusing the vetted ChaCha20 core already in `cookie.c` (no new crypto).
- Header protection: whole message for handshakes / 16-byte header for transport; key = `HeaderProtectionKey` used directly; nonce = the first 12 on-wire padding bytes; counter 0. Egress encrypts **after** MAC1/MAC2 (HP wraps the MACs); ingress recovers the type via keystream then decrypts on the H-range match. Enforces `S1–S4 ≥ 12` (nonce length).
- Random trailers: ingress accepts + strips over-long handshakes; egress appends a cleartext trailer sized from a per-slot adaptive `udp_window` (seeded 500, grows to the real datagram envelope). Transport is untouched (its padding would need to be inside the AEAD).
- Config via `/proc/awg_proxy/add`: new `HP_KEY=<64hex>` / `RT=1` tokens.

**Go / API / UI**
- `nwg`: thread `HeaderProtectionKey` + `RandomTrailers` from `storage.AWGObfuscation` into `KmodConfig` → `buildProcLine`; clamp `S<12→12` under HP.
- `systemInfo.awgProxyVersion` exposes the loaded `/proc/awg_proxy/version`.
- Frontend `supportsAwg31Proxy(awgProxyVersion >= 1.4.0)` un-gates the awg3 editor for NativeWG, showing **only header protection + RandomTrailers** (a new `awg3Limited` flag hides the kernel-only timers/content-padding, which a proxy can't do).

### Scope / non-goals
- `content_padding_addition` and the configurable timers stay **kernel-only** — they're inside the AEAD / in the WG state machine, out of reach for a keyless proxy. They're transparent/local, so they don't block interop.
- The NDMS-native-ASC path is untouched (stays ≤ 2.0). AWG 3.1 flows only through the proxy.

### Testing
- **kmod host suite** (`kmod/awg-proxy/tests`): header-protection encrypt/decrypt vs an **independent OpenSSL golden vector** (3 blocks), round-trip + scope (handshake whole-msg vs transport 16B), non-mutating ingress peek, RT accept/strip, `S≥12` reject, trailer-length bounds.
- **Compiles against the real Keenetic 4.9-ndm aarch64 kernel** (SDK, KN-3812): `awg_proxy.ko` builds with matching `vermagic=4.9-ndm-5 ... aarch64` and no new warnings — validates `proxy.c`, the part host tests can't reach.
- Go (`nwg`/`api`/`config`) + frontend (1630) suites green.

### Remaining (not in this PR)
**On-hardware validation** — `insmod` the rebuilt 1.4.0 `awg_proxy.ko` on a real router and complete a handshake + transport against a live `amneziawg-go` 3.1 server. The maintainer rebuilds/ships the `.ko` (the SDK build is verified working); the software gates itself on the 1.4.0 proxy version until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
