### PR TITLE
предикат занятости номера OpkgTun

### DIFF
--- a/internal/storage/opkgtun.go
+++ b/internal/storage/opkgtun.go
@@ -1,0 +1,44 @@
+package storage
+
+import "github.com/hoaxisr/awg-manager/internal/tunnel"
+
+// OpkgTunIndex — номер OpkgTun, который занимает эта запись, и признак того,
+// занимает ли она его вообще.
+//
+// Единственный источник номера — tunnel.OpkgTunIndexOf поверх NewNames, то есть
+// та же функция, что строит имя интерфейса. Своего разбора идентификатора здесь
+// нет намеренно: он разошёлся бы с реальностью на клиентских ID, которые ручка
+// создания принимает как есть.
+//
+// Номер не занимают:
+//   - nativewg — живёт как Wireguard<N>, OpkgTun не создаёт; его идентификатор
+//     awg<N> занимает пространство ИДЕНТИФИКАТОРОВ, но не номеров интерфейсов
+//     (легаси-записи такого рода лежат и в kernel-диапазоне awg10..16);
+//   - wdtt-raw — номер приходит от своей подсистемы и хранится в RawNdmsIface,
+//     а из идентификатора вида "wdttraw-<клиент>" вывелся бы ложный ноль;
+//   - записи без NDMS-имени (OS 4.x, awgm<N>).
+//
+// Пустой Backend считается kernel — так же его трактуют nextAvailableID и
+// рантайм-диспатч по бэкенду.
+func (t AWGTunnel) OpkgTunIndex() (int, bool) {
+	switch t.Backend {
+	case "nativewg", "wdtt-raw":
+		return 0, false
+	}
+	return tunnel.OpkgTunIndexOf(t.ID)
+}
+
+// OpkgTunIndicesOf — номера OpkgTun, занятые набором записей.
+//
+// Пустая карта означает «занятых нет». Отличать это от «не смогли посмотреть»
+// обязан вызывающий: перечисление записей может отказать, и тогда занятость
+// неизвестна — выдавать по ней номер нельзя.
+func OpkgTunIndicesOf(tunnels []AWGTunnel) map[int]bool {
+	indices := make(map[int]bool, len(tunnels))
+	for _, t := range tunnels {
+		if idx, ok := t.OpkgTunIndex(); ok {
+			indices[idx] = true
+		}
+	}
+	return indices
+}

--- a/internal/storage/opkgtun_test.go
+++ b/internal/storage/opkgtun_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import "testing"
+
+func TestAWGTunnelOpkgTunIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		tunnel  AWGTunnel
+		wantIdx int
+		wantOK  bool
+	}{
+		{"kernel", AWGTunnel{ID: "awg12", Backend: "kernel"}, 12, true},
+		{"пустой backend — legacy kernel", AWGTunnel{ID: "awg13"}, 13, true},
+		{"nativewg в своём диапазоне", AWGTunnel{ID: "awg25", Backend: "nativewg"}, 0, false},
+		{"legacy nativewg в kernel-диапазоне", AWGTunnel{ID: "awg12", Backend: "nativewg"}, 0, false},
+		{"raw-клиент wdtt", AWGTunnel{ID: "wdttraw-home", Backend: "wdtt-raw"}, 0, false},
+		{"OS4-запись", AWGTunnel{ID: "awgm5", Backend: "kernel"}, 0, false},
+		{"клиентский ID", AWGTunnel{ID: "home4", Backend: "kernel"}, 4, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := tt.tunnel.OpkgTunIndex()
+			if ok != tt.wantOK {
+				t.Fatalf("OpkgTunIndex() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && idx != tt.wantIdx {
+				t.Errorf("OpkgTunIndex() = %d, want %d", idx, tt.wantIdx)
+			}
+		})
+	}
+}
+
+func TestOpkgTunIndicesOf(t *testing.T) {
+	tunnels := []AWGTunnel{
+		{ID: "awg10", Backend: "kernel"},
+		{ID: "awg13"},                             // legacy kernel
+		{ID: "awg25", Backend: "nativewg"},        // номер не занимает
+		{ID: "wdttraw-home", Backend: "wdtt-raw"}, // номер живёт в RawNdmsIface
+		{ID: "awgm5", Backend: "kernel"},          // OS4, NDMS-имени нет
+	}
+
+	got := OpkgTunIndicesOf(tunnels)
+
+	want := map[int]bool{10: true, 13: true}
+	if len(got) != len(want) {
+		t.Fatalf("OpkgTunIndicesOf() = %v, want %v", got, want)
+	}
+	for idx := range want {
+		if !got[idx] {
+			t.Errorf("номер %d должен быть занят, got %v", idx, got)
+		}
+	}
+}
+
+// Пустая выдача при пустом входе — отдельный случай: аллокатор обязан отличать
+// «занятых нет» от «не смогли посмотреть», и второе выражается ошибкой у
+// поставщика, а не пустой картой здесь.
+func TestOpkgTunIndicesOfEmpty(t *testing.T) {
+	if got := OpkgTunIndicesOf(nil); len(got) != 0 {
+		t.Errorf("OpkgTunIndicesOf(nil) = %v, want пустую карту", got)
+	}
+}

