### PR TITLE
снос мёртвой половины контракта операторов

### DIFF
--- a/internal/orchestrator/execute.go
+++ b/internal/orchestrator/execute.go
@@ -484,16 +484,7 @@ func (o *Orchestrator) executeRestoreEndpointTracking(ctx context.Context) error
 		}
 
 		// Restore tracking (route already exists in system)
-		isp := t.ActiveWAN
-		if isp == "" {
-			// Migration: tunnel from older version without ActiveWAN
-			if resolved, err := o.resolveWAN(ctx, t.ISPInterface); err == nil {
-				isp = resolved
-			} else {
-				o.appLog.Warn("resolve-wan", t.ID, "no stored ActiveWAN: "+err.Error())
-			}
-		}
-		ip, err := o.kernelOp.RestoreEndpointTracking(ctx, t.ID, t.Peer.Endpoint, isp)
+		ip, err := o.kernelOp.RestoreEndpointTracking(ctx, t.ID, t.Peer.Endpoint)
 		if err != nil {
 			o.appLog.Warn("restore-endpoint-tracking", t.ID, err.Error())
 			continue

--- a/internal/testing/ip.go
+++ b/internal/testing/ip.go
@@ -12,7 +12,7 @@ import (
 
 // defaultIPCheckServices is the built-in list of IP detection services.
 var defaultIPCheckServices = []IPCheckService{
-	{Label: "2ip", URL: "https://2ip.ru"},
+	{Label: "2ip", URL: "https://2ip.io"},
 	{Label: "wtfismyip", URL: "https://wtfismyip.com/text"},
 	{Label: "ipinfo", URL: "https://ipinfo.io/ip"},
 }

--- a/internal/tunnel/ops/operator.go
+++ b/internal/tunnel/ops/operator.go
@@ -22,12 +22,6 @@ type Operator interface {
 	// Used for: NotCreated, Broken, boot.
 	ColdStart(ctx context.Context, cfg tunnel.Config) error
 
-	// Start brings up an existing amneziawg interface after Stop.
-	// Interface already exists with address and WG config loaded.
-	// ip link set up + firewall.
-	// Used for: Disabled (after Stop), Dead (after PingCheck stop).
-	Start(ctx context.Context, cfg tunnel.Config) error
-
 	// Stop brings down a tunnel: kills backend process + removes firewall rules.
 	// Used for: user Stop, PingCheck dead.
 	Stop(ctx context.Context, tunnelID string) error
@@ -35,10 +29,6 @@ type Operator interface {
 	// Delete completely removes a tunnel.
 	// Receives the full stored tunnel for reliable cleanup (persisted endpoint IP, etc.).
 	Delete(ctx context.Context, stored *storage.AWGTunnel) error
-
-	// Recover attempts to bring a broken tunnel into a consistent state.
-	// Based on current state, may kill zombie processes, clean up orphaned resources, etc.
-	Recover(ctx context.Context, tunnelID string, state tunnel.StateInfo) error
 
 	// Reconcile re-applies system configuration around an already-running process.
 	// Used when the process survived a daemon restart.
@@ -72,9 +62,8 @@ type Operator interface {
 
 	// RestoreEndpointTracking restores endpoint route tracking without creating the route.
 	// Used on daemon restart for tunnels that are already running.
-	// ispInterface is the resolved ISP interface name (for dashboard display).
 	// Returns the resolved endpoint IP on success (empty string on non-fatal failure).
-	RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint, ispInterface string) (string, error)
+	RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint string) (string, error)
 
 	// GetTrackedEndpointIP returns the currently tracked endpoint IP for a tunnel.
 	// Returns empty string if no endpoint route is tracked.
@@ -96,14 +85,6 @@ type Operator interface {
 	// GetDefaultGatewayInterface returns the current default gateway interface name.
 	// Used by resolveWAN for auto-mode tunnels.
 	GetDefaultGatewayInterface(ctx context.Context) (string, error)
-
-	// GetResolvedISP returns the resolved ISP interface name for a running tunnel.
-	// For auto-mode tunnels, this is the WAN picked during SetupEndpointRoute.
-	// Returns empty string if no resolved ISP is tracked.
-	GetResolvedISP(tunnelID string) string
-
-	// HasWANIPv6 checks if a WAN interface has IPv6 connectivity via RCI.
-	HasWANIPv6(ctx context.Context, ifaceName string) bool
 
 	// GetSystemName resolves a router interface ID (e.g., "PPPoE0") to its kernel
 	// interface name (e.g., "ppp0") via RCI. Returns the ID unchanged if resolution fails.

--- a/internal/tunnel/ops/operator_os4.go
+++ b/internal/tunnel/ops/operator_os4.go
@@ -35,11 +35,6 @@ type OperatorOS4Impl struct {
 	firewall firewall.Manager
 	appLog   *logging.ScopedLogger
 
-	// Resolved ISP tracking (tunnelID -> WAN interface name)
-	// Tracks which WAN each tunnel is bound to for WAN event matching.
-	resolvedISP   map[string]string
-	resolvedISPMu sync.RWMutex
-
 	// DNS tracking (tunnelID -> DNS servers applied via NDMS)
 	appliedDNS   map[string][]string
 	appliedDNSMu sync.RWMutex
@@ -54,13 +49,12 @@ func NewOperatorOS4(
 	firewallMgr firewall.Manager,
 ) *OperatorOS4Impl {
 	o := &OperatorOS4Impl{
-		queries:     queries,
-		commands:    commands,
-		wg:          wgClient,
-		backend:     backendImpl,
-		firewall:    firewallMgr,
-		resolvedISP: make(map[string]string),
-		appliedDNS:  make(map[string][]string),
+		queries:    queries,
+		commands:   commands,
+		wg:         wgClient,
+		backend:    backendImpl,
+		firewall:   firewallMgr,
+		appliedDNS: make(map[string][]string),
 	}
 	// OS4 has no mockable ipRun field of its own — client-route uses
 	// exec.Run directly. The warn-logger is bound to o.
@@ -165,13 +159,6 @@ func (o *OperatorOS4Impl) Start(ctx context.Context, cfg tunnel.Config) error {
 		}
 	}
 
-	// Track resolved ISP for WAN event matching
-	if cfg.ISPInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[cfg.ID] = cfg.ISPInterface
-		o.resolvedISPMu.Unlock()
-	}
-
 	o.logInfo("start", cfg.ID, "Tunnel started successfully")
 	return nil
 }
@@ -200,11 +187,6 @@ func (o *OperatorOS4Impl) Stop(ctx context.Context, tunnelID string) error {
 		_ = o.commands.Interfaces.ClearDNS(ctx, ifaceName, dnsServers)
 	}
 
-	// Clear resolved ISP tracking
-	o.resolvedISPMu.Lock()
-	delete(o.resolvedISP, tunnelID)
-	o.resolvedISPMu.Unlock()
-
 	o.logInfo("stop", tunnelID, "Tunnel stopped")
 	return nil
 }
@@ -223,32 +205,6 @@ func (o *OperatorOS4Impl) RemoveDefaultRoute(ctx context.Context, tunnelID strin
 func (o *OperatorOS4Impl) Delete(ctx context.Context, stored *storage.AWGTunnel) error {
 	// On OS4, stop and delete are the same
 	return o.Stop(ctx, stored.ID)
-}
-
-// Recover attempts to bring a broken tunnel into a consistent state.
-// Stops the backend and force-removes the interface to reach a clean state.
-func (o *OperatorOS4Impl) Recover(ctx context.Context, tunnelID string, state tunnel.StateInfo) error {
-	ifaceName := tunnelID
-
-	o.logInfo("recover", tunnelID, fmt.Sprintf("Recovering from state: %s", state.State))
-
-	// Stop via backend
-	_ = o.backend.Stop(ctx, ifaceName)
-
-	// Force-remove interface at kernel level
-	o.deleteInterface(ctx, ifaceName)
-
-	// Clean up DNS entries
-	o.appliedDNSMu.Lock()
-	dnsServers := o.appliedDNS[tunnelID]
-	delete(o.appliedDNS, tunnelID)
-	o.appliedDNSMu.Unlock()
-	if len(dnsServers) > 0 {
-		_ = o.commands.Interfaces.ClearDNS(ctx, ifaceName, dnsServers)
-	}
-
-	o.logInfo("recover", tunnelID, "Recovery complete")
-	return nil
 }
 
 // Suspend on OS4 is a no-op — OS4 has no NDMS layer.
@@ -322,14 +278,9 @@ func (o *OperatorOS4Impl) CleanupEndpointRoute(ctx context.Context, tunnelID str
 	return nil
 }
 
-// RestoreEndpointTracking restores resolved ISP tracking on daemon restart.
-// Routing is not managed by OS4, but resolvedISP is needed for WAN event matching.
-func (o *OperatorOS4Impl) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint, ispInterface string) (string, error) {
-	if ispInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[tunnelID] = ispInterface
-		o.resolvedISPMu.Unlock()
-	}
+// RestoreEndpointTracking на OS4 не делает ничего: маршрутизацию оператор здесь
+// не ведёт, а соответствие туннеля и WAN оркестратор берёт из записи (ActiveWAN).
+func (o *OperatorOS4Impl) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint string) (string, error) {
 	return "", nil
 }
 
@@ -352,13 +303,6 @@ func (o *OperatorOS4Impl) GetDefaultGatewayInterface(ctx context.Context) (strin
 		}
 	}
 	return "", fmt.Errorf("no default gateway found")
