### PR TITLE
xhttp: параметры extra доезжают до конфига (#797)

### DIFF
--- a/internal/singbox/vlink/clash.go
+++ b/internal/singbox/vlink/clash.go
@@ -109,7 +109,8 @@ func clashFieldsToValues(p map[string]any) url.Values {
 	case "xhttp", "splithttp":
 		// mihomo carries xhttp under xhttp-opts with top-level string path/host
 		// (not []string) plus a mode. We don't run mihomo — convert to our
-		// sing-box xhttp transport. x_padding_bytes is defaulted downstream.
+		// sing-box xhttp transport. The remaining options, xmux among them,
+		// go through the share-link extra= path (#797).
 		xh := nestedMap(p, "xhttp-opts")
 		if path := asString(xh["path"]); path != "" {
 			v.Set("path", path)
@@ -119,6 +120,9 @@ func clashFieldsToValues(p map[string]any) url.Values {
 		}
 		if mode := asString(xh["mode"]); mode != "" {
 			v.Set("mode", mode)
+		}
+		if extra := xhttpExtraFromClash(xh); extra != "" {
+			v.Set("extra", extra)
 		}
 	}
 

--- a/internal/singbox/vlink/clash_vless_test.go
+++ b/internal/singbox/vlink/clash_vless_test.go
@@ -218,3 +218,68 @@ func TestMapClashVless_XHTTP(t *testing.T) {
 		t.Errorf("transport.x_padding_bytes=%v want default 100-1000", tr["x_padding_bytes"])
 	}
 }
+
+// mihomo keeps xmux under xhttp-opts.reuse-settings in kebab-case; the whole
+// block was dropped on import (#797).
+func TestMapClashVless_XHTTPReuseSettings(t *testing.T) {
+	in := map[string]any{
+		"name":    "xh",
+		"type":    "vless",
+		"server":  "h.example.com",
+		"port":    443,
+		"uuid":    "3a3b1c2e-9999-4321-aaaa-1234567890ab",
+		"network": "xhttp",
+		"xhttp-opts": map[string]any{
+			"path":                     "/xh",
+			"mode":                     "auto",
+			"x-padding-bytes":          "200-800",
+			"no-grpc-header":           true,
+			"sc-max-each-post-bytes":   1000000,
+			"sc-min-posts-interval-ms": "30",
+			"headers":                  map[string]any{"X-Foo": "bar"},
+			"reuse-settings": map[string]any{
+				"max-concurrency":     "32-64",
+				"max-connections":     0,
+				"c-max-reuse-times":   0,
+				"h-max-request-times": "600-900",
+				"h-max-reusable-secs": "1800-3000",
+				"h-keep-alive-period": 0,
+			},
+		},
+	}
+	got, err := mapClashVless(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	var ob map[string]any
+	if err := json.Unmarshal(got.Outbound, &ob); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tr, _ := ob["transport"].(map[string]any)
+	xmux, ok := tr["xmux"].(map[string]any)
+	if !ok {
+		t.Fatalf("no xmux: %v", tr)
+	}
+	if xmux["max_concurrency"] != "32-64" || xmux["h_max_reusable_secs"] != "1800-3000" {
+		t.Errorf("xmux=%v", xmux)
+	}
+	if xmux["c_max_reuse_times"] != float64(0) || xmux["h_keep_alive_period"] != float64(0) {
+		t.Errorf("zero-valued xmux fields lost: %v", xmux)
+	}
+	if tr["x_padding_bytes"] != "200-800" {
+		t.Errorf("x_padding_bytes=%v", tr["x_padding_bytes"])
+	}
+	if tr["no_grpc_header"] != true {
+		t.Errorf("no_grpc_header=%v", tr["no_grpc_header"])
+	}
+	if tr["sc_max_each_post_bytes"] != float64(1000000) {
+		t.Errorf("sc_max_each_post_bytes=%v", tr["sc_max_each_post_bytes"])
+	}
+	if tr["sc_min_posts_interval_ms"] != "30" {
+		t.Errorf("sc_min_posts_interval_ms=%v", tr["sc_min_posts_interval_ms"])
+	}
+	hdr, _ := tr["headers"].(map[string]any)
+	if hdr["X-Foo"] != "bar" {
+		t.Errorf("headers=%v", tr["headers"])
+	}
+}

--- a/internal/singbox/vlink/encode.go
+++ b/internal/singbox/vlink/encode.go
@@ -371,6 +371,12 @@ func streamQueryFromOutbound(ob map[string]any) (url.Values, error) {
 		q.Set("type", network)
 	}
 
+	// #709: the egress interface is ours alone, but a link that drops it comes
+	// back bound to nothing.
+	if bind, _ := ob["bind_interface"].(string); bind != "" {
+		q.Set("bind_interface", bind)
+	}
+
 	if tls, _ := ob["tls"].(map[string]any); tls != nil {
 		reality, _ := tls["reality"].(map[string]any)
 		hasReality := reality != nil && reality["enabled"] == true

--- a/internal/singbox/vlink/encode.go
+++ b/internal/singbox/vlink/encode.go
@@ -355,8 +355,12 @@ func streamQueryFromOutbound(ob map[string]any) (url.Values, error) {
 			if mode, _ := transport["mode"].(string); mode != "" {
 				q.Set("mode", mode)
 			}
-			// x_padding_bytes is an internal/server-negotiated default; not part
-			// of the share-link standard, so it is intentionally not emitted.
+			// Everything else xhttp carries travels in Xray's extra= object,
+			// x_padding_bytes included: since #797 it can come from the link
+			// rather than from our default, so dropping it would lose it.
+			if extra := xhttpExtraFromTransport(transport); extra != "" {
+				q.Set("extra", extra)
+			}
 		default:
 			// Unknown transport (e.g. quic) — fail closed rather than silently
 			// emitting a plain-tcp link that misroutes.

--- a/internal/singbox/vlink/stream.go
+++ b/internal/singbox/vlink/stream.go
@@ -101,6 +101,13 @@ func BuildStreamFromQuery(q url.Values, defaultHost string) (*StreamBuilder, err
 	s.ServiceName = q.Get("serviceName")
 	s.Mode = q.Get("mode")
 	if s.Network == "xhttp" {
+		// The option layer refuses anything else and takes the whole config
+		// down with it, so the bad link is rejected on its own instead.
+		switch s.Mode {
+		case "", "auto", "packet-up", "stream-up", "stream-one":
+		default:
+			return nil, fmt.Errorf("vlink: unsupported xhttp mode %q", s.Mode)
+		}
 		s.XHTTPExtra = parseXHTTPExtra(q.Get("extra"))
 	}
 

--- a/internal/singbox/vlink/stream.go
+++ b/internal/singbox/vlink/stream.go
@@ -19,9 +19,10 @@ type StreamBuilder struct {
 	EarlyData           int
 	EarlyDataHeaderName string
 	ServiceName         string
-	Mode                string // xhttp mode: auto | packet-up | stream-up | stream-one
-	XPaddingBytes       string // xhttp x_padding_bytes (mandatory, non-zero); defaulted in MergeIntoOutbound
-	BindInterface       string // egress kernel interface for dial (#709)
+	Mode                string         // xhttp mode: auto | packet-up | stream-up | stream-one
+	XPaddingBytes       string         // xhttp x_padding_bytes (mandatory, non-zero); defaulted in MergeIntoOutbound
+	XHTTPExtra          map[string]any // xhttp fields from ?extra=, already in sing-box snake_case (#797)
+	BindInterface       string         // egress kernel interface for dial (#709)
 }
 
 // outboundTLS is the parsed TLS / Reality block ready to be emitted as
@@ -99,6 +100,9 @@ func BuildStreamFromQuery(q url.Values, defaultHost string) (*StreamBuilder, err
 	}
 	s.ServiceName = q.Get("serviceName")
 	s.Mode = q.Get("mode")
+	if s.Network == "xhttp" {
+		s.XHTTPExtra = parseXHTTPExtra(q.Get("extra"))
+	}
 
 	// TLS / Reality
 	sec := strings.ToLower(q.Get("security"))
@@ -255,11 +259,14 @@ func (s *StreamBuilder) MergeIntoOutbound(out map[string]any) {
 			if s.Mode != "" {
 				transport["mode"] = s.Mode
 			}
-			pad := s.XPaddingBytes
-			if pad == "" {
-				pad = "100-1000"
+			for k, v := range s.XHTTPExtra {
+				transport[k] = v
 			}
-			transport["x_padding_bytes"] = pad
+			if s.XPaddingBytes != "" {
+				transport["x_padding_bytes"] = s.XPaddingBytes
+			} else if transport["x_padding_bytes"] == nil {
+				transport["x_padding_bytes"] = "100-1000"
+			}
 		}
 		out["transport"] = transport
 	}

--- a/internal/singbox/vlink/stream_xhttp_extra_test.go
+++ b/internal/singbox/vlink/stream_xhttp_extra_test.go
@@ -1,0 +1,217 @@
+package vlink
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+)
+
+// issue #797: xmux inside ?extra= was dropped, so every parallel stream opened
+// its own REALITY handshake.
+func TestBuildStreamFromQuery_XHTTPExtraXmux(t *testing.T) {
+	q := parseQuery(t, "type=xhttp&extra="+
+		`%7B%22xmux%22%3A%7B%22maxConcurrency%22%3A%2232-64%22%2C%22cMaxReuseTimes%22%3A0%2C%22hMaxRequestTimes%22%3A%22600-900%22%2C%22hMaxReusableSecs%22%3A%221800-3000%22%2C%22hKeepAlivePeriod%22%3A0%7D%7D`)
+	s, err := BuildStreamFromQuery(q, "example.com")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := map[string]any{}
+	s.MergeIntoOutbound(out)
+	tr, _ := out["transport"].(map[string]any)
+	xmux, ok := tr["xmux"].(map[string]any)
+	if !ok {
+		t.Fatalf("no xmux in transport: %v", tr)
+	}
+	want := map[string]any{
+		"max_concurrency":     "32-64",
+		"c_max_reuse_times":   float64(0),
+		"h_max_request_times": "600-900",
+		"h_max_reusable_secs": "1800-3000",
+		"h_keep_alive_period": float64(0),
+	}
+	got, _ := json.Marshal(xmux)
+	wantJSON, _ := json.Marshal(want)
+	if string(got) != string(wantJSON) {
+		t.Errorf("xmux=%s, want %s", got, wantJSON)
+	}
+}
+
+func TestBuildStreamFromQuery_XHTTPExtraScalars(t *testing.T) {
+	extra := `{"headers":{"X-Foo":"bar"},"noGRPCHeader":false,"noSSEHeader":true,` +
+		`"scMaxEachPostBytes":1000000,"scMinPostsIntervalMs":30,"scMaxBufferedPosts":30,` +
+		`"scStreamUpServerSecs":"20-80","xPaddingBytes":"200-800"}`
+	q := parseQuery(t, "type=xhttp&extra="+urlEscape(extra))
+	s, err := BuildStreamFromQuery(q, "example.com")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := map[string]any{}
+	s.MergeIntoOutbound(out)
+	tr, _ := out["transport"].(map[string]any)
+
+	// x_padding_bytes from the link must win over the built-in default.
+	if tr["x_padding_bytes"] != "200-800" {
+		t.Errorf("x_padding_bytes=%v, want 200-800", tr["x_padding_bytes"])
+	}
+	if tr["no_sse_header"] != true {
+		t.Errorf("no_sse_header=%v, want true", tr["no_sse_header"])
+	}
+	if tr["no_grpc_header"] != false {
+		t.Errorf("no_grpc_header=%v, want false", tr["no_grpc_header"])
+	}
+	if tr["sc_max_each_post_bytes"] != float64(1000000) {
+		t.Errorf("sc_max_each_post_bytes=%v", tr["sc_max_each_post_bytes"])
+	}
+	if tr["sc_min_posts_intervals_ms"] != nil {
+		t.Errorf("unexpected typo key emitted: %v", tr)
+	}
+	if tr["sc_min_posts_interval_ms"] != float64(30) {
+		t.Errorf("sc_min_posts_interval_ms=%v", tr["sc_min_posts_interval_ms"])
+	}
+	if tr["sc_max_buffered_posts"] != float64(30) {
+		t.Errorf("sc_max_buffered_posts=%v", tr["sc_max_buffered_posts"])
+	}
+	if tr["sc_stream_up_server_secs"] != "20-80" {
+		t.Errorf("sc_stream_up_server_secs=%v", tr["sc_stream_up_server_secs"])
+	}
+	hdr, ok := tr["headers"].(map[string]string)
+	if !ok || hdr["X-Foo"] != "bar" {
+		t.Errorf("headers=%#v", tr["headers"])
+	}
+}
+
+// The option layer refuses max_connections together with max_concurrency, and
+// that refusal kills the whole config, not just this outbound. Xray's own
+// semantics: concurrency wins.
+func TestBuildStreamFromQuery_XHTTPExtraXmuxConflict(t *testing.T) {
+	cases := []struct {
+		name       string
+		xmux       string
+		wantConcur any
+		wantConns  any
+	}{
+		{"both set", `{"maxConcurrency":"32-64","maxConnections":4}`, "32-64", nil},
+		{"zero connections kept", `{"maxConcurrency":"32-64","maxConnections":0}`, "32-64", float64(0)},
+		{"connections only", `{"maxConnections":4}`, nil, float64(4)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := parseQuery(t, "type=xhttp&extra="+urlEscape(`{"xmux":`+tc.xmux+`}`))
+			s, err := BuildStreamFromQuery(q, "example.com")
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			out := map[string]any{}
+			s.MergeIntoOutbound(out)
+			xmux, _ := out["transport"].(map[string]any)["xmux"].(map[string]any)
+			if xmux["max_concurrency"] != tc.wantConcur {
+				t.Errorf("max_concurrency=%v, want %v", xmux["max_concurrency"], tc.wantConcur)
+			}
+			if xmux["max_connections"] != tc.wantConns {
+				t.Errorf("max_connections=%v, want %v", xmux["max_connections"], tc.wantConns)
+			}
+		})
+	}
+}
+
+// The link from issue #797, placeholder values.
+const issue797Link = "vless://00000000-1111-2222-3333-444444444444@example.com:443?type=xhttp&security=reality&encryption=none&pbk=REPLACE_WITH_PUBLIC_KEY&sid=0123abcd&fp=chrome&sni=example.com&host=example.com&path=%2Fyour-path&mode=auto&spx=%2F&extra=%7B%22headers%22%3A%7B%7D%2C%22noGRPCHeader%22%3Afalse%2C%22scMaxEachPostBytes%22%3A1000000%2C%22scMinPostsIntervalMs%22%3A30%2C%22xPaddingBytes%22%3A%22100-1000%22%2C%22xmux%22%3A%7B%22cMaxReuseTimes%22%3A0%2C%22hKeepAlivePeriod%22%3A0%2C%22hMaxRequestTimes%22%3A%22600-900%22%2C%22hMaxReusableSecs%22%3A%221800-3000%22%2C%22maxConcurrency%22%3A%2232-64%22%2C%22maxConnections%22%3A0%7D%7D#Example-XHTTP-Reality"
+
+func TestParseLink_XHTTPExtraEndToEnd(t *testing.T) {
+	p, err := ParseLink(issue797Link)
+	if err != nil {
+		t.Fatalf("ParseLink: %v", err)
+	}
+	var ob map[string]any
+	if err := json.Unmarshal(p.Outbound, &ob); err != nil {
+		t.Fatalf("unmarshal outbound: %v", err)
+	}
+	tr, _ := ob["transport"].(map[string]any)
+	xmux, ok := tr["xmux"].(map[string]any)
+	if !ok {
+		t.Fatalf("no xmux: %s", p.Outbound)
+	}
+	if xmux["max_concurrency"] != "32-64" {
+		t.Errorf("max_concurrency=%v", xmux["max_concurrency"])
+	}
+	if tr["sc_max_each_post_bytes"] != float64(1000000) {
+		t.Errorf("sc_max_each_post_bytes=%v", tr["sc_max_each_post_bytes"])
+	}
+	// "headers":{} carries nothing and the option layer wants it absent.
+	if _, present := tr["headers"]; present {
+		t.Errorf("empty headers emitted: %v", tr["headers"])
+	}
+}
+
+// A malformed or hostile extra must not take the link — or the config — down.
+func TestBuildStreamFromQuery_XHTTPExtraJunk(t *testing.T) {
+	for _, extra := range []string{"not-json", "[1,2]", `{"xmux":"nope"}`,
+		`{"xPaddingBytes":true,"scMaxBufferedPosts":"x","headers":{"Host":"a","X-Ok":1}}`,
+		`{"xmux":{"maxConcurrency":"a-b","unknownKey":1}}`} {
+		q := parseQuery(t, "type=xhttp&extra="+urlEscape(extra))
+		s, err := BuildStreamFromQuery(q, "example.com")
+		if err != nil {
+			t.Fatalf("extra=%s: %v", extra, err)
+		}
+		out := map[string]any{}
+		s.MergeIntoOutbound(out)
+		tr, _ := out["transport"].(map[string]any)
+		want := map[string]any{"type": "xhttp", "host": "example.com", "x_padding_bytes": "100-1000"}
+		got, _ := json.Marshal(tr)
+		wantJSON, _ := json.Marshal(want)
+		if string(got) != string(wantJSON) {
+			t.Errorf("extra=%s produced %s, want %s", extra, got, wantJSON)
+		}
+	}
+}
+
+// xbadoption.Range refuses from > to and decodes into int32; a value the
+// option layer rejects would take the whole config down, so it never gets
+// emitted.
+func TestBuildStreamFromQuery_XHTTPExtraOutOfRange(t *testing.T) {
+	for _, extra := range []string{
+		`{"xPaddingBytes":"64-32"}`,
+		`{"xPaddingBytes":1.5}`,
+		`{"xPaddingBytes":3000000000}`,
+		`{"xPaddingBytes":"1-3000000000"}`,
+		`{"xPaddingBytes":-5}`,
+	} {
+		q := parseQuery(t, "type=xhttp&extra="+urlEscape(extra))
+		s, err := BuildStreamFromQuery(q, "example.com")
+		if err != nil {
+			t.Fatalf("extra=%s: %v", extra, err)
+		}
+		out := map[string]any{}
+		s.MergeIntoOutbound(out)
+		tr, _ := out["transport"].(map[string]any)
+		if tr["x_padding_bytes"] != "100-1000" {
+			t.Errorf("extra=%s: x_padding_bytes=%v, want the default", extra, tr["x_padding_bytes"])
+		}
+	}
+}
+
+func urlEscape(s string) string { return url.QueryEscape(s) }
+
+// A link imported with xmux must carry it again when shared back out (#797).
+func TestEncodeOutbound_XHTTPExtraRoundTrip(t *testing.T) {
+	p, err := ParseLink(issue797Link)
+	if err != nil {
+		t.Fatalf("ParseLink: %v", err)
+	}
+	link, err := EncodeOutbound(p.Outbound, "x")
+	if err != nil {
+		t.Fatalf("EncodeOutbound: %v", err)
+	}
+	back, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("re-parse %s: %v", link, err)
+	}
+	var first, second map[string]any
+	_ = json.Unmarshal(p.Outbound, &first)
+	_ = json.Unmarshal(back.Outbound, &second)
+	got, _ := json.Marshal(second["transport"])
+	want, _ := json.Marshal(first["transport"])
+	if string(got) != string(want) {
+		t.Errorf("transport after round-trip:\n got %s\nwant %s", got, want)
+	}
+}

--- a/internal/singbox/vlink/stream_xhttp_extra_test.go
+++ b/internal/singbox/vlink/stream_xhttp_extra_test.go
@@ -215,3 +215,27 @@ func TestEncodeOutbound_XHTTPExtraRoundTrip(t *testing.T) {
 		t.Errorf("transport after round-trip:\n got %s\nwant %s", got, want)
 	}
 }
+
+// The option layer refuses a disabled padding outright ("x_padding_bytes
+// cannot be disabled"), and that refusal takes the whole config down, so a
+// zero from the link must never reach it.
+func TestBuildStreamFromQuery_XHTTPExtraZeroPadding(t *testing.T) {
+	for _, extra := range []string{
+		`{"xPaddingBytes":"0"}`,
+		`{"xPaddingBytes":0}`,
+		`{"xPaddingBytes":"0-100"}`,
+		`{"xPaddingBytes":"100-0"}`,
+	} {
+		q := parseQuery(t, "type=xhttp&extra="+urlEscape(extra))
+		s, err := BuildStreamFromQuery(q, "example.com")
+		if err != nil {
+			t.Fatalf("extra=%s: %v", extra, err)
+		}
+		out := map[string]any{}
+		s.MergeIntoOutbound(out)
+		tr, _ := out["transport"].(map[string]any)
+		if tr["x_padding_bytes"] != "100-1000" {
+			t.Errorf("extra=%s: x_padding_bytes=%v, want the default", extra, tr["x_padding_bytes"])
+		}
+	}
+}

--- a/internal/singbox/vlink/stream_xhttp_extra_test.go
+++ b/internal/singbox/vlink/stream_xhttp_extra_test.go
@@ -239,3 +239,38 @@ func TestBuildStreamFromQuery_XHTTPExtraZeroPadding(t *testing.T) {
 		}
 	}
 }