--- a/internal/tunnel/opkgtun_index.go
+++ b/internal/tunnel/opkgtun_index.go
@@ -1,0 +1,28 @@
+package tunnel
+
+import "strconv"
+
+// OpkgTunIndexOf — номер OpkgTun, который получит туннель с этим идентификатором.
+//
+// Номер выводится из NewNames — той же функции, что СТРОИТ имя интерфейса, —
+// поэтому предикат не может разойтись с реальностью: если NewNames построит
+// OpkgTun4, здесь вернётся 4. Собственный разбор идентификатора был бы четвёртой
+// копией правила и слепым к клиентским ID: ручка создания принимает любой
+// идентификатор вида [a-zA-Z][a-zA-Z0-9_-]{0,31}, а extractTunnelNum берёт хвост
+// с первой цифры и подставляет "0", если цифр нет.
+//
+// false означает, что номер не занят: NDMS-имени нет (OS 4.x, awgm<N>).
+// ВНИМАНИЕ: по идентификатору нельзя отсеять nativewg и raw-клиентов wdtt —
+// у них номер либо не в идентификаторе, либо не в пространстве OpkgTun. Это
+// делает вызывающий по backend записи (storage.AWGTunnel.OpkgTunIndex).
+func OpkgTunIndexOf(tunnelID string) (int, bool) {
+	names := NewNames(tunnelID)
+	if names.NDMSName == "" {
+		return 0, false
+	}
+	num, err := strconv.Atoi(names.TunnelNum)
+	if err != nil {
+		return 0, false
+	}
+	return num, true
+}

--- a/internal/tunnel/opkgtun_index_test.go
+++ b/internal/tunnel/opkgtun_index_test.go
@@ -1,0 +1,67 @@
+package tunnel
+
+import "testing"
+
+func TestOpkgTunIndexOf(t *testing.T) {
+	tests := []struct {
+		name     string
+		tunnelID string
+		wantIdx  int
+		wantOK   bool
+	}{
+		{"kernel-диапазон", "awg12", 12, true},
+		{"legacy-нумерация", "awg0", 0, true},
+		{"nativewg-диапазон по ID", "awg25", 25, true},
+		{"OS4 без NDMS-имени", "awgm5", 0, false},
+		{"OS4 нулевой", "awgm0", 0, false},
+		{"клиентский ID с цифрой", "home4", 4, true},
+		{"клиентский ID без цифр", "myvpn", 0, true},
+		// Фолбэк extractTunnelNum даёт "0" на любом ID без цифр — отсев
+		// raw-клиентов и nativewg возможен только по backend, не по имени.
+		{"raw-клиент wdtt", "wdttraw-home", 0, true},
+		{"пустой ID", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := OpkgTunIndexOf(tt.tunnelID)
+			if ok != tt.wantOK {
+				t.Fatalf("OpkgTunIndexOf(%q) ok = %v, want %v", tt.tunnelID, ok, tt.wantOK)
+			}
+			if ok && idx != tt.wantIdx {
+				t.Errorf("OpkgTunIndexOf(%q) = %d, want %d", tt.tunnelID, idx, tt.wantIdx)
+			}
+		})
+	}
+}
+
+// Предикат обязан совпадать с NewNames: имя строит она, и расхождение означало
+// бы, что аллокатор считает свободным номер, который занят живым интерфейсом.
+func TestOpkgTunIndexOfMatchesNewNames(t *testing.T) {
+	ids := []string{"awg0", "awg10", "awg16", "awg25", "awgm3", "home4", "myvpn", "wdttraw-x"}
+
+	for _, id := range ids {
+		idx, ok := OpkgTunIndexOf(id)
+		ndmsName := NewNames(id).NDMSName
+
+		if ok != (ndmsName != "") {
+			t.Errorf("%q: ok = %v, а NDMSName = %q", id, ok, ndmsName)
+			continue
+		}
+		if ok && ndmsName != "OpkgTun"+itoa(idx) {
+			t.Errorf("%q: индекс %d не сходится с именем %q", id, idx, ndmsName)
+		}
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}


### PR DESCRIPTION
Наша половина контракта занятости номеров OpkgTun, согласованного с веткой
`feature/proxy-runtime-core` (решения Р1, Р2 в `finding-opkgtun-shared-pool.md`).

`internal/tunnel.OpkgTunIndexOf` выводит номер из `NewNames` — той же функции,
что строит имя интерфейса. Своего разбора идентификатора нет намеренно: ручка
создания принимает клиентский `req.ID`, а `extractTunnelNum` берёт хвост с
первой цифры с фолбэком в ноль, поэтому строгий разбор `awg<число>` ошибался бы
в запрещённую сторону — считал бы занятый номер свободным.

`storage.AWGTunnel.OpkgTunIndex` фильтрует по backend: `nativewg` живёт как
`Wireguard<N>`, у `wdtt-raw` номер лежит в `RawNdmsIface`. Пустой `Backend` —
kernel, как его трактуют `nextAvailableID` и рантайм-диспатч.

Вызывающих пока нет: `nextAvailableID` переводится на общий источник отдельно,
после того как в develop появится строгое чтение хранилища.

Проверка: таблица на девять случаев, страж «предикат совпадает с NewNames»,
три мутации (снятие отсева wdtt-raw даёт ложный ноль; пустой backend перестаёт
быть kernel; снятие проверки пустого NDMS-имени тянет в занятость OS4-запись) —
все пойманы. Железо не задействовано: вызывающих нет.