### PR TITLE
OS5-оператор не обслуживает записи от KeeneticOS 4.x

### DIFF
--- a/internal/tunnel/ops/operator_os5.go
+++ b/internal/tunnel/ops/operator_os5.go
@@ -37,6 +37,17 @@ func opkgTunExists(ctx context.Context, q *query.Queries, name string) bool {
 // - "10.0.0.2"    → ("10.0.0.2", "255.255.255.255")  (defaults to /32)
 // Returns the original input as-is if parsing fails (best-effort; caller
 // validates elsewhere).
+// errOS4Tunnel — отказ обслуживать запись, оставшуюся от KeeneticOS 4.x.
+//
+// У идентификаторов awgm<N> NewNames не строит NDMS-имени, а весь путь OS 5.x
+// стоит на OpkgTun: пустое имя уезжало в RCI идентификатором интерфейса. Само
+// такое состояние не чинится — прошивка обновилась, а запись осталась в старом
+// формате, поэтому текст называет пользователю его действие.
+func errOS4Tunnel(op, tunnelID string) error {
+	return tunnel.NewOpError(op, tunnelID, "ndms",
+		fmt.Errorf("туннель создан на KeeneticOS 4.x — удалите его и импортируйте конфиг заново"))
+}
+
 func splitAddressMask(addr string) (string, string) {
 	if addr == "" {
 		return "", ""
@@ -263,6 +274,10 @@ func (o *OperatorOS5Impl) Start(ctx context.Context, cfg tunnel.Config) error {
 // Used for: BootReady, NotCreated, Broken.
 func (o *OperatorOS5Impl) ColdStart(ctx context.Context, cfg tunnel.Config) error {
 	names := tunnel.NewNames(cfg.ID)
+
+	if names.NDMSName == "" {
+		return errOS4Tunnel("start", cfg.ID)
+	}
 
 	// Validate config
 	if err := cfg.Validate(); err != nil {
@@ -569,9 +584,15 @@ func (o *OperatorOS5Impl) Delete(ctx context.Context, stored *storage.AWGTunnel)
 	// 2. Remove NDMS interface — cleans everything:
 	//    address, MTU, security-level, ip global, default route, DNS name-servers
 	// DeleteOpkgTun triggers conf: disabled hook before removal.
-	o.expectHook(names.NDMSName, "disabled")
-	if err := o.commands.Interfaces.DeleteOpkgTun(ctx, names.NDMSName); err != nil {
-		o.logWarn("delete", stored.ID, "DeleteOpkgTun: "+err.Error())
+	//
+	// У записи от KeeneticOS 4.x NDMS-имени нет: удалять в NDMS нечего, а пустая
+	// строка уехала бы в RCI идентификатором интерфейса. Пропускаем шаг, но не
+	// отказываем — иначе такой туннель нельзя удалить, то есть и пересоздать.
+	if names.NDMSName != "" {
+		o.expectHook(names.NDMSName, "disabled")
+		if err := o.commands.Interfaces.DeleteOpkgTun(ctx, names.NDMSName); err != nil {
+			o.logWarn("delete", stored.ID, "DeleteOpkgTun: "+err.Error())
+		}
 	}
 
 	// 3. Remove kernel interface (our amneziawg — NDMS can't delete what we created)
@@ -627,6 +648,10 @@ func (o *OperatorOS5Impl) Recover(ctx context.Context, tunnelID string, state tu
 // Assumes: process is running, interface exists. Re-applies WG config, NDMS, routing, firewall.
 func (o *OperatorOS5Impl) Reconcile(ctx context.Context, cfg tunnel.Config) error {
 	names := tunnel.NewNames(cfg.ID)
+
+	if names.NDMSName == "" {
+		return errOS4Tunnel("reconcile", cfg.ID)
+	}
 
 	o.logInfo("reconcile", cfg.ID, "Reconciling NDMS state around running process")
 	o.appLog.Info("reconcile", cfg.ID, "Восстановление конфигурации NDMS")

--- a/internal/tunnel/ops/operator_os5_awgm_test.go
+++ b/internal/tunnel/ops/operator_os5_awgm_test.go
@@ -1,0 +1,83 @@
+package ops
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
+	"github.com/hoaxisr/awg-manager/internal/tunnel"
+)
+
+// Запись awgm<N> осталась от KeeneticOS 4.x: NewNames не даёт ей NDMS-имени.
+// До гейта операторы уносили пустую строку прямо в RCI как идентификатор
+// интерфейса. Здесь queries и commands — nil, поэтому любое обращение к NDMS
+// упало бы паникой: тест краснеет и на снятом гейте, и на попытке обойти его
+// сбоку.
+func newOS5ForAWGM() *OperatorOS5Impl {
+	return NewOperatorOS5(nil, nil, &MockWGClient{}, &MockBackend{}, &MockFirewall{})
+}
+
+func awgmConfig() tunnel.Config {
+	return tunnel.Config{
+		ID:      "awgm5",
+		Name:    "legacy",
+		Address: "10.8.0.2/24",
+		MTU:     1420,
+	}
+}
+
+func TestOS5ColdStartRejectsOS4Tunnel(t *testing.T) {
+	o := newOS5ForAWGM()
+	backend := o.backend.(*MockBackend)
+	o.ipRun = mockIPRun
+
+	err := o.ColdStart(context.Background(), awgmConfig())
+	if err == nil {
+		t.Fatal("ColdStart для awgm-записи обязан отказать, got nil")
+	}
+	if !strings.Contains(err.Error(), "4.x") {
+		t.Errorf("ошибка должна называть причину, got: %v", err)
+	}
+	if len(backend.StartCalls) != 0 {
+		t.Errorf("интерфейс не должен подниматься: %v", backend.StartCalls)
+	}
+}
+
+func TestOS5ReconcileRejectsOS4Tunnel(t *testing.T) {
+	o := newOS5ForAWGM()
+	backend := o.backend.(*MockBackend)
+	o.ipRun = mockIPRun
+
+	err := o.Reconcile(context.Background(), awgmConfig())
+	if err == nil {
+		t.Fatal("Reconcile для awgm-записи обязан отказать, got nil")
+	}
+	if len(backend.StartCalls) != 0 {
+		t.Errorf("интерфейс не должен подниматься: %v", backend.StartCalls)
+	}
+}
+
+// Удаление обязано пройти: без него миграционное действие пользователя —
+// «удалите и импортируйте конфиг заново» — невыполнимо.
+func TestOS5DeleteSkipsNDMSForOS4Tunnel(t *testing.T) {
+	o := newOS5ForAWGM()
+	rec := &ipRunRecorder{}
+	o.ipRun = rec.run
+
+	stored := &storage.AWGTunnel{ID: "awgm5", Name: "legacy"}
+
+	if err := o.Delete(context.Background(), stored); err != nil {
+		t.Fatalf("Delete обязан пройти без NDMS, got: %v", err)
+	}
+
+	var deletedLink bool
+	for _, call := range rec.Calls {
+		if strings.Contains(call, "link del dev awgm5") {
+			deletedLink = true
+		}
+	}
+	if !deletedLink {
+		t.Errorf("kernel-интерфейс должен быть снят, вызовы: %v", rec.Calls)
+	}
+}


### PR DESCRIPTION
У идентификаторов `awgm<N>` `NewNames` не строит NDMS-имени, и пустая строка
уезжала в RCI идентификатором интерфейса — при создании в `ColdStart` и
`Reconcile`, при сносе в `Delete`. Сценарий боевой: при апгрейде прошивки
4.x → 5.x такие записи остаются в хранилище.

Создание и сверка отказывают с текстом, который называет действие пользователя.
Удаление, наоборот, пропускает шаг NDMS и проходит — иначе такой туннель нельзя
удалить, то есть и пересоздать.

Проверка: три теста с `nil` вместо NDMS-зависимостей — до фикса падали настоящей
паникой на `CreateOpkgTun` с пустым именем.

Приёмка на стенде (5.01.C.3.0-1, mipsel) пройдена:
- включение подложенной записи `awgm5` даёт нужный текст в ответе ручки и в журнале;
- в `/sys/class/net` мусорного интерфейса не появилось;
- удаление прошло, `verified:true`, запись исчезла;
- регресс: `awg10` остановлен и поднят через общий `ColdStart` — вернулся в
  running со свежим хэндшейком и трафиком; `Reconcile` проверился попутно.

Не покрыто: автоподъём на загрузке объясняет причину только в журнале — в списке
туннель выглядит неработающим без пояснения. Решено не закрывать: причина видна
по первому клику «включить».