### PR TITLE
Владение содержимым 00-base.json: транзакция, самолечение записи, честные комментарии

### DIFF
--- a/internal/singbox/config.go
+++ b/internal/singbox/config.go
@@ -26,7 +26,7 @@ type Config struct {
 
 // NewConfig returns the empty slot-shape skeleton for 10-tunnels.json:
 // inbounds + outbounds + route only. log/dns/experimental are intentionally
-// omitted — those keys belong to 00-base.json (owned by ensureBaseConfigWithLogLevel).
+// omitted — those keys belong to 00-base.json (owned by ensureBaseConfig).
 // Emitting them here used to pollute 10-tunnels.json on first tunnel-add
 // with dns-bootstrap/dns-doh tags that 00-base owns, tripping the
 // orchestrator's cross-slot duplicate-tag validator.
@@ -1153,7 +1153,7 @@ func MigrateLegacyConfigDir(dir string) error {
 }
 
 // writeJSONFile is the shared atomic JSON writer used by
-// MigrateLegacyConfigDir + ensureBaseConfigWithLogLevel. Marshals with indent for
+// MigrateLegacyConfigDir + ensureBaseConfig. Marshals with indent for
 // human-editable fragments. Uses the fsync'ed temp+rename writer so a power
 // loss mid-write cannot leave a truncated config fragment behind.
 func writeJSONFile(path string, data any) error {

--- a/internal/singbox/legacy_config_test.go
+++ b/internal/singbox/legacy_config_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
 
 func writeLegacyConfig(t *testing.T, path string, body map[string]any) {
@@ -273,6 +275,73 @@ func TestEnsureLegacyConfigMigrated_NoCustomDNSOmitsBlock(t *testing.T) {
 	_ = json.Unmarshal(data, &got)
 	if _, has := got["dns"]; has {
 		t.Error("dns block must be absent when only our bootstrap remains")
+	}
+}
+
+// TestEnsureLegacyConfigMigrated_DanglingDNSDohRuleValidates — пин F43.
+// Легаси-конфиг несёт dns.rules со ссылкой на "dns-doh" и dns.final той же
+// ссылкой. dns-doh — легаси-фантом: сервер отфильтрован (owned-set), а
+// dns.final миграция НЕ копирует вовсе (dnsSlot несёт только servers+rules).
+// Сирота в dns.rules[].server доезжает до merged, но наш кросс-слотовый
+// валидатор его не проверяет (dnsRuleJSON собирает только rule_set), и
+// sing-box резолвит dns.rules per-query, мягко деградируя на ненайденный
+// транспорт — check проходит (docs/plans/2026-08-29-base-config-defects.md
+// §0). Пин защищает именно это: будущая правка миграции, которая начнёт
+// копировать dns.final, открыла бы жёсткую ссылку заново.
+func TestEnsureLegacyConfigMigrated_DanglingDNSDohRuleValidates(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.d")
+	// config.d уже существует к моменту миграции — как в реальном буте,
+	// где ensureBaseConfig (шаг раньше в reconcileConfigSteps) успевает
+	// создать 00-base.json первым.
+	ensureBaseConfig(configDir, "info", "", 0)
+
+	writeLegacyConfig(t, filepath.Join(dir, "config.json"), map[string]any{
+		"dns": map[string]any{
+			"final": "dns-doh",
+			"servers": []any{
+				map[string]any{"tag": "dns-bootstrap", "type": "udp", "server": "1.1.1.1"},
+				map[string]any{"tag": "dns-doh", "type": "https", "server": "cloudflare-dns.com"},
+				map[string]any{"tag": "dns-custom", "type": "udp", "server": "8.8.8.8"},
+			},
+			"rules": []any{
+				map[string]any{"domain_suffix": ".example.com", "server": "dns-doh"},
+			},
+		},
+		"inbounds": []any{
+			map[string]any{"tag": "vless-1-in", "type": "mixed", "listen": "127.0.0.1", "listen_port": 1080},
+		},
+		"outbounds": []any{
+			map[string]any{"type": "direct", "tag": "direct"},
+			map[string]any{"type": "vless", "tag": "vless-1", "server": "x"},
+		},
+		"route": map[string]any{
+			"rules": []any{
+				map[string]any{"inbound": "vless-1-in", "outbound": "vless-1"},
+			},
+		},
+	})
+
+	ensureLegacyConfigMigrated(dir)
+
+	proc := NewProcess("", configDir, filepath.Join(dir, "singbox.pid"))
+	orch := singboxorch.New(configDir, proc)
+	for _, meta := range singboxorch.KnownSlots() {
+		switch meta.Slot {
+		case singboxorch.SlotBase, singboxorch.SlotTunnels:
+		default:
+			continue
+		}
+		if err := orch.Register(meta); err != nil {
+			t.Fatalf("register %s: %v", meta.Slot, err)
+		}
+	}
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	res := orch.Validate()
+	if !res.Ok() {
+		t.Fatalf("merged config должен быть валиден при сироте dns.rules[].server=dns-doh: %s", res.Error())
 	}
 }
 

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -28,7 +28,7 @@ var defaultCacheDBPath = filepath.Join(defaultDir, "cache.db")
 // package decoupled from the operator's path layout (it just receives a string).
 func DefaultCacheDBPath() string { return defaultCacheDBPath }
 
-// ensureBaseConfigWithLogLevel writes a minimal 00-base.json if config.d is
+// ensureBaseConfig writes a minimal 00-base.json if config.d is
 // empty, so sing-box starts standalone (direct outbound + bootstrap DNS) before
 // any tunnels are added. Also surgically self-heals an older base config
 // that hard-coded the wrong Clash API port (9090 instead of ours), which
@@ -697,7 +697,7 @@ func removeFinalFromBase(basePath string, loggers ...*slog.Logger) {
 // FIRST-FILE-WINS across config.d (proven for route.final by
 // router_final_merge_test.go), so 00-base.json's dns.final / dns.strategy
 // always beat the user's 20-router.json values. This self-heal runs on every
-// operator init (right after ensureBaseConfigWithLogLevel) so existing on-disk
+// operator init (right after ensureBaseConfig) so existing on-disk
 // base files heal on reload. It is a boot self-heal, not a settings migration.
 // Mirrors removeFinalFromBase, which did the same for route.final.
 //
@@ -708,8 +708,8 @@ func removeFinalFromBase(basePath string, loggers ...*slog.Logger) {
 // (the only slot that then sets it) wins when enabled. Same observable
 // behavior as the old explicit "dns-bootstrap".
 //
-// dns.strategy сюда не относится — ею занимается отдельный шаг
-// reconcile-dns-strategy (reconcileBaseDNSStrategy): у strategy нет
+// dns.strategy сюда не относится — ею занимается reconcileDerivedDefaults:
+// у strategy нет
 // first-server fallback'а, поэтому её примирение симметрично (стрижка при
 // владении routing-слотом / восстановление дефолта без владельца).
 //

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -430,10 +430,15 @@ func filterOutDeviceProxyRouteRules(in []any) []any {
 	return out
 }
 
-// filterOutOurDNSServers removes dns.servers entries whose tag is one of
-// the well-known tags 00-base.json owns ("dns-bootstrap", "dns-doh"). All
-// other entries — user-added custom resolvers — pass through so they end
-// up in 10-tunnels.json and survive the migration.
+// filterOutOurDNSServers removes dns.servers entries tagged with our two
+// historical tags, "dns-bootstrap" and "dns-doh". "dns-doh" is a legacy
+// phantom: the current 00-base.json (freshBaseConfig) does not emit it —
+// only pre-fix installs and old config.json snapshots still carry it — but
+// this owned-set exists precisely to strip that historical pollution out of
+// 10-tunnels.json, so the tag stays listed here on purpose (see F43,
+// docs/plans/2026-08-29-base-config-defects.md). All other entries —
+// user-added custom resolvers — pass through so they end up in
+// 10-tunnels.json and survive the migration.
 func filterOutOurDNSServers(in []any) []any {
 	owned := map[string]bool{
 		"dns-bootstrap": true,
@@ -535,7 +540,9 @@ func setClashController(m map[string]any, want string) bool {
 }
 
 // setBootstrapServer ставит адрес серверу с тегом dns-bootstrap. Возвращает
-// false, если менять нечего: записи нет или адрес уже такой.
+// false, если менять нечего: записи нет или адрес уже такой. Не создаёт
+// запись — этим занимается reconcileBootstrapServer, который решает, что
+// делать при отсутствующей записи.
 func setBootstrapServer(m map[string]any, want string) bool {
 	dns, _ := m["dns"].(map[string]any)
 	if dns == nil {
@@ -556,22 +563,71 @@ func setBootstrapServer(m map[string]any, want string) bool {
 	return false
 }
 
-// patchBaseBootstrapDNS приводит адрес сервера dns-bootstrap к заданному в
-// настройках (issue #770). Пустая настройка — no-op: до её появления адрес
-// правили руками прямо в 00-base.json, и такие правки обязаны выжить.
-// Записи с тегом dns-bootstrap нет — тоже no-op: патчер правит адрес, а не
-// проектирует структуру файла.
+// reconcileBootstrapServer владеет ФАКТОМ наличия записи dns-bootstrap
+// (F44): 99-defaults.json ссылается на этот тег безусловно
+// (reconcileDerivedDefaults), а наш же кросс-слотовый валидатор даёт
+// блокирующий unknown-dns-server на висячую ссылку — без записи ни один
+// reload/cold start не проходит. Адресом при непустой настройке продолжает
+// владеть менеджер, при пустой — пользователь (issue #770): до появления
+// настройки адрес правили руками прямо в 00-base.json, такие правки обязаны
+// выжить.
+//
+//   - записи нет → создаём {type:udp, tag:dns-bootstrap, server: want, а при
+//     пустой настройке — defaultBootstrapDNS}, достраивая недостающие уровни
+//     dns/servers;
+//   - запись есть, want == "" → не трогаем;
+//   - запись есть, want != "" → правим адрес через setBootstrapServer.
+//
+// Осознанная потеря: пользователь, перенёсший объявление тега dns-bootstrap
+// в свой слот (90-user.json) и удаливший запись из базы, получит после
+// самолечения блокирующий duplicate-dns с именами обоих файлов — явную
+// ошибку вместо тихого «ни один reload не проходит» (см. ADR-0002).
+//
+// Возвращает true, если base изменена (нужна запись файла).
+func reconcileBootstrapServer(base map[string]any, want string) bool {
+	dns, _ := base["dns"].(map[string]any)
+	if dns == nil {
+		dns = map[string]any{}
+		base["dns"] = dns
+	}
+	servers, _ := dns["servers"].([]any)
+	for _, v := range servers {
+		s, _ := v.(map[string]any)
+		if s == nil || s["tag"] != "dns-bootstrap" {
+			continue
+		}
+		if want == "" {
+			return false
+		}
+		return setBootstrapServer(base, want)
+	}
+	dns["servers"] = append(servers, map[string]any{"type": "udp", "tag": "dns-bootstrap", "server": bootstrapAddr(want)})
+	return true
+}
+
+// bootstrapAddr — адрес, который получит СОЗДАВАЕМАЯ запись dns-bootstrap:
+// настройка, а при пустой — исторический дефолт. Общий с логом
+// patchBaseBootstrapDNS: два вычисления «какой адрес мы применили»
+// разъехались бы, и лог начал бы врать.
+func bootstrapAddr(want string) string {
+	if want == "" {
+		return defaultBootstrapDNS
+	}
+	return want
+}
+
+// patchBaseBootstrapDNS приводит запись dns-bootstrap в 00-base.json к
+// желаемому состоянию через reconcileBootstrapServer: наличием записи
+// владеет менеджер, адресом при непустой настройке — тоже менеджер, при
+// пустой — пользователь.
 func patchBaseBootstrapDNS(basePath, want string, loggers ...*slog.Logger) {
 	want = sanitizeBootstrapDNS(want)
-	if want == "" {
-		return
-	}
 	log := firstLogger(loggers)
 	m, ok := readSlotJSON(stepPatchBaseBootstrapDNS, basePath, log)
 	if !ok {
 		return
 	}
-	if !setBootstrapServer(m, want) {
+	if !reconcileBootstrapServer(m, want) {
 		return
 	}
 	if !writeSlotJSON(stepPatchBaseBootstrapDNS, basePath, m, log) {
@@ -580,7 +636,7 @@ func patchBaseBootstrapDNS(basePath, want string, loggers ...*slog.Logger) {
 	logConfigPatchInfo(log, "singbox base config reconciled",
 		"patch", stepPatchBaseBootstrapDNS,
 		"path", basePath,
-		"newServer", want,
+		"newServer", bootstrapAddr(want),
 	)
 }
 
@@ -1118,16 +1174,16 @@ func (o *Operator) ApplyClashPort(port int) error {
 	return nil
 }
 
-// ApplyBootstrapDNS приводит адрес dns-bootstrap в 00-base.json к значению
-// настройки без перезапуска демона (issue #770). Пустое значение — no-op:
-// настройка снята, файл остаётся как есть.
+// ApplyBootstrapDNS приводит запись dns-bootstrap в 00-base.json к значению
+// настройки без перезапуска демона (issue #770). Наличием записи владеет
+// менеджер (F44): отсутствующая запись самолечится даже при пустой
+// настройке — иначе unknown-dns-server валит следующий reload вместо
+// тихого no-op. Пустое значение при СУЩЕСТВУЮЩЕЙ записи — no-op (ручные
+// правки адреса обязаны выжить).
 func (o *Operator) ApplyBootstrapDNS(server string) error {
 	server = sanitizeBootstrapDNS(server)
-	if server == "" {
-		return nil
-	}
 	return o.mutateBase(func(base map[string]any) bool {
-		return setBootstrapServer(base, server)
+		return reconcileBootstrapServer(base, server)
 	})
 }
 

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -585,12 +585,26 @@ func setBootstrapServer(m map[string]any, want string) bool {
 //
 // Возвращает true, если base изменена (нужна запись файла).
 func reconcileBootstrapServer(base map[string]any, want string) bool {
-	dns, _ := base["dns"].(map[string]any)
+	// Ключ есть, но это не объект (строка, число, массив) — чужое содержимое
+	// неизвестной формы. Такой 00-base.json движок не загрузит в любом случае,
+	// а подмена его нашей картой стёрла бы то, что пользователь туда положил:
+	// молча выходим, как выходил прежний setBootstrapServer. То же и для
+	// dns.servers не-массивом. Достраиваем только ОТСУТСТВУЮЩИЕ уровни;
+	// литеральный null считается отсутствием, а не чужим содержимым.
+	raw, has := base["dns"]
+	dns, _ := raw.(map[string]any)
+	if has && raw != nil && dns == nil {
+		return false
+	}
 	if dns == nil {
 		dns = map[string]any{}
 		base["dns"] = dns
 	}
-	servers, _ := dns["servers"].([]any)
+	rawServers, hasServers := dns["servers"]
+	servers, _ := rawServers.([]any)
+	if hasServers && rawServers != nil && servers == nil {
+		return false
+	}
 	for _, v := range servers {
 		s, _ := v.(map[string]any)
 		if s == nil || s["tag"] != "dns-bootstrap" {

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -1135,6 +1135,10 @@ func (o *Operator) ApplyBootstrapDNS(server string) error {
 // решить, менять ли (false — выходим без записи), записать через
 // оркестратор — там валидация merged-конфига и коалесцированный reload.
 //
+// Чтение и запись идут ОДНОЙ транзакцией оркестратора (Mutate): читать файл
+// самим, а потом звать Save, значило бы работать со снимком, взятым вне лока,
+// — параллельная правка другого скаляра терялась (дефект F41).
+//
 // Оркестратор обязателен: в проде SetOrch вызывается до старта HTTP
 // (wiring_singbox.go), «раннего бута» без него не существует — все три
 // вызывающих (ApplyLogLevel/ApplyClashPort/ApplyBootstrapDNS) достижимы
@@ -1144,57 +1148,54 @@ func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
 	if o.orch == nil {
 		return fmt.Errorf("mutate base config: orchestrator not wired")
 	}
-	basePath := filepath.Join(o.configPath, "00-base.json")
-	var base map[string]any
-	restored := false
-	data, err := os.ReadFile(basePath)
-	switch {
-	case os.IsNotExist(err):
-		// Пропал ТОЛЬКО файл, каталог на месте — ВОССТАНАВЛИВАЕМ, а не
-		// считаем намерением пользователя, симметрично трактовке
-		// отсутствующего блока clash_api в ADR-0001. Молчаливый выход
-		// оставлял настройку сохранённой в settings.json, но не доехавшей
-		// до базы до следующего бута.
-		//
-		// Нет самого config.d — движок удалён вместе с каталогом, и
-		// воскрешать его правкой настройки нельзя: молчим, как молчали.
-		// Прежде этим различием не владел никто — ApplyLogLevel
-		// восстанавливал базу даже поверх снесённого каталога, а
-		// ApplyClashPort/ApplyBootstrapDNS не восстанавливали никогда.
-		if _, statErr := os.Stat(o.configPath); os.IsNotExist(statErr) {
-			return nil
-		} else if statErr != nil {
-			return fmt.Errorf("stat config.d: %w", statErr)
+	// Кандидат на восстановление считается ДО взятия лока оркестратора:
+	// desired* ходят в SettingsStore, а под чужим локом блокирующей работе
+	// делать нечего. Нужен он только в ветке «файла нет».
+	fresh := freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort())
+	return o.orch.Mutate(orchestrator.SlotBase, func(data []byte, exists bool) ([]byte, error) {
+		var base map[string]any
+		restored := false
+		if exists {
+			if err := json.Unmarshal(data, &base); err != nil {
+				return nil, fmt.Errorf("parse 00-base.json: %w", err)
+			}
+			// Файл с литеральным null — валидный JSON, дающий nil-карту;
+			// запись в неё паникует. Гард был у прежнего ApplyLogLevel и
+			// потерялся при сведении к общему транспорту.
+			if base == nil {
+				base = map[string]any{}
+			}
+		} else {
+			// Пропал ТОЛЬКО файл, каталог на месте — ВОССТАНАВЛИВАЕМ, а не
+			// считаем намерением пользователя, симметрично трактовке
+			// отсутствующего блока clash_api в ADR-0001. Молчаливый выход
+			// оставлял настройку сохранённой в settings.json, но не доехавшей
+			// до базы до следующего бута.
+			//
+			// Нет самого config.d — движок удалён вместе с каталогом, и
+			// воскрешать его правкой настройки нельзя: молчим, как молчали.
+			// Прежде этим различием не владел никто — ApplyLogLevel
+			// восстанавливал базу даже поверх снесённого каталога, а
+			// ApplyClashPort/ApplyBootstrapDNS не восстанавливали никогда.
+			if _, statErr := os.Stat(o.configPath); os.IsNotExist(statErr) {
+				return nil, nil
+			} else if statErr != nil {
+				return nil, fmt.Errorf("stat config.d: %w", statErr)
+			}
+			base = fresh
+			restored = true
 		}
-		base = freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort())
-		restored = true
-	case err != nil:
-		return fmt.Errorf("read 00-base.json: %w", err)
-	default:
-		if err := json.Unmarshal(data, &base); err != nil {
-			return fmt.Errorf("parse 00-base.json: %w", err)
+		// Свежая база уже несёт желаемые значения, так что мутатор на ней
+		// обычно говорит «менять нечего»; писать всё равно надо — файла-то нет.
+		if !mutate(base) && !restored {
+			return nil, nil
 		}
-		// Файл с литеральным null — валидный JSON, дающий nil-карту; запись
-		// в неё паникует. Гард был у прежнего ApplyLogLevel и потерялся при
-		// сведении к общему транспорту.
-		if base == nil {
-			base = map[string]any{}
+		raw, err := json.MarshalIndent(base, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshal 00-base.json: %w", err)
 		}
-	}
-	// Свежая база уже несёт желаемые значения, так что мутатор на ней обычно
-	// говорит «менять нечего»; писать всё равно надо — файла-то нет.
-	if !mutate(base) && !restored {
-		return nil
-	}
-
-	raw, err := json.MarshalIndent(base, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal 00-base.json: %w", err)
-	}
-	if err := o.orch.Save(orchestrator.SlotBase, raw); err != nil {
-		return fmt.Errorf("save base slot: %w", err)
-	}
-	return nil
+		return raw, nil
+	})
 }
 
 // preflightConfigDir validates config.d/ before any action that would

--- a/internal/singbox/operator_baseconfig_bootstrap_test.go
+++ b/internal/singbox/operator_baseconfig_bootstrap_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	singboxorch "github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
 )
 
 // bootstrapServerOf извлекает адрес сервера dns-bootstrap из базового конфига.
@@ -105,8 +107,26 @@ func TestPatchBaseBootstrapDNS(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			path := baseWithServers(t, t.TempDir(), c.servers)
+			var before time.Time
+			if c.want == "" {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				before = info.ModTime()
+				time.Sleep(10 * time.Millisecond)
+			}
 			patchBaseBootstrapDNS(path, c.want)
 			patchBaseBootstrapDNS(path, c.want) // идемпотентность
+			if c.want == "" {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !info.ModTime().Equal(before) {
+					t.Errorf("файл переписан при пустой настройке и существующей записи: %v → %v", before, info.ModTime())
+				}
+			}
 			base := readBaseFixture(t, path)
 			if got := bootstrapServerOf(t, base); got != c.expect {
 				t.Errorf("dns-bootstrap.server = %q, want %q", got, c.expect)
@@ -120,8 +140,10 @@ func TestPatchBaseBootstrapDNS(t *testing.T) {
 	}
 }
 
-// Записи dns-bootstrap в базе нет (пользователь её удалил) — патчер не
-// выдумывает сервер: структуру файла он не проектирует, а только правит адрес.
+// Записи dns-bootstrap в базе нет (пользователь её удалил) — патчер её
+// ВОССТАНАВЛИВАЕТ (F44): 99-defaults.json ссылается на этот тег безусловно,
+// и без записи наш же валидатор блокирует каждый reload/cold start
+// unknown-dns-server. Соседний пользовательский сервер не задет.
 func TestPatchBaseBootstrapDNS_NoBootstrapEntry(t *testing.T) {
 	path := baseWithServers(t, t.TempDir(), []any{
 		map[string]any{"type": "udp", "tag": "dns-custom", "server": "192.168.0.1"},
@@ -129,13 +151,54 @@ func TestPatchBaseBootstrapDNS_NoBootstrapEntry(t *testing.T) {
 	patchBaseBootstrapDNS(path, "8.8.8.8")
 
 	base := readBaseFixture(t, path)
+	if got := bootstrapServerOf(t, base); got != "8.8.8.8" {
+		t.Errorf("dns-bootstrap.server = %q, want 8.8.8.8 (запись должна быть создана)", got)
+	}
 	dns, _ := base["dns"].(map[string]any)
 	servers, _ := dns["servers"].([]any)
-	if len(servers) != 1 {
-		t.Fatalf("dns.servers = %#v, want the single custom entry untouched", servers)
+	if len(servers) != 2 {
+		t.Fatalf("dns.servers = %#v, want 2 entries (custom + созданный bootstrap)", servers)
 	}
-	if s, _ := servers[0].(map[string]any); s["tag"] != "dns-custom" || s["server"] != "192.168.0.1" {
-		t.Errorf("custom server changed: %#v", servers[0])
+	foundCustom := false
+	for _, v := range servers {
+		s, _ := v.(map[string]any)
+		if s["tag"] == "dns-custom" {
+			foundCustom = true
+			if s["server"] != "192.168.0.1" {
+				t.Errorf("custom server changed: %#v", s)
+			}
+		}
+	}
+	if !foundCustom {
+		t.Error("dns-custom server missing after self-heal")
+	}
+}
+
+// Записи нет и настройка пуста — создаём с историческим дефолтом, а не
+// оставляем движок без резолвера.
+func TestPatchBaseBootstrapDNS_NoBootstrapEntry_EmptySetting(t *testing.T) {
+	path := baseWithServers(t, t.TempDir(), []any{
+		map[string]any{"type": "udp", "tag": "dns-custom", "server": "192.168.0.1"},
+	})
+	patchBaseBootstrapDNS(path, "")
+
+	base := readBaseFixture(t, path)
+	if got := bootstrapServerOf(t, base); got != defaultBootstrapDNS {
+		t.Errorf("dns-bootstrap.server = %q, want %q (исторический дефолт)", got, defaultBootstrapDNS)
+	}
+}
+
+// Блока dns вообще нет — недостающие уровни достраиваются, а не молчим.
+func TestPatchBaseBootstrapDNS_NoDNSBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "00-base.json")
+	writeFixtureJSON(t, path, map[string]any{"log": map[string]any{"level": "info"}})
+
+	patchBaseBootstrapDNS(path, "8.8.8.8")
+
+	base := readBaseFixture(t, path)
+	if got := bootstrapServerOf(t, base); got != "8.8.8.8" {
+		t.Errorf("dns-bootstrap.server = %q, want 8.8.8.8", got)
 	}
 }
 
@@ -195,6 +258,45 @@ func TestOperator_ApplyBootstrapDNS(t *testing.T) {
 	}
 	if got := bootstrapServerOf(t, readBaseFixture(t, path)); got != "8.8.8.8" {
 		t.Errorf("снятие настройки переписало файл: %q, want 8.8.8.8", got)
+	}
+}
+
+// Запись dns-bootstrap удалена руками (файл при этом на месте) —
+// ApplyBootstrapDNS создаёт её заново: рантайм-путь обязан лечить тот же
+// дефект F44, что и бутовый патчер, а не только адрес существующей записи.
+func TestOperator_ApplyBootstrapDNS_NoBootstrapEntry_CreatesIt(t *testing.T) {
+	dir := t.TempDir()
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
+	basePath := filepath.Join(dir, "config.d", "00-base.json")
+
+	base := readBaseFixture(t, basePath)
+	dns, _ := base["dns"].(map[string]any)
+	dns["servers"] = []any{map[string]any{"type": "udp", "tag": "dns-custom", "server": "192.168.0.1"}}
+	raw, err := json.MarshalIndent(base, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(basePath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := op.ApplyBootstrapDNS("8.8.8.8"); err != nil {
+		t.Fatalf("ApplyBootstrapDNS: %v", err)
+	}
+	got := readBaseFixture(t, basePath)
+	if addr := bootstrapServerOf(t, got); addr != "8.8.8.8" {
+		t.Errorf("dns-bootstrap.server = %q, want 8.8.8.8 (запись должна быть создана заново)", addr)
+	}
+	servers, _ := got["dns"].(map[string]any)["servers"].([]any)
+	foundCustom := false
+	for _, v := range servers {
+		s, _ := v.(map[string]any)
+		if s["tag"] == "dns-custom" {
+			foundCustom = true
+		}
+	}
+	if !foundCustom {
+		t.Error("dns-custom server missing after self-heal")
 	}
 }
 
@@ -429,6 +531,43 @@ func TestOperator_ApplyBaseScalars_NullBaseDoesNotPanic(t *testing.T) {
 	logBlock, _ := base["log"].(map[string]any)
 	if lvl, _ := logBlock["level"].(string); lvl != "debug" {
 		t.Errorf("log.level = %q, want debug", lvl)
+	}
+}
+
+// Интеграционный пин F44: набор шагов бутового примирения самолечит
+// отсутствующую запись dns-bootstrap так, что merged-конфиг проходит НАШ
+// собственный кросс-слотовый валидатор. На старом коде (патчер не создаёт
+// отсутствующую запись) это репро факта §0 плана — валидатор давал бы
+// unknown-dns-server на ссылку 99-defaults.json → route.default_domain_resolver.
+func TestReconcileConfigSteps_HealsMissingBootstrapEntry(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.d")
+	baseWithServers(t, configDir, []any{
+		map[string]any{"type": "udp", "tag": "dns-custom", "server": "192.168.0.1"},
+	})
+
+	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
+		s.run()
+	}
+
+	proc := NewProcess("", configDir, filepath.Join(dir, "singbox.pid"))
+	orch := singboxorch.New(configDir, proc)
+	for _, meta := range singboxorch.KnownSlots() {
+		switch meta.Slot {
+		case singboxorch.SlotBase, singboxorch.SlotDefaults:
+		default:
+			continue
+		}
+		if err := orch.Register(meta); err != nil {
+			t.Fatalf("register %s: %v", meta.Slot, err)
+		}
+	}
+	if err := orch.Bootstrap(); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	res := orch.Validate()
+	if !res.Ok() {
+		t.Fatalf("merged config невалиден после самолечения: %s", res.Error())
 	}
 }
 

--- a/internal/singbox/operator_baseconfig_bootstrap_test.go
+++ b/internal/singbox/operator_baseconfig_bootstrap_test.go
@@ -595,3 +595,43 @@ func TestMutateBase_WithoutOrchestratorFails(t *testing.T) {
 		t.Errorf("00-base.json переписан без оркестратора: было %s, стало %s", before, after)
 	}
 }
+
+// Не-объектный dns — чужое содержимое неизвестной формы: самолечение записи
+// НЕ должно подменять его нашей картой. Такой 00-base.json движок и так не
+// загрузит, но затирать пользовательское мы не вправе (F44, ревью ветки).
+// Литеральный null — не содержимое, а отсутствие: его достраиваем.
+//
+// Краснеет на мутации «убрать гарды has/hasServers» — dns:"user-string"
+// заменяется картой с нашей записью.
+func TestReconcileBootstrapServer_LeavesNonObjectDNSAlone(t *testing.T) {
+	t.Run("dns строкой", func(t *testing.T) {
+		base := map[string]any{"dns": "user-string"}
+		if reconcileBootstrapServer(base, "9.9.9.9") {
+			t.Fatal("не-объектный dns объявлен изменённым")
+		}
+		if base["dns"] != "user-string" {
+			t.Fatalf("чужое содержимое dns затёрто: %#v", base["dns"])
+		}
+	})
+	t.Run("servers строкой", func(t *testing.T) {
+		base := map[string]any{"dns": map[string]any{"servers": "oops"}}
+		if reconcileBootstrapServer(base, "9.9.9.9") {
+			t.Fatal("не-массивные servers объявлены изменёнными")
+		}
+		dns, _ := base["dns"].(map[string]any)
+		if dns["servers"] != "oops" {
+			t.Fatalf("чужое содержимое dns.servers затёрто: %#v", dns["servers"])
+		}
+	})
+	t.Run("dns null достраивается", func(t *testing.T) {
+		base := map[string]any{"dns": nil}
+		if !reconcileBootstrapServer(base, "9.9.9.9") {
+			t.Fatal("null-dns не достроен, ожидалось создание записи")
+		}
+		dns, _ := base["dns"].(map[string]any)
+		servers, _ := dns["servers"].([]any)
+		if len(servers) != 1 {
+			t.Fatalf("запись не создана: %#v", dns)
+		}
+	})
+}

--- a/internal/singbox/operator_baseconfig_concurrency_test.go
+++ b/internal/singbox/operator_baseconfig_concurrency_test.go
@@ -1,0 +1,163 @@
+package singbox
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// clashControllerOf достаёт experimental.clash_api.external_controller.
+func clashControllerOf(t *testing.T, base map[string]any) string {
+	t.Helper()
+	exp, _ := base["experimental"].(map[string]any)
+	api, _ := exp["clash_api"].(map[string]any)
+	addr, _ := api["external_controller"].(string)
+	return addr
+}
+
+func logLevelOf(t *testing.T, base map[string]any) string {
+	t.Helper()
+	logBlock, _ := base["log"].(map[string]any)
+	lvl, _ := logBlock["level"].(string)
+	return lvl
+}
+
+// Две параллельные правки РАЗНЫХ скаляров базы обязаны сойтись в файле обе.
+// Прежде mutateBase читал 00-base.json сам, вне лока оркестратора, и писал
+// снимок через Save: правка, приехавшая, пока мутатор работал со снимком,
+// затиралась (дефект F41 — классический lost update).
+//
+// Конструкция детерминирована взаимоисключением, а не таймингом: A паркуется
+// ВНУТРИ мутатора, B стартует после этого. На исправленном коде B заперт
+// локом, poll просто истекает, обе правки ложатся последовательно. На
+// дефектном — B успевает записаться за миллисекунды, poll это видит, и A
+// затирает его своим снимком.
+func TestMutateBase_ConcurrentEditsDoNotLoseUpdates(t *testing.T) {
+	dir := t.TempDir()
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
+	basePath := filepath.Join(dir, "config.d", "00-base.json")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	wantAddr := ClashAddr(9095)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := op.mutateBase(func(base map[string]any) bool {
+			close(entered)
+			<-release
+			return setLogLevel(base, "debug")
+		}); err != nil {
+			t.Errorf("mutateBase A: %v", err)
+		}
+	}()
+
+	<-entered
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := op.mutateBase(func(base map[string]any) bool {
+			return setClashController(base, wantAddr)
+		}); err != nil {
+			t.Errorf("mutateBase B: %v", err)
+		}
+	}()
+
+	// Ждём появления правки B на диске, пока A запаркован. На исправленном
+	// коде она появиться не может — 300 мс это просто верхняя граница
+	// ожидания, а не гарантия чего-либо.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(basePath); err == nil && bytes.Contains(data, []byte(wantAddr)) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(release)
+	wg.Wait()
+
+	base := readBaseFixture(t, basePath)
+	if got := logLevelOf(t, base); got != "debug" {
+		t.Errorf("log.level = %q, want debug (правка A потеряна)", got)
+	}
+	if got := clashControllerOf(t, base); got != wantAddr {
+		t.Errorf("external_controller = %q, want %q (правка B потеряна)", got, wantAddr)
+	}
+}
+
+// Правки базы из разных вкладок настроек идут параллельно (порт Clash,
+// уровень журнала, bootstrap-DNS). Под -race это ловит разделяемое состояние
+// между вызовами mutateBase — карту базы или кандидата на восстановление,
+// пережившего вызов.
+func TestApplyBaseScalars_NoRaceUnderConcurrentAppliers(t *testing.T) {
+	dir := t.TempDir()
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
+	basePath := filepath.Join(dir, "config.d", "00-base.json")
+
+	levels := []string{"debug", "info", "warn"}
+	ports := []int{9091, 9092, 9093}
+	resolvers := []string{"1.1.1.1", "8.8.8.8", "9.9.9.9"}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			if err := op.ApplyLogLevel(levels[i%len(levels)]); err != nil {
+				t.Errorf("ApplyLogLevel: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			if err := op.ApplyClashPort(ports[i%len(ports)]); err != nil {
+				t.Errorf("ApplyClashPort: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			if err := op.ApplyBootstrapDNS(resolvers[i%len(resolvers)]); err != nil {
+				t.Errorf("ApplyBootstrapDNS: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	base := readBaseFixture(t, basePath)
+	if got := logLevelOf(t, base); !contains(levels, got) {
+		t.Errorf("log.level = %q, want одно из %v", got, levels)
+	}
+	addr := clashControllerOf(t, base)
+	okAddr := false
+	for _, p := range ports {
+		if addr == ClashAddr(p) {
+			okAddr = true
+		}
+	}
+	if !okAddr {
+		t.Errorf("external_controller = %q, want адрес одного из портов %v", addr, ports)
+	}
+	if got := bootstrapServerOf(t, base); !contains(resolvers, got) {
+		t.Errorf("dns-bootstrap.server = %q, want одно из %v", got, resolvers)
+	}
+}
+
+func contains(list []string, v string) bool {
+	for _, s := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -1147,8 +1147,13 @@ func TestPatchTunnelsSlotStripBaseOwnedBlocks_StripsDanglingFinalReference(t *te
 
 // TestPatchTunnelsSlotStripBaseOwnedBlocks_PreservesUserDNSRules keeps the dns
 // block alive when servers got filtered to zero but the user has rules
-// pointing at base-owned tags (dns rules reference, but don't own,
-// server tags — sing-box merges across slots).
+// pointing at one of our owned tags. Nobody currently declares "dns-doh"
+// (legacy phantom, see F43) — the surviving rule below is a dangling
+// reference, but our cross-slot validator never inspects dns.rules[].server
+// (only dns.final and route.default_domain_resolver.server), and sing-box
+// resolves dns.rules servers per-query at runtime, logging and skipping a
+// missing transport rather than failing config load. So the orphaned rule
+// is harmless, not "merged across slots" by some owner.
 func TestPatchTunnelsSlotStripBaseOwnedBlocks_PreservesUserDNSRules(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "10-tunnels.json")

--- a/internal/singbox/orchestrator/mutate_test.go
+++ b/internal/singbox/orchestrator/mutate_test.go
@@ -1,0 +1,155 @@
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newMutateOrch — оркестратор с одним зарегистрированным AlwaysOn-слотом и
+// путём к его активному файлу. fakeProc обязателен: применённая мутация
+// планирует debounce-reload, и выстреливший таймер идёт в o.proc.
+func newMutateOrch(t *testing.T) (*Orchestrator, string) {
+	t.Helper()
+	dir := t.TempDir()
+	o := newFakeOrch(t, dir, &fakeProc{running: true})
+	if err := o.Register(SlotMeta{Slot: SlotBase, Filename: "00-base.json", AlwaysOn: true}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := o.Bootstrap(); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	return o, filepath.Join(dir, "00-base.json")
+}
+
+func mutateReloadScheduled(o *Orchestrator) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.reloadTimer != nil || o.pendingReload
+}
+
+// Мутатор видит текущее содержимое слота, результат ложится на диск и
+// планирует reload — как обычный Save.
+func TestMutate_AppliesAndSchedulesReload(t *testing.T) {
+	o, path := newMutateOrch(t)
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []byte
+	sawExists := false
+	if err := o.Mutate(SlotBase, func(cur []byte, exists bool) ([]byte, error) {
+		seen, sawExists = cur, exists
+		return []byte(`{"a":2}`), nil
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	if string(seen) != `{"a":1}` || !sawExists {
+		t.Errorf("мутатор получил (%q, exists=%v), want (`{\"a\":1}`, true)", seen, sawExists)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"a":2}` {
+		t.Errorf("на диске %q, want `{\"a\":2}`", data)
+	}
+	if !mutateReloadScheduled(o) {
+		t.Error("применённая мутация обязана планировать reload")
+	}
+}
+
+// nil от мутатора — «менять нечего»: ни записи, ни reload.
+func TestMutate_NilResultDoesNotWrite(t *testing.T) {
+	o, path := newMutateOrch(t)
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := o.Mutate(SlotBase, func(cur []byte, exists bool) ([]byte, error) {
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Errorf("файл тронут при nil-результате: %q", data)
+	}
+	if mutateReloadScheduled(o) {
+		t.Error("nil-результат не должен планировать reload")
+	}
+}
+
+// Байт-в-байт тот же результат reload не планирует — зеркало гейта Save.
+func TestMutate_IdenticalBytesDoNotScheduleReload(t *testing.T) {
+	o, path := newMutateOrch(t)
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := o.Mutate(SlotBase, func(cur []byte, exists bool) ([]byte, error) {
+		return append([]byte(nil), cur...), nil
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	if mutateReloadScheduled(o) {
+		t.Error("неизменившийся слот не должен планировать reload")
+	}
+}
+
+// Файла слота нет — мутатор зовётся с exists=false и пустым cur, а его
+// результат создаёт файл.
+func TestMutate_MissingFileReportsNotExists(t *testing.T) {
+	o, path := newMutateOrch(t)
+
+	sawExists := true
+	var seen []byte
+	if err := o.Mutate(SlotBase, func(cur []byte, exists bool) ([]byte, error) {
+		seen, sawExists = cur, exists
+		return []byte(`{"a":1}`), nil
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	if sawExists || len(seen) != 0 {
+		t.Errorf("мутатор получил (%q, exists=%v), want (пусто, false)", seen, sawExists)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("файл не создан: %v", err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Errorf("на диске %q, want `{\"a\":1}`", data)
+	}
+}
+
+// Ошибка мутатора отменяет запись целиком.
+func TestMutate_MutatorErrorSkipsWrite(t *testing.T) {
+	o, path := newMutateOrch(t)
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	boom := errors.New("boom")
+
+	err := o.Mutate(SlotBase, func(cur []byte, exists bool) ([]byte, error) {
+		return []byte(`{"a":2}`), boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Mutate = %v, want %v", err, boom)
+	}
+
+	data, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(data) != `{"a":1}` {
+		t.Errorf("файл переписан при ошибке мутатора: %q", data)
+	}
+}

--- a/internal/singbox/orchestrator/orchestrator.go
+++ b/internal/singbox/orchestrator/orchestrator.go
@@ -374,6 +374,57 @@ func (o *Orchestrator) slotBytesUnchangedLocked(slot Slot, jsonBytes []byte) (bo
 	return bytes.Equal(old, jsonBytes), nil
 }
 
+// Mutate атомарно правит слот под локом: чтение с того же пути, куда пишет
+// saveLocked → мутатор → запись + debounce reload (unchanged-гейт как у Save).
+// Мутатор получает текущие байты слота и признак его наличия; nil в ответе —
+// «менять нечего», ни записи, ни reload. Ошибка мутатора отменяет запись.
+//
+// Зачем поверх Save: продюсер, читающий файл сам, а потом зовущий Save,
+// работает со снимком, взятым ВНЕ лока, — параллельная правка того же слота
+// теряется (дефект F41, 00-base.json). Приём тот же, что у
+// storage.SettingsStore.Update.
+//
+// Мутатор исполняется ПОД ЛОКОМ оркестратора: он обязан быть чистым и
+// быстрым. Любой метод оркестратора из него — дедлок (mu нерекурсивен),
+// любая блокирующая работа держит на себе всех продюсеров конфига.
+func (o *Orchestrator) Mutate(slot Slot, mut func(cur []byte, exists bool) ([]byte, error)) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	meta, ok := o.slots[slot]
+	if !ok {
+		return ErrUnknownSlot
+	}
+	path := o.disabledPath(meta)
+	if o.enabled[slot] {
+		path = o.activePath(meta)
+	}
+	cur, err := os.ReadFile(path)
+	exists := true
+	switch {
+	case os.IsNotExist(err):
+		cur, exists = nil, false
+	case err != nil:
+		// В отличие от байт-гейта Save, здесь ошибка чтения фатальна: отдать
+		// мутатору пустой cur значило бы дать ему затереть нечитаемый файл.
+		return fmt.Errorf("read %s: %w", meta.Filename, err)
+	}
+	next, err := mut(cur, exists)
+	if err != nil {
+		return err
+	}
+	if next == nil {
+		return nil
+	}
+	if err := o.saveLocked(slot, next); err != nil {
+		return err
+	}
+	if exists && bytes.Equal(cur, next) {
+		return nil
+	}
+	o.scheduleReload()
+	return nil
+}
+
 // SaveSilent is Save without the SIGHUP debounce. The slot file is
 // written but no reload is scheduled. Used by intentional "update on
 // disk only" paths (e.g. selector.default change that must not disturb


### PR DESCRIPTION
Правка 00-base идёт одной транзакцией оркестратора (Orchestrator.Mutate) — конкурентные правки разных скаляров больше не затирают друг друга. Отсутствующая запись dns-bootstrap самолечится: висячая ссылка из 99-defaults валила reload блокирующим unknown-dns-server.