-}
-
-// GetResolvedISP returns the resolved ISP interface name for a running tunnel.
-func (o *OperatorOS4Impl) GetResolvedISP(tunnelID string) string {
-	o.resolvedISPMu.RLock()
-	defer o.resolvedISPMu.RUnlock()
-	return o.resolvedISP[tunnelID]
 }
 
 // SetMTU sets MTU on a running tunnel interface via ip link.
@@ -439,14 +383,6 @@ func (o *OperatorOS4Impl) logInfo(action, target, message string) {
 // logWarn logs a warning message via the UI-visible scoped logger.
 func (o *OperatorOS4Impl) logWarn(action, target, message string) {
 	o.appLog.Warn(action, target, message)
-}
-
-// HasWANIPv6 checks if a WAN interface has IPv6 connectivity via NDMS RCI.
-func (o *OperatorOS4Impl) HasWANIPv6(ctx context.Context, ifaceName string) bool {
-	if o.queries == nil {
-		return false
-	}
-	return o.queries.Interfaces.HasIPv6Global(ctx, ifaceName)
 }
 
 // GetSystemName on OS4 returns ndmsID as-is (no system-name RCI on OS4;

--- a/internal/tunnel/ops/operator_os4_test.go
+++ b/internal/tunnel/ops/operator_os4_test.go
@@ -166,28 +166,6 @@ func TestOperatorOS4_Delete_SameAsStop(t *testing.T) {
 	}
 }
 