+
+// The option layer refuses any mode outside its four, and that refusal takes
+// the whole config down — so the link is rejected instead.
+func TestBuildStreamFromQuery_XHTTPMode(t *testing.T) {
+	for _, mode := range []string{"auto", "packet-up", "stream-up", "stream-one", ""} {
+		if _, err := BuildStreamFromQuery(parseQuery(t, "type=xhttp&mode="+mode), "example.com"); err != nil {
+			t.Errorf("mode=%q rejected: %v", mode, err)
+		}
+	}
+	if _, err := BuildStreamFromQuery(parseQuery(t, "type=xhttp&mode=oops"), "example.com"); err == nil {
+		t.Error("mode=oops accepted, want an error")
+	}
+}
+
+// #709: the egress interface survived import but was dropped when the tunnel
+// was shared back out.
+func TestEncodeOutbound_BindInterface(t *testing.T) {
+	p, err := ParseLink("vless://00000000-1111-2222-3333-444444444444@example.com:443?type=ws&bind_interface=nwg0#x")
+	if err != nil {
+		t.Fatalf("ParseLink: %v", err)
+	}
+	link, err := EncodeOutbound(p.Outbound, "x")
+	if err != nil {
+		t.Fatalf("EncodeOutbound: %v", err)
+	}
+	back, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("re-parse %s: %v", link, err)
+	}
+	var ob map[string]any
+	_ = json.Unmarshal(back.Outbound, &ob)
+	if ob["bind_interface"] != "nwg0" {
+		t.Errorf("bind_interface after round-trip=%v, link=%s", ob["bind_interface"], link)
+	}
+}

