### PR TITLE
порт Clash API настраивается из UI (#788)

### DIFF
--- a/cmd/awg-manager/wiring_singbox.go
+++ b/cmd/awg-manager/wiring_singbox.go
@@ -55,6 +55,7 @@ func (a *app) setupSingbox() {
 		AppLogger:       a.loggingService,
 		SingboxLogLevel: a.settingsStore.GetSingboxLogLevel,
 		BootstrapDNS:    a.settingsStore.GetSingboxBootstrapDNS,
+		ClashPort:       a.settingsStore.GetSingboxClashPort,
 		// Seed the sticky-stop flag from disk so the watchdog respects
 		// a user-pressed Stop across awgm restarts. SetManuallyStopped
 		// writes the new intent back through a single-field updater so
@@ -308,7 +309,7 @@ func (a *app) setupSingbox() {
 
 	trafficCtx, trafficCancel := context.WithCancel(context.Background())
 	a.deferOnExit(trafficCancel)
-	go singbox.NewTrafficAggregator(a.singboxOp.Clash().Address(), a.eventBus, a.trafficHistory).Run(trafficCtx)
+	go singbox.NewTrafficAggregator(a.singboxOp.Clash().Address, a.eventBus, a.trafficHistory).Run(trafficCtx)
 
 	delayCtx, delayCancel := context.WithCancel(context.Background())
 	a.deferOnExit(delayCancel)
@@ -318,7 +319,7 @@ func (a *app) setupSingbox() {
 	// UI log view (replaces the old file-based log; see process.go).
 	logFwdCtx, logFwdCancel := context.WithCancel(context.Background())
 	a.deferOnExit(logFwdCancel)
-	go singbox.NewLogForwarder(a.singboxOp.Clash().Address(), a.loggingService).Run(logFwdCtx)
+	go singbox.NewLogForwarder(a.singboxOp.Clash().Address, a.loggingService).Run(logFwdCtx)
 
 	// Updater service (awg-manager self-update check/apply + scheduled
 	// auto-install for both awg-manager and the managed sing-box binary).

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1271,6 +1271,7 @@ const api_SettingsData: v.GenericSchema = v.looseObject({
 	server: v.optional(v.nullable(v.lazy(() => api_ServerSettingsDTO))),
 	sessionTtlHours: v.optional(v.nullable(v.number())),
 	singboxBootstrapDNS: v.optional(v.nullable(v.string())),
+	singboxClashPort: v.optional(v.nullable(v.number())),
 	updates: v.optional(v.nullable(v.lazy(() => api_UpdateSettingsDTO))),
 	usageLevel: v.optional(v.nullable(v.string())),
 });

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -29,6 +29,11 @@
 		bootstrapDNS?: string;
 		onsaveBootstrapDNS?: (value: string) => void;
 		bootstrapSaving?: boolean;
+		/** Порт Clash API sing-box; 0 или пусто = порт по умолчанию. */
+		clashPort?: number;
+		onsaveClashPort?: (value: number) => void;
+		clashPortSaving?: boolean;
+		clashPortError?: string | null;
 	}
 
 	let {
@@ -50,7 +55,13 @@
 		bootstrapDNS = '',
 		onsaveBootstrapDNS,
 		bootstrapSaving = false,
+		clashPort = 0,
+		onsaveClashPort,
+		clashPortSaving = false,
+		clashPortError = null,
 	}: Props = $props();
+
+	const DEFAULT_CLASH_PORT = 9099;
 
 	// Черновик поля bootstrap-DNS. Настройки на странице грузятся один раз,
 	// внешних обновлений у этого props нет — ресинк не нужен, начальное
@@ -65,6 +76,16 @@
 		return v === '' || isIPv4(v) || isIPv6(v);
 	});
 	const bootstrapDirty = $derived(bootstrapDraft.trim() !== bootstrapDNS);
+
+	// Черновик порта Clash API — та же схема, что у bootstrap-DNS: настройки
+	// грузятся один раз, внешних обновлений props нет, ресинк не нужен.
+	// svelte-ignore state_referenced_locally
+	let clashPortDraft = $state(String(clashPort || DEFAULT_CLASH_PORT));
+	const clashPortValue = $derived(Number(clashPortDraft.trim()));
+	const clashPortValid = $derived(
+		/^\d+$/.test(clashPortDraft.trim()) && clashPortValue >= 1024 && clashPortValue <= 65535
+	);
+	const clashPortDirty = $derived(clashPortValue !== (clashPort || DEFAULT_CLASH_PORT));
 
 	let confirmUninstall = $state(false);
 
@@ -269,6 +290,41 @@
 							loading={bootstrapSaving}
 							disabled={!bootstrapValid || !bootstrapDirty || bootstrapSaving}
 							onclick={() => onsaveBootstrapDNS?.(bootstrapDraft.trim())}
+						>
+							Сохранить
+						</Button>
+					</div>
+				</div>
+			{/if}
+			{#if singboxInstalled && onsaveClashPort}
+				<div class="setting-row bootstrap-row">
+					<div class="integration-meta">
+						<span class="font-medium">Порт Clash API</span>
+						<span class="setting-description">
+							Служебный канал управления sing-box: через него работают журнал,
+							активные соединения, замеры задержки и переключение подписок.
+							Слушается только на 127.0.0.1 и наружу не выставляется.
+						</span>
+						<span class="setting-description">
+							Менять стоит, только если порт {DEFAULT_CLASH_PORT} занял сторонний
+							пакет — тогда sing-box не стартует. Занятый порт форма не примет.
+						</span>
+					</div>
+					<div class="bootstrap-field">
+						<Input
+							type="text"
+							bind:value={clashPortDraft}
+							placeholder={String(DEFAULT_CLASH_PORT)}
+							disabled={clashPortSaving}
+							error={clashPortValid ? (clashPortError ?? undefined) : 'Нужен порт от 1024 до 65535'}
+							fullWidth
+						/>
+						<Button
+							variant="secondary"
+							size="sm"
+							loading={clashPortSaving}
+							disabled={!clashPortValid || !clashPortDirty || clashPortSaving}
+							onclick={() => onsaveClashPort?.(clashPortValue)}
 						>
 							Сохранить
 						</Button>

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -61,7 +61,13 @@
 		clashPortError = null,
 	}: Props = $props();
 
+	// Копии Go-констант: singbox.DefaultClashPort и api.minClashPort. Фронт не
+	// импортирует Go, а бэкенд остаётся авторитетом — невалидное он отвергнет
+	// и без нас. Здесь они только чтобы подсказка и placeholder не врали, так
+	// что при смене первоисточника поправить нужно и тут.
 	const DEFAULT_CLASH_PORT = 9099;
+	const MIN_CLASH_PORT = 1024;
+	const MAX_CLASH_PORT = 65535;
 
 	// Черновик поля bootstrap-DNS. Настройки на странице грузятся один раз,
 	// внешних обновлений у этого props нет — ресинк не нужен, начальное
@@ -83,7 +89,9 @@
 	let clashPortDraft = $state(String(clashPort || DEFAULT_CLASH_PORT));
 	const clashPortValue = $derived(Number(clashPortDraft.trim()));
 	const clashPortValid = $derived(
-		/^\d+$/.test(clashPortDraft.trim()) && clashPortValue >= 1024 && clashPortValue <= 65535
+		/^\d+$/.test(clashPortDraft.trim()) &&
+			clashPortValue >= MIN_CLASH_PORT &&
+			clashPortValue <= MAX_CLASH_PORT
 	);
 	const clashPortDirty = $derived(clashPortValue !== (clashPort || DEFAULT_CLASH_PORT));
 
@@ -316,7 +324,7 @@
 							bind:value={clashPortDraft}
 							placeholder={String(DEFAULT_CLASH_PORT)}
 							disabled={clashPortSaving}
-							error={clashPortValid ? (clashPortError ?? undefined) : 'Нужен порт от 1024 до 65535'}
+							error={clashPortValid ? (clashPortError ?? undefined) : `Нужен порт от ${MIN_CLASH_PORT} до ${MAX_CLASH_PORT}`}
 							fullWidth
 						/>
 						<Button

--- a/frontend/src/lib/types/system.ts
+++ b/frontend/src/lib/types/system.ts
@@ -289,6 +289,13 @@ export interface Settings {
 	 * Пусто — адрес в конфиге не навязывается (issue #770).
 	 */
 	singboxBootstrapDNS?: string;
+	/**
+	 * Порт experimental.clash_api.external_controller в 00-base.json.
+	 * Хост всегда 127.0.0.1: Clash API — служебный канал управления
+	 * awg-manager, а не пользовательский слушатель. 0 — порт по
+	 * умолчанию (9099), issue #788.
+	 */
+	singboxClashPort?: number;
 }
 
 // #endregion

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -560,6 +560,30 @@ $effect(() => {
 		}
 	}
 
+	let savingClashPort = $state(false);
+	let clashPortError = $state<string | null>(null);
+
+	// Порт Clash API применяется бэкендом сразу: он переписывает
+	// external_controller в 00-base.json, перечитывает конфиг sing-box и
+	// переставляет собственного клиента. Отказ по занятости порта приходит
+	// текстом ошибки и показывается прямо под полем.
+	async function saveClashPort(value: number) {
+		if (!settings) return;
+		savingClashPort = true;
+		clashPortError = null;
+		try {
+			settings = await api.updateSettings({ ...settings, singboxClashPort: value });
+			setGlobalSettings(settings);
+			notifications.success(`Порт Clash API: ${value}`);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : "Ошибка сохранения порта Clash API";
+			clashPortError = msg;
+			notifications.error(msg);
+		} finally {
+			savingClashPort = false;
+		}
+	}
+
 	async function toggleUpdateCheck(enabled: boolean) {
 		if (!settings) return;
 		saving = true;
@@ -785,6 +809,10 @@ $effect(() => {
 					bootstrapDNS={settings.singboxBootstrapDNS ?? ''}
 					bootstrapSaving={savingBootstrapDNS}
 					onsaveBootstrapDNS={saveBootstrapDNS}
+					clashPort={settings.singboxClashPort ?? 0}
+					clashPortSaving={savingClashPort}
+					{clashPortError}
+					onsaveClashPort={saveClashPort}
 				/>
 				</div>
 			</aside>

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/response"
+	"github.com/hoaxisr/awg-manager/internal/singbox"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
@@ -127,6 +128,11 @@ type SettingsData struct {
 	// before any other resolver exists, so it must be a literal IP, no
 	// hostname and no port. Empty leaves 00-base.json untouched.
 	SingboxBootstrapDNS string `json:"singboxBootstrapDNS,omitempty" example:"8.8.8.8"`
+	// SingboxClashPort is the port of experimental.clash_api.external_controller
+	// in 00-base.json. The host is always 127.0.0.1 — Clash API is
+	// awg-manager's internal control channel, not a user-facing listener
+	// (ADR 0001). 0 means "default" (9099). Issue #788.
+	SingboxClashPort int `json:"singboxClashPort,omitempty" example:"9099"`
 }
 
 // SettingsResponse is the envelope for GET /settings/get.
@@ -158,6 +164,8 @@ type SettingsHandler struct {
 	applyLogSettings        func()
 	applySingboxLogSettings func() error
 	applyBootstrapDNS       func(string) error
+	applyClashPort          func(int) error
+	clashPorts              clashPortInspector
 	downloadSvc             *downloader.Service
 	log                     *logging.ScopedLogger
 	bus                     *events.Bus
@@ -224,6 +232,18 @@ func (h *SettingsHandler) SetApplySingboxLogSettings(fn func() error) {
 // address into the running sing-box (issue #770).
 func (h *SettingsHandler) SetApplyBootstrapDNS(fn func(string) error) {
 	h.applyBootstrapDNS = fn
+}
+
+// SetApplyClashPort wires the hook that pushes a changed Clash API port
+// into 00-base.json and repoints our ClashClient (issue #788).
+func (h *SettingsHandler) SetApplyClashPort(fn func(int) error) {
+	h.applyClashPort = fn
+}
+
+// SetClashPortInspector wires the /proc scanner used to reject a Clash API
+// port already held by a foreign process.
+func (h *SettingsHandler) SetClashPortInspector(insp clashPortInspector) {
+	h.clashPorts = insp
 }
 
 func (h *SettingsHandler) SetDownloadService(svc *downloader.Service) {
@@ -374,6 +394,17 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Порт Clash API проверяем ТОЛЬКО при реальной смене: наш sing-box в этот
+	// момент слушает СТАРЫЙ порт, так что сверка «а не мы ли держим новый»
+	// не нужна — совпасть значения могут лишь при сохранении того же порта,
+	// а это не смена (issue #788).
+	if patch.SingboxClashPort != nil && oldSettings.SingboxClashPort != merged.SingboxClashPort {
+		if msg := validateClashPort(merged.SingboxClashPort, merged.Server.Port, h.clashPorts); msg != "" {
+			response.Error(w, msg, "SINGBOX_CLASH_PORT_INVALID")
+			return
+		}
+	}
+
 	// Validate usageLevel after merge. Empty merged.UsageLevel is
 	// impossible because oldSettings always carries a value (default
 	// settings populate it; migration v15 backfills it), so we only
@@ -474,6 +505,18 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		h.log.Info("singbox-bootstrap-dns", "",
 			fmt.Sprintf("Sing-box bootstrap DNS changed: %s -> %s",
 				orDefaultLabel(oldSettings.SingboxBootstrapDNS), orDefaultLabel(merged.SingboxBootstrapDNS)))
+	}
+
+	if oldSettings.SingboxClashPort != merged.SingboxClashPort && h.applyClashPort != nil {
+		if err := h.applyClashPort(merged.SingboxClashPort); err != nil {
+			h.log.Error("singbox-clash-port", "", "failed to apply clash port: "+err.Error())
+			response.Error(w, err.Error(), "SINGBOX_CLASH_PORT_APPLY_ERROR")
+			return
+		}
+		h.log.Info("singbox-clash-port", "",
+			fmt.Sprintf("Sing-box Clash API port changed: %d -> %d",
+				singbox.EffectiveClashPort(oldSettings.SingboxClashPort),
+				singbox.EffectiveClashPort(merged.SingboxClashPort)))
 	}
 
 	// Handle ping check toggle AFTER settings are saved

--- a/internal/api/settings_clashport.go
+++ b/internal/api/settings_clashport.go
@@ -33,7 +33,12 @@ func reservedClashPort(port, serverPort int) string {
 	case port == router.RedirectPort:
 		return "REDIRECT sing-box"
 	case port >= firstTunnelPort && port <= lastTunnelPort:
-		return "входы туннелей sing-box и прокси для устройств"
+		// Только диапазон входов туннелей. Порт device-proxy настраивается
+		// в 1024-65535 и сюда попадает лишь по умолчанию (1099), а
+		// выключенный инстанс не поймает и скан занятости — сокета нет.
+		// Обратная сверка (device-proxy знает про наш порт) не сделана: это
+		// правка в валидаторе deviceproxy, отдельная задача.
+		return "входы туннелей sing-box"
 	case inQoSPortRange(router.QoSTPROXYPortBase, port):
 		return "QoS-классы (TPROXY)"
 	case inQoSPortRange(router.QoSRedirectPortBase, port):

--- a/internal/api/settings_clashport.go
+++ b/internal/api/settings_clashport.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router"
+	sysports "github.com/hoaxisr/awg-manager/internal/sys/ports"
+)
+
+// minClashPort — нижняя граница выбора. Привилегированные порты (<1024)
+// отсекаем: awg-manager на роутере ходит от root, так что технически
+// занять их смог бы, но соседство с системными службами — лишний риск.
+const minClashPort = 1024
+
+// clashPortInspector — подмножество sys/ports.Scanner, нужное валидации.
+// Интерфейс, а не структура, чтобы тест подставлял свою занятость.
+type clashPortInspector interface {
+	InspectPort(port int, proto string) ([]sysports.Binding, error)
+}
+
+// reservedClashPort возвращает название СВОЕГО слушателя, за которым уже
+// закреплён порт, или "" — если порт нам не принадлежит. Карта резервов
+// читается из единственных источников правды (router, singbox), а не копией
+// чисел: разъехаться нечему.
+func reservedClashPort(port, serverPort int) string {
+	firstTunnelPort, lastTunnelPort := singbox.TunnelInboundPortRange()
+	switch {
+	case port == serverPort:
+		return "веб-интерфейс awg-manager"
+	case port == router.TPROXYPort:
+		return "TPROXY sing-box"
+	case port == router.RedirectPort:
+		return "REDIRECT sing-box"
+	case port >= firstTunnelPort && port <= lastTunnelPort:
+		return "входы туннелей sing-box и прокси для устройств"
+	case inQoSPortRange(router.QoSTPROXYPortBase, port):
+		return "QoS-классы (TPROXY)"
+	case inQoSPortRange(router.QoSRedirectPortBase, port):
+		return "QoS-классы (REDIRECT)"
+	}
+	return ""
+}
+
+func inQoSPortRange(base, port int) bool {
+	return port >= base && port < base+router.MaxQoSClasses
+}
+
+// validateClashPort проверяет выбранный порт Clash API: диапазон, пересечение
+// с нашей картой резервов и занятость чужим процессом. Возвращает текст
+// ошибки для пользователя или "" — если порт годен.
+//
+// Занятость проверяется на СЕРВЕРЕ, а не на фронте: это валидация на границе
+// доверия, и HTTP-ручки /system/ports/* закрыты expert-гейтом, то есть
+// обычному пользователю недоступны (issue #788).
+//
+// Цена ошибки высокая: SIGHUP в sing-box — это Close + пересоздание инстанса,
+// и если новый слушающий сокет занять не удалось, процесс выходит целиком.
+//
+// ponytail: между проверкой и рестартом остаётся TOCTOU-окно — порт может
+// занять кто-то ещё в эти доли секунды. Принято осознанно: закрывать его
+// пришлось бы вторым путём записи конфига с откатом, а видимость у отказа
+// есть — FATAL уезжает в /logs через LogForwarder.
+func validateClashPort(port, serverPort int, insp clashPortInspector) string {
+	effective := singbox.EffectiveClashPort(port)
+	if effective < minClashPort || effective > 65535 {
+		return fmt.Sprintf("порт Clash API должен быть в диапазоне %d-65535", minClashPort)
+	}
+	if owner := reservedClashPort(effective, serverPort); owner != "" {
+		return fmt.Sprintf("порт %d уже зарезервирован под %s", effective, owner)
+	}
+	if insp == nil {
+		return ""
+	}
+	bindings, err := insp.InspectPort(effective, "tcp")
+	if err != nil || len(bindings) == 0 {
+		// Ошибку скана не считаем поводом отказать: /proc может быть
+		// недоступен, а запрет из-за этого выглядел бы как отказ по занятости.
+		return ""
+	}
+	return fmt.Sprintf("порт %d занят: %s", effective, describeBinding(bindings[0]))
+}
+
+// describeBinding собирает человекочитаемое имя держателя порта из того, что
+// нашёл сканер: имя процесса, PID, путь и init.d-сервис заполнены не всегда.
+func describeBinding(b sysports.Binding) string {
+	name := b.ProcessName
+	if name == "" {
+		name = b.Exe
+	}
+	if name == "" {
+		name = "неизвестный процесс"
+	}
+	if b.PID > 0 {
+		name = fmt.Sprintf("%s (PID %d)", name, b.PID)
+	}
+	if b.Service != "" {
+		name = fmt.Sprintf("%s, сервис %s", name, b.Service)
+	}
+	return name
+}

--- a/internal/api/settings_clashport_test.go
+++ b/internal/api/settings_clashport_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -89,5 +90,90 @@ func TestDescribeBinding(t *testing.T) {
 				t.Errorf("want %q, got %q", c.want, got)
 			}
 		})
+	}
+}
+
+// Гейт «проверять только при реальной смене»: наш sing-box в момент проверки
+// слушает СТАРЫЙ порт, поэтому пересохранение того же значения не должно
+// упираться в собственную занятость.
+func TestUpdate_SingboxClashPort_ValidatesOnlyOnChange(t *testing.T) {
+	h, _ := newSettingsHandlerFromRaw(t, `{"schemaVersion":2,"singboxClashPort":9500}`)
+	h.SetClashPortInspector(stubInspector{bindings: []sysports.Binding{{
+		Port: 9500, ProcessName: "sing-box", PID: 42,
+	}}})
+
+	// Тот же порт при занятом сокете — проходит: смены нет.
+	if rec := postSettingsUpdate(t, h, `{"singboxClashPort":9500}`); rec.Code != http.StatusOK {
+		t.Fatalf("пересохранение того же порта: status %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Смена на занятый порт — отказ с именем держателя.
+	rec := postSettingsUpdate(t, h, `{"singboxClashPort":9600}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("смена на занятый порт: status %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "sing-box") {
+		t.Errorf("отказ должен называть держателя порта: %s", rec.Body.String())
+	}
+}
+
+// Отвергнутый валидацией порт не должен оседать в сторадже: иначе он молча
+// применился бы на следующем старте awgm.
+func TestUpdate_SingboxClashPort_RejectedValueNotStored(t *testing.T) {
+	h, store := newSettingsHandlerFromRaw(t, `{"schemaVersion":2}`)
+	if rec := postSettingsUpdate(t, h, `{"singboxClashPort":80}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	got, err := store.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.SingboxClashPort != 0 {
+		t.Errorf("отвергнутый порт сохранён: %d", got.SingboxClashPort)
+	}
+}
+
+func TestUpdate_SingboxClashPort_AppliesOnChange(t *testing.T) {
+	h, _ := newSettingsHandlerFromRaw(t, `{"schemaVersion":2}`)
+	var applied []int
+	h.SetApplyClashPort(func(p int) error {
+		applied = append(applied, p)
+		return nil
+	})
+
+	if rec := postSettingsUpdate(t, h, `{"singboxClashPort":9500}`); rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(applied) != 1 || applied[0] != 9500 {
+		t.Fatalf("applied = %#v, want [9500]", applied)
+	}
+
+	// Повтор без смены значения sing-box дёргать не должен.
+	if rec := postSettingsUpdate(t, h, `{"singboxClashPort":9500}`); rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if len(applied) != 1 {
+		t.Errorf("applied = %#v, повторное применение без смены", applied)
+	}
+}
+
+// Провал применения отдаёт ошибку, но настройки к этому моменту УЖЕ сохранены
+// (общий для всех applyX-хуков порядок в Update). Тест фиксирует расхождение
+// явно: пользователь видит отказ, а порт уже в сторадже и оживёт на следующем
+// старте. Отдельная задача — общая для clash-порта, bootstrap-DNS и уровня
+// лога; пока поведение зафиксировано, чтобы не поменялось незамеченным.
+func TestUpdate_SingboxClashPort_ApplyFailureStillPersists(t *testing.T) {
+	h, store := newSettingsHandlerFromRaw(t, `{"schemaVersion":2}`)
+	h.SetApplyClashPort(func(int) error { return errors.New("orchestrator down") })
+
+	rec := postSettingsUpdate(t, h, `{"singboxClashPort":9500}`)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("ожидалась ошибка применения, got 200")
+	}
+	got, err := store.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.SingboxClashPort != 9500 {
+		t.Errorf("SingboxClashPort = %d; тест фиксирует, что настройка сохраняется ДО применения", got.SingboxClashPort)
 	}
 }

--- a/internal/api/settings_clashport_test.go
+++ b/internal/api/settings_clashport_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/singbox"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router"
+	sysports "github.com/hoaxisr/awg-manager/internal/sys/ports"
+)
+
+type stubInspector struct {
+	bindings []sysports.Binding
+	err      error
+}
+
+func (s stubInspector) InspectPort(int, string) ([]sysports.Binding, error) {
+	return s.bindings, s.err
+}
+
+func TestValidateClashPort(t *testing.T) {
+	const serverPort = 8080
+	busy := stubInspector{bindings: []sysports.Binding{{
+		Port: 9500, ProcessName: "wt-client", PID: 1234, Service: "S99wt",
+	}}}
+	free := stubInspector{}
+
+	cases := []struct {
+		name string
+		port int
+		insp clashPortInspector
+		want string // подстрока; "" — порт должен быть принят
+	}{
+		{"свободный порт принимается", 9500, free, ""},
+		{"0 = дефолт, принимается", 0, free, ""},
+		{"ниже диапазона", 80, free, "диапазоне"},
+		{"выше диапазона", 70000, free, "диапазоне"},
+		{"порт веб-интерфейса", serverPort, free, "веб-интерфейс"},
+		{"TPROXY sing-box", router.TPROXYPort, free, "TPROXY"},
+		{"REDIRECT sing-box", router.RedirectPort, free, "REDIRECT"},
+		{"первый порт QoS TPROXY", router.QoSTPROXYPortBase, free, "QoS"},
+		{"последний порт QoS TPROXY", router.QoSTPROXYPortBase + router.MaxQoSClasses - 1, free, "QoS"},
+		{"за границей диапазона QoS", router.QoSTPROXYPortBase + router.MaxQoSClasses, free, ""},
+		{"первый порт QoS REDIRECT", router.QoSRedirectPortBase, free, "QoS"},
+		{"вход туннеля", 1080, free, "входы туннелей"},
+		{"занят чужим процессом", 9500, busy, "wt-client"},
+		{"ошибка скана не блокирует", 9500, stubInspector{err: errors.New("no /proc")}, ""},
+		{"без сканера проверяется только карта резервов", 9500, nil, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := validateClashPort(c.port, serverPort, c.insp)
+			if c.want == "" {
+				if got != "" {
+					t.Errorf("порт должен быть принят, отказ: %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, c.want) {
+				t.Errorf("отказ должен содержать %q, got %q", c.want, got)
+			}
+		})
+	}
+}
+
+// Дефолтный порт не должен попадать в собственную карту резервов — иначе
+// свежая установка не смогла бы сохранить настройки.
+func TestDefaultClashPortNotReserved(t *testing.T) {
+	if owner := reservedClashPort(singbox.DefaultClashPort, 8080); owner != "" {
+		t.Errorf("дефолтный порт зарезервирован под %q", owner)
+	}
+}
+
+func TestDescribeBinding(t *testing.T) {
+	cases := []struct {
+		name string
+		in   sysports.Binding
+		want string
+	}{
+		{"полная запись", sysports.Binding{ProcessName: "wt-client", PID: 7, Service: "S99wt"}, "wt-client (PID 7), сервис S99wt"},
+		{"только exe", sysports.Binding{Exe: "/opt/bin/x", PID: 7}, "/opt/bin/x (PID 7)"},
+		{"пустая запись", sysports.Binding{}, "неизвестный процесс"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := describeBinding(c.in); got != c.want {
+				t.Errorf("want %q, got %q", c.want, got)
+			}
+		})
+	}
+}

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -3395,6 +3395,14 @@ definitions:
           hostname and no port. Empty leaves 00-base.json untouched.
         example: 8.8.8.8
         type: string
+      singboxClashPort:
+        description: |-
+          SingboxClashPort is the port of experimental.clash_api.external_controller
+          in 00-base.json. The host is always 127.0.0.1 — Clash API is
+          awg-manager's internal control channel, not a user-facing listener
+          (ADR 0001). 0 means "default" (9099). Issue #788.
+        example: 9099
+        type: integer
       updates:
         $ref: '#/definitions/api.UpdateSettingsDTO'
       usageLevel:

--- a/internal/server/server_routes.go
+++ b/internal/server/server_routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/openapi"
 	"github.com/hoaxisr/awg-manager/internal/response"
+	sysports "github.com/hoaxisr/awg-manager/internal/sys/ports"
 
 	"github.com/hoaxisr/awg-manager/internal/logging"
 )
@@ -140,6 +141,13 @@ func (s *Server) buildRouteHandlers() *routeHandlers {
 		}
 		return s.singboxOp.ApplyBootstrapDNS(server)
 	})
+	h.settingsHandler.SetApplyClashPort(func(port int) error {
+		if s.singboxOp == nil {
+			return nil
+		}
+		return s.singboxOp.ApplyClashPort(port)
+	})
+	h.settingsHandler.SetClashPortInspector(sysports.NewScanner())
 	h.settingsHandler.SetApplySingboxLogSettings(func() error {
 		if s.singboxOp == nil || s.settings == nil {
 			return nil

--- a/internal/singbox/clash.go
+++ b/internal/singbox/clash.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 )
 
 // ClashClient is a thin HTTP client for sing-box's Clash API.
+//
+// address меняется в рантайме (пользователь может сменить порт — issue #788),
+// а читают его конкурентно DelayChecker, LogForwarder, прокси Clash и
+// подписочные селекторы, поэтому доступ к полю только через Address/SetAddress.
 type ClashClient struct {
-	address string // e.g. "127.0.0.1:9099" — see singbox.clashAPIAddr
+	mu      sync.RWMutex
+	address string // e.g. "127.0.0.1:9099" — see singbox.clashAddr
 	http    *http.Client
 }
 
@@ -39,7 +45,7 @@ type DelayHistory struct {
 
 // GetProxies returns the map of proxies keyed by name.
 func (c *ClashClient) GetProxies() (map[string]ClashProxy, error) {
-	u := fmt.Sprintf("http://%s/proxies", c.address)
+	u := fmt.Sprintf("http://%s/proxies", c.Address())
 	resp, err := c.http.Get(u)
 	if err != nil {
 		return nil, err
@@ -83,7 +89,7 @@ func (c *ClashClient) TestDelay(name, testURL string, timeout time.Duration) (in
 	q := url.Values{}
 	q.Set("url", testURL)
 	q.Set("timeout", fmt.Sprintf("%d", timeout.Milliseconds()))
-	u := fmt.Sprintf("http://%s/proxies/%s/delay?%s", c.address, url.PathEscape(name), q.Encode())
+	u := fmt.Sprintf("http://%s/proxies/%s/delay?%s", c.Address(), url.PathEscape(name), q.Encode())
 	resp, err := c.http.Get(u)
 	if err != nil {
 		return 0, err
@@ -104,7 +110,7 @@ func (c *ClashClient) TestDelay(name, testURL string, timeout time.Duration) (in
 // IsHealthy checks Clash API availability (fast health probe).
 func (c *ClashClient) IsHealthy() bool {
 	cli := &http.Client{Timeout: 1 * time.Second}
-	resp, err := cli.Get(fmt.Sprintf("http://%s/version", c.address))
+	resp, err := cli.Get(fmt.Sprintf("http://%s/version", c.Address()))
 	if err != nil {
 		return false
 	}
@@ -113,7 +119,19 @@ func (c *ClashClient) IsHealthy() bool {
 }
 
 // Address returns the Clash API address for WebSocket proxying.
-func (c *ClashClient) Address() string { return c.address }
+func (c *ClashClient) Address() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.address
+}
+
+// SetAddress repoints the client at a new Clash API endpoint. Called when the
+// user changes the port (issue #788); in-flight requests keep the old address.
+func (c *ClashClient) SetAddress(addr string) {
+	c.mu.Lock()
+	c.address = addr
+	c.mu.Unlock()
+}
 
 // SetSelector tells a running sing-box via the Clash API to switch the
 // active member of a selector outbound. Live switch: existing
@@ -124,7 +142,7 @@ func (c *ClashClient) SetSelector(selectorTag, memberTag string) error {
 	if err != nil {
 		return err
 	}
-	u := fmt.Sprintf("http://%s/proxies/%s", c.address, url.PathEscape(selectorTag))
+	u := fmt.Sprintf("http://%s/proxies/%s", c.Address(), url.PathEscape(selectorTag))
 	req, err := http.NewRequest(http.MethodPut, u, bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -147,7 +165,7 @@ func (c *ClashClient) SetSelector(selectorTag, memberTag string) error {
 // callers can treat "no selector yet" as distinct from a transport
 // error.
 func (c *ClashClient) SelectorActive(selectorTag string) (string, error) {
-	u := fmt.Sprintf("http://%s/proxies/%s", c.address, url.PathEscape(selectorTag))
+	u := fmt.Sprintf("http://%s/proxies/%s", c.Address(), url.PathEscape(selectorTag))
 	resp, err := c.http.Get(u)
 	if err != nil {
 		return "", err

--- a/internal/singbox/clash.go
+++ b/internal/singbox/clash.go
@@ -17,7 +17,7 @@ import (
 // подписочные селекторы, поэтому доступ к полю только через Address/SetAddress.
 type ClashClient struct {
 	mu      sync.RWMutex
-	address string // e.g. "127.0.0.1:9099" — see singbox.clashAddr
+	address string // e.g. "127.0.0.1:9099" — построен через ClashAddr
 	http    *http.Client
 }
 

--- a/internal/singbox/clash_port_test.go
+++ b/internal/singbox/clash_port_test.go
@@ -103,6 +103,94 @@ func TestSetClashController(t *testing.T) {
 	}
 }
 
+// ApplyClashPort целиком: запись в базу и переустановка клиента, включая
+// порядок этих двух шагов и поведение при отсутствующем 00-base.json.
+func TestOperator_ApplyClashPort(t *testing.T) {
+	controllerOf := func(t *testing.T, basePath string) string {
+		t.Helper()
+		raw, err := os.ReadFile(basePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		exp, _ := m["experimental"].(map[string]any)
+		clash, _ := exp["clash_api"].(map[string]any)
+		addr, _ := clash["external_controller"].(string)
+		return addr
+	}
+
+	t.Run("база и клиент переезжают вместе", func(t *testing.T) {
+		dir := t.TempDir()
+		op := NewOperator(OperatorDeps{Dir: dir})
+		basePath := filepath.Join(dir, "config.d", "00-base.json")
+
+		if err := op.ApplyClashPort(9500); err != nil {
+			t.Fatalf("ApplyClashPort: %v", err)
+		}
+		if got := controllerOf(t, basePath); got != "127.0.0.1:9500" {
+			t.Errorf("в конфиге %q, want 127.0.0.1:9500", got)
+		}
+		if got := op.Clash().Address(); got != "127.0.0.1:9500" {
+			t.Errorf("клиент смотрит в %q, want 127.0.0.1:9500", got)
+		}
+	})
+
+	t.Run("повторное применение того же порта — no-op без ошибки", func(t *testing.T) {
+		dir := t.TempDir()
+		op := NewOperator(OperatorDeps{Dir: dir, ClashPort: func() int { return 9500 }})
+		if err := op.ApplyClashPort(9500); err != nil {
+			t.Fatalf("ApplyClashPort: %v", err)
+		}
+		if got := op.Clash().Address(); got != "127.0.0.1:9500" {
+			t.Errorf("клиент смотрит в %q, want 127.0.0.1:9500", got)
+		}
+	})
+
+	// Файл пропасть посреди жизни может только при ручном вмешательстве;
+	// mutateBase такое молча пропускает. Клиент при этом всё равно уезжает на
+	// новый порт — расхождение самолечится на следующем буте, когда
+	// NewOperator пересоздаст базу с портом из настроек. Тест фиксирует это
+	// поведение явно, чтобы оно не поменялось незамеченным.
+	t.Run("пропавшая база — не ошибка, но и не запись", func(t *testing.T) {
+		dir := t.TempDir()
+		op := NewOperator(OperatorDeps{Dir: dir})
+		basePath := filepath.Join(dir, "config.d", "00-base.json")
+		if err := os.Remove(basePath); err != nil {
+			t.Fatal(err)
+		}
+		if err := op.ApplyClashPort(9500); err != nil {
+			t.Fatalf("ApplyClashPort: %v", err)
+		}
+		if _, err := os.Stat(basePath); !os.IsNotExist(err) {
+			t.Errorf("база воссоздана, ожидался no-op: %v", err)
+		}
+		if got := op.Clash().Address(); got != "127.0.0.1:9500" {
+			t.Errorf("клиент смотрит в %q, want 127.0.0.1:9500", got)
+		}
+	})
+
+	// Провалившаяся запись не должна оставлять клиент смотреть в порт,
+	// которого нет в конфиге: SetAddress зовётся строго после успеха.
+	t.Run("битая база — клиент остаётся на старом порту", func(t *testing.T) {
+		dir := t.TempDir()
+		op := NewOperator(OperatorDeps{Dir: dir})
+		basePath := filepath.Join(dir, "config.d", "00-base.json")
+		if err := os.WriteFile(basePath, []byte("{не json"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		before := op.Clash().Address()
+		if err := op.ApplyClashPort(9500); err == nil {
+			t.Fatal("ожидалась ошибка разбора 00-base.json")
+		}
+		if got := op.Clash().Address(); got != before {
+			t.Errorf("клиент переставлен при провале записи: %q, было %q", got, before)
+		}
+	})
+}
+
 func TestEffectiveClashPort(t *testing.T) {
 	for _, c := range []struct{ in, want int }{
 		{0, DefaultClashPort},

--- a/internal/singbox/clash_port_test.go
+++ b/internal/singbox/clash_port_test.go
@@ -1,0 +1,140 @@
+package singbox
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Порт из настроек доезжает и до свежей базы, и до существующей: 00-base.json
+// остаётся выигрывающей позицией merge, а значением владеем мы (ADR 0001).
+func TestClashPort_ReachesBaseConfig(t *testing.T) {
+	readController := func(t *testing.T, basePath string) string {
+		t.Helper()
+		raw, err := os.ReadFile(basePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m struct {
+			Experimental struct {
+				ClashAPI struct {
+					ExternalController string `json:"external_controller"`
+				} `json:"clash_api"`
+			} `json:"experimental"`
+		}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return m.Experimental.ClashAPI.ExternalController
+	}
+
+	t.Run("fresh base uses configured port", func(t *testing.T) {
+		configDir := filepath.Join(t.TempDir(), "config.d")
+		ensureBaseConfig(configDir, "info", "", 9500)
+		if got := readController(t, filepath.Join(configDir, "00-base.json")); got != "127.0.0.1:9500" {
+			t.Errorf("want 127.0.0.1:9500, got %q", got)
+		}
+	})
+
+	t.Run("port 0 falls back to default", func(t *testing.T) {
+		configDir := filepath.Join(t.TempDir(), "config.d")
+		ensureBaseConfig(configDir, "info", "", 0)
+		if got := readController(t, filepath.Join(configDir, "00-base.json")); got != ClashAddr(DefaultClashPort) {
+			t.Errorf("want default, got %q", got)
+		}
+	})
+
+	t.Run("existing base is repointed", func(t *testing.T) {
+		configDir := filepath.Join(t.TempDir(), "config.d")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		basePath := filepath.Join(configDir, "00-base.json")
+		stale := `{"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"},"cache_file":{"enabled":true}}}`
+		if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
+			t.Fatal(err)
+		}
+		ensureBaseConfig(configDir, "info", "", 9500)
+		if got := readController(t, basePath); got != "127.0.0.1:9500" {
+			t.Errorf("want 127.0.0.1:9500, got %q", got)
+		}
+		// Соседние ключи внутри experimental не должны пострадать.
+		raw, _ := os.ReadFile(basePath)
+		var m map[string]any
+		_ = json.Unmarshal(raw, &m)
+		exp := m["experimental"].(map[string]any)
+		if _, has := exp["cache_file"]; !has {
+			t.Errorf("cache_file вымыт правкой порта: %s", raw)
+		}
+	})
+}
+
+// setClashController создаёт недостающие уровни: отсутствие блока — не воля
+// пользователя, а состояние, которое мы чиним.
+func TestSetClashController(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{"empty config", `{}`, "127.0.0.1:9500", true},
+		{"no clash_api", `{"experimental":{"cache_file":{"enabled":true}}}`, "127.0.0.1:9500", true},
+		{"null clash_api", `{"experimental":{"clash_api":null}}`, "127.0.0.1:9500", true},
+		{"already correct", `{"experimental":{"clash_api":{"external_controller":"127.0.0.1:9500"}}}`, "127.0.0.1:9500", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var m map[string]any
+			if err := json.Unmarshal([]byte(c.in), &m); err != nil {
+				t.Fatal(err)
+			}
+			if got := setClashController(m, "127.0.0.1:9500"); got != c.changed {
+				t.Errorf("changed: want %v, got %v", c.changed, got)
+			}
+			exp := m["experimental"].(map[string]any)
+			clash := exp["clash_api"].(map[string]any)
+			if got := clash["external_controller"]; got != c.want {
+				t.Errorf("want %q, got %v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestEffectiveClashPort(t *testing.T) {
+	for _, c := range []struct{ in, want int }{
+		{0, DefaultClashPort},
+		{-1, DefaultClashPort},
+		{9500, 9500},
+	} {
+		if got := EffectiveClashPort(c.in); got != c.want {
+			t.Errorf("EffectiveClashPort(%d): want %d, got %d", c.in, c.want, got)
+		}
+	}
+}
+
+// Адрес клиента меняется в рантайме и читается конкурентно — гонки быть не
+// должно (гоняется под -race).
+func TestClashClient_SetAddressConcurrent(t *testing.T) {
+	c := NewClashClient(ClashAddr(0))
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			c.SetAddress("127.0.0.1:9500")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = c.Address()
+		}
+	}()
+	wg.Wait()
+	if got := c.Address(); got != "127.0.0.1:9500" {
+		t.Errorf("want 127.0.0.1:9500, got %q", got)
+	}
+}

--- a/internal/singbox/derived_defaults_test.go
+++ b/internal/singbox/derived_defaults_test.go
@@ -27,7 +27,7 @@ func TestMergedScalars_SlotWinsOverDefaults(t *testing.T) {
 				},
 				"route": map[string]any{"default_domain_resolver": map[string]any{"server": "real"}},
 			})
-			for _, s := range reconcileConfigSteps(dir, configDir, "info", "", nil) {
+			for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
 				s.run()
 			}
 			m := mergedMap(t, configDir)
@@ -47,7 +47,7 @@ func TestMergedScalars_SlotWinsOverDefaults(t *testing.T) {
 func TestMergedScalars_DefaultsApplyWithoutOwner(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", nil) {
+	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
 		s.run()
 	}
 	m := mergedMap(t, configDir)
@@ -168,7 +168,7 @@ func TestReconcileDerivedDefaults_Idempotent(t *testing.T) {
 // Свежая установка не должна нести оба скаляра в базе: там они лежали бы в
 // ВЫИГРЫВАЮЩЕЙ позиции merge и затеняли бы выбор режимного слота.
 func TestFreshBaseConfig_OmitsDerivedScalars(t *testing.T) {
-	base := freshBaseConfig("info", "")
+	base := freshBaseConfig("info", "", 0)
 	dns, _ := base["dns"].(map[string]any)
 	if _, has := dns["strategy"]; has {
 		t.Errorf("свежая база не должна нести dns.strategy: %v", dns)

--- a/internal/singbox/logs.go
+++ b/internal/singbox/logs.go
@@ -14,7 +14,10 @@ import (
 )
 
 type LogForwarder struct {
-	clashAddr string
+	// clashAddr — ПОСТАВЩИК адреса, а не снимок: порт Clash API меняется в
+	// рантайме (issue #788), а Run переподключается каждые reconnect секунд,
+	// так что новый адрес подхватывается сам, без перезапуска горутины.
+	clashAddr func() string
 	app       logging.AppLogger
 
 	inbound  *logging.ScopedLogger
@@ -28,7 +31,7 @@ type LogForwarder struct {
 	reconnect time.Duration
 }
 
-func NewLogForwarder(clashAddr string, appLogger logging.AppLogger) *LogForwarder {
+func NewLogForwarder(clashAddr func() string, appLogger logging.AppLogger) *LogForwarder {
 	return &LogForwarder{
 		clashAddr: clashAddr,
 		app:       appLogger,
@@ -57,7 +60,7 @@ func (f *LogForwarder) Run(ctx context.Context) {
 }
 
 func (f *LogForwarder) runOnce(ctx context.Context) {
-	url := fmt.Sprintf("http://%s/logs?level=trace", f.clashAddr)
+	url := fmt.Sprintf("http://%s/logs?level=trace", f.clashAddr())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return

--- a/internal/singbox/logs_test.go
+++ b/internal/singbox/logs_test.go
@@ -38,7 +38,7 @@ func (c *captureLogger) snapshot() []captured {
 
 func TestLogForwarder_LevelMapping(t *testing.T) {
 	cap := &captureLogger{}
-	f := NewLogForwarder("unused", cap)
+	f := NewLogForwarder(func() string { return "unused" }, cap)
 
 	cases := []struct {
 		name string
@@ -165,7 +165,7 @@ func TestLogForwarder_SubgroupClassification(t *testing.T) {
 
 func TestLogForwarder_DropsEmptyAndMalformed(t *testing.T) {
 	cap := &captureLogger{}
-	f := NewLogForwarder("unused", cap)
+	f := NewLogForwarder(func() string { return "unused" }, cap)
 
 	f.forward(nil)
 	f.forward([]byte(""))
@@ -179,7 +179,7 @@ func TestLogForwarder_DropsEmptyAndMalformed(t *testing.T) {
 }
 
 func TestLogForwarder_NilAppLoggerIsSafe(t *testing.T) {
-	f := NewLogForwarder("unused", nil)
+	f := NewLogForwarder(func() string { return "unused" }, nil)
 	f.forward([]byte(`{"type":"info","payload":"hello"}`))
 }
 
@@ -226,7 +226,7 @@ func TestSanitizeSingboxLogText_RedactsDomainsAndIPs(t *testing.T) {
 
 func TestLogForwarder_PreservesSensitiveHostsBeforeOutputMasking(t *testing.T) {
 	cap := &captureLogger{}
-	f := NewLogForwarder("unused", cap)
+	f := NewLogForwarder(func() string { return "unused" }, cap)
 
 	f.forward([]byte(`{"type":"debug","payload":"dns: lookup succeed for node.example.org: 203.0.113.77"}`))
 
@@ -257,7 +257,7 @@ func TestLogForwarder_PreservesSensitiveHosts_AllLevels(t *testing.T) {
 	for _, lvl := range cases {
 		t.Run(lvl, func(t *testing.T) {
 			cap := &captureLogger{}
-			f := NewLogForwarder("unused", cap)
+			f := NewLogForwarder(func() string { return "unused" }, cap)
 			line := `{"type":"` + lvl + `","payload":"dns: lookup succeed for node.example.org: 203.0.113.77 and [2606:2800:220:1:248:1893:25c8:1946]:443"}`
 			f.forward([]byte(line))
 

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -2,6 +2,7 @@ package singbox
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -27,13 +28,33 @@ const (
 	// is always used instead of a user-installed sing-box on PATH.
 	defaultBinary = installer.DefaultBinaryPath
 
-	// clashAPIAddr is the Clash API endpoint baked into our generated
-	// config.json. Port 9099 is chosen to not collide with a user-managed
-	// sing-box instance that might already be bound to the default 9090
-	// — otherwise our log forwarder / traffic aggregator would latch onto
-	// their process and stream their tunnels into our UI.
-	clashAPIAddr = "127.0.0.1:9099"
+	// DefaultClashPort is the Clash API port baked into our generated
+	// config.json when the user has not chosen one. 9099 is chosen to not
+	// collide with a user-managed sing-box instance that might already be
+	// bound to the default 9090 — otherwise our log forwarder / traffic
+	// aggregator would latch onto their process and stream their tunnels
+	// into our UI.
+	DefaultClashPort = 9099
+
+	// clashHost — хост Clash API. Не настраивается: это служебный канал
+	// управления awg-manager, а не публичный интерфейс (ADR 0001), и
+	// наружу он ходит только через авторизованный /api/singbox/clash/*.
+	clashHost = "127.0.0.1"
 )
+
+// EffectiveClashPort resolves a stored setting to the port actually used:
+// 0 (and any non-positive value) means "not configured" → DefaultClashPort.
+func EffectiveClashPort(port int) int {
+	if port <= 0 {
+		return DefaultClashPort
+	}
+	return port
+}
+
+// ClashAddr returns the Clash API endpoint for a port. Port 0 means "default".
+func ClashAddr(port int) string {
+	return fmt.Sprintf("%s:%d", clashHost, EffectiveClashPort(port))
+}
 
 // defaultDir is the directory of the managed binary. var (not const) so
 // it stays in lockstep with installer.DefaultBinaryPath if that ever moves.
@@ -105,7 +126,10 @@ type Operator struct {
 	// только на буте: ApplyLogLevel пересоздаёт 00-base.json, если файла нет,
 	// и без этого поля подставил бы исторический дефолт, потеряв настройку.
 	bootstrapDNS func() string
-	configPath   string
+	// clashPort — живой доступ к Settings.SingboxClashPort, по той же причине,
+	// что и bootstrapDNS: пересоздание 00-base.json не должно терять настройку.
+	clashPort  func() int
+	configPath string
 	pidPath      string
 
 	proc      *Process
@@ -287,6 +311,10 @@ type OperatorDeps struct {
 	// (Settings.SingboxBootstrapDNS). Optional; empty result means "do not
 	// touch 00-base.json" — see patchBaseBootstrapDNS.
 	BootstrapDNS func() string
+	// ClashPort returns the desired Clash API port from settings
+	// (Settings.SingboxClashPort). Optional; 0 means DefaultClashPort.
+	// Issue #788, ADR 0001.
+	ClashPort func() int
 }
 
 func NewOperator(d OperatorDeps) *Operator {
@@ -316,16 +344,22 @@ func NewOperator(d OperatorDeps) *Operator {
 		desiredBootstrapDNS = d.BootstrapDNS()
 	}
 
+	desiredClashPort := 0
+	if d.ClashPort != nil {
+		desiredClashPort = d.ClashPort()
+	}
+
 	configPath := filepath.Join(dir, "config.d")
 	pidPath := filepath.Join(dir, "sing-box.pid")
 
-	for _, s := range reconcileConfigSteps(dir, configPath, desiredSingboxLogLevel, desiredBootstrapDNS, log) {
+	for _, s := range reconcileConfigSteps(dir, configPath, desiredSingboxLogLevel, desiredBootstrapDNS, desiredClashPort, log) {
 		s.run()
 	}
 
 	op := &Operator{
 		log:               log,
 		bootstrapDNS:      d.BootstrapDNS,
+		clashPort:         d.ClashPort,
 		dir:               dir,
 		binary:            binary,
 		configPath:        configPath,
@@ -333,7 +367,7 @@ func NewOperator(d OperatorDeps) *Operator {
 		proc:              NewProcess(binary, configPath, pidPath),
 		validator:         NewValidator(binary),
 		proxyMgr:          NewProxyManager(d.Queries, d.Commands),
-		clash:             NewClashClient(clashAPIAddr),
+		clash:             NewClashClient(ClashAddr(desiredClashPort)),
 		processLogger:     logging.NewScopedLogger(d.AppLogger, logging.GroupSingbox, logging.SubSBProcess),
 		runtimeLogger:     logging.NewScopedLogger(d.AppLogger, logging.GroupSingbox, logging.SubSBRuntime),
 		persistManualStop: d.SetManuallyStopped,

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -34,11 +34,11 @@ func DefaultCacheDBPath() string { return defaultCacheDBPath }
 // that hard-coded the wrong Clash API port (9090 instead of
 // clashAPIAddr's 9099), which silently broke our LogForwarder /
 // DelayChecker on existing installs.
-func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, loggers ...*slog.Logger) {
+func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, loggers ...*slog.Logger) {
 	log := firstLogger(loggers)
 	basePath := filepath.Join(configDir, "00-base.json")
 	if _, err := os.Stat(basePath); err == nil {
-		patchBaseClashPort(basePath, log)
+		patchBaseClashPort(basePath, desiredClashPort, log)
 		patchBaseLogLevel(basePath, desiredLogLevel, log)
 		patchBaseDirectOutbound(basePath, log)
 		patchBaseCacheFilePath(basePath, log)
@@ -50,7 +50,7 @@ func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, lo
 			"step", stepEnsureBaseConfig, "path", configDir, "err", err)
 		return
 	}
-	writeSlotJSON(stepEnsureBaseConfig, basePath, freshBaseConfig(desiredLogLevel, desiredBootstrapDNS), log)
+	writeSlotJSON(stepEnsureBaseConfig, basePath, freshBaseConfig(desiredLogLevel, desiredBootstrapDNS, desiredClashPort), log)
 }
 
 func logConfigPatchInfo(log *slog.Logger, msg string, args ...any) {
@@ -101,11 +101,11 @@ type reconcileStep struct {
 // MigrateLegacyConfigDir в config.go). Внутри набора ограничений порядка нет:
 // шаги попарно коммутируют по конечному состоянию (закреплено
 // TestReconcileConfigSteps_CommuteReversed).
-func reconcileConfigSteps(dir, configPath, desiredLogLevel, desiredBootstrapDNS string, log *slog.Logger) []reconcileStep {
+func reconcileConfigSteps(dir, configPath, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, log *slog.Logger) []reconcileStep {
 	base := filepath.Join(configPath, "00-base.json")
 	tunnels := filepath.Join(configPath, "10-tunnels.json")
 	return []reconcileStep{
-		{stepEnsureBaseConfig, func() { ensureBaseConfig(configPath, desiredLogLevel, desiredBootstrapDNS, log) }},
+		{stepEnsureBaseConfig, func() { ensureBaseConfig(configPath, desiredLogLevel, desiredBootstrapDNS, desiredClashPort, log) }},
 		{stepMigrateLegacyTunnels, func() { ensureLegacyConfigMigrated(dir, log) }},
 		{stepStripBaseOwnedBlocks, func() { patchTunnelsSlotStripBaseOwnedBlocks(tunnels, log) }},
 		// Компат-фиксы нужны каждому продюсеру outbound'ов: 10-tunnels пишет
@@ -486,32 +486,46 @@ func patchBaseLogLevel(basePath, desiredLevel string, loggers ...*slog.Logger) {
 	writeSlotJSON(stepPatchBaseLogLevel, basePath, m, log)
 }
 
-// patchBaseClashPort rewrites only the experimental.clash_api.external_controller
-// field if it points anywhere other than clashAPIAddr. Other fields
-// (user customizations: log level, DNS servers, etc.) are preserved
-// verbatim. No-op when the file already has the correct port or has no
-// experimental.clash_api block at all (latter case: the user removed
-// clash_api on purpose; respect that).
-func patchBaseClashPort(basePath string, loggers ...*slog.Logger) {
+// patchBaseClashPort приводит experimental.clash_api.external_controller к
+// нашему адресу (порт из настроек, хост всегда 127.0.0.1). Остальные поля —
+// пользовательские правки уровня лога, DNS-серверов и прочего — сохраняются
+// дословно. No-op, только когда адрес уже правильный.
+//
+// Отсутствующий блок clash_api ВОССТАНАВЛИВАЕТСЯ, а не считается намерением
+// пользователя: Clash API — служебный канал управления awg-manager, и его
+// значением и наличием владеем мы (ADR 0001). Без блока молча слепнут
+// LogForwarder, DelayChecker, /connections и селекторы подписок, причём
+// sing-box при этом стартует нормально и в журнале не будет ни строчки.
+func patchBaseClashPort(basePath string, port int, loggers ...*slog.Logger) {
 	log := firstLogger(loggers)
 	m, ok := readSlotJSON(stepPatchBaseClashPort, basePath, log)
 	if !ok {
 		return
 	}
+	if !setClashController(m, ClashAddr(port)) {
+		return
+	}
+	writeSlotJSON(stepPatchBaseClashPort, basePath, m, log)
+}
+
+// setClashController ставит experimental.clash_api.external_controller в want,
+// создавая недостающие уровни. Возвращает false, если адрес уже такой.
+func setClashController(m map[string]any, want string) bool {
 	exp, _ := m["experimental"].(map[string]any)
 	if exp == nil {
-		return
+		exp = map[string]any{}
+		m["experimental"] = exp
 	}
 	clash, _ := exp["clash_api"].(map[string]any)
 	if clash == nil {
-		return
+		clash = map[string]any{}
+		exp["clash_api"] = clash
 	}
-	current, _ := clash["external_controller"].(string)
-	if current == clashAPIAddr {
-		return
+	if current, _ := clash["external_controller"].(string); current == want {
+		return false
 	}
-	clash["external_controller"] = clashAPIAddr
-	writeSlotJSON(stepPatchBaseClashPort, basePath, m, log)
+	clash["external_controller"] = want
+	return true
 }
 
 // setBootstrapServer ставит адрес серверу с тегом dns-bootstrap. Возвращает
@@ -978,7 +992,7 @@ const defaultBootstrapDNS = "1.1.1.1"
 // freshBaseConfig returns the canonical base sing-box config. Single source
 // of truth for ensureBaseConfig (initial write + self-heal path). Empty
 // bootstrapDNS falls back to defaultBootstrapDNS.
-func freshBaseConfig(logLevel, bootstrapDNS string) map[string]any {
+func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int) map[string]any {
 	bootstrapDNS = sanitizeBootstrapDNS(bootstrapDNS)
 	if bootstrapDNS == "" {
 		bootstrapDNS = defaultBootstrapDNS
@@ -986,10 +1000,10 @@ func freshBaseConfig(logLevel, bootstrapDNS string) map[string]any {
 	return map[string]any{
 		"log": map[string]any{"level": normalizeSingboxLogLevel(logLevel), "timestamp": true},
 		"experimental": map[string]any{
-			// MUST match clashAPIAddr — our ClashClient and LogForwarder
-			// connect here. Hard-coding 9090 (sing-box default) used to
-			// silently break log forwarding on existing installs.
-			"clash_api": map[string]any{"external_controller": clashAPIAddr},
+			// MUST match ClashClient.Address() — our ClashClient and
+			// LogForwarder connect here. Hard-coding 9090 (sing-box default)
+			// used to silently break log forwarding on existing installs.
+			"clash_api": map[string]any{"external_controller": ClashAddr(clashPort)},
 			// Absolute path to writable dir. Sing-box default resolves
 			// relative path against CWD which is "/" (read-only on Entware) —
 			// caused FATAL on user installs.
@@ -1050,7 +1064,7 @@ func (o *Operator) ApplyLogLevel(level string) error {
 		// Свежая база условно-своих скаляров больше не несёт: их дефолты
 		// живут в 99-defaults.json и перекрываются слотом-владельцем сами
 		// (см. reconcileDerivedDefaults) — уступать нечем и некому.
-		base = freshBaseConfig(desired, o.desiredBootstrapDNS())
+		base = freshBaseConfig(desired, o.desiredBootstrapDNS(), o.desiredClashPort())
 	case err != nil:
 		return fmt.Errorf("read 00-base.json: %w", err)
 	default:
@@ -1103,6 +1117,33 @@ func (o *Operator) desiredBootstrapDNS() string {
 		return ""
 	}
 	return sanitizeBootstrapDNS(o.bootstrapDNS())
+}
+
+// desiredClashPort — порт Clash API из настроек; 0 означает DefaultClashPort.
+func (o *Operator) desiredClashPort() int {
+	if o.clashPort == nil {
+		return 0
+	}
+	return o.clashPort()
+}
+
+// ApplyClashPort приводит experimental.clash_api.external_controller в
+// 00-base.json к новому порту и перенаправляет туда же наш ClashClient
+// (issue #788). Демон перечитывает конфиг штатным reload'ом: SIGHUP в форке —
+// это Close + пересоздание инстанса, так что слушающий сокет Clash API
+// переезжает без перезапуска процесса.
+//
+// ClashClient переставляется ПОСЛЕ успешной записи: провалившаяся запись
+// оставила бы клиент смотреть в порт, которого в конфиге нет.
+func (o *Operator) ApplyClashPort(port int) error {
+	addr := ClashAddr(port)
+	if err := o.mutateBase(func(base map[string]any) bool {
+		return setClashController(base, addr)
+	}); err != nil {
+		return err
+	}
+	o.clash.SetAddress(addr)
+	return nil
 }
 
 // ApplyBootstrapDNS приводит адрес dns-bootstrap в 00-base.json к значению

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -31,9 +31,8 @@ func DefaultCacheDBPath() string { return defaultCacheDBPath }
 // ensureBaseConfigWithLogLevel writes a minimal 00-base.json if config.d is
 // empty, so sing-box starts standalone (direct outbound + bootstrap DNS) before
 // any tunnels are added. Also surgically self-heals an older base config
-// that hard-coded the wrong Clash API port (9090 instead of
-// clashAPIAddr's 9099), which silently broke our LogForwarder /
-// DelayChecker on existing installs.
+// that hard-coded the wrong Clash API port (9090 instead of ours), which
+// silently broke our LogForwarder / DelayChecker on existing installs.
 func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, loggers ...*slog.Logger) {
 	log := firstLogger(loggers)
 	basePath := filepath.Join(configDir, "00-base.json")
@@ -1129,9 +1128,16 @@ func (o *Operator) desiredClashPort() int {
 
 // ApplyClashPort приводит experimental.clash_api.external_controller в
 // 00-base.json к новому порту и перенаправляет туда же наш ClashClient
-// (issue #788). Демон перечитывает конфиг штатным reload'ом: SIGHUP в форке —
-// это Close + пересоздание инстанса, так что слушающий сокет Clash API
-// переезжает без перезапуска процесса.
+// (issue #788). Перезапуск демона не нужен: SIGHUP в форке — это Close +
+// пересоздание инстанса, так что слушающий сокет Clash API переезжает сам.
+//
+// Применение АСИНХРОННОЕ: при подключённом оркестраторе запись лишь взводит
+// debounced reload (250 мс), и валидация merged-конфига произойдёт уже после
+// возврата отсюда. Отсюда окно в сотни миллисекунд, когда клиент смотрит на
+// порт, который ещё никто не слушает, — его закрывают ретраи LogForwarder и
+// TrafficAggregator. Если же merged-конфиг сломан чем-то ПОСТОРОННИМ, reload
+// откажет валидацией и демон останется на старом порту, а клиент уедет на
+// новый; сам порт валидацию сломать не может.
 //
 // ClashClient переставляется ПОСЛЕ успешной записи: провалившаяся запись
 // оставила бы клиент смотреть в порт, которого в конфиге нет.

--- a/internal/singbox/operator_baseconfig_bootstrap_test.go
+++ b/internal/singbox/operator_baseconfig_bootstrap_test.go
@@ -44,7 +44,7 @@ func TestFreshBaseConfig_BootstrapServer(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			base := freshBaseConfig("info", c.bootstrap)
+			base := freshBaseConfig("info", c.bootstrap, 0)
 			if got := bootstrapServerOf(t, base); got != c.want {
 				t.Errorf("dns-bootstrap.server = %q, want %q", got, c.want)
 			}
@@ -290,7 +290,7 @@ func TestReconcileConfigSteps_IdempotentWithBootstrapDNS(t *testing.T) {
 	})
 
 	run := func() {
-		for _, s := range reconcileConfigSteps(dir, configDir, "info", "8.8.8.8", nil) {
+		for _, s := range reconcileConfigSteps(dir, configDir, "info", "8.8.8.8", 0, nil) {
 			s.run()
 		}
 	}

--- a/internal/singbox/operator_process.go
+++ b/internal/singbox/operator_process.go
@@ -861,8 +861,7 @@ func (o *Operator) startAndWait(ctx context.Context) (spawned bool, err error) {
 		}
 		return false, err
 	}
-	// Конфиг без experimental.clash_api (пользователь удалил блок намеренно —
-	// patchBaseClashPort такое уважает) НЕ ждём по Clash: waitClashReady
+	// Конфиг без experimental.clash_api НЕ ждём по Clash: waitClashReady
 	// гарантированно упёрся бы в таймаут и убил живой процесс, а каждый цикл
 	// watchdog'а сжигал бы backoff-бюджет (issue #456 FIX-H). Мягкий старт:
 	// спавн уже проверен grace-периодом Process.Start.
@@ -899,10 +898,13 @@ func (o *Operator) startAndWait(ctx context.Context) (spawned bool, err error) {
 }
 
 // configDeclaresClashAPI reports whether the merged config.d declares an
-// experimental.clash_api block. Зеркалит допущение patchBaseClashPort:
-// отсутствие блока — осознанный выбор пользователя, который надо уважать.
-// Консервативно: любая ошибка чтения/парса → true (сохраняем легаси-гейт
-// по Clash, а не тихо ослабляем проверку готовности).
+// experimental.clash_api block.
+//
+// Отсутствие блока НЕ является выражением воли пользователя: блоком владеем
+// мы, и patchBaseClashPort его восстанавливает (ADR 0001). Проверка осталась
+// защитой от битого конфига — например, слот выше подсунул clash_api: null, —
+// чтобы старт не завис на таймауте готовности. Консервативно: любая ошибка
+// чтения/парса → true (не ослабляем проверку готовности молча).
 func (o *Operator) configDeclaresClashAPI() bool {
 	merged, err := configmerge.MergeDir(o.configPath)
 	if err != nil {

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -170,7 +170,7 @@ func TestOperator_GetStatus_PopulatesInstallStateAndBytes(t *testing.T) {
 func TestEnsureBaseConfig_FullSkeleton(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 
 	raw, err := os.ReadFile(filepath.Join(configDir, "00-base.json"))
 	if err != nil {
@@ -234,9 +234,9 @@ func TestEnsureBaseConfig_Idempotent(t *testing.T) {
 	}
 	// First call applies surgical heals (e.g. route.default_domain_resolver
 	// for sing-box 1.13+). Second call must be a no-op — same bytes.
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	first, _ := os.ReadFile(basePath)
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	second, _ := os.ReadFile(basePath)
 	if string(first) != string(second) {
 		t.Errorf("ensureBaseConfig not idempotent: first=%s second=%s", first, second)
@@ -258,7 +258,7 @@ func TestEnsureBaseConfig_PatchesStaleClashPort(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -282,11 +282,14 @@ func TestEnsureBaseConfig_PatchesStaleClashPort(t *testing.T) {
 	}
 }
 
-func TestEnsureBaseConfig_NoClashApiBlockUntouched(t *testing.T) {
+func TestEnsureBaseConfig_MissingClashApiBlockRestored(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
 	_ = os.MkdirAll(configDir, 0755)
-	// User explicitly removed clash_api — respect that, don't re-add.
+	// Блок clash_api отсутствует — восстанавливаем: им владеем мы, а не
+	// пользователь (ADR 0001). Без блока молча слепнут LogForwarder,
+	// DelayChecker, /connections и селекторы подписок, причём sing-box
+	// стартует нормально и в журнале не будет ни строчки.
 	// log.level is "debug" so the log-level heal also leaves it alone.
 	// route.default_domain_resolver IS materialised because sing-box 1.13+
 	// FATALs without it; that injection is unrelated to clash_api.
@@ -295,14 +298,22 @@ func TestEnsureBaseConfig_NoClashApiBlockUntouched(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if _, has := m["experimental"]; has {
-		t.Errorf("experimental block must NOT be re-added, got %s", raw)
+	exp, ok := m["experimental"].(map[string]any)
+	if !ok {
+		t.Fatalf("experimental block must be restored, got %s", raw)
+	}
+	clash, ok := exp["clash_api"].(map[string]any)
+	if !ok {
+		t.Fatalf("clash_api block must be restored, got %s", raw)
+	}
+	if got := clash["external_controller"]; got != ClashAddr(0) {
+		t.Errorf("external_controller want %q, got %v", ClashAddr(0), got)
 	}
 	if m["log"].(map[string]any)["level"] != "info" {
 		t.Errorf("log.level want info, got %v", m["log"])
@@ -325,7 +336,7 @@ func TestEnsureBaseConfig_PatchesStaleLogLevel(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -348,7 +359,7 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -360,7 +371,7 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 func TestEnsureBaseConfigWithLogLevel_UsesDesiredLevel(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	ensureBaseConfig(configDir, "warn", "")
+	ensureBaseConfig(configDir, "warn", "", 0)
 
 	raw, err := os.ReadFile(filepath.Join(configDir, "00-base.json"))
 	if err != nil {
@@ -498,7 +509,7 @@ func TestEnsureBaseConfig_PatchesMissingDomainResolver(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -531,7 +542,7 @@ func TestEnsureBaseConfig_RespectsExistingDomainResolver(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -552,7 +563,7 @@ func TestEnsureBaseConfig_MaterialisesMissingRouteBlock(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -586,7 +597,7 @@ func TestEnsureBaseConfig_MigratesIpv4OnlyStrategy(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -609,7 +620,7 @@ func TestEnsureBaseConfig_KeepsNonLegacyStrategy(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -713,7 +724,7 @@ func TestClassifyProcessLine(t *testing.T) {
 }
 
 func TestFreshBaseConfig_CacheFilePathIsAbsolute(t *testing.T) {
-	cfg := freshBaseConfig("info", "")
+	cfg := freshBaseConfig("info", "", 0)
 	exp := cfg["experimental"].(map[string]any)
 	cf := exp["cache_file"].(map[string]any)
 	if cf["enabled"] != true {
@@ -735,7 +746,7 @@ func TestEnsureBaseConfig_PatchesRelativeCachePath(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -760,7 +771,7 @@ func TestEnsureBaseConfig_LeavesAbsoluteCachePathUntouched(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	json.Unmarshal(raw, &m)
@@ -1193,7 +1204,7 @@ func TestEnsureBaseConfig_PatchesMissingDirectOutbound(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -1220,7 +1231,7 @@ func TestEnsureBaseConfig_PreservesExistingDirectOutbound(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -1245,7 +1256,7 @@ func TestEnsureBaseConfig_PrependsDirectWhenMissing(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 	raw, err := os.ReadFile(basePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1287,7 +1298,7 @@ func TestEnsureBaseConfig_MovesExistingDirectToFirstOutbound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureBaseConfig(configDir, "info", "")
+	ensureBaseConfig(configDir, "info", "", 0)
 
 	raw, err := os.ReadFile(basePath)
 	if err != nil {
@@ -1932,7 +1943,7 @@ func TestRemoveFinalFromBase_MalformedJSON_NoOp(t *testing.T) {
 // --- freshBaseConfig DNS (#445) ---
 
 func TestFreshBaseConfig_OmitsDNSFinal_KeepsStrategy(t *testing.T) {
-	cfg := freshBaseConfig("info", "")
+	cfg := freshBaseConfig("info", "", 0)
 	dns, ok := cfg["dns"].(map[string]any)
 	if !ok {
 		t.Fatalf("dns block missing/wrong type: %v", cfg["dns"])

--- a/internal/singbox/proxy.go
+++ b/internal/singbox/proxy.go
@@ -25,6 +25,13 @@ func markProxyMgrDur(label string, start time.Time) {
 // in case NDMS ever returns something unexpected.
 const maxProxySlots = 128
 
+// TunnelInboundPortRange returns the inclusive listen-port range reserved for
+// sing-box tunnel inbounds (firstPort+slot). Exported so port-conflict
+// validation elsewhere reads the same numbers instead of copying them.
+func TunnelInboundPortRange() (first, last int) {
+	return firstPort, firstPort + maxProxySlots - 1
+}
+
 // ErrProxyComponentMissing is returned when the router lacks the NDMS
 // "proxy" component. Without it, no ProxyN interface can be created, so
 // sing-box cannot route any traffic. Surfaced to the UI as a distinct

--- a/internal/singbox/reconcile_prologue_test.go
+++ b/internal/singbox/reconcile_prologue_test.go
@@ -18,7 +18,7 @@ func TestPatchers_WarnOnBrokenFile_SilentOnMissing(t *testing.T) {
 		run  func(path string, log *slog.Logger)
 	}
 	cases := []tc{
-		{"patch-base-clash-port", func(p string, l *slog.Logger) { patchBaseClashPort(p, l) }},
+		{"patch-base-clash-port", func(p string, l *slog.Logger) { patchBaseClashPort(p, 0, l) }},
 		{"patch-base-log-level", func(p string, l *slog.Logger) { patchBaseLogLevel(p, "info", l) }},
 		{"patch-base-direct-outbound", func(p string, l *slog.Logger) { patchBaseDirectOutbound(p, l) }},
 		{"patch-base-cache-file", func(p string, l *slog.Logger) { patchBaseCacheFilePath(p, l) }},

--- a/internal/singbox/reconcile_steps_test.go
+++ b/internal/singbox/reconcile_steps_test.go
@@ -171,7 +171,7 @@ func runReconcile(t *testing.T, dir string, reversed bool) {
 	if err := MigrateLegacyConfigDir(dir); err != nil {
 		t.Fatalf("MigrateLegacyConfigDir: %v", err)
 	}
-	steps := reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", nil)
+	steps := reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, nil)
 	if reversed {
 		for i, j := 0, len(steps)-1; i < j; i, j = i+1, j-1 {
 			steps[i], steps[j] = steps[j], steps[i]
@@ -325,7 +325,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 		},
 		stepMigrateLegacyTunnels: func(t *testing.T) string { // legacy без config.d/10-tunnels
 			dir := t.TempDir()
-			writeFixtureJSON(t, filepath.Join(dir, "config.d", "00-base.json"), freshBaseConfig("info", ""))
+			writeFixtureJSON(t, filepath.Join(dir, "config.d", "00-base.json"), freshBaseConfig("info", "", 0))
 			writeFixtureJSON(t, filepath.Join(dir, "config.json"), map[string]any{
 				"outbounds": []any{map[string]any{"type": "naive", "tag": "nv1", "server": "s", "server_port": 443}},
 				"route":     map[string]any{"rules": []any{}},
@@ -402,7 +402,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 		},
 	}
 
-	for _, s := range reconcileConfigSteps("", "", "info", "", nil) {
+	for _, s := range reconcileConfigSteps("", "", "info", "", 0, nil) {
 		mk, ok := fixtures[s.name]
 		if !ok {
 			t.Fatalf("шаг %q без фикстуры идемпотентности — дополните таблицу", s.name)
@@ -424,7 +424,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 
 func findReconcileStep(t *testing.T, dir, name string) reconcileStep {
 	t.Helper()
-	for _, s := range reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", nil) {
+	for _, s := range reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, nil) {
 		if s.name == name {
 			return s
 		}

--- a/internal/singbox/router/qos.go
+++ b/internal/singbox/router/qos.go
@@ -26,7 +26,8 @@ const (
 	// reserved contiguous ranges for per-class inbounds (base+index, index <
 	// MaxQoSClasses): UDP TPROXY 51281-51288, TCP REDIRECT 51301-51308.
 	// Chosen to not collide with TPROXYPort (51271), RedirectPort (51272) or
-	// any other AWGM listener (device-proxy 1080+, clash API 9099); the two
+	// any other AWGM listener (device-proxy 1080+, clash API — по умолчанию
+	// 9099, настраивается: singbox.DefaultClashPort); the two
 	// ranges do not overlap each other (51281+8 = 51289 < 51301).
 	QoSTPROXYPortBase   = 51281
 	QoSRedirectPortBase = 51301

--- a/internal/singbox/traffic.go
+++ b/internal/singbox/traffic.go
@@ -34,7 +34,8 @@ type HistoryFeeder interface {
 // When a HistoryFeeder is provided, each publish also feeds the rate-history
 // store so /api/tunnels/traffic backfill works for singbox tags.
 type TrafficAggregator struct {
-	clashAddr string
+	// clashAddr — ПОСТАВЩИК адреса, а не снимок: см. LogForwarder.clashAddr.
+	clashAddr func() string
 	publisher TrafficPublisher
 	feeder    HistoryFeeder
 	interval  time.Duration
@@ -46,7 +47,7 @@ type TrafficAggregator struct {
 	uploadTotal   int64
 }
 
-func NewTrafficAggregator(clashAddr string, pub TrafficPublisher, feeder HistoryFeeder) *TrafficAggregator {
+func NewTrafficAggregator(clashAddr func() string, pub TrafficPublisher, feeder HistoryFeeder) *TrafficAggregator {
 	return &TrafficAggregator{
 		clashAddr: clashAddr,
 		publisher: pub,
@@ -74,7 +75,7 @@ func (t *TrafficAggregator) Run(ctx context.Context) {
 }
 
 func (t *TrafficAggregator) runOnce(ctx context.Context) {
-	url := fmt.Sprintf("ws://%s/connections", t.clashAddr)
+	url := fmt.Sprintf("ws://%s/connections", t.clashAddr())
 	conn, _, err := websocket.Dial(ctx, url, nil)
 	if err != nil {
 		return

--- a/internal/singbox/traffic_test.go
+++ b/internal/singbox/traffic_test.go
@@ -32,7 +32,7 @@ func (f *fakeFeeder) Feed(id string, rxBytes, txBytes int64) {
 
 func TestTrafficAggregator_Ingest(t *testing.T) {
 	pub := &fakePublisher{}
-	agg := NewTrafficAggregator("unused", pub, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, pub, nil)
 	msg := []byte(`{
 		"downloadTotal": 900000,
 		"uploadTotal": 40000,
@@ -59,7 +59,7 @@ func TestTrafficAggregator_Ingest(t *testing.T) {
 
 func TestTrafficAggregator_Publish(t *testing.T) {
 	pub := &fakePublisher{}
-	agg := NewTrafficAggregator("unused", pub, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, pub, nil)
 	agg.tags["A"] = &TrafficSnapshot{Tag: "A", Upload: 1, Download: 2}
 	agg.tags["B"] = &TrafficSnapshot{Tag: "B", Upload: 3, Download: 4}
 	agg.downloadTotal = 123
@@ -94,7 +94,7 @@ func TestTrafficAggregator_Publish(t *testing.T) {
 func TestTrafficAggregator_PublishFeedsHistory(t *testing.T) {
 	pub := &fakePublisher{}
 	feeder := &fakeFeeder{}
-	agg := NewTrafficAggregator("unused", pub, feeder)
+	agg := NewTrafficAggregator(func() string { return "unused" }, pub, feeder)
 	agg.tags["A"] = &TrafficSnapshot{Tag: "A", Upload: 100, Download: 500}
 	agg.tags["B"] = &TrafficSnapshot{Tag: "B", Upload: 7, Download: 13}
 	agg.publish()
@@ -117,14 +117,14 @@ func TestTrafficAggregator_PublishFeedsHistory(t *testing.T) {
 
 func TestTrafficAggregator_PublishWithoutFeederIsSafe(t *testing.T) {
 	pub := &fakePublisher{}
-	agg := NewTrafficAggregator("unused", pub, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, pub, nil)
 	agg.tags["A"] = &TrafficSnapshot{Tag: "A", Upload: 1, Download: 2}
 	// Should not panic.
 	agg.publish()
 }
 
 func TestTrafficAggregator_IngestBadJSON(t *testing.T) {
-	agg := NewTrafficAggregator("unused", nil, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, nil, nil)
 	agg.ingest([]byte(`not json`))
 	if len(agg.tags) != 0 {
 		t.Errorf("bad json should not mutate state")
@@ -132,7 +132,7 @@ func TestTrafficAggregator_IngestBadJSON(t *testing.T) {
 }
 
 func TestTrafficAggregator_IngestEmptyChains(t *testing.T) {
-	agg := NewTrafficAggregator("unused", nil, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, nil, nil)
 	msg := []byte(`{"connections":[{"chains":[],"upload":100,"download":500}]}`)
 	agg.ingest(msg)
 	if len(agg.tags) != 0 {
@@ -145,7 +145,7 @@ func TestTrafficAggregator_IngestEmptyChains(t *testing.T) {
 // member card both surface non-zero traffic — the v2.10.0 regression where
 // "Суммарный трафик" sat at 0 B on the subscriptions page.
 func TestTrafficAggregator_IngestCreditsEveryChainHop(t *testing.T) {
-	agg := NewTrafficAggregator("unused", nil, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, nil, nil)
 	msg := []byte(`{"connections":[{"chains":["Proxy0","Germany"],"upload":10,"download":20}]}`)
 	agg.ingest(msg)
 	if got := agg.tags["Germany"]; got == nil || got.Upload != 10 || got.Download != 20 {
@@ -160,7 +160,7 @@ func TestTrafficAggregator_IngestCreditsEveryChainHop(t *testing.T) {
 // chains (e.g. when a selector resolves through itself). Each connection's
 // bytes must credit each tag exactly once.
 func TestTrafficAggregator_IngestDedupsWithinSingleConnection(t *testing.T) {
-	agg := NewTrafficAggregator("unused", nil, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, nil, nil)
 	msg := []byte(`{"connections":[{"chains":["A","A","B"],"upload":7,"download":13}]}`)
 	agg.ingest(msg)
 	if got := agg.tags["A"]; got == nil || got.Upload != 7 || got.Download != 13 {
@@ -173,7 +173,7 @@ func TestTrafficAggregator_IngestDedupsWithinSingleConnection(t *testing.T) {
 
 func TestTrafficAggregator_PublishEmitsMemoryEvent(t *testing.T) {
 	pub := &fakePublisher{}
-	agg := NewTrafficAggregator("unused", pub, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, pub, nil)
 	agg.ingest([]byte(`{"memory":99999,"connections":[]}`))
 	agg.publish()
 	// publish emits singbox:traffic, singbox:traffic-totals and singbox:memory.
@@ -195,7 +195,7 @@ func TestTrafficAggregator_PublishEmitsMemoryEvent(t *testing.T) {
 // Cross-connection accumulation still works after the every-hop change —
 // two connections through the same chain double the totals on every tag.
 func TestTrafficAggregator_IngestAccumulatesAcrossConnections(t *testing.T) {
-	agg := NewTrafficAggregator("unused", nil, nil)
+	agg := NewTrafficAggregator(func() string { return "unused" }, nil, nil)
 	msg := []byte(`{"connections":[
 		{"chains":["Proxy0","Germany"],"upload":10,"download":20},
 		{"chains":["Proxy0","Germany"],"upload":100,"download":200}

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -929,6 +929,16 @@ func (s *SettingsStore) GetSingboxBootstrapDNS() string {
 	return settings.SingboxBootstrapDNS
 }
 
+// GetSingboxClashPort returns the configured Clash API port.
+// 0 means "not configured" — the operator falls back to its default.
+func (s *SettingsStore) GetSingboxClashPort() int {
+	settings, err := s.Get()
+	if err != nil {
+		return 0
+	}
+	return settings.SingboxClashPort
+}
+
 // GetLoggingMaxAge returns the max age for log entries in hours.
 func (s *SettingsStore) GetLoggingMaxAge() int {
 	settings, err := s.Get()

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -71,6 +71,12 @@ type Settings struct {
 	// резолвера — только IP, без домена и порта. Пусто = не вмешиваться в
 	// файл (исторически адрес правили руками). Issue #770.
 	SingboxBootstrapDNS string `json:"singboxBootstrapDNS,omitempty"`
+	// SingboxClashPort — порт experimental.clash_api.external_controller в
+	// 00-base.json. Хост всегда 127.0.0.1: это служебный канал управления
+	// awg-manager (LogForwarder, DelayChecker, селекторы подписок,
+	// /connections, прокси /api/singbox/clash/*), а не пользовательская
+	// настройка sing-box. 0 = порт по умолчанию. Issue #788, ADR 0001.
+	SingboxClashPort int `json:"singboxClashPort,omitempty"`
 	// ManagedPeerAllowIPsMigrated marks the one-time NDMS sweep that strips
 	// the legacy default 0.0.0.0/0 from managed-server peers' allow-ips
 	// (per-peer /32 only). New firmware rejects multiple peers sharing

--- a/internal/storage/types_patch.go
+++ b/internal/storage/types_patch.go
@@ -38,6 +38,7 @@ type SettingsPatch struct {
 	SingboxManuallyStopped      *bool                  `json:"singboxManuallyStopped,omitempty"`
 	CreateNDMSProxyForSingbox   *bool                  `json:"createNDMSProxyForSingbox,omitempty"`
 	SingboxBootstrapDNS         *string                `json:"singboxBootstrapDNS,omitempty"`
+	SingboxClashPort            *int                   `json:"singboxClashPort,omitempty"`
 	ManagedPeerAllowIPsMigrated *bool                  `json:"managedPeerAllowIPsMigrated,omitempty"`
 }
 


### PR DESCRIPTION
Closes #788.

Сторонний пакет (в issue — rdp из Entware Manager) мог занять 9099, и sing-box не стартовал: `FATAL … address already in use`. Порт был зашит константой, а дотянуться до него пользователь не мог вообще — `00-base.json` выигрывает merge (first-file-wins), и `patchBaseClashPort` приводил его к константе на каждом старте, так что даже ручная правка файла и эксперт-редактор не помогали.

## Что сделано

Порт переехал в настройки (`Settings.SingboxClashPort`, дефолт 9099), поле — в «Настройки → Интеграции» рядом с Bootstrap-DNS. Владельцем значения остались мы: `00-base.json` сохраняет выигрышную позицию merge, чужой слот перебить порт не может. Clash API — служебный канал управления awg-manager (журнал, активные соединения, замеры задержки, селекторы подписок, прокси `/api/singbox/clash/*`), а не пользовательский слушатель, и отказ при перебитом порте тихий: sing-box стартует нормально, слепнет только UI.

Отсутствие блока `clash_api` больше не считается волей пользователя — восстанавливаем. **Смена поведения**: у тех, кто удалял блок руками, слушатель вернётся после обновления.

Сохранение отвергает порт из нашей карты резервов (веб-интерфейс, TPROXY/REDIRECT, оба диапазона QoS, входы туннелей 1080+) и порт, занятый чужим процессом — с именем и PID, через готовый `sys/ports.Scanner`. Проверка на сервере: ручки `/system/ports/*` под expert-гейтом, обычному пользователю недоступны.

Применяется без перезапуска демона. `LogForwarder` и `TrafficAggregator` держали адрес снимком на старте — теперь спрашивают его каждый цикл переподключения; адрес у `ClashClient` под `RWMutex`.

## Осознанно не сделано

- TOCTOU между пре-флайтом и рестартом: порт может занять кто-то в эти доли секунды. Второй путь записи конфига с откатом городить не стали, отказ виден в `/logs`.
- Настройки сохраняются ДО применения — унаследованный порядок, общий с bootstrap-DNS и уровнем лога; чинить надо втроём. Поведение зафиксировано тестом.
- Обратная сверка коллизии: валидатор device-proxy про наш порт не знает. Дыра была и с константой 9099.