-func TestOperatorOS4_Recover(t *testing.T) {
-	backendMock := &MockBackend{running: true}
-
-	op := NewOperatorOS4(nil, nil, &MockWGClient{}, backendMock, &MockFirewall{})
-
-	state := tunnel.StateInfo{
-		State:          tunnel.StateBroken,
-		ProcessRunning: true,
-		InterfaceUp:    false,
-	}
-
-	err := op.Recover(context.Background(), "awg0", state)
-
-	if err != nil {
-		t.Fatalf("Recover() error = %v", err)
-	}
-	// On OS4, recovery just stops everything
-	if len(backendMock.StopCalls) != 1 {
-		t.Errorf("Backend.Stop should be called for recovery")
-	}
-}
-
 func TestOperatorOS4_ApplyConfig(t *testing.T) {
 	wgClient := &MockWGClient{}
 	op := NewOperatorOS4(nil, nil, wgClient, &MockBackend{}, &MockFirewall{})

--- a/internal/tunnel/ops/operator_os5.go
+++ b/internal/tunnel/ops/operator_os5.go
@@ -87,11 +87,6 @@ type OperatorOS5Impl struct {
 	endpointRoutes   map[string]string
 	endpointRoutesMu sync.RWMutex
 
-	// Resolved ISP tracking (tunnelID -> WAN interface name)
-	// Tracks the actual WAN used for auto-mode tunnels.
-	resolvedISP   map[string]string
-	resolvedISPMu sync.RWMutex
-
 	// DNS tracking (tunnelID -> DNS servers applied via NDMS)
 	// Used to clean up DNS entries on Stop/Delete.
 	appliedDNS   map[string][]string
@@ -119,7 +114,6 @@ func NewOperatorOS5(
 		firewall:       firewallMgr,
 		ipRun:          exec.Run,
 		endpointRoutes: make(map[string]string),
-		resolvedISP:    make(map[string]string),
 		appliedDNS:     make(map[string][]string),
 	}
 	// Wire clientRouteOps after o is built — it captures o.ipRun and
@@ -213,60 +207,6 @@ func (o *OperatorOS5Impl) Create(ctx context.Context, cfg tunnel.Config) error {
 	// Save configuration
 
 	o.logInfo("create", cfg.ID, "Created OpkgTun in NDMS (address + MTU configured)")
-	return nil
-}
-
-// Start brings up an existing amneziawg interface after our Stop.
-// Interface already exists with address and WG config — just bring it up.
-// Sequence: ip link set up → InterfaceUp → routes → firewall → Save.
-// Used for: Disabled (after our Stop), Dead (after PingCheck).
-func (o *OperatorOS5Impl) Start(ctx context.Context, cfg tunnel.Config) error {
-	names := tunnel.NewNames(cfg.ID)
-
-	// Bring link up.
-	if result, err := o.ipRun(ctx, "/opt/sbin/ip", "link", "set", "up", "dev", names.IfaceName); err != nil {
-		return tunnel.NewOpError("start", cfg.ID, "link", fmt.Errorf("ip link up: %w", exec.FormatError(result, err)))
-	}
-
-	// NDMS InterfaceUp sets conf: running. Commands register the expected
-	// hook themselves via the HookNotifier wired at startup.
-	if err := o.commands.Interfaces.InterfaceUp(ctx, names.NDMSName); err != nil {
-		return tunnel.NewOpError("start", cfg.ID, "ndms", fmt.Errorf("interface up: %w", err))
-	}
-
-	o.logInfo("start", cfg.ID, "Interface up")
-
-	// Endpoint route.
-	if cfg.Endpoint != "" {
-		routeEndpoint := endpointWithResolvedIP(cfg.Endpoint, cfg.EndpointIP)
-		if _, err := o.SetupEndpointRoute(ctx, cfg.ID, routeEndpoint, cfg.KernelDevice, cfg.ISPInterface); err != nil {
-			o.logWarn("start", cfg.ID, "Endpoint route failed (non-fatal): "+err.Error())
-		}
-	}
-
-	// Track resolved ISP.
-	if cfg.ISPInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[cfg.ID] = cfg.ISPInterface
-		o.resolvedISPMu.Unlock()
-	}
-
-	// Default route.
-	if cfg.DefaultRoute {
-		if err := o.commands.Routes.SetDefaultRoute(ctx, names.NDMSName); err != nil {
-			o.logWarn("start", cfg.ID, "Default route failed (non-fatal): "+err.Error())
-		}
-	}
-
-	// Firewall.
-	if err := o.firewall.AddRules(ctx, names.IfaceName); err != nil {
-		return tunnel.NewOpError("start", cfg.ID, "firewall", err)
-	}
-
-	// Save.
-
-	o.logInfo("start", cfg.ID, "Tunnel started (light — existing interface)")
-	o.appLog.Info("start", cfg.ID, "Туннель запущен")
 	return nil
 }
 
@@ -419,14 +359,6 @@ func (o *OperatorOS5Impl) ColdStart(ctx context.Context, cfg tunnel.Config) erro
 		endpointRouteOK = true // no endpoint — nothing to route
 	}
 
