### PR TITLE
K7: сборка sing-box-рантайма одним конструктором

### DIFF
--- a/cmd/awg-manager/cleanup.go
+++ b/cmd/awg-manager/cleanup.go
@@ -19,8 +19,6 @@ import (
 	ndmsquery "github.com/hoaxisr/awg-manager/internal/ndms/query"
 	ndmstransport "github.com/hoaxisr/awg-manager/internal/ndms/transport"
 	"github.com/hoaxisr/awg-manager/internal/orchestrator"
-	"github.com/hoaxisr/awg-manager/internal/singbox"
-	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/sys/env"
@@ -54,7 +52,7 @@ func runCleanup(dataDir string) {
 	fmt.Println("awg-manager cleanup: removing all managed resources...")
 
 	settingsStore := storage.NewSettingsStore(dataDir)
-	settingsStore.Load()
+	cleanupSettings, _ := settingsStore.Load()
 
 	loggingService := logging.NewService(settingsStore)
 	defer loggingService.Stop()
@@ -143,40 +141,19 @@ func runCleanup(dataDir string) {
 	// short-circuits inside reconcile via ErrNotSupportedOnOS4).
 	dnsSvc := dnsroute.NewService(dnsStore, cleanupNDMSQueries, cleanupNDMSCommands, nil, nil)
 
-	singboxOp := singbox.NewOperator(singbox.OperatorDeps{
-		Log:                slog.Default().With("component", "singbox"),
-		Queries:            cleanupNDMSQueries,
-		Commands:           cleanupNDMSCommands,
-		SingboxLogLevel:    settingsStore.GetSingboxLogLevel,
-		IsNDMSProxyEnabled: settingsStore.IsSingboxNDMSProxyEnabled,
+	// Cleanup собирает то же sing-box-ядро тем же конструктором, что демон
+	// (buildSingboxCore); сам cleanup зовёт только singboxOp.Cleanup.
+	core := buildSingboxCore(singboxCoreDeps{
+		queries:                cleanupNDMSQueries,
+		commands:               cleanupNDMSCommands,
+		settings:               settingsStore,
+		appLog:                 loggingService,
+		bus:                    cleanupEventBus,
+		bootLog:                bootLog,
+		dataDir:                dataDir,
+		initialManuallyStopped: cleanupSettings != nil && cleanupSettings.SingboxManuallyStopped,
 	})
-
-	// Cleanup mode: bootstrap the orchestrator so any subsequent
-	// operator call that goes through ApplyConfig writes the slot
-	// file rather than the legacy in-place tunnels.json. Cleanup
-	// itself only invokes singboxOp.Cleanup, but we keep the wiring
-	// symmetrical to the daemon path so future cleanup steps have it
-	// available.
-	cleanupSingboxConfigDir := singboxOp.ConfigDir()
-	if err := singbox.MigrateDeviceProxyOutOfTunnels(cleanupSingboxConfigDir); err != nil {
-		bootLog.Warn("deviceproxy-migration", "", err.Error())
-	}
-	if _, err := singbox.MigrateRuleSetURLsToFork(cleanupSingboxConfigDir); err != nil {
-		bootLog.Warn("ruleset-fork-migration", "", err.Error())
-	}
-	if _, err := router.MigrateAddressOrRules(cleanupSingboxConfigDir); err != nil {
-		bootLog.Warn("address-or-migration", "", err.Error())
-	}
-	cleanupSbOrch := singboxorch.New(cleanupSingboxConfigDir, singboxOp.Process())
-	for _, meta := range singboxorch.KnownSlots() {
-		if err := cleanupSbOrch.Register(meta); err != nil {
-			bootLog.Error("singbox-orchestrator", string(meta.Slot), "register failed: "+err.Error())
-		}
-	}
-	if err := cleanupSbOrch.Bootstrap(); err != nil {
-		bootLog.Error("singbox-orchestrator", "bootstrap", err.Error())
-	}
-	singboxOp.SetOrch(cleanupSbOrch)
+	singboxOp := core.op
 
 	accessPolicySvc := accesspolicy.New(cleanupNDMSCommands.Policies, cleanupNDMSCommands.Interfaces, cleanupNDMSQueries, settingsStore, nil, ndmsquery.NewPolicyMarkStore(cleanupNDMSTransport, nil))
 

--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"log/slog"
+	"path/filepath"
+
+	"github.com/hoaxisr/awg-manager/internal/awg3endpoint"
+	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	ndmscommand "github.com/hoaxisr/awg-manager/internal/ndms/command"
+	ndmsquery "github.com/hoaxisr/awg-manager/internal/ndms/query"
+	"github.com/hoaxisr/awg-manager/internal/singbox"
+	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
+	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/singbox/router"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// singboxCoreDeps — всё, что нужно ядру sing-box-рантайма и что обязан
+// предоставить вызывающий (демон или cleanup).
+type singboxCoreDeps struct {
+	queries  *ndmsquery.Queries
+	commands *ndmscommand.Commands
+	settings *storage.SettingsStore // источник замыканий OperatorDeps
+	appLog   *logging.Service       // AppLogger + логгер оркестратора
+	bus      *events.Bus
+	bootLog  *logging.ScopedLogger
+	dataDir  string // awg3.json
+	// initialManuallyStopped — снимок Settings.SingboxManuallyStopped,
+	// прочитанный вызывающим (демон держит его в a.settings).
+	initialManuallyStopped bool
+}
+
+type singboxCore struct {
+	op        *singbox.Operator
+	orch      *singboxorch.Orchestrator
+	awg3Store *awg3endpoint.Store
+	migrated  bool // ruleset-URL/address-or переписали файлы — runtime решает про reload
+}
+
+// buildSingboxCore собирает общую для демона и cleanup часть sing-box-рантайма:
+// оператор, оркестратор config.d со всеми слотами и store импортированных
+// AWG3-endpoint'ов.
+func buildSingboxCore(d singboxCoreDeps) singboxCore {
+	// Sing-box integration
+	op := singbox.NewOperator(singbox.OperatorDeps{
+		Log:             slog.Default().With("component", "singbox"),
+		Queries:         d.queries,
+		Commands:        d.commands,
+		AppLogger:       d.appLog,
+		SingboxLogLevel: d.settings.GetSingboxLogLevel,
+		BootstrapDNS:    d.settings.GetSingboxBootstrapDNS,
+		ClashPort:       d.settings.GetSingboxClashPort,
+		// Seed the sticky-stop flag from disk so the watchdog respects
+		// a user-pressed Stop across awgm restarts. SetManuallyStopped
+		// writes the new intent back through a single-field updater so
+		// concurrent writers on other Settings fields (e.g. router
+		// service toggling SingboxRouter) cannot silently overwrite it.
+		InitialManuallyStopped: d.initialManuallyStopped,
+		SetManuallyStopped:     d.settings.SetSingboxManuallyStopped,
+		IsNDMSProxyEnabled:     d.settings.IsSingboxNDMSProxyEnabled,
+		Bus:                    d.bus,
+	})
+	// Если на старте флаг disabled — orphan-cleanup (после возможного
+	// обрыва прошлой MigrateOff в любой момент). Reconcile подберёт
+	// сигнал на первом тике watchdog'а.
+	if !d.settings.IsSingboxNDMSProxyEnabled() {
+		op.MarkNeedsOrphanCleanup()
+	}
+
+	// config.d orchestrator — the single writer of slot files (00-base /
+	// 10-tunnels / 15-awg / 20-router / 30-deviceproxy). Producers route
+	// their writes through Save / SetEnabled so a "disabled" domain
+	// actually moves the file out of sing-box's view (config.d/disabled/)
+	// instead of leaving stale content behind.
+	singboxConfigDir := op.ConfigDir()
+	if err := singbox.MigrateDeviceProxyOutOfTunnels(singboxConfigDir); err != nil {
+		d.bootLog.Warn("deviceproxy-migration", "", err.Error())
+	}
+	ruleSetURLsMigrated, err := singbox.MigrateRuleSetURLsToFork(singboxConfigDir)
+	if err != nil {
+		d.bootLog.Warn("ruleset-fork-migration", "", err.Error())
+	}
+	addressOrMigrated, err := router.MigrateAddressOrRules(singboxConfigDir)
+	if err != nil {
+		d.bootLog.Warn("address-or-migration", "", err.Error())
+	}
+	orch := singboxorch.New(singboxConfigDir, op.Process())
+	orch.SetLogger(func(level, msg string) {
+		switch level {
+		case "warn":
+			d.appLog.AppLog(logging.LevelWarn, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
+		case "error":
+			d.appLog.AppLog(logging.LevelError, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
+		default:
+			d.appLog.AppLog(logging.LevelInfo, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
+		}
+	})
+	orch.SetValidator(&orchValidatorAdapter{v: singbox.NewValidator(installer.DefaultBinaryPath)})
+	// Propagate the sticky-stop intent so reload-triggered cold-starts
+	// (slot-file writes from router/deviceproxy/subscriptions) respect a
+	// user-pressed Stop in the same way the watchdog does.
+	orch.SetShouldRun(func() bool { return !op.IsManuallyStopped() })
+	// AWG3 imported endpoints — store owns awg3.json, service projects it into
+	// the 16-awg3.json slot. Constructed here so the SlotAwg3 HasContent closure
+	// (below) can read the store, mirroring SlotTunnels' HasUserTunnels gate.
+	awg3Store := awg3endpoint.NewStore(filepath.Join(d.dataDir, "awg3.json"))
+	for _, meta := range singboxorch.KnownSlots() {
+		// SlotTunnels is AlwaysOn but only counts as "active work" when
+		// the user has defined sing-box tunnels — wire HasContent so
+		// the daemon stops running for an empty 10-tunnels.json.
+		if meta.Slot == singboxorch.SlotTunnels {
+			meta.HasContent = func() bool {
+				return op.HasUserTunnels()
+			}
+		}
+		// SlotAwg3 is AlwaysOn too — it only justifies keeping the daemon
+		// running once the user has imported at least one AWG3 endpoint.
+		if meta.Slot == singboxorch.SlotAwg3 {
+			meta.HasContent = func() bool {
+				return awg3Store.Len() > 0
+			}
+		}
+		if err := orch.Register(meta); err != nil {
+			d.bootLog.Error("singbox-orchestrator", string(meta.Slot), "register failed: "+err.Error())
+		}
+	}
+	if err := orch.Bootstrap(); err != nil {
+		d.bootLog.Error("singbox-orchestrator", "bootstrap", err.Error())
+	}
+
+	// Wire orchestrator into Operator so ApplyConfig writes 10-tunnels.json
+	// through SlotTunnels rather than an in-place write that bypasses
+	// the orchestrator's validate / debounced reload.
+	op.SetOrch(orch)
+	// Предикат перезапуска для watchdog/Reconcile (#456): упавший sing-box
+	// поднимается и когда легаси-туннелей нет, но активны orchestrator-слоты
+	// (router / deviceproxy / subscriptions / пользовательские туннели).
+	op.SetActiveWorkFn(orch.HasActiveWork)
+
+	return singboxCore{
+		op:        op,
+		orch:      orch,
+		awg3Store: awg3Store,
+		migrated:  ruleSetURLsMigrated || addressOrMigrated,
+	}
+}

--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"path/filepath"
+	"runtime"
 
 	"github.com/hoaxisr/awg-manager/internal/awg3endpoint"
 	"github.com/hoaxisr/awg-manager/internal/events"
@@ -13,6 +14,7 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
 	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 	"github.com/hoaxisr/awg-manager/internal/singbox/router"
+	"github.com/hoaxisr/awg-manager/internal/singbox/subscription"
 	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
@@ -143,5 +145,166 @@ func buildSingboxCore(d singboxCoreDeps) singboxCore {
 		orch:      orch,
 		awg3Store: awg3Store,
 		migrated:  ruleSetURLsMigrated || addressOrMigrated,
+	}
+}
+
+// setupSingboxRuntime собирает демонский sing-box-рантайм: ядро
+// (buildSingboxCore), AWG3-сервис, подписочный слой и managed-binary
+// installer. Присваивает поля *app; периферия (handlers / фоновые
+// воркеры / updater) остаётся в setupSingbox.
+func (a *app) setupSingboxRuntime() {
+	var err error
+	core := buildSingboxCore(singboxCoreDeps{
+		queries:                a.ndmsQueries,
+		commands:               a.ndmsCommands,
+		settings:               a.settingsStore,
+		appLog:                 a.loggingService,
+		bus:                    a.eventBus,
+		bootLog:                a.bootLog,
+		dataDir:                a.dataDir,
+		initialManuallyStopped: a.settings.SingboxManuallyStopped,
+	})
+	a.singboxOp = core.op
+	a.sbOrch = core.orch
+	a.awg3Store = core.awg3Store
+	singboxConfigDir := a.singboxOp.ConfigDir()
+	a.awg3Svc = awg3endpoint.NewService(a.awg3Store, a.sbOrch, a.loggingService)
+	// Project any imported AWG3 endpoints into 16-awg3.json on boot so a
+	// restart re-materializes the slot from awg3.json (the source of truth).
+	// Skip when there is neither a store record nor a 16-awg3.json file:
+	// Sync would only spawn a `sing-box check` subprocess (seconds on MIPS,
+	// warns without the binary) to produce an empty slot that is already empty.
+	// If the slot file exists while the store is empty, still Sync to clear it.
+	slotExists := func() bool {
+		_, _, ok := a.sbOrch.EffectiveStat(singboxorch.SlotAwg3)
+		return ok
+	}
+	// || is lazy: EffectiveStat (a stat syscall) runs only when the store is empty.
+	if a.awg3Store.Len() > 0 || slotExists() {
+		if err := a.awg3Svc.Sync(); err != nil {
+			a.bootLog.Warn("awg3-sync", "boot", err.Error())
+		}
+	}
+	// Миграция URL rule-set'ов переписала файлы мимо оркестратора: переживший
+	// рестарт awgm sing-box иначе держит старые (заблокированные) URL в памяти
+	// до случайного reload по другому поводу. Холодный старт (процесс не
+	// запущен) прочитает новые файлы сам — reload не нужен.
+	// То же и для нормализации правил «пресет ИЛИ свои адреса» (#699).
+	if core.migrated {
+		if running, _ := a.singboxOp.IsRunning(); running {
+			a.bootLog.Info("ruleset-fork-migration", "", "правила/URL мигрированы — перечитываем конфиг живого sing-box")
+			if err := a.sbOrch.ReloadNow(); err != nil {
+				a.bootLog.Warn("ruleset-fork-migration", "reload", err.Error())
+			}
+		}
+	}
+	// Legacy download-proxy slot (35-download-proxy.json) is no longer used
+	// by the downloader, but disable it on boot in case a previous awgm
+	// process crashed with the slot still enabled.
+	if err := a.sbOrch.SetEnabledSilent(singboxorch.SlotDownloadProxy, false); err != nil {
+		a.bootLog.Warn("singbox-orchestrator", "downloadproxy-disable", err.Error())
+	}
+	// Reflect Settings into orchestrator slot enabled-state. router /
+	// deviceproxy / subscriptions are content-driven; tunnels / awg
+	// are AlwaysOn (registered as such above) and cannot be toggled
+	// here — Register already marked them enabled. deviceproxy is
+	// reflected after deviceProxySvc is constructed below.
+	if curSettings, err := a.settingsStore.Load(); err == nil && curSettings != nil {
+		mode := curSettings.SingboxRouter.RoutingMode
+		_ = a.sbOrch.SetEnabled(router.RouterSlotForMode(mode), curSettings.SingboxRouter.Enabled)
+		_ = a.sbOrch.SetEnabled(router.OtherRouterSlot(mode), false)
+		// Повторное примирение base здесь больше не нужно: разметка слотов
+		// меняет владельца dns.strategy, но дефолт лежит в 99-defaults.json —
+		// в проигрывающей позиции merge, — и перекрывается активным слотом
+		// сам. Раньше рассинхрон base пережил бы бут и не лечился периодическим
+		// Reconcile (его drift-heal берётся только при запаркованном слоте, а
+		// он здесь уже распаркован).
+	}
+
+	// Subscription service — owns 40-subscriptions.json in config.d.
+	// NewOperatorAdapter registers the slot into sbOrch (must happen before
+	// Bootstrap so Bootstrap can scan the file). LoadFromDisk reads any
+	// existing 40-subscriptions.json so the in-memory state is consistent.
+	subStorePath := filepath.Join(a.dataDir, "subscriptions.json")
+	a.subStore, err = subscription.NewStore(subStorePath)
+	if err != nil {
+		a.bootLog.Error("subscription-store", "", err.Error())
+	}
+	subProxyMgr := singbox.NewProxyManager(a.ndmsQueries, a.ndmsCommands)
+	a.subAdapter = subscription.NewOperatorAdapter(a.sbOrch, subProxyMgr, a.singboxOp.Clash())
+	// Wire the Operator's cached sing-box build-tag probe into the
+	// subscription adapter so flush() Pass 1 can cheaply pre-filter
+	// outbounds whose type requires a missing optional build tag
+	// (naive). The probe is cached by binary
+	// mtime+size in Operator.detectVersionAndFeaturesCached — common
+	// path is ~10µs per call (stat-only check, no subprocess).
+	a.subAdapter.SetSingboxFeaturesFn(a.singboxOp.SingboxFeatures)
+	if err := a.subAdapter.LoadFromDisk(singboxConfigDir); err != nil {
+		a.bootLog.Warn("subscription-adapter", "load-from-disk", err.Error())
+	}
+	a.subSvc = subscription.NewService(a.subStore, a.subAdapter)
+	a.subSvc.SetAppLogger(a.loggingService)
+	// Gate subscription ProxyN creation on the global toggle (same flag the
+	// Operator uses for tunnels) so disabling it stops subscriptions from
+	// creating NDMS Proxy interfaces too.
+	a.subSvc.SetNDMSProxyEnabled(a.settingsStore.IsSingboxNDMSProxyEnabled)
+	if err := a.subSvc.LoadHappKeys(); err != nil {
+		a.bootLog.Warn("subscription-happ-keys", "load-from-disk", err.Error())
+	}
+
+	// Сводные группы (#372) — отдельный JSON-файл рядом с subscriptions.json.
+	subGroupStorePath := filepath.Join(a.dataDir, "subscription-groups.json")
+	a.subGroupStore, err = subscription.NewGroupStore(subGroupStorePath)
+	if err != nil {
+		// Битый файл групп: карантиним (<path>.corrupt — данные сохраняются
+		// для ручного восстановления, как у других store) и пересоздаём
+		// пустой store. Иначе функциональность групп молча выключалась бы,
+		// а их ProxyN оставались бы без владельца до конца аптайма.
+		a.bootLog.Error("subscription-group-store", "", err.Error()+" — quarantining and recreating empty store")
+		storage.QuarantineCorrupt(subGroupStorePath, err)
+		a.subGroupStore, err = subscription.NewGroupStore(subGroupStorePath)
+		if err != nil {
+			a.bootLog.Error("subscription-group-store", "", "recreate after quarantine failed: "+err.Error())
+		}
+	}
+	if a.subGroupStore != nil {
+		a.subSvc.SetGroupStore(a.subGroupStore)
+	}
+
+	// Let NDMS-proxy enable/disable + orphan cleanup manage subscription
+	// composite proxies (a set separate from Tunnels()).
+	a.singboxOp.SetSubscriptionProxySet(subProxySet{store: a.subStore, groups: a.subGroupStore})
+	// On MigrateOn, reconcile subscription proxies through the service so
+	// subscriptions created while the toggle was off get a freshly allocated
+	// ProxyN (not just the already-indexed ones).
+	a.singboxOp.SetSubscriptionProxySync(a.subSvc.SyncProxies)
+
+	// Wire managed-binary installer into Operator. The installer is keyed
+	// by the build-time arch string (e.g. "mipsel-3.4") so it can resolve
+	// the correct download URL and SHA256 from EmbeddedBinaries.
+	arch := detectArch()
+	if arch == "" {
+		a.bootLog.Warn("managed-singbox", runtime.GOARCH, "could not derive arch — install/update disabled")
+	} else {
+		spec, ok := installer.EmbeddedBinaries[arch]
+		if !ok {
+			a.bootLog.Warn("managed-singbox", arch, "no embedded BinarySpec — install/update disabled")
+		} else {
+			a.singboxInstaller = installer.New(installer.DefaultBinaryPath, arch, spec, a.loggingService)
+			a.singboxOp.SetInstaller(a.singboxInstaller)
+
+			// Stream sing-box install/update lifecycle over SSE so the UI
+			// can render a live progress bar instead of a blocking spinner.
+			a.singboxOp.SetInstallProgressReporter(func(op, phase string, downloaded, total int64, errMsg string) {
+				a.eventBus.Publish("singbox:install-progress", events.SingboxInstallProgressEvent{
+					Op:         op,
+					Phase:      phase,
+					Downloaded: downloaded,
+					Total:      total,
+					Error:      errMsg,
+				})
+			})
+
+		}
 	}
 }

--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -28,6 +28,9 @@ type singboxCoreDeps struct {
 	bus      *events.Bus
 	bootLog  *logging.ScopedLogger
 	dataDir  string // awg3.json
+	// dir — каталог управляемого sing-box; пусто = дефолт оператора
+	// (каталог рядом с бинарём).
+	dir string
 	// initialManuallyStopped — снимок Settings.SingboxManuallyStopped,
 	// прочитанный вызывающим (демон держит его в a.settings).
 	initialManuallyStopped bool
@@ -47,6 +50,7 @@ func buildSingboxCore(d singboxCoreDeps) singboxCore {
 	// Sing-box integration
 	op := singbox.NewOperator(singbox.OperatorDeps{
 		Log:             slog.Default().With("component", "singbox"),
+		Dir:             d.dir,
 		Queries:         d.queries,
 		Commands:        d.commands,
 		AppLogger:       d.appLog,
@@ -162,6 +166,7 @@ func (a *app) setupSingboxRuntime() {
 		bus:                    a.eventBus,
 		bootLog:                a.bootLog,
 		dataDir:                a.dataDir,
+		dir:                    a.singboxDir,
 		initialManuallyStopped: a.settings.SingboxManuallyStopped,
 	})
 	a.singboxOp = core.op

--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -227,9 +227,11 @@ func (a *app) setupSingboxRuntime() {
 	}
 
 	// Subscription service — owns 40-subscriptions.json in config.d.
-	// NewOperatorAdapter registers the slot into sbOrch (must happen before
-	// Bootstrap so Bootstrap can scan the file). LoadFromDisk reads any
-	// existing 40-subscriptions.json so the in-memory state is consistent.
+	// Слот регистрирует цикл KnownSlots внутри buildSingboxCore, до
+	// Bootstrap; Register внутри NewOperatorAdapter — no-op дубль с той же
+	// meta (ErrSlotAlreadyRegistered там глотается, см. его докстринг).
+	// А вот LoadFromDisk обязан идти ПОСЛЕ Bootstrap: он приводит память
+	// адаптера в соответствие с тем, что оказалось на диске.
 	subStorePath := filepath.Join(a.dataDir, "subscriptions.json")
 	a.subStore, err = subscription.NewStore(subStorePath)
 	if err != nil {

--- a/cmd/awg-manager/singbox_core_test.go
+++ b/cmd/awg-manager/singbox_core_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/awg3endpoint"
+	"github.com/hoaxisr/awg-manager/internal/events"
+	"github.com/hoaxisr/awg-manager/internal/logging"
+	"github.com/hoaxisr/awg-manager/internal/singbox"
+	"github.com/hoaxisr/awg-manager/internal/storage"
+)
+
+// newTestCore собирает ядро над временными каталогами: dir — каталог
+// sing-box (config.d), dataDir — awg3.json. queries/commands nil: ядру без
+// NDMS они не нужны, ровно как тестам internal/singbox (newOrchedOperator).
+func newTestCore(t *testing.T) singboxCore {
+	t.Helper()
+	dataDir := t.TempDir()
+	settingsStore := storage.NewSettingsStore(dataDir)
+	loggingService := logging.NewService(settingsStore)
+	t.Cleanup(loggingService.Stop)
+	return buildSingboxCore(singboxCoreDeps{
+		settings: settingsStore,
+		appLog:   loggingService,
+		bus:      events.NewBus(),
+		bootLog:  logging.NewScopedLogger(loggingService, logging.GroupSystem, logging.SubCleanup),
+		dataDir:  dataDir,
+		dir:      t.TempDir(),
+	})
+}
+
+// Пин на проводку слотов внутри buildSingboxCore: Register + Bootstrap +
+// SetOrch. Запись 10-tunnels.json идёт через оркестратор, поэтому любой
+// пропущенный шаг проводки виден отказом ApplyConfig.
+// Краснеет на мутации «убрать op.SetOrch(orch)» — ApplyConfig возвращает
+// «apply tunnels config: orchestrator not wired».
+//
+// Честно про границу пина: он пинит ЗАПИСЬ слота, но не валидацию. Без
+// бинаря sing-box (dev-машина, CI) валидация падает, оператор считает
+// merged-конфиг сломанным не нами и пишет слот через ветку
+// mergedAlreadyInvalid (operator_tunnels.go:649-654) — зелёный получается
+// именно оттуда.
+func TestBuildSingboxCore_ApplyConfigWritesSlot(t *testing.T) {
+	core := newTestCore(t)
+
+	cfg := singbox.NewConfig()
+	cfg.AddTunnelWithListenPort("A", "vless", "h", 1, 0, json.RawMessage(`{"type":"vless","tag":"A"}`))
+	if err := core.op.ApplyConfig(context.Background(), cfg); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+
+	slot := filepath.Join(core.op.ConfigDir(), "10-tunnels.json")
+	if _, err := os.Stat(slot); err != nil {
+		t.Fatalf("слот не записан: %v", err)
+	}
+}
+
+// Пин на подмену meta.HasContent для SlotAwg3: слот AlwaysOn, и без подмены
+// он не считается работой вообще — импортированный endpoint не удержал бы
+// sing-box запущенным (#456).
+// Краснеет на мутации «убрать подмену HasContent для SlotAwg3» — после
+// записи endpoint'а HasActiveWork остаётся false.
+func TestBuildSingboxCore_Awg3HasContent(t *testing.T) {
+	core := newTestCore(t)
+
+	if core.orch.HasActiveWork() {
+		t.Fatal("HasActiveWork=true на пустом ядре")
+	}
+	if err := core.awg3Store.Add(awg3endpoint.Record{
+		ID:       "1",
+		Tag:      "e1",
+		Endpoint: json.RawMessage(`{"type":"awg","tag":"e1"}`),
+	}); err != nil {
+		t.Fatalf("awg3Store.Add: %v", err)
+	}
+	if !core.orch.HasActiveWork() {
+		t.Fatal("HasActiveWork=false при импортированном AWG3-endpoint")
+	}
+}
+
+// Пин на конструирующие строки setupSingboxRuntime: потерянное присваивание
+// полю *app компилятор не ловит (класс дефекта 0c663c006), а nil-поле
+// доезжает до первого обращения уже в рантайме.
+// Краснеет на мутации «удалить любую строку постройки» — например
+// a.awg3Svc = awg3endpoint.NewService(...).
+// singboxInstaller НЕ проверяется: на dev-машине detectArch() уходит в
+// warn-ветку и поле остаётся nil — это легальное прод-состояние.
+//
+// Проверки развёрнуты по полям намеренно: таблица со значениями в any
+// была бы вакуумной — типизированный nil-указатель, положенный в
+// интерфейс, не равен nil, и мутант проходил бы зелёным.
+func TestSetupSingboxRuntime_FieldsConstructed(t *testing.T) {
+	dataDir := t.TempDir()
+	settingsStore := storage.NewSettingsStore(dataDir)
+	loggingService := logging.NewService(settingsStore)
+	t.Cleanup(loggingService.Stop)
+	a := &app{
+		dataDir:        dataDir,
+		singboxDir:     t.TempDir(),
+		settingsStore:  settingsStore,
+		settings:       &storage.Settings{},
+		loggingService: loggingService,
+		bootLog:        logging.NewScopedLogger(loggingService, logging.GroupSystem, logging.SubCleanup),
+		eventBus:       events.NewBus(),
+	}
+
+	a.setupSingboxRuntime()
+
+	if a.singboxOp == nil {
+		t.Error("singboxOp не собран")
+	}
+	if a.sbOrch == nil {
+		t.Error("sbOrch не собран")
+	}
+	if a.awg3Store == nil {
+		t.Error("awg3Store не собран")
+	}
+	if a.awg3Svc == nil {
+		t.Error("awg3Svc не собран")
+	}
+	if a.subStore == nil {
+		t.Error("subStore не собран")
+	}
+	if a.subAdapter == nil {
+		t.Error("subAdapter не собран")
+	}
+	if a.subSvc == nil {
+		t.Error("subSvc не собран")
+	}
+	if a.subGroupStore == nil {
+		t.Error("subGroupStore не собран")
+	}
+}

--- a/cmd/awg-manager/wiring.go
+++ b/cmd/awg-manager/wiring.go
@@ -83,6 +83,10 @@ type app struct {
 	settings      *storage.Settings
 	awgStore      *storage.AWGTunnelStore
 
+	// singboxDir — каталог sing-box для setupSingboxRuntime. В проде пустой
+	// (оператор берёт дефолт рядом с бинарём); существует ради подмены
+	// каталога во временный в пинах конструктора.
+	singboxDir     string
 	loggingService *logging.Service
 	bootLog        *logging.ScopedLogger
 

--- a/cmd/awg-manager/wiring_server.go
+++ b/cmd/awg-manager/wiring_server.go
@@ -139,7 +139,6 @@ func (a *app) setupServer() {
 	)
 
 	a.srv.SetSingboxOperator(a.singboxOp)
-	a.singboxOp.SetEventBus(a.eventBus)
 
 }
 

--- a/cmd/awg-manager/wiring_singbox.go
+++ b/cmd/awg-manager/wiring_singbox.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/api"
 	"github.com/hoaxisr/awg-manager/internal/awg3endpoint"
 	"github.com/hoaxisr/awg-manager/internal/events"
-	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/singbox"
 	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
 	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
@@ -47,93 +46,21 @@ func (a *singboxUpdaterAdapter) Update(ctx context.Context) error {
 // the background workers (watchdog, traffic, delay, log forwarder).
 func (a *app) setupSingbox() {
 	var err error
-	// Sing-box integration
-	a.singboxOp = singbox.NewOperator(singbox.OperatorDeps{
-		Log:             slog.Default().With("component", "singbox"),
-		Queries:         a.ndmsQueries,
-		Commands:        a.ndmsCommands,
-		AppLogger:       a.loggingService,
-		SingboxLogLevel: a.settingsStore.GetSingboxLogLevel,
-		BootstrapDNS:    a.settingsStore.GetSingboxBootstrapDNS,
-		ClashPort:       a.settingsStore.GetSingboxClashPort,
-		// Seed the sticky-stop flag from disk so the watchdog respects
-		// a user-pressed Stop across awgm restarts. SetManuallyStopped
-		// writes the new intent back through a single-field updater so
-		// concurrent writers on other Settings fields (e.g. router
-		// service toggling SingboxRouter) cannot silently overwrite it.
-		InitialManuallyStopped: a.settings.SingboxManuallyStopped,
-		SetManuallyStopped:     a.settingsStore.SetSingboxManuallyStopped,
-		IsNDMSProxyEnabled:     a.settingsStore.IsSingboxNDMSProxyEnabled,
-		Bus:                    a.eventBus,
+	core := buildSingboxCore(singboxCoreDeps{
+		queries:                a.ndmsQueries,
+		commands:               a.ndmsCommands,
+		settings:               a.settingsStore,
+		appLog:                 a.loggingService,
+		bus:                    a.eventBus,
+		bootLog:                a.bootLog,
+		dataDir:                a.dataDir,
+		initialManuallyStopped: a.settings.SingboxManuallyStopped,
 	})
-	// Если на старте флаг disabled — orphan-cleanup (после возможного
-	// обрыва прошлой MigrateOff в любой момент). Reconcile подберёт
-	// сигнал на первом тике watchdog'а.
-	if !a.settingsStore.IsSingboxNDMSProxyEnabled() {
-		a.singboxOp.MarkNeedsOrphanCleanup()
-	}
-
-	// config.d orchestrator — the single writer of slot files (00-base /
-	// 10-tunnels / 15-awg / 20-router / 30-deviceproxy). Producers route
-	// their writes through Save / SetEnabled so a "disabled" domain
-	// actually moves the file out of sing-box's view (config.d/disabled/)
-	// instead of leaving stale content behind.
+	a.singboxOp = core.op
+	a.sbOrch = core.orch
+	a.awg3Store = core.awg3Store
 	singboxConfigDir := a.singboxOp.ConfigDir()
-	if err := singbox.MigrateDeviceProxyOutOfTunnels(singboxConfigDir); err != nil {
-		a.bootLog.Warn("deviceproxy-migration", "", err.Error())
-	}
-	ruleSetURLsMigrated, err := singbox.MigrateRuleSetURLsToFork(singboxConfigDir)
-	if err != nil {
-		a.bootLog.Warn("ruleset-fork-migration", "", err.Error())
-	}
-	addressOrMigrated, err := router.MigrateAddressOrRules(singboxConfigDir)
-	if err != nil {
-		a.bootLog.Warn("address-or-migration", "", err.Error())
-	}
-	a.sbOrch = singboxorch.New(singboxConfigDir, a.singboxOp.Process())
-	a.sbOrch.SetLogger(func(level, msg string) {
-		switch level {
-		case "warn":
-			a.loggingService.AppLog(logging.LevelWarn, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
-		case "error":
-			a.loggingService.AppLog(logging.LevelError, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
-		default:
-			a.loggingService.AppLog(logging.LevelInfo, logging.GroupSingbox, logging.SubSBProcess, "orchestrator", "", msg)
-		}
-	})
-	a.sbOrch.SetValidator(&orchValidatorAdapter{v: singbox.NewValidator(installer.DefaultBinaryPath)})
-	// Propagate the sticky-stop intent so reload-triggered cold-starts
-	// (slot-file writes from router/deviceproxy/subscriptions) respect a
-	// user-pressed Stop in the same way the watchdog does.
-	a.sbOrch.SetShouldRun(func() bool { return !a.singboxOp.IsManuallyStopped() })
-	// AWG3 imported endpoints — store owns awg3.json, service projects it into
-	// the 16-awg3.json slot. Constructed here so the SlotAwg3 HasContent closure
-	// (below) can read the store, mirroring SlotTunnels' HasUserTunnels gate.
-	a.awg3Store = awg3endpoint.NewStore(filepath.Join(a.dataDir, "awg3.json"))
 	a.awg3Svc = awg3endpoint.NewService(a.awg3Store, a.sbOrch, a.loggingService)
-	for _, meta := range singboxorch.KnownSlots() {
-		// SlotTunnels is AlwaysOn but only counts as "active work" when
-		// the user has defined sing-box tunnels — wire HasContent so
-		// the daemon stops running for an empty 10-tunnels.json.
-		if meta.Slot == singboxorch.SlotTunnels {
-			meta.HasContent = func() bool {
-				return a.singboxOp.HasUserTunnels()
-			}
-		}
-		// SlotAwg3 is AlwaysOn too — it only justifies keeping the daemon
-		// running once the user has imported at least one AWG3 endpoint.
-		if meta.Slot == singboxorch.SlotAwg3 {
-			meta.HasContent = func() bool {
-				return a.awg3Store.Len() > 0
-			}
-		}
-		if err := a.sbOrch.Register(meta); err != nil {
-			a.bootLog.Error("singbox-orchestrator", string(meta.Slot), "register failed: "+err.Error())
-		}
-	}
-	if err := a.sbOrch.Bootstrap(); err != nil {
-		a.bootLog.Error("singbox-orchestrator", "bootstrap", err.Error())
-	}
 	// Project any imported AWG3 endpoints into 16-awg3.json on boot so a
 	// restart re-materializes the slot from awg3.json (the source of truth).
 	// Skip when there is neither a store record nor a 16-awg3.json file:
@@ -155,7 +82,7 @@ func (a *app) setupSingbox() {
 	// до случайного reload по другому поводу. Холодный старт (процесс не
 	// запущен) прочитает новые файлы сам — reload не нужен.
 	// То же и для нормализации правил «пресет ИЛИ свои адреса» (#699).
-	if ruleSetURLsMigrated || addressOrMigrated {
+	if core.migrated {
 		if running, _ := a.singboxOp.IsRunning(); running {
 			a.bootLog.Info("ruleset-fork-migration", "", "правила/URL мигрированы — перечитываем конфиг живого sing-box")
 			if err := a.sbOrch.ReloadNow(); err != nil {
@@ -243,15 +170,6 @@ func (a *app) setupSingbox() {
 	// subscriptions created while the toggle was off get a freshly allocated
 	// ProxyN (not just the already-indexed ones).
 	a.singboxOp.SetSubscriptionProxySync(a.subSvc.SyncProxies)
-
-	// Wire orchestrator into Operator so ApplyConfig writes 10-tunnels.json
-	// through SlotTunnels rather than an in-place write that bypasses
-	// the orchestrator's validate / debounced reload.
-	a.singboxOp.SetOrch(a.sbOrch)
-	// Предикат перезапуска для watchdog/Reconcile (#456): упавший sing-box
-	// поднимается и когда легаси-туннелей нет, но активны orchestrator-слоты
-	// (router / deviceproxy / subscriptions / пользовательские туннели).
-	a.singboxOp.SetActiveWorkFn(a.sbOrch.HasActiveWork)
 
 	// Wire managed-binary installer into Operator. The installer is keyed
 	// by the build-time arch string (e.g. "mipsel-3.4") so it can resolve

--- a/cmd/awg-manager/wiring_singbox.go
+++ b/cmd/awg-manager/wiring_singbox.go
@@ -3,20 +3,11 @@ package main
 import (
 	"context"
 	"errors"
-	"path/filepath"
 
 	"log/slog"
-	"runtime"
 
 	"github.com/hoaxisr/awg-manager/internal/api"
-	"github.com/hoaxisr/awg-manager/internal/awg3endpoint"
-	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/singbox"
-	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
-	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
-	"github.com/hoaxisr/awg-manager/internal/singbox/router"
-	"github.com/hoaxisr/awg-manager/internal/singbox/subscription"
-	"github.com/hoaxisr/awg-manager/internal/storage"
 	"github.com/hoaxisr/awg-manager/internal/updater"
 )
 
@@ -41,164 +32,11 @@ func (a *singboxUpdaterAdapter) Update(ctx context.Context) error {
 	return err
 }
 
-// setupSingbox builds the sing-box operator, the config.d slot
-// orchestrator, the subscription service, the managed-binary installer and
-// the background workers (watchdog, traffic, delay, log forwarder).
+// setupSingbox wires the sing-box runtime (setupSingboxRuntime) and then
+// its periphery: HTTP handlers and the background workers (watchdog,
+// traffic, delay, log forwarder) plus the updater service.
 func (a *app) setupSingbox() {
-	var err error
-	core := buildSingboxCore(singboxCoreDeps{
-		queries:                a.ndmsQueries,
-		commands:               a.ndmsCommands,
-		settings:               a.settingsStore,
-		appLog:                 a.loggingService,
-		bus:                    a.eventBus,
-		bootLog:                a.bootLog,
-		dataDir:                a.dataDir,
-		initialManuallyStopped: a.settings.SingboxManuallyStopped,
-	})
-	a.singboxOp = core.op
-	a.sbOrch = core.orch
-	a.awg3Store = core.awg3Store
-	singboxConfigDir := a.singboxOp.ConfigDir()
-	a.awg3Svc = awg3endpoint.NewService(a.awg3Store, a.sbOrch, a.loggingService)
-	// Project any imported AWG3 endpoints into 16-awg3.json on boot so a
-	// restart re-materializes the slot from awg3.json (the source of truth).
-	// Skip when there is neither a store record nor a 16-awg3.json file:
-	// Sync would only spawn a `sing-box check` subprocess (seconds on MIPS,
-	// warns without the binary) to produce an empty slot that is already empty.
-	// If the slot file exists while the store is empty, still Sync to clear it.
-	slotExists := func() bool {
-		_, _, ok := a.sbOrch.EffectiveStat(singboxorch.SlotAwg3)
-		return ok
-	}
-	// || is lazy: EffectiveStat (a stat syscall) runs only when the store is empty.
-	if a.awg3Store.Len() > 0 || slotExists() {
-		if err := a.awg3Svc.Sync(); err != nil {
-			a.bootLog.Warn("awg3-sync", "boot", err.Error())
-		}
-	}
-	// Миграция URL rule-set'ов переписала файлы мимо оркестратора: переживший
-	// рестарт awgm sing-box иначе держит старые (заблокированные) URL в памяти
-	// до случайного reload по другому поводу. Холодный старт (процесс не
-	// запущен) прочитает новые файлы сам — reload не нужен.
-	// То же и для нормализации правил «пресет ИЛИ свои адреса» (#699).
-	if core.migrated {
-		if running, _ := a.singboxOp.IsRunning(); running {
-			a.bootLog.Info("ruleset-fork-migration", "", "правила/URL мигрированы — перечитываем конфиг живого sing-box")
-			if err := a.sbOrch.ReloadNow(); err != nil {
-				a.bootLog.Warn("ruleset-fork-migration", "reload", err.Error())
-			}
-		}
-	}
-	// Legacy download-proxy slot (35-download-proxy.json) is no longer used
-	// by the downloader, but disable it on boot in case a previous awgm
-	// process crashed with the slot still enabled.
-	if err := a.sbOrch.SetEnabledSilent(singboxorch.SlotDownloadProxy, false); err != nil {
-		a.bootLog.Warn("singbox-orchestrator", "downloadproxy-disable", err.Error())
-	}
-	// Reflect Settings into orchestrator slot enabled-state. router /
-	// deviceproxy / subscriptions are content-driven; tunnels / awg
-	// are AlwaysOn (registered as such above) and cannot be toggled
-	// here — Register already marked them enabled. deviceproxy is
-	// reflected after deviceProxySvc is constructed below.
-	if curSettings, err := a.settingsStore.Load(); err == nil && curSettings != nil {
-		mode := curSettings.SingboxRouter.RoutingMode
-		_ = a.sbOrch.SetEnabled(router.RouterSlotForMode(mode), curSettings.SingboxRouter.Enabled)
-		_ = a.sbOrch.SetEnabled(router.OtherRouterSlot(mode), false)
-		// Повторное примирение base здесь больше не нужно: разметка слотов
-		// меняет владельца dns.strategy, но дефолт лежит в 99-defaults.json —
-		// в проигрывающей позиции merge, — и перекрывается активным слотом
-		// сам. Раньше рассинхрон base пережил бы бут и не лечился периодическим
-		// Reconcile (его drift-heal берётся только при запаркованном слоте, а
-		// он здесь уже распаркован).
-	}
-
-	// Subscription service — owns 40-subscriptions.json in config.d.
-	// NewOperatorAdapter registers the slot into sbOrch (must happen before
-	// Bootstrap so Bootstrap can scan the file). LoadFromDisk reads any
-	// existing 40-subscriptions.json so the in-memory state is consistent.
-	subStorePath := filepath.Join(a.dataDir, "subscriptions.json")
-	a.subStore, err = subscription.NewStore(subStorePath)
-	if err != nil {
-		a.bootLog.Error("subscription-store", "", err.Error())
-	}
-	subProxyMgr := singbox.NewProxyManager(a.ndmsQueries, a.ndmsCommands)
-	a.subAdapter = subscription.NewOperatorAdapter(a.sbOrch, subProxyMgr, a.singboxOp.Clash())
-	// Wire the Operator's cached sing-box build-tag probe into the
-	// subscription adapter so flush() Pass 1 can cheaply pre-filter
-	// outbounds whose type requires a missing optional build tag
-	// (naive). The probe is cached by binary
-	// mtime+size in Operator.detectVersionAndFeaturesCached — common
-	// path is ~10µs per call (stat-only check, no subprocess).
-	a.subAdapter.SetSingboxFeaturesFn(a.singboxOp.SingboxFeatures)
-	if err := a.subAdapter.LoadFromDisk(singboxConfigDir); err != nil {
-		a.bootLog.Warn("subscription-adapter", "load-from-disk", err.Error())
-	}
-	a.subSvc = subscription.NewService(a.subStore, a.subAdapter)
-	a.subSvc.SetAppLogger(a.loggingService)
-	// Gate subscription ProxyN creation on the global toggle (same flag the
-	// Operator uses for tunnels) so disabling it stops subscriptions from
-	// creating NDMS Proxy interfaces too.
-	a.subSvc.SetNDMSProxyEnabled(a.settingsStore.IsSingboxNDMSProxyEnabled)
-	if err := a.subSvc.LoadHappKeys(); err != nil {
-		a.bootLog.Warn("subscription-happ-keys", "load-from-disk", err.Error())
-	}
-
-	// Сводные группы (#372) — отдельный JSON-файл рядом с subscriptions.json.
-	subGroupStorePath := filepath.Join(a.dataDir, "subscription-groups.json")
-	a.subGroupStore, err = subscription.NewGroupStore(subGroupStorePath)
-	if err != nil {
-		// Битый файл групп: карантиним (<path>.corrupt — данные сохраняются
-		// для ручного восстановления, как у других store) и пересоздаём
-		// пустой store. Иначе функциональность групп молча выключалась бы,
-		// а их ProxyN оставались бы без владельца до конца аптайма.
-		a.bootLog.Error("subscription-group-store", "", err.Error()+" — quarantining and recreating empty store")
-		storage.QuarantineCorrupt(subGroupStorePath, err)
-		a.subGroupStore, err = subscription.NewGroupStore(subGroupStorePath)
-		if err != nil {
-			a.bootLog.Error("subscription-group-store", "", "recreate after quarantine failed: "+err.Error())
-		}
-	}
-	if a.subGroupStore != nil {
-		a.subSvc.SetGroupStore(a.subGroupStore)
-	}
-
-	// Let NDMS-proxy enable/disable + orphan cleanup manage subscription
-	// composite proxies (a set separate from Tunnels()).
-	a.singboxOp.SetSubscriptionProxySet(subProxySet{store: a.subStore, groups: a.subGroupStore})
-	// On MigrateOn, reconcile subscription proxies through the service so
-	// subscriptions created while the toggle was off get a freshly allocated
-	// ProxyN (not just the already-indexed ones).
-	a.singboxOp.SetSubscriptionProxySync(a.subSvc.SyncProxies)
-
-	// Wire managed-binary installer into Operator. The installer is keyed
-	// by the build-time arch string (e.g. "mipsel-3.4") so it can resolve
-	// the correct download URL and SHA256 from EmbeddedBinaries.
-	arch := detectArch()
-	if arch == "" {
-		a.bootLog.Warn("managed-singbox", runtime.GOARCH, "could not derive arch — install/update disabled")
-	} else {
-		spec, ok := installer.EmbeddedBinaries[arch]
-		if !ok {
-			a.bootLog.Warn("managed-singbox", arch, "no embedded BinarySpec — install/update disabled")
-		} else {
-			a.singboxInstaller = installer.New(installer.DefaultBinaryPath, arch, spec, a.loggingService)
-			a.singboxOp.SetInstaller(a.singboxInstaller)
-
-			// Stream sing-box install/update lifecycle over SSE so the UI
-			// can render a live progress bar instead of a blocking spinner.
-			a.singboxOp.SetInstallProgressReporter(func(op, phase string, downloaded, total int64, errMsg string) {
-				a.eventBus.Publish("singbox:install-progress", events.SingboxInstallProgressEvent{
-					Op:         op,
-					Phase:      phase,
-					Downloaded: downloaded,
-					Total:      total,
-					Error:      errMsg,
-				})
-			})
-
-		}
-	}
+	a.setupSingboxRuntime()
 
 	delayChecker := singbox.NewDelayChecker(
 		a.singboxOp.Clash(),

--- a/cmd/awg-manager/wiring_singbox.go
+++ b/cmd/awg-manager/wiring_singbox.go
@@ -64,6 +64,7 @@ func (a *app) setupSingbox() {
 		InitialManuallyStopped: a.settings.SingboxManuallyStopped,
 		SetManuallyStopped:     a.settingsStore.SetSingboxManuallyStopped,
 		IsNDMSProxyEnabled:     a.settingsStore.IsSingboxNDMSProxyEnabled,
+		Bus:                    a.eventBus,
 	})
 	// Если на старте флаг disabled — orphan-cleanup (после возможного
 	// обрыва прошлой MigrateOff в любой момент). Reconcile подберёт

--- a/internal/singbox/clash_port_test.go
+++ b/internal/singbox/clash_port_test.go
@@ -123,9 +123,8 @@ func TestOperator_ApplyClashPort(t *testing.T) {
 	}
 
 	t.Run("база и клиент переезжают вместе", func(t *testing.T) {
-		dir := t.TempDir()
-		op := NewOperator(OperatorDeps{Dir: dir})
-		basePath := filepath.Join(dir, "config.d", "00-base.json")
+		op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: t.TempDir()})
+		basePath := filepath.Join(op.ConfigDir(), "00-base.json")
 
 		if err := op.ApplyClashPort(9500); err != nil {
 			t.Fatalf("ApplyClashPort: %v", err)
@@ -139,8 +138,7 @@ func TestOperator_ApplyClashPort(t *testing.T) {
 	})
 
 	t.Run("повторное применение того же порта — no-op без ошибки", func(t *testing.T) {
-		dir := t.TempDir()
-		op := NewOperator(OperatorDeps{Dir: dir, ClashPort: func() int { return 9500 }})
+		op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: t.TempDir(), ClashPort: func() int { return 9500 }})
 		if err := op.ApplyClashPort(9500); err != nil {
 			t.Fatalf("ApplyClashPort: %v", err)
 		}
@@ -157,9 +155,8 @@ func TestOperator_ApplyClashPort(t *testing.T) {
 	// прочими условно-своими скалярами. Симметрично трактовке отсутствующего
 	// блока clash_api в ADR-0001: отсутствие — не намерение пользователя.
 	t.Run("пропавшая база при живом каталоге — восстанавливается", func(t *testing.T) {
-		dir := t.TempDir()
-		op := NewOperator(OperatorDeps{Dir: dir})
-		basePath := filepath.Join(dir, "config.d", "00-base.json")
+		op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: t.TempDir()})
+		basePath := filepath.Join(op.ConfigDir(), "00-base.json")
 		if err := os.Remove(basePath); err != nil {
 			t.Fatal(err)
 		}
@@ -177,9 +174,8 @@ func TestOperator_ApplyClashPort(t *testing.T) {
 	// Провалившаяся запись не должна оставлять клиент смотреть в порт,
 	// которого нет в конфиге: SetAddress зовётся строго после успеха.
 	t.Run("битая база — клиент остаётся на старом порту", func(t *testing.T) {
-		dir := t.TempDir()
-		op := NewOperator(OperatorDeps{Dir: dir})
-		basePath := filepath.Join(dir, "config.d", "00-base.json")
+		op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: t.TempDir()})
+		basePath := filepath.Join(op.ConfigDir(), "00-base.json")
 		if err := os.WriteFile(basePath, []byte("{не json"), 0644); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -319,6 +319,9 @@ type OperatorDeps struct {
 	// (Settings.SingboxClashPort). Optional; 0 means DefaultClashPort.
 	// Issue #788, ADR 0001.
 	ClashPort func() int
+	// Bus is the event bus for publishing resource changes (SSE). Optional:
+	// every call site guards on nil (Bus.Publish itself would panic).
+	Bus *events.Bus
 }
 
 func NewOperator(d OperatorDeps) *Operator {
@@ -376,6 +379,7 @@ func NewOperator(d OperatorDeps) *Operator {
 		processLogger:     logging.NewScopedLogger(d.AppLogger, logging.GroupSingbox, logging.SubSBProcess),
 		runtimeLogger:     logging.NewScopedLogger(d.AppLogger, logging.GroupSingbox, logging.SubSBRuntime),
 		persistManualStop: d.SetManuallyStopped,
+		bus:               d.Bus,
 	}
 	op.manuallyStopped.Store(d.InitialManuallyStopped)
 	op.ndmsProxyEnabledFn = d.IsNDMSProxyEnabled
@@ -394,11 +398,6 @@ func NewOperator(d OperatorDeps) *Operator {
 	}
 	return op
 }
-
-// SetEventBus wires the event bus so Operator can publish tunnel-set
-// change events consumed by deviceproxy.Service (and potentially
-// other subscribers in the future).
-func (o *Operator) SetEventBus(bus *events.Bus) { o.bus = bus }
 
 // Process exposes the underlying *Process so the orchestrator can
 // drive lifecycle (Start / Stop / Reload / IsRunning). The Process

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -1132,11 +1132,18 @@ func (o *Operator) ApplyBootstrapDNS(server string) error {
 }
 
 // mutateBase — общий транспорт правки 00-base.json: прочитать, дать мутатору
-// решить, менять ли (false — выходим без записи), записать. Запись через
-// оркестратор, когда он подключён: там валидация merged-конфига и
-// коалесцированный reload. Без оркестратора (ранний бут, тесты) — прямая
-// запись плюс reload живого процесса.
+// решить, менять ли (false — выходим без записи), записать через
+// оркестратор — там валидация merged-конфига и коалесцированный reload.
+//
+// Оркестратор обязателен: в проде SetOrch вызывается до старта HTTP
+// (wiring_singbox.go), «раннего бута» без него не существует — все три
+// вызывающих (ApplyLogLevel/ApplyClashPort/ApplyBootstrapDNS) достижимы
+// только через HTTP-хуки (server_routes.go). Тесты поднимают оркестратор
+// сами (см. newOrchedOperator).
 func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
+	if o.orch == nil {
+		return fmt.Errorf("mutate base config: orchestrator not wired")
+	}
 	basePath := filepath.Join(o.configPath, "00-base.json")
 	var base map[string]any
 	restored := false
@@ -1180,24 +1187,12 @@ func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
 		return nil
 	}
 
-	if o.orch != nil {
-		raw, err := json.MarshalIndent(base, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal 00-base.json: %w", err)
-		}
-		if err := o.orch.Save(orchestrator.SlotBase, raw); err != nil {
-			return fmt.Errorf("save base slot: %w", err)
-		}
-		return nil
+	raw, err := json.MarshalIndent(base, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal 00-base.json: %w", err)
 	}
-
-	if err := writeJSONFile(basePath, base); err != nil {
-		return fmt.Errorf("write base file: %w", err)
-	}
-	if running, _ := o.proc.IsRunning(); running {
-		if err := o.proc.Reload(); err != nil {
-			return fmt.Errorf("reload sing-box: %w", err)
-		}
+	if err := o.orch.Save(orchestrator.SlotBase, raw); err != nil {
+		return fmt.Errorf("save base slot: %w", err)
 	}
 	return nil
 }

--- a/internal/singbox/operator_baseconfig_bootstrap_test.go
+++ b/internal/singbox/operator_baseconfig_bootstrap_test.go
@@ -181,7 +181,7 @@ func TestOperator_BootstrapDNSReachesBaseConfig(t *testing.T) {
 func TestOperator_ApplyBootstrapDNS(t *testing.T) {
 	dir := t.TempDir()
 	path := baseWithServers(t, filepath.Join(dir, "config.d"), []any{bootstrapEntry("1.1.1.1")})
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
 
 	if err := op.ApplyBootstrapDNS("8.8.8.8"); err != nil {
 		t.Fatalf("ApplyBootstrapDNS: %v", err)
@@ -203,7 +203,7 @@ func TestOperator_ApplyBootstrapDNS(t *testing.T) {
 // адрес, а не подставлять исторический дефолт.
 func TestOperator_ApplyLogLevel_KeepsBootstrapDNS(t *testing.T) {
 	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir, BootstrapDNS: func() string { return "8.8.8.8" }})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir, BootstrapDNS: func() string { return "8.8.8.8" }})
 	basePath := filepath.Join(dir, "config.d", "00-base.json")
 	if err := os.Remove(basePath); err != nil {
 		t.Fatal(err)
@@ -270,7 +270,7 @@ func TestSetBootstrapServer_ReportsChange(t *testing.T) {
 // следующего бута, — при том что ApplyLogLevel базу пересоздавал.
 func TestOperator_ApplyBootstrapDNS_NoBaseFile_RestoresIt(t *testing.T) {
 	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir, SingboxLogLevel: func() string { return "debug" }})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir, SingboxLogLevel: func() string { return "debug" }})
 	basePath := filepath.Join(dir, "config.d", "00-base.json")
 	if err := os.Remove(basePath); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,10 @@ func TestOperator_ApplyBootstrapDNS_NoBaseFile_RestoresIt(t *testing.T) {
 // именно воскрешал.
 func TestOperator_ApplyBaseScalars_NoConfigDir_StaysSilent(t *testing.T) {
 	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
+	// config.d сносим ПОСЛЕ подключения оркестратора: Bootstrap успевает
+	// увидеть каталог (иначе упал бы сам), проверяемое здесь молчание —
+	// про снос каталога в рантайме, уже после старта.
 	configDir := filepath.Join(dir, "config.d")
 	if err := os.RemoveAll(configDir); err != nil {
 		t.Fatal(err)
@@ -356,7 +359,7 @@ func TestOperator_BootstrapDNS_IgnoresNonIP(t *testing.T) {
 	for _, bad := range []string{"dns.google", "8.8.8.8:53", "не адрес"} {
 		t.Run(bad, func(t *testing.T) {
 			dir := t.TempDir()
-			op := NewOperator(OperatorDeps{Dir: dir, BootstrapDNS: func() string { return bad }})
+			op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir, BootstrapDNS: func() string { return bad }})
 			basePath := filepath.Join(dir, "config.d", "00-base.json")
 			if got := bootstrapServerOf(t, readBaseFixture(t, basePath)); got != "1.1.1.1" {
 				t.Errorf("свежая база: dns-bootstrap.server = %q, want 1.1.1.1", got)
@@ -378,7 +381,7 @@ func TestOperator_BootstrapDNS_IgnoresNonIP(t *testing.T) {
 func TestOperator_ApplyBootstrapDNS_DoesNotRewriteWhenUnchanged(t *testing.T) {
 	dir := t.TempDir()
 	path := baseWithServers(t, filepath.Join(dir, "config.d"), []any{bootstrapEntry("8.8.8.8")})
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
 
 	before, err := os.Stat(path)
 	if err != nil {
@@ -414,7 +417,7 @@ func TestOperator_ApplyBootstrapDNS_DoesNotRewriteWhenUnchanged(t *testing.T) {
 // общему mutateBase он терялся; тест на старом коде падает паникой.
 func TestOperator_ApplyBaseScalars_NullBaseDoesNotPanic(t *testing.T) {
 	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
 	basePath := filepath.Join(dir, "config.d", "00-base.json")
 	if err := os.WriteFile(basePath, []byte("null"), 0o644); err != nil {
 		t.Fatal(err)
@@ -426,5 +429,30 @@ func TestOperator_ApplyBaseScalars_NullBaseDoesNotPanic(t *testing.T) {
 	logBlock, _ := base["log"].(map[string]any)
 	if lvl, _ := logBlock["level"].(string); lvl != "debug" {
 		t.Errorf("log.level = %q, want debug", lvl)
+	}
+}
+
+// mutateBase больше не пишет 00-base.json напрямую мимо оркестратора: без
+// него правка отвергается ошибкой, а не молчаливой прямой записью плюс
+// reload (тот же класс дефекта, что уже снят в writeTunnelsSlot).
+func TestMutateBase_WithoutOrchestratorFails(t *testing.T) {
+	dir := t.TempDir()
+	op := NewOperator(OperatorDeps{Dir: dir})
+	basePath := filepath.Join(dir, "config.d", "00-base.json")
+	before, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := op.ApplyLogLevel("debug"); err == nil {
+		t.Fatal("ApplyLogLevel без оркестратора = nil, want ошибку")
+	}
+
+	after, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("00-base.json переписан без оркестратора: было %s, стало %s", before, after)
 	}
 }

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -418,8 +418,7 @@ func TestPatchBaseLogLevel_AppliesDesiredLevel(t *testing.T) {
 }
 
 func TestOperatorApplyLogLevel_UpdatesBaseConfig(t *testing.T) {
-	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op, _ := newOrchedOperator(t)
 	basePath := filepath.Join(op.ConfigDir(), "00-base.json")
 	if err := op.ApplyLogLevel("warn"); err != nil {
 		t.Fatalf("ApplyLogLevel: %v", err)
@@ -439,8 +438,7 @@ func TestOperatorApplyLogLevel_UpdatesBaseConfig(t *testing.T) {
 }
 
 func TestOperatorApplyLogLevel_BrokenBaseJSONReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op, _ := newOrchedOperator(t)
 	basePath := filepath.Join(op.ConfigDir(), "00-base.json")
 	if err := os.WriteFile(basePath, []byte("{broken"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hoaxisr/awg-manager/internal/events"
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/singbox/installer"
 	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
@@ -2190,5 +2191,17 @@ func TestParseTunnelLinksInput(t *testing.T) {
 	}
 	if len(res.Outbounds) != 2 {
 		t.Fatalf("outbounds=%d want 2", len(res.Outbounds))
+	}
+}
+
+func TestNewOperator_WiresEventBus(t *testing.T) {
+	// Проверяем, что конструктор корректно присваивает Bus из OperatorDeps.
+	bus := events.NewBus()
+	op := NewOperator(OperatorDeps{
+		Dir: t.TempDir(),
+		Bus: bus,
+	})
+	if op.bus != bus {
+		t.Fatalf("bus mismatch: got %p, want %p", op.bus, bus)
 	}
 }

--- a/internal/singbox/operator_tunnels_slot_test.go
+++ b/internal/singbox/operator_tunnels_slot_test.go
@@ -27,8 +27,17 @@ import (
 // зарегистрирован».
 func newOrchedOperator(t *testing.T) (*Operator, string) {
 	t.Helper()
-	dir := t.TempDir()
-	op := NewOperator(OperatorDeps{Dir: dir})
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: t.TempDir()})
+	return op, filepath.Join(op.ConfigDir(), "10-tunnels.json")
+}
+
+// newOrchedOperatorWithDeps — как newOrchedOperator, но с произвольными
+// OperatorDeps: нужен тестам base-конфига (ApplyLogLevel/ApplyClashPort/
+// ApplyBootstrapDNS), которым важны колбэки настроек, а не значение,
+// возвращаемое хелпером-обёрткой.
+func newOrchedOperatorWithDeps(t *testing.T, deps OperatorDeps) *Operator {
+	t.Helper()
+	op := NewOperator(deps)
 	orch := singboxorch.New(op.ConfigDir(), op.Process())
 	for _, meta := range singboxorch.KnownSlots() {
 		switch meta.Slot {
@@ -44,7 +53,7 @@ func newOrchedOperator(t *testing.T) (*Operator, string) {
 		t.Fatalf("bootstrap: %v", err)
 	}
 	op.SetOrch(orch)
-	return op, filepath.Join(op.ConfigDir(), "10-tunnels.json")
+	return op
 }
 
 func TestApplyConfig_WritesSlotThroughOrchestrator(t *testing.T) {


### PR DESCRIPTION
Ядро sing-box собирается двумя слоями в composition root: buildSingboxCore (общий для демона и cleanup) и setupSingboxRuntime (демонский). Ручной дубль сборки в cleanup.go снят, два молчаливых легаси-пути записи конфигов заменены явными ошибками.