### PR TITLE
явный идентификатор при создании проверяется занятостью

### DIFF
--- a/internal/api/tunnels_create_id_test.go
+++ b/internal/api/tunnels_create_id_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func createBody(id string) string {
+	idField := ""
+	if id != "" {
+		idField = `"id":"` + id + `",`
+	}
+	return `{` + idField + `"name":"t","type":"awg","backend":"kernel",
+		"interface":{"privateKey":"CA9lE1yLCcziI8Oq0dXDYr3QtdzFCEsKYw8sxAQ132o=","address":"10.9.0.2/32","mtu":1280},
+		"peer":{"publicKey":"hOPHc7ZBk0dGrLLDFrCG7WHYzZ8SS5xBWMzOJ9CkNFo=","endpoint":"192.0.2.1:51820","allowedIPs":["0.0.0.0/0"]}}`
+}
+
+func postCreate(t *testing.T, h *TunnelsHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/tunnels/create", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.Create(rec, req)
+	return rec
+}
+
+// Идентификатор, присланный клиентом, задаёт номер интерфейса ровно так же, как
+// сгенерированный, поэтому обязан проходить ту же проверку занятости. Иначе
+// запись создастся на номере, который держит чужая подсистема, и первое же
+// включение усыновит её интерфейс.
+func TestCreate_ExplicitIDRejectedWhenIndexTaken(t *testing.T) {
+	h, _ := newTunnelsUpdateHarness(t, &stubTunnelSvc{})
+	h.SetOpkgTunOccupancy(func(context.Context) (map[int]bool, error) {
+		return map[int]bool{12: true}, nil
+	})
+
+	rec := postCreate(t, h, createBody("awg12"))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("занятый номер обязан давать 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "12") {
+		t.Errorf("ответ должен называть занятый номер, got %s", rec.Body.String())
+	}
+}
+
+func TestCreate_ExplicitIDAcceptedWhenIndexFree(t *testing.T) {
+	h, store := newTunnelsUpdateHarness(t, &stubTunnelSvc{})
+	h.SetOpkgTunOccupancy(func(context.Context) (map[int]bool, error) {
+		return map[int]bool{12: true}, nil
+	})
+
+	rec := postCreate(t, h, createBody("awg13"))
+
+	// До конца создание в тесте не доходит: хендлер пишет .conf по
+	// захардкоженному пути, куда здесь нет прав. Проверяем то, что нас
+	// касается — свободный номер не отвергнут проверкой занятости.
+	if rec.Code == http.StatusConflict {
+		t.Fatalf("свободный номер не должен отвергаться: %s", rec.Body.String())
+	}
+	_ = store
+}
+
+// Клиентский идентификатор без цифр всё равно получает номер интерфейса —
+// extractTunnelNum подставляет ноль. Проверка обязана смотреть на этот номер,
+// а не на текст идентификатора.
+func TestCreate_ExplicitCustomIDUsesDerivedIndex(t *testing.T) {
+	h, _ := newTunnelsUpdateHarness(t, &stubTunnelSvc{})
+	h.SetOpkgTunOccupancy(func(context.Context) (map[int]bool, error) {
+		return map[int]bool{0: true}, nil
+	})
+
+	rec := postCreate(t, h, createBody("myvpn"))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("идентификатор без цифр займёт нулевой номер — он занят, ожидался 409, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// nativewg номеров OpkgTun не занимает: спрашивать занятость незачем, и отказ
+// источника не должен мешать созданию.
+func TestCreate_ExplicitIDNativeWGSkipsOccupancy(t *testing.T) {
+	h, _ := newTunnelsUpdateHarness(t, &stubTunnelSvc{})
+	h.SetOpkgTunOccupancy(func(context.Context) (map[int]bool, error) {
+		t.Error("занятость не должна спрашиваться для nativewg")
+		return nil, nil
+	})
+
+	body := strings.Replace(createBody("awg25"), `"backend":"kernel"`, `"backend":"nativewg"`, 1)
+	rec := postCreate(t, h, body)
+
+	if rec.Code == http.StatusConflict {
+		t.Fatalf("nativewg не должен упираться в занятость: %s", rec.Body.String())
+	}
+}

--- a/internal/api/tunnels_crud.go
+++ b/internal/api/tunnels_crud.go
@@ -3,8 +3,10 @@ package api
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -249,6 +251,9 @@ func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	} else if !isValidTunnelID(tunnelID) {
 		response.Error(w, "invalid tunnel ID", "INVALID_ID")
 		return
+	} else if err := h.checkExplicitIDFree(r.Context(), tunnelID, req.Backend); err != nil {
+		response.ErrorWithStatus(w, http.StatusConflict, err.Error(), "INDEX_TAKEN")
+		return
 	}
 
 	// Prepare tunnel data
@@ -326,6 +331,36 @@ func (h *TunnelsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response.Success(w, resp)
+}
+
+// checkExplicitIDFree проверяет присланный клиентом идентификатор той же
+// занятостью, что и сгенерированный.
+//
+// Идентификатор задаёт номер интерфейса OpkgTun — включая клиентские вроде
+// "myvpn", которым extractTunnelNum подставляет ноль. Без этой проверки запись
+// создавалась бы на номере, который держит чужая подсистема, и первое же
+// включение усыновило бы её интерфейс: kernel-путь опознаёт свой интерфейс по
+// номеру, а не по описанию.
+//
+// nativewg не спрашивается: он живёт как Wireguard<N> и номеров OpkgTun не
+// занимает. Пустой источник занятости — тоже не отказ: явный идентификатор
+// принимали и до появления занятости, ломать это на неполной проводке незачем.
+func (h *TunnelsHandler) checkExplicitIDFree(ctx context.Context, tunnelID, backend string) error {
+	if backend == "nativewg" || h.opkgOccupancy == nil {
+		return nil
+	}
+	idx, occupies := tunnel.OpkgTunIndexOf(tunnelID)
+	if !occupies {
+		return nil
+	}
+	taken, err := h.opkgOccupancy(ctx)
+	if err != nil {
+		return fmt.Errorf("не удалось проверить занятость номеров: %w", err)
+	}
+	if taken[idx] {
+		return fmt.Errorf("номер интерфейса OpkgTun%d уже занят — выберите другой идентификатор или не задавайте его вовсе", idx)
+	}
+	return nil
 }
 
 // Update updates an existing tunnel.

--- a/internal/singbox/router/ifacealloc.go
+++ b/internal/singbox/router/ifacealloc.go
@@ -85,10 +85,16 @@ type OpkgTunIndexLister interface {
 	LiveOpkgTunIndices(ctx context.Context) (map[int]bool, error)
 }
 
-// UnionOpkgTunIndices — pure-ядро union занятых индексов OpkgTun: объединяет
-// kernel-числа из /sys/class/net (sysinfo.ListSystemInterfaces) с индексами,
-// извлечёнными из NDMS system-имён интерфейсов. Вынесено отдельно от адаптера,
-// чтобы покрыть тестом без /sys и без NDMS.
+// UnionOpkgTunIndices — pure-ядро набора занятых индексов OpkgTun: собирает
+// kernel-числа из /sys/class/net (sysinfo.ListSystemInterfaces) и индексы,
+// извлечённые из имён интерфейсов NDMS. Вынесено отдельно от адаптера, чтобы
+// покрыть тестом без /sys и без NDMS.
+//
+// Оба источника опциональны, и прод-адаптер зовёт её ДВУМЯ половинами:
+// живые интерфейсы и записи NDMS отвечают на разные вопросы и складываются не
+// здесь, а в занятости для выдачи номера (storage.OpkgTunOccupancy). Так что
+// «union» в имени — про способность сложить два источника, а не про то, что
+// каждый вызов их объединяет.
 //
 // Имена из NDMS прогоняются через sysinfo.ExtractInterfaceNumber, которая
 // заякорена (^opkgtun\d+$, ^awgm\d+$, ^awg\d+$): nwg2/Wireguard0/br0 не матчатся


### PR DESCRIPTION
Присланный клиентом `id` проходил только проверку формата, тогда как он задаёт
номер интерфейса `OpkgTun` ровно так же, как сгенерированный — включая
идентификаторы без цифр вроде `myvpn`, которым `extractTunnelNum` подставляет
ноль. Запись могла создаться на номере, который держит чужая подсистема, и
первое же включение усыновило бы её интерфейс: kernel-путь опознаёт свой
интерфейс по номеру, а не по описанию.

Теперь номер вычисляется через `tunnel.OpkgTunIndexOf` и проверяется той же
занятостью, что и при генерации. Занят — 409 с указанием номера.

Границы: `nativewg` не спрашивается (живёт как `Wireguard<N>`), незаданный
источник занятости отказом не становится — явные идентификаторы принимали и до
её появления.

Проверка: четыре теста, две мутации (nativewg платит; занятость проверяется, но
не применяется) — пойманы.

Отдельно поправлена докстрока `UnionOpkgTunIndices`: она обещала, что каждый
вызов объединяет два источника, но после разделения адаптер зовёт её двумя
половинами, а складываются они в занятости для выдачи.