-	// Track resolved ISP for dashboard display (NDMS name from service layer).
-	// SetupEndpointRoute works in kernel namespace and doesn't track NDMS names.
-	if cfg.ISPInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[cfg.ID] = cfg.ISPInterface
-		o.resolvedISPMu.Unlock()
-	}
-
 	// Default route: only when DefaultRoute is enabled.
 	// NDMS manages the route via the kernel backend.
 	// Non-fatal: if NDMS is not ready (e.g. boot race), tunnel starts without
@@ -468,36 +400,6 @@ func (o *OperatorOS5Impl) ColdStart(ctx context.Context, cfg tunnel.Config) erro
 	return nil
 }
 
-// TeardownForRestart removes firewall, routes, DNS, and sets link down
-// WITHOUT calling InterfaceDown. NDMS intent stays "running" so no conf-layer
-// hooks are fired. The amneziawg interface is preserved (only link toggled down)
-// so that a light Start can bring it back up.
-func (o *OperatorOS5Impl) TeardownForRestart(ctx context.Context, tunnelID string) {
-	names := tunnel.NewNames(tunnelID)
-
-	// Remove firewall rules (no-op if already absent).
-	_ = o.firewall.RemoveRules(ctx, names.IfaceName)
-
-	// Remove endpoint route from kernel + clear tracking.
-	_ = o.CleanupEndpointRoute(ctx, tunnelID)
-
-	// Clear DNS servers from NDMS (Start will re-apply).
-	o.clearAppliedDNS(ctx, tunnelID, names)
-
-	// Link down only — amneziawg interface stays, WG config stays loaded.
-	// NO backend.Stop (ip link del) — that would destroy the device and
-	// require ColdStart to recreate, which can fail on NDMS transient errors.
-	o.ipRun(ctx, "/opt/sbin/ip", "link", "set", "down", "dev", names.IfaceName)
-
-	// Clear in-memory tracking.
-	o.resolvedISPMu.Lock()
-	delete(o.resolvedISP, tunnelID)
-	o.resolvedISPMu.Unlock()
-
-	// NO InterfaceDown — NDMS intent stays "running".
-	o.logInfo("teardown", tunnelID, "Teardown for restart (link down, device preserved)")
-}
-
 // Stop brings down a tunnel without destroying the interface.
 // ip link set down + InterfaceDown (conf: disabled) + Save.
 // NDMS handles routing/failover automatically when link goes down.