--- a/internal/singbox/vlink/xhttp_extra.go
+++ b/internal/singbox/vlink/xhttp_extra.go
@@ -1,0 +1,272 @@
+package vlink
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// xmuxFields maps the camelCase keys Xray puts inside ?extra=.xmux to the
+// snake_case fields our sing-box fork accepts (option.V2RayXHTTPXmuxOptions).
+// The bool says whether the value is a Range (number, "N" or "N-M"); the rest
+// are plain integers.
+var xmuxFields = map[string]struct {
+	key     string
+	isRange bool
+}{
+	"maxConcurrency":   {"max_concurrency", true},
+	"maxConnections":   {"max_connections", true},
+	"cMaxReuseTimes":   {"c_max_reuse_times", true},
+	"hMaxRequestTimes": {"h_max_request_times", true},
+	"hMaxReusableSecs": {"h_max_reusable_secs", true},
+	"hKeepAlivePeriod": {"h_keep_alive_period", false},
+}
+
+type extraKind int
+
+const (
+	kindRange extraKind = iota // number, "N" or "N-M"
+	kindBool
+	kindInt
+	kindHeaders
+)
+
+// extraFields maps the camelCase keys of Xray's xhttpSettings to the
+// snake_case fields of option.V2RayXHTTPBaseOptions in our fork. Keys carried
+// by dedicated query parameters (host, path, mode) and downloadSettings — a
+// whole nested outbound — are deliberately absent.
+var extraFields = map[string]struct {
+	key  string
+	kind extraKind
+}{
+	"headers":              {"headers", kindHeaders},
+	"xPaddingBytes":        {"x_padding_bytes", kindRange},
+	"noGRPCHeader":         {"no_grpc_header", kindBool},
+	"noSSEHeader":          {"no_sse_header", kindBool},
+	"scMaxEachPostBytes":   {"sc_max_each_post_bytes", kindRange},
+	"scMinPostsIntervalMs": {"sc_min_posts_interval_ms", kindRange},
+	"scMaxBufferedPosts":   {"sc_max_buffered_posts", kindInt},
+	"scStreamUpServerSecs": {"sc_stream_up_server_secs", kindRange},
+}
+
+// clashXHTTPFields maps mihomo's kebab-case xhttp-opts keys to the camelCase
+// keys Xray uses inside extra=, so a Clash import goes through exactly the same
+// mapping and validation as a share link. mihomo's session-table /
+// session-length have no field in our fork, and download-settings is a whole
+// nested outbound — both are left out.
+// Reference: mihomo adapter/outbound/vless.go (XHTTPOptions).
+var clashXHTTPFields = map[string]string{
+	"headers":                  "headers",
+	"x-padding-bytes":          "xPaddingBytes",
+	"no-grpc-header":           "noGRPCHeader",
+	"sc-max-each-post-bytes":   "scMaxEachPostBytes",
+	"sc-min-posts-interval-ms": "scMinPostsIntervalMs",
+}
+
+// clashXmuxFields maps mihomo's reuse-settings — its name for xmux — to the
+// camelCase keys of Xray's extra.xmux.
+var clashXmuxFields = map[string]string{
+	"max-concurrency":     "maxConcurrency",
+	"max-connections":     "maxConnections",
+	"c-max-reuse-times":   "cMaxReuseTimes",
+	"h-max-request-times": "hMaxRequestTimes",
+	"h-max-reusable-secs": "hMaxReusableSecs",
+	"h-keep-alive-period": "hKeepAlivePeriod",
+}
+
+// xhttpExtraFromClash renders mihomo's xhttp-opts as an Xray extra= object.
+// Values travel untouched: parseXHTTPExtra validates them downstream.
+func xhttpExtraFromClash(opts map[string]any) string {
+	extra := map[string]any{}
+	for kebab, camel := range clashXHTTPFields {
+		if v, ok := opts[kebab]; ok {
+			extra[camel] = v
+		}
+	}
+	if reuse, ok := opts["reuse-settings"].(map[string]any); ok {
+		xmux := map[string]any{}
+		for kebab, camel := range clashXmuxFields {
+			if v, ok := reuse[kebab]; ok {
+				xmux[camel] = v
+			}
+		}
+		if len(xmux) > 0 {
+			extra["xmux"] = xmux
+		}
+	}
+	if len(extra) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(extra)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+// parseXHTTPExtra decodes the Xray ?extra= object into sing-box xhttp
+// transport fields. sing-box decodes strictly, so anything unknown or of the
+// wrong type is dropped rather than passed on: one bad share link must not
+// make the whole config unloadable.
+func parseXHTTPExtra(raw string) map[string]any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var extra map[string]any
+	if json.Unmarshal([]byte(raw), &extra) != nil {
+		return nil
+	}
+
+	out := map[string]any{}
+	for k, v := range extra {
+		f, known := extraFields[k]
+		if !known {
+			continue
+		}
+		switch f.kind {
+		case kindRange:
+			if isRangeValue(v) {
+				out[f.key] = v
+			}
+		case kindBool:
+			if b, ok := v.(bool); ok {
+				out[f.key] = b
+			}
+		case kindInt:
+			if isWholeNumber(v) {
+				out[f.key] = v
+			}
+		case kindHeaders:
+			if h := stringMap(v); len(h) > 0 {
+				out[f.key] = h
+			}
+		}
+	}
+	if xmuxRaw, ok := extra["xmux"].(map[string]any); ok {
+		xmux := map[string]any{}
+		for k, v := range xmuxRaw {
+			f, known := xmuxFields[k]
+			if !known {
+				continue
+			}
+			if f.isRange {
+				if isRangeValue(v) {
+					xmux[f.key] = v
+				}
+			} else if isWholeNumber(v) {
+				xmux[f.key] = v
+			}
+		}
+		// The option layer refuses both at once and that rejection takes the
+		// whole config down; Xray's semantics are that concurrency wins.
+		if rangeUpper(xmux["max_concurrency"]) > 0 && rangeUpper(xmux["max_connections"]) > 0 {
+			delete(xmux, "max_connections")
+		}
+		if len(xmux) > 0 {
+			out["xmux"] = xmux
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// xhttpExtraFromTransport rebuilds the Xray ?extra= object from an xhttp
+// transport block, so a link imported with xmux carries it again when shared
+// back out. Returns "" when there is nothing worth carrying.
+func xhttpExtraFromTransport(transport map[string]any) string {
+	extra := map[string]any{}
+	for camel, f := range extraFields {
+		if v, ok := transport[f.key]; ok {
+			extra[camel] = v
+		}
+	}
+	if xmuxRaw, ok := transport["xmux"].(map[string]any); ok {
+		xmux := map[string]any{}
+		for camel, f := range xmuxFields {
+			if v, ok := xmuxRaw[f.key]; ok {
+				xmux[camel] = v
+			}
+		}
+		if len(xmux) > 0 {
+			extra["xmux"] = xmux
+		}
+	}
+	if len(extra) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(extra)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+// stringMap keeps only string-valued headers and drops "host": the option
+// layer rejects a headers entry named host (xhttp carries it top-level).
+func stringMap(v any) map[string]string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := map[string]string{}
+	for k, val := range m {
+		s, ok := val.(string)
+		if !ok || strings.EqualFold(k, "host") {
+			continue
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// rangeUpper returns the upper bound of an already-validated Range value, the
+// same field the option layer compares against zero.
+func rangeUpper(v any) int64 {
+	_, hi, _ := rangeBounds(v)
+	return hi
+}
+
+// isRangeValue reports whether v survives xbadoption.Range: a number, "N" or
+// "N-M", decoded into int32 and refused when from > to.
+func isRangeValue(v any) bool {
+	_, _, ok := rangeBounds(v)
+	return ok
+}
+
+// rangeBounds parses the Range forms Xray emits. Negatives are refused along
+// with everything out of int32: sing-box would fail the whole config on them.
+func rangeBounds(v any) (lo, hi int64, ok bool) {
+	switch t := v.(type) {
+	case float64:
+		if !isWholeNumber(t) {
+			return 0, 0, false
+		}
+		return int64(t), int64(t), true
+	case string:
+		loStr, hiStr, found := strings.Cut(t, "-")
+		lo, err := strconv.ParseInt(loStr, 10, 32)
+		if err != nil || lo < 0 {
+			return 0, 0, false
+		}
+		if !found {
+			return lo, lo, true
+		}
+		hi, err := strconv.ParseInt(hiStr, 10, 32)
+		if err != nil || hi < lo {
+			return 0, 0, false
+		}
+		return lo, hi, true
+	}
+	return 0, 0, false
+}
+
+// isWholeNumber reports whether v is a non-negative integer that fits int32 —
+// the width every numeric xhttp option decodes into.
+func isWholeNumber(v any) bool {
+	n, ok := v.(float64)
+	return ok && n == math.Trunc(n) && n >= 0 && n <= math.MaxInt32
+}

--- a/internal/singbox/vlink/xhttp_extra.go
+++ b/internal/singbox/vlink/xhttp_extra.go
@@ -26,7 +26,8 @@ var xmuxFields = map[string]struct {
 type extraKind int
 
 const (
-	kindRange extraKind = iota // number, "N" or "N-M"
+	kindRange         extraKind = iota // number, "N" or "N-M"
+	kindPositiveRange                  // a Range the option layer refuses at zero
 	kindBool
 	kindInt
 	kindHeaders
@@ -41,7 +42,7 @@ var extraFields = map[string]struct {
 	kind extraKind
 }{
 	"headers":              {"headers", kindHeaders},
-	"xPaddingBytes":        {"x_padding_bytes", kindRange},
+	"xPaddingBytes":        {"x_padding_bytes", kindPositiveRange},
 	"noGRPCHeader":         {"no_grpc_header", kindBool},
 	"noSSEHeader":          {"no_sse_header", kindBool},
 	"scMaxEachPostBytes":   {"sc_max_each_post_bytes", kindRange},
@@ -52,9 +53,11 @@ var extraFields = map[string]struct {
 
 // clashXHTTPFields maps mihomo's kebab-case xhttp-opts keys to the camelCase
 // keys Xray uses inside extra=, so a Clash import goes through exactly the same
-// mapping and validation as a share link. mihomo's session-table /
-// session-length have no field in our fork, and download-settings is a whole
-// nested outbound — both are left out.
+// mapping and validation as a share link. Deliberately partial: mihomo also
+// carries the padding/session/seq/uplink knobs our fork has fields for, but
+// they never travel in a share link, so both import paths stay identical and
+// drop them. session-table / session-length have no field in the fork at all,
+// and download-settings is a whole nested outbound.
 // Reference: mihomo adapter/outbound/vless.go (XHTTPOptions).
 var clashXHTTPFields = map[string]string{
 	"headers":                  "headers",
@@ -128,6 +131,12 @@ func parseXHTTPExtra(raw string) map[string]any {
 		switch f.kind {
 		case kindRange:
 			if isRangeValue(v) {
+				out[f.key] = v
+			}
+		case kindPositiveRange:
+			// "x_padding_bytes cannot be disabled" — a zero from the link
+			// would make the whole config unloadable.
+			if lo, _, ok := rangeBounds(v); ok && lo > 0 {
 				out[f.key] = v
 			}
 		case kindBool:
@@ -237,8 +246,10 @@ func isRangeValue(v any) bool {
 	return ok
 }
 
-// rangeBounds parses the Range forms Xray emits. Negatives are refused along
-// with everything out of int32: sing-box would fail the whole config on them.
+// rangeBounds parses the Range forms Xray emits. Values out of int32 are
+// refused because sing-box would fail the whole config on them; negatives are
+// refused as a house rule — Xray never emits one, and for x_padding_bytes the
+// option layer does reject it.
 func rangeBounds(v any) (lo, hi int64, ok bool) {
 	switch t := v.(type) {
 	case float64:


### PR DESCRIPTION
Закрывает #797.

Разбор VLESS-ссылки выбрасывал весь объект `extra`, включая `xmux`. Без мультиплексирования каждый параллельный поток открывал отдельный REALITY-хендшейк — на дальних маршрутах это давало таймауты и обрывы на всём, что открывает несколько соединений разом.

## Что изменилось

- **Импорт ссылок**: `extra` разбирается целиком по схеме форка. Значения не того типа или вне int32 отбрасываются — кривая ссылка не должна ронять конфигурацию, общую на все туннели.
- **`xmux`**: `max_connections` снимается при заданном `max_concurrency` — иначе ядро отвергает конфигурацию целиком (проверено запуском декодера).
- **Clash/mihomo**: `xhttp-opts`, включая `reuse-settings`, идут тем же путём. Схема сверена с исходниками mihomo, а не с документацией.
- **Экспорт**: `extra` собирается обратно — ссылка больше не теряет `xmux`. Побочно `x_padding_bytes` теперь попадает в исходящую ссылку: с этого коммита он может приходить из ссылки, а не только из нашего дефолта.

## Найдено и починено по ходу ревью

- **`xPaddingBytes: "0"` клал весь конфиг.** Ядро отвергает выключенную набивку отдельной проверкой, и отказ уносит всю конфигурацию. В Xray `\"0\"` — штатный способ выключить padding, вход реальный.
- **`mode` не валидировался.** Ядро знает четыре значения, на пятом отказывается читать конфигурацию. Теперь отвергается одна ссылка.
- **`bind_interface` (#709) терялся при экспорте.** Разбирался при импорте, при сборке ссылки пропадал — поделился туннелем, привязка к интерфейсу исчезла.

## Проверка

по форку \`amnezia-box-awg14\` на теге \`1.14.0-rc.1-awgm.14\`. Сгенерированный transport-блок скормлен настоящему декодеру форка — принят, значения совпали с ручным обходом из issue.