### PR TITLE
Гейт NAT читает список выходов

### DIFF
--- a/internal/api/proxy_instances.go
+++ b/internal/api/proxy_instances.go
@@ -676,7 +676,13 @@ func (h *ProxyInstancesHandler) opkgTunSupported() bool {
 func (h *ProxyInstancesHandler) gateCheck(rec instancestore.Record) error {
 	if rec.Kind == instancestore.KindWdttServer && rec.WdttServer != nil {
 		c := rec.WdttServer
-		if strings.TrimSpace(c.NatMode) == "internet-only" && strings.TrimSpace(c.NatStaticWAN) == "" {
+		// Выход берётся через StaticNATList — тем же способом, что и
+		// roles.Validate. Читать одну legacy-одиночку нельзя: старый движок
+		// после PR #750 писал СПИСОК и явно чистил одиночку («источник правды
+		// теперь список», 722cda888), а посев переносит обе формы как есть,
+		// — такая запись валидна для рантайма, но здесь отбивалась 400 на
+		// любом PATCH, включая переименование (F59).
+		if strings.TrimSpace(c.NatMode) == "internet-only" && len(c.StaticNATList()) == 0 {
 			return &proxyGateError{code: proxyCodeConfigInvalid,
 				msg: "natMode internet-only: не выбран WAN (natStaticWan)"}
 		}
@@ -777,6 +783,18 @@ func proxyApplyConfig(rec *instancestore.Record, raw json.RawMessage) error {
 	proxyResetPresentSlices(proxyConfigPtr(rec), keys)
 	if err := json.Unmarshal(raw, proxyConfigPtr(rec)); err != nil {
 		return fmt.Errorf("невалидный конфиг роли %s: %w", rec.Kind, err)
+	}
+	// natStaticWan и natStaticWans — две формы одного поля, и присланная
+	// форма обязана стать источником правды целиком. Иначе выбор WAN в UI
+	// (фронт говорит ТОЛЬКО на одиночку) молча не вступал бы в силу:
+	// StaticNATList предпочитает список, а он остался бы от старого движка,
+	// который писал список и чистил одиночку (F59, коммит 722cda888).
+	if c := rec.WdttServer; c != nil {
+		_, sentOne := keys["natStaticWan"]
+		_, sentList := keys["natStaticWans"]
+		if sentOne && !sentList {
+			c.NatStaticWANs = nil
+		}
 	}
 	return nil
 }

--- a/internal/api/proxy_instances_test.go
+++ b/internal/api/proxy_instances_test.go
@@ -1315,3 +1315,58 @@ func TestProxyListenMoves_Ack(t *testing.T) {
 		}
 	})
 }
+
+// F59: старый движок после PR #750 писал СПИСОК выходов static-NAT и явно
+// чистил legacy-одиночку («источник правды теперь список», 722cda888), а
+// посев переносит обе формы как есть. Такая запись валидна для рантайма
+// (roles.Validate читает StaticNATList), но gateCheck смотрел только на
+// одиночку — и любой PATCH, включая переименование, отбивался 422.
+//
+// Краснеет на мутации «вернуть в gateCheck проверку c.NatStaticWAN».
+func TestProxyInstancesPatch_GateAcceptsStaticNATList(t *testing.T) {
+	rec := fullServerRecord()
+	rec.WdttServer.NatMode = "internet-only"
+	rec.WdttServer.NatStaticWAN = ""                       // так его оставил старый движок
+	rec.WdttServer.NatStaticWANs = []string{"ISP", "ISP2"} // источник правды
+
+	mgr := &fakeProxyManager{
+		records: []instancestore.Record{rec},
+		seed:    manager.SeedInfo{Booted: true, Certified: true},
+	}
+	h := newProxyHandler(t, mgr, fakeProxyStates{})
+	rr := doProxy(t, h, http.MethodPatch, "/api/proxyrt/instances/wdtt-server:default",
+		`{"name":"Новое имя"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("код = %d, ждали 200: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// Продолжение F59: фронт говорит только на одиночку natStaticWan. Если при её
+// присылке оставить список от старого движка, StaticNATList продолжит
+// предпочитать список — выбор WAN в интерфейсе молча не вступит в силу.
+//
+// Краснеет на мутации «убрать обнуление NatStaticWANs в proxyApplyConfig».
+func TestProxyInstancesPatch_SingularStaticWANReplacesList(t *testing.T) {
+	rec := fullServerRecord()
+	rec.WdttServer.NatMode = "internet-only"
+	rec.WdttServer.NatStaticWAN = ""
+	rec.WdttServer.NatStaticWANs = []string{"ISP", "ISP2"}
+
+	mgr := &fakeProxyManager{
+		records: []instancestore.Record{rec},
+		seed:    manager.SeedInfo{Booted: true, Certified: true},
+	}
+	h := newProxyHandler(t, mgr, fakeProxyStates{})
+	rr := doProxy(t, h, http.MethodPatch, "/api/proxyrt/instances/wdtt-server:default",
+		`{"config":{"natStaticWan":"ISP3"}}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("код = %d, ждали 200: %s", rr.Code, rr.Body.String())
+	}
+	if len(mgr.mutated) == 0 {
+		t.Fatal("запись не сохранена")
+	}
+	got := mgr.mutated[len(mgr.mutated)-1].WdttServer
+	if list := got.StaticNATList(); len(list) != 1 || list[0] != "ISP3" {
+		t.Fatalf("выбор WAN не вступил в силу: StaticNATList=%v (NatStaticWANs=%v)", list, got.NatStaticWANs)
+	}
+}


### PR DESCRIPTION
wdtt-сервер, настроенный после #750, снова принимает PATCH: гейт смотрел на legacy-одиночку, которую старый движок затирал в пользу списка. Заодно выбор WAN в интерфейсе теперь вступает в силу — присланная форма поля становится источником правды целиком.