@@ -514,11 +416,6 @@ func (o *OperatorOS5Impl) Stop(ctx context.Context, tunnelID string) error {
 	o.interfaceDownBestEffort(ctx, tunnelID, names.NDMSName)
 
 	// Save NDMS config so router UI reflects conf: disabled.
-
-	// Clear resolved ISP tracking.
-	o.resolvedISPMu.Lock()
-	delete(o.resolvedISP, tunnelID)
-	o.resolvedISPMu.Unlock()
 
 	o.logInfo("stop", tunnelID, "Tunnel stopped (link down, conf: disabled)")
 	o.appLog.Info("stop", tunnelID, "Туннель остановлен")
@@ -603,43 +500,12 @@ func (o *OperatorOS5Impl) Delete(ctx context.Context, stored *storage.AWGTunnel)
 	o.endpointRoutesMu.Lock()
 	delete(o.endpointRoutes, stored.ID)
 	o.endpointRoutesMu.Unlock()
-	o.resolvedISPMu.Lock()
-	delete(o.resolvedISP, stored.ID)
-	o.resolvedISPMu.Unlock()
 	o.appliedDNSMu.Lock()
 	delete(o.appliedDNS, stored.ID)
 	o.appliedDNSMu.Unlock()
 
 	o.logInfo("delete", stored.ID, "Tunnel deleted")
 	o.appLog.Info("delete", stored.ID, "Туннель удалён")
-	return nil
-}
-
-// Recover attempts to bring a broken tunnel into a consistent state.
-// Stops the backend, removes the kernel interface, and brings down the
-// NDMS interface to reach a clean state for restart.
-func (o *OperatorOS5Impl) Recover(ctx context.Context, tunnelID string, state tunnel.StateInfo) error {
-	names := tunnel.NewNames(tunnelID)
-
-	o.logInfo("recover", tunnelID, fmt.Sprintf("Recovering from state: %s (%s)", state.State, state.Details))
-
-	// 1. Stop via backend (removes kernel interface)
-	if err := o.backend.Stop(ctx, names.IfaceName); err != nil {
-		o.logWarn("recover", tunnelID, "Backend stop: "+err.Error())
-	}
-
-	// 2. Bring NDMS interface down but NEVER delete OpkgTun.
-	// Deleting OpkgTun destroys Policy bindings that the user configured
-	// through NDMS — these cannot be recreated automatically.
-	// Start will re-configure NDMS via SetAddress + InterfaceUp (phase 4),
-	// which re-associates OpkgTun with the newly created device. Commands
-	// register the expected "disabled" hook via HookNotifier.
-	_ = o.commands.Interfaces.InterfaceDown(ctx, names.NDMSName)
-
-	// Clean up DNS entries
-	o.clearAppliedDNS(ctx, tunnelID, names)
-
-	o.logInfo("recover", tunnelID, "Recovery complete")
 	return nil
 }
 
@@ -771,13 +637,6 @@ func (o *OperatorOS5Impl) Reconcile(ctx context.Context, cfg tunnel.Config) erro
 		}
 	} else {
 		endpointRouteOK = true
-	}
-
-	// Track resolved ISP for dashboard display (NDMS name from service layer).
-	if cfg.ISPInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[cfg.ID] = cfg.ISPInterface
-		o.resolvedISPMu.Unlock()
 	}
 
 	// Default route: only when DefaultRoute is enabled.
@@ -937,13 +796,6 @@ func (o *OperatorOS5Impl) GetDefaultGatewayInterface(ctx context.Context) (strin
 	return o.queries.Routes.GetDefaultGatewayInterface(ctx)
 }
 
-// GetResolvedISP returns the resolved ISP interface name for a running tunnel.
-func (o *OperatorOS5Impl) GetResolvedISP(tunnelID string) string {
-	o.resolvedISPMu.RLock()
-	defer o.resolvedISPMu.RUnlock()
-	return o.resolvedISP[tunnelID]
-}
-
 // rollbackStart cleans up after a failed start operation.
 // justCreated indicates whether we created the OpkgTun in this Start attempt.
 // When false (OpkgTun already existed), we preserve NDMS conf state (conf: running)
@@ -970,11 +822,6 @@ func (o *OperatorOS5Impl) logInfo(action, target, message string) {
 // logWarn logs a warning message via the UI-visible scoped logger.
 func (o *OperatorOS5Impl) logWarn(action, target, message string) {
 	o.appLog.Warn(action, target, message)
-}
-
-// HasWANIPv6 checks if a WAN interface has IPv6 connectivity via NDMS RCI.
-func (o *OperatorOS5Impl) HasWANIPv6(ctx context.Context, ifaceName string) bool {
-	return o.queries.Interfaces.HasIPv6Global(ctx, ifaceName)
 }
 
 // GetSystemName resolves an NDMS ID to its kernel interface name via NDMS RCI.

--- a/internal/tunnel/ops/operator_os5_routing.go
+++ b/internal/tunnel/ops/operator_os5_routing.go
@@ -112,11 +112,6 @@ func (o *OperatorOS5Impl) CleanupEndpointRoute(ctx context.Context, tunnelID str
 	}
 	o.endpointRoutesMu.Unlock()
 
-	// Clear resolved ISP tracking
-	o.resolvedISPMu.Lock()
-	delete(o.resolvedISP, tunnelID)
-	o.resolvedISPMu.Unlock()
-
 	if !exists || endpointIP == "" {
 		return nil
 	}
@@ -149,7 +144,7 @@ func (o *OperatorOS5Impl) CleanupEndpointRoute(ctx context.Context, tunnelID str
 // RestoreEndpointTracking restores endpoint route tracking without creating the route.
 // Used on daemon restart for tunnels that are already running.
 // Returns the resolved endpoint IP on success, empty string on non-fatal failure.
-func (o *OperatorOS5Impl) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint, ispInterface string) (string, error) {
+func (o *OperatorOS5Impl) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint string) (string, error) {
 	if endpoint == "" {
 		return "", nil
 	}
@@ -165,13 +160,6 @@ func (o *OperatorOS5Impl) RestoreEndpointTracking(ctx context.Context, tunnelID,
 	o.endpointRoutesMu.Lock()
 	o.endpointRoutes[tunnelID] = endpointIP
 	o.endpointRoutesMu.Unlock()
-
-	// Restore resolved ISP for dashboard display
-	if ispInterface != "" {
-		o.resolvedISPMu.Lock()
-		o.resolvedISP[tunnelID] = ispInterface
-		o.resolvedISPMu.Unlock()
-	}
 
 	o.logInfo("restore_tracking", tunnelID, "Restored endpoint tracking for "+endpointIP)
 	return endpointIP, nil

--- a/internal/tunnel/service/impl_test.go
+++ b/internal/tunnel/service/impl_test.go
@@ -37,7 +37,6 @@ type MockOperator struct {
 	startError       error
 	stopError        error
 	deleteError      error
-	recoverError     error
 	applyConfigError error
 	setMTUError      error
 
@@ -46,14 +45,10 @@ type MockOperator struct {
 	// TrackedEndpointIPs maps tunnelID -> IP for GetTrackedEndpointIP.
 	TrackedEndpointIPs map[string]string
 
-	CreateCalls  []tunnel.Config
-	StartCalls   []tunnel.Config
-	StopCalls    []string
-	DeleteCalls  []string
-	RecoverCalls []struct {
-		ID    string
-		State tunnel.StateInfo
-	}
+	CreateCalls                  []tunnel.Config
+	StartCalls                   []tunnel.Config
+	StopCalls                    []string
+	DeleteCalls                  []string
 	ReconcileCalls               []tunnel.Config
 	ApplyConfigCalls             []struct{ ID, Path string }
 	SetupEndpointRouteCalls      []struct{ ID, Endpoint, ISP string }
@@ -81,11 +76,6 @@ func (m *MockOperator) ColdStart(ctx context.Context, cfg tunnel.Config) error {
 	return m.startError
 }
 
-func (m *MockOperator) Start(ctx context.Context, cfg tunnel.Config) error {
-	m.StartCalls = append(m.StartCalls, cfg)
-	return m.startError
-}
-
 func (m *MockOperator) Stop(ctx context.Context, tunnelID string) error {
 	m.StopCalls = append(m.StopCalls, tunnelID)
 	return m.stopError
@@ -94,14 +84,6 @@ func (m *MockOperator) Stop(ctx context.Context, tunnelID string) error {
 func (m *MockOperator) Delete(ctx context.Context, stored *storage.AWGTunnel) error {
 	m.DeleteCalls = append(m.DeleteCalls, stored.ID)
 	return m.deleteError
-}
-
-func (m *MockOperator) Recover(ctx context.Context, tunnelID string, state tunnel.StateInfo) error {
-	m.RecoverCalls = append(m.RecoverCalls, struct {
-		ID    string
-		State tunnel.StateInfo
-	}{tunnelID, state})
-	return m.recoverError
 }
 
 func (m *MockOperator) Reconcile(ctx context.Context, cfg tunnel.Config) error {
@@ -124,7 +106,7 @@ func (m *MockOperator) CleanupEndpointRoute(ctx context.Context, tunnelID string
 	return nil
 }
 
-func (m *MockOperator) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint, ispInterface string) (string, error) {
+func (m *MockOperator) RestoreEndpointTracking(ctx context.Context, tunnelID, endpoint string) (string, error) {
 	m.RestoreEndpointTrackingCalls = append(m.RestoreEndpointTrackingCalls, struct{ ID, Endpoint string }{tunnelID, endpoint})
 	return m.SetupEndpointRouteIP, nil
 }
@@ -160,10 +142,6 @@ func (m *MockOperator) RemoveDefaultRoute(ctx context.Context, tunnelID string) 
 	return nil
 }
 
-func (m *MockOperator) GetResolvedISP(tunnelID string) string {
-	return ""
-}
-
 func (m *MockOperator) UpdateDescription(ctx context.Context, tunnelID, description string) error {
 	m.UpdateDescriptionCalls = append(m.UpdateDescriptionCalls, struct{ ID, Desc string }{tunnelID, description})
 	return nil
@@ -187,8 +165,6 @@ func (m *MockOperator) SyncAddress(ctx context.Context, tunnelID string, address
 func (m *MockOperator) GetDefaultGatewayInterface(ctx context.Context) (string, error) {
 	return "PPPoE1", nil
 }
-
-func (m *MockOperator) HasWANIPv6(ctx context.Context, ifaceName string) bool { return false }
 
 func (m *MockOperator) GetSystemName(_ context.Context, ndmsID string) string { return ndmsID }
 

--- a/internal/tunnel/sysinfo/interfaces.go
+++ b/internal/tunnel/sysinfo/interfaces.go
@@ -19,8 +19,7 @@ var (
 	awgPattern     = regexp.MustCompile(`^awg(\d+)$`)
 
 	// awg-manager managed tunnel patterns
-	// OS 5.x uses opkgtun100+ (same pattern, just different numbers)
-	// OS 4.x uses awgmX
+	// OS 4.x uses awgmX; на 5.x наши туннели — те же opkgtunN выше
 	awgmPattern = regexp.MustCompile(`^awgm(\d+)$`)
 )
 
@@ -46,8 +45,9 @@ func ExtractInterfaceNumber(ifaceName string) (int, bool) {
 }
 
 // ListSystemInterfaces returns a list of tunnel interface numbers found in the system.
-// On OS 5.0+: scans for opkgtunX interfaces (external tunnels use 0-99, awg-manager uses 100+)
-// On OS 4.x: scans for awgX and awgmX interfaces (external use awgX, awg-manager uses awgmX)
+// На 5.x собирает номера opkgtunX, на 4.x — awgX и awgmX. Деления «наши/чужие»
+// по номеру НЕТ: диапазоны подсистем разведены выше (storage.nextAvailableID и
+// аллокаторы режимов роутера и wdtt), а здесь нужны все занятые номера подряд.
 func ListSystemInterfaces() ([]int, error) {
 	entries, err := os.ReadDir("/sys/class/net")
 	if err != nil {

--- a/internal/wdtt/ndms_iface.go
+++ b/internal/wdtt/ndms_iface.go
@@ -27,7 +27,7 @@ type NDMSOpkgTunCommands interface {
 }
 
 const (
-	// Диапазон 17..49: вне fakeip (0..9) и типичных awg10..16 / managed 100+.
+	// Диапазон 17..49: вне fakeip (0..9) и AWG-туннелей (10..16).
 	wdttOpkgIndexMin    = 17
 	wdttOpkgIndexMax    = 49
 	wdttLegacyIndexMin  = 90


### PR DESCRIPTION
Из `ops.Operator` ушли `Start`, `Recover`, `GetResolvedISP` и `HasWANIPv6` — ни
одного вызова в проде. Реализации удалены у OS5 (вместе с `TeardownForRestart`,
который в контракте и не состоял), у OS4 — все кроме `Start`: он там остался
внутренней частью `ColdStart`, но перестал быть точкой контракта.

Замысел «лёгкого запуска» через `Start` был недостижим: любой запуск идёт через
`ColdStart`, и он же обслуживает Broken-состояние, ради которого существовал
`Recover`.

**Осторожность, из-за которой это откладывалось:** одноимённый `GetResolvedISP`
у СЕРВИСА живой и нужен диагностике и списку туннелей — он читает `ActiveWAN` из
записи и к оператору не ходит. Снесён только операторский.

**Снос по цепочке.** После удаления единственного читателя осиротели карты
`resolvedISP` — они только писались и чистились. Вместе с ними ушёл параметр
`ispInterface` у `RestoreEndpointTracking` и блок в оркестраторе, который ради
этого параметра резолвил WAN через NDMS на каждом восстановлении отслеживания:
результат уходил в мёртвую карту. Комментарий «resolvedISP нужен для
сопоставления WAN-событий» врал и до этой ветки — сопоставление идёт по записи
(`decide.go`).

**Убрана фикция «managed 100+»**: такого диапазона нет ни у кого,
`internal/managed` интерфейсы OpkgTun не создаёт вовсе. Комментарий-первоисточник
обосновывал им границы диапазонов в двух подсистемах; заодно переписан
комментарий сканера, утверждавший деление «чужие 0-99, наши 100+», хотя код
собирает все номера подряд.

Плюс правка владельца: домен 2ip в списке проверок внешнего адреса.

Итого −326 строк, +23. Сборка, `go vet` и полный тестовый прогон зелёные; файлы,
которые сейчас правит параллельная работа над ресурсной моделью, не затронуты —
и она, по проверке, ничего из удалённого не использует.