### PR TITLE
feat(singbox): allow configuring cache.db storage location (flash vs /tmp RAM) (#842)

### DIFF
--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -49,11 +49,11 @@ type singboxCore struct {
 func buildSingboxCore(d singboxCoreDeps) singboxCore {
 	// Sing-box integration
 	op := singbox.NewOperator(singbox.OperatorDeps{
-		Log:             slog.Default().With("component", "singbox"),
-		Dir:             d.dir,
-		Queries:         d.queries,
-		Commands:        d.commands,
-		AppLogger:       d.appLog,
+		Log:               slog.Default().With("component", "singbox"),
+		Dir:               d.dir,
+		Queries:           d.queries,
+		Commands:          d.commands,
+		AppLogger:         d.appLog,
 		SingboxLogLevel:   d.settings.GetSingboxLogLevel,
 		BootstrapDNS:      d.settings.GetSingboxBootstrapDNS,
 		ClashPort:         d.settings.GetSingboxClashPort,

--- a/cmd/awg-manager/singbox_core.go
+++ b/cmd/awg-manager/singbox_core.go
@@ -54,9 +54,10 @@ func buildSingboxCore(d singboxCoreDeps) singboxCore {
 		Queries:         d.queries,
 		Commands:        d.commands,
 		AppLogger:       d.appLog,
-		SingboxLogLevel: d.settings.GetSingboxLogLevel,
-		BootstrapDNS:    d.settings.GetSingboxBootstrapDNS,
-		ClashPort:       d.settings.GetSingboxClashPort,
+		SingboxLogLevel:   d.settings.GetSingboxLogLevel,
+		BootstrapDNS:      d.settings.GetSingboxBootstrapDNS,
+		ClashPort:         d.settings.GetSingboxClashPort,
+		CacheFileLocation: d.settings.GetSingboxCacheFileLocation,
 		// Seed the sticky-stop flag from disk so the watchdog respects
 		// a user-pressed Stop across awgm restarts. SetManuallyStopped
 		// writes the new intent back through a single-field updater so

--- a/cmd/awg-manager/wiring_server.go
+++ b/cmd/awg-manager/wiring_server.go
@@ -333,8 +333,15 @@ func (a *app) setupRouter() {
 		FakeIPTun: func() router.FakeIPTunParams {
 			p := router.DefaultFakeIPTunParams()
 			p.CachePath = singbox.DefaultCacheDBPath()
+			p.TempCachePath = singbox.TempCacheDBPath
 			return p
 		}(),
+		ApplyCacheFileLocation: func(location string) error {
+			if a.singboxOp == nil {
+				return nil
+			}
+			return a.singboxOp.ApplyCacheFileLocation(location)
+		},
 		// Синхронный мост «роутер → device-proxy»: после перепарковки слотов
 		// маршрутизации (Enable/Disable/смена режима) слот 30 перегенерируется
 		// ДО ближайшего reload — селекторы device-proxy деградируют ссылки на

--- a/cmd/awg-manager/wiring_server.go
+++ b/cmd/awg-manager/wiring_server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hoaxisr/awg-manager/internal/logging"
 	"github.com/hoaxisr/awg-manager/internal/monitoring"
 	"github.com/hoaxisr/awg-manager/internal/server"
-	"github.com/hoaxisr/awg-manager/internal/singbox"
 	"github.com/hoaxisr/awg-manager/internal/singbox/awgoutbounds"
 	singboxcfg "github.com/hoaxisr/awg-manager/internal/singbox/configmerge"
 	"github.com/hoaxisr/awg-manager/internal/singbox/dnsrewrite"
@@ -329,19 +328,10 @@ func (a *app) setupRouter() {
 		RunningConfig: a.ndmsQueries.RunningConfig,
 		NATState:      &routerNATStateAdapter{nat: a.ndmsQueries.NAT, static: a.ndmsQueries.StaticNAT},
 		// *RouteStore satisfies DefaultGatewayResolver directly.
-		DefaultGateway: a.ndmsQueries.Routes,
-		FakeIPTun: func() router.FakeIPTunParams {
-			p := router.DefaultFakeIPTunParams()
-			p.CachePath = singbox.DefaultCacheDBPath()
-			p.TempCachePath = singbox.TempCacheDBPath
-			return p
-		}(),
-		ApplyCacheFileLocation: func(location string) error {
-			if a.singboxOp == nil {
-				return nil
-			}
-			return a.singboxOp.ApplyCacheFileLocation(location)
-		},
+		DefaultGateway:         a.ndmsQueries.Routes,
+		FakeIPTun:              router.DefaultFakeIPTunParams(),
+		CacheDBPath:            a.singboxOp.CacheDBPath,
+		ApplyCacheFileLocation: a.singboxOp.ApplyCacheFileLocation,
 		// Синхронный мост «роутер → device-proxy»: после перепарковки слотов
 		// маршрутизации (Enable/Disable/смена режима) слот 30 перегенерируется
 		// ДО ближайшего reload — селекторы device-proxy деградируют ссылки на

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1776,6 +1776,7 @@ const api_SingboxRouterSettingsResponse: v.GenericSchema = v.looseObject({
 
 const api_SingboxRouterStatusData: v.GenericSchema = v.looseObject({
 	active: v.optional(v.nullable(v.boolean())),
+	cacheDbPath: v.optional(v.nullable(v.string())),
 	crashCount: v.optional(v.nullable(v.number())),
 	deviceCount: v.optional(v.nullable(v.number())),
 	deviceMode: v.optional(v.nullable(v.string())),

--- a/frontend/src/lib/api/schemas.gen.ts
+++ b/frontend/src/lib/api/schemas.gen.ts
@@ -1749,6 +1749,7 @@ const api_SingboxRouterSettingsData: v.GenericSchema = v.looseObject({
 	bypassExtraSubnets: v.optional(v.nullable(v.string())),
 	bypassGeoipTags: v.optional(v.nullable(v.array(v.string()))),
 	bypassPresets: v.optional(v.nullable(v.array(v.string()))),
+	cacheFileLocation: v.optional(v.nullable(v.string())),
 	deviceMode: v.optional(v.nullable(v.string())),
 	enabled: v.optional(v.nullable(v.boolean())),
 	fakeipMtu: v.optional(v.nullable(v.number())),

--- a/frontend/src/lib/components/fakeip/FakeIPTab.svelte
+++ b/frontend/src/lib/components/fakeip/FakeIPTab.svelte
@@ -180,6 +180,7 @@
 				fakeipIface={$status?.fakeipIface}
 				fakeipDns={$status?.fakeipDns}
 				toggleBusy={switchBusy}
+				cacheFileLocation={$settings?.cacheFileLocation ?? 'flash'}
 				onToggleEngine={handleToggleEngine}
 				onRestart={handleRestart}
 			/>

--- a/frontend/src/lib/components/fakeip/FakeIPTab.svelte
+++ b/frontend/src/lib/components/fakeip/FakeIPTab.svelte
@@ -180,7 +180,6 @@
 				fakeipIface={$status?.fakeipIface}
 				fakeipDns={$status?.fakeipDns}
 				toggleBusy={switchBusy}
-				cacheFileLocation={$settings?.cacheFileLocation ?? 'flash'}
 				onToggleEngine={handleToggleEngine}
 				onRestart={handleRestart}
 			/>

--- a/frontend/src/lib/components/fakeip/overview/EngineSettingsCard.svelte
+++ b/frontend/src/lib/components/fakeip/overview/EngineSettingsCard.svelte
@@ -61,8 +61,6 @@
 		onRestart: () => void | Promise<void>;
 		/** Блокирует тумблер, пока переключение в полёте (управляется страницей). */
 		toggleBusy?: boolean;
-		/** Место хранения кэша sing-box ('flash' или 'tmp') (issue #842). */
-		cacheFileLocation?: 'flash' | 'tmp';
 	}
 
 	let {
@@ -79,7 +77,6 @@
 		onToggleEngine,
 		onRestart,
 		toggleBusy = false,
-		cacheFileLocation = 'flash',
 	}: Props = $props();
 
 	let restarting = $state(false);
@@ -156,16 +153,6 @@
 	function handleWan(v: string): void {
 		if (v === '') void save({ wanAutoDetect: true, wanInterface: '' });
 		else void save({ wanAutoDetect: false, wanInterface: v });
-	}
-
-	const cacheLocationOptions: DropdownOption<'flash' | 'tmp'>[] = [
-		{ value: 'flash', label: 'Flash /opt (диск)' },
-		{ value: 'tmp', label: 'RAM /tmp (память)' },
-	];
-
-	function handleCacheLocation(val: string): void {
-		const loc = val === 'tmp' ? 'tmp' : 'flash';
-		void save({ cacheFileLocation: loc });
 	}
 
 	function handleSniffer(next: boolean): void {
@@ -291,21 +278,6 @@
 					loading={saving}
 					onchange={handleSniffer}
 				/>
-			</span>
-		</div>
-
-		<!-- Хранилище кэша (issue #842). -->
-		<div class="erow">
-			<span class="k">Хранилище кэша</span>
-			<span class="val ctl">
-				<Dropdown
-					value={cacheFileLocation}
-					options={cacheLocationOptions}
-					disabled={saving}
-					fullWidth
-					onchange={handleCacheLocation}
-				/>
-				<span class="ctl-hint">RAM (/tmp) снижает износ Flash-памяти роутера при частых DNS/FakeIP записях.</span>
 			</span>
 		</div>
 

--- a/frontend/src/lib/components/fakeip/overview/EngineSettingsCard.svelte
+++ b/frontend/src/lib/components/fakeip/overview/EngineSettingsCard.svelte
@@ -61,6 +61,8 @@
 		onRestart: () => void | Promise<void>;
 		/** Блокирует тумблер, пока переключение в полёте (управляется страницей). */
 		toggleBusy?: boolean;
+		/** Место хранения кэша sing-box ('flash' или 'tmp') (issue #842). */
+		cacheFileLocation?: 'flash' | 'tmp';
 	}
 
 	let {
@@ -77,6 +79,7 @@
 		onToggleEngine,
 		onRestart,
 		toggleBusy = false,
+		cacheFileLocation = 'flash',
 	}: Props = $props();
 
 	let restarting = $state(false);
@@ -153,6 +156,16 @@
 	function handleWan(v: string): void {
 		if (v === '') void save({ wanAutoDetect: true, wanInterface: '' });
 		else void save({ wanAutoDetect: false, wanInterface: v });
+	}
+
+	const cacheLocationOptions: DropdownOption<'flash' | 'tmp'>[] = [
+		{ value: 'flash', label: 'Flash /opt (диск)' },
+		{ value: 'tmp', label: 'RAM /tmp (память)' },
+	];
+
+	function handleCacheLocation(val: string): void {
+		const loc = val === 'tmp' ? 'tmp' : 'flash';
+		void save({ cacheFileLocation: loc });
 	}
 
 	function handleSniffer(next: boolean): void {
@@ -278,6 +291,21 @@
 					loading={saving}
 					onchange={handleSniffer}
 				/>
+			</span>
+		</div>
+
+		<!-- Хранилище кэша (issue #842). -->
+		<div class="erow">
+			<span class="k">Хранилище кэша</span>
+			<span class="val ctl">
+				<Dropdown
+					value={cacheFileLocation}
+					options={cacheLocationOptions}
+					disabled={saving}
+					fullWidth
+					onchange={handleCacheLocation}
+				/>
+				<span class="ctl-hint">RAM (/tmp) снижает износ Flash-памяти роутера при частых DNS/FakeIP записях.</span>
 			</span>
 		</div>
 

--- a/frontend/src/lib/components/fakeip/overview/OverviewTab.svelte
+++ b/frontend/src/lib/components/fakeip/overview/OverviewTab.svelte
@@ -35,7 +35,6 @@
 		fakeipIface?: string;
 		fakeipDns?: string;
 		toggleBusy: boolean;
-		cacheFileLocation?: 'flash' | 'tmp';
 		onToggleEngine: (turnOn: boolean) => void;
 		onRestart: () => void;
 	}
@@ -53,7 +52,6 @@
 		fakeipIface,
 		fakeipDns,
 		toggleBusy,
-		cacheFileLocation,
 		onToggleEngine,
 		onRestart,
 	}: Props = $props();
@@ -109,7 +107,6 @@
 		{fakeipIface}
 		{fakeipDns}
 		{toggleBusy}
-		{cacheFileLocation}
 		{onToggleEngine}
 		{onRestart}
 	/>

--- a/frontend/src/lib/components/fakeip/overview/OverviewTab.svelte
+++ b/frontend/src/lib/components/fakeip/overview/OverviewTab.svelte
@@ -35,6 +35,7 @@
 		fakeipIface?: string;
 		fakeipDns?: string;
 		toggleBusy: boolean;
+		cacheFileLocation?: 'flash' | 'tmp';
 		onToggleEngine: (turnOn: boolean) => void;
 		onRestart: () => void;
 	}
@@ -52,6 +53,7 @@
 		fakeipIface,
 		fakeipDns,
 		toggleBusy,
+		cacheFileLocation,
 		onToggleEngine,
 		onRestart,
 	}: Props = $props();
@@ -107,6 +109,7 @@
 		{fakeipIface}
 		{fakeipDns}
 		{toggleBusy}
+		{cacheFileLocation}
 		{onToggleEngine}
 		{onRestart}
 	/>

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -429,6 +429,21 @@
           </div>
         </div>
         <p class="hint">Как долго sing-box держит UDP-сессии активными. Увеличьте если игры или другие UDP-приложения обрываются каждые несколько минут.</p>
+        <div class="field">
+          <label class="lbl" for="ed-cache-location">Место хранения кэша (cache.db)</label>
+          <div class="udp-timeout-row">
+            <select
+              id="ed-cache-location"
+              class="inp"
+              value={cfg.cacheFileLocation ?? 'flash'}
+              onchange={(e) => void applyPatch({ cacheFileLocation: ((e.currentTarget as HTMLSelectElement).value as 'flash' | 'tmp') })}
+            >
+              <option value="flash">Диск роутера (Flash /opt) — по умолчанию</option>
+              <option value="tmp">Оперативная память (RAM /tmp) — защита Flash</option>
+            </select>
+          </div>
+        </div>
+        <p class="hint">Хранение в RAM (/tmp) защищает флеш-память роутера от постоянных записей cache.db. Кэш сбрасывается при перезагрузке.</p>
       </section>
 
       <!-- QoS-маршрутизация (DSCP): onPatch возвращает Promise — карточка

--- a/frontend/src/lib/components/sb-router/StatusDrawer.svelte
+++ b/frontend/src/lib/components/sb-router/StatusDrawer.svelte
@@ -40,6 +40,9 @@
 
   let open = $derived($drawerOpen);
   let s = $derived($status);
+  // Эффективный путь cache.db: при незаданной настройке это может быть
+  // рукописный путь из 00-base.json, который селектор выразить не может.
+  let cacheDbNow = $derived(s?.cacheDbPath ? ` Сейчас: ${s.cacheDbPath}` : '');
   let cfg = $derived($storeSettings);
   let isExpert = $derived($mode === 'expert');
 
@@ -223,6 +226,11 @@
     wanAutoOverride = override;
     if (patch) void applyPatch(patch);
   }
+  function onCacheLocationChange(e: Event) {
+    const v = (e.currentTarget as HTMLSelectElement).value;
+    if (v === 'flash' || v === 'tmp') void applyPatch({ cacheFileLocation: v });
+  }
+
   function onWanInterfaceChange(e: Event) {
     const action = planSelectWanInterface((e.currentTarget as HTMLSelectElement).value);
     if (!action) return;
@@ -371,6 +379,33 @@
       </section>
     {/if}
 
+    <!-- Кэш sing-box (issue #842): единственное место настройки, вне expert-гейта —
+         износ флеша касается любого режима с fakeip. -->
+    {#if cfg}
+      <section class="sec">
+        <div class="sec-cap">Кэш sing-box</div>
+        <div class="field">
+          <label class="lbl" for="ed-cache-location">Хранилище cache.db</label>
+          <select
+            id="ed-cache-location"
+            class="inp"
+            value={cfg.cacheFileLocation ?? ''}
+            onchange={onCacheLocationChange}
+          >
+            <!-- Пустое значение — «настройка не задана, путь из 00-base.json»;
+                 показываем, пока оно есть, иначе выбрать «Флеш» было бы нечем.
+                 Повторный выбор пустого отсекает onCacheLocationChange. -->
+            {#if !cfg.cacheFileLocation}
+              <option value="">Не задано — как в 00-base.json</option>
+            {/if}
+            <option value="flash">Флеш роутера (/opt)</option>
+            <option value="tmp">Оперативная память (/tmp)</option>
+          </select>
+        </div>
+        <p class="hint">В RAM записи FakeIP-карты и Clash не изнашивают флеш, но кэш не переживает перезагрузку. Выбор перезаписывает путь cache_file в 00-base.json, включая заданный вручную.{cacheDbNow}</p>
+      </section>
+    {/if}
+
     {#if isExpert && cfg}
       <!-- Источник трафика (deviceMode/policy) — только TPROXY: в policy-tun
            захват задаётся привязкой интерфейса к политике доступа NDMS. -->
@@ -429,21 +464,6 @@
           </div>
         </div>
         <p class="hint">Как долго sing-box держит UDP-сессии активными. Увеличьте если игры или другие UDP-приложения обрываются каждые несколько минут.</p>
-        <div class="field">
-          <label class="lbl" for="ed-cache-location">Место хранения кэша (cache.db)</label>
-          <div class="udp-timeout-row">
-            <select
-              id="ed-cache-location"
-              class="inp"
-              value={cfg.cacheFileLocation ?? 'flash'}
-              onchange={(e) => void applyPatch({ cacheFileLocation: ((e.currentTarget as HTMLSelectElement).value as 'flash' | 'tmp') })}
-            >
-              <option value="flash">Диск роутера (Flash /opt) — по умолчанию</option>
-              <option value="tmp">Оперативная память (RAM /tmp) — защита Flash</option>
-            </select>
-          </div>
-        </div>
-        <p class="hint">Хранение в RAM (/tmp) защищает флеш-память роутера от постоянных записей cache.db. Кэш сбрасывается при перезагрузке.</p>
       </section>
 
       <!-- QoS-маршрутизация (DSCP): onPatch возвращает Promise — карточка

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -64,8 +64,9 @@ export interface SingboxRouterSettings {
 	qosClasses?: SingboxQosClass[];
 	/**
 	 * Место хранения кэша sing-box (cache.db) (issue #842).
-	 * 'flash' (default) — на флеш-памяти (/opt/etc/awg-manager/singbox/cache.db).
+	 * 'flash' — на флеш-памяти (/opt/etc/awg-manager/singbox/cache.db).
 	 * 'tmp' — в оперативной памяти (/tmp/singbox-cache.db, tmpfs/RAM) для защиты Flash.
+	 * Отсутствует — не задано: путь из 00-base.json как есть (см. Status.cacheDbPath).
 	 */
 	cacheFileLocation?: 'flash' | 'tmp';
 }
@@ -165,6 +166,8 @@ export interface SingboxRouterStatus {
 	fakeipDns?: string;
 	/** Адрес tun-шлюза (хост /30, e.g. «172.18.0.1») в режиме fakeip-tun. */
 	fakeipTunAddr?: string;
+	/** Эффективный путь cache.db: по cacheFileLocation, при пустой настройке — из 00-base.json. */
+	cacheDbPath?: string;
 	/**
 	 * Kernel-имя tun-интерфейса режима policy-tun (e.g. "opkgtun0"). Пусто вне
 	 * policy-tun и при выключенном движке.

--- a/frontend/src/lib/types/sbRouter.ts
+++ b/frontend/src/lib/types/sbRouter.ts
@@ -62,6 +62,12 @@ export interface SingboxRouterSettings {
 	 * wire → absent on legacy/mock payloads (treat undefined as []).
 	 */
 	qosClasses?: SingboxQosClass[];
+	/**
+	 * Место хранения кэша sing-box (cache.db) (issue #842).
+	 * 'flash' (default) — на флеш-памяти (/opt/etc/awg-manager/singbox/cache.db).
+	 * 'tmp' — в оперативной памяти (/tmp/singbox-cache.db, tmpfs/RAM) для защиты Flash.
+	 */
+	cacheFileLocation?: 'flash' | 'tmp';
 }
 
 /** One QoS/DSCP routing class (SingboxRouterSettings.qosClasses entry). */

--- a/internal/api/singbox_router_dto.go
+++ b/internal/api/singbox_router_dto.go
@@ -137,6 +137,10 @@ type SingboxRouterSettingsData struct {
 	// source-preserve (см. GET /singbox/router/policy-tun/nat-preview).
 	// Обнуляется бэкендом при policyTunSourcePreserve=false.
 	PolicyTunNATSegments []string `json:"policyTunNatSegments,omitempty" example:"Home"`
+	// CacheFileLocation sets where sing-box stores cache.db ("flash" or "tmp").
+	// "flash" (default) saves to /opt/etc/awg-manager/singbox/cache.db.
+	// "tmp" saves to RAM tmpfs (/tmp/singbox-cache.db) to eliminate flash wear.
+	CacheFileLocation string `json:"cacheFileLocation,omitempty" example:"flash" enums:"flash,tmp"`
 }
 
 // SingboxRouterQoSClassDTO mirrors storage.SingboxQoSClass — one DSCP-based

--- a/internal/api/singbox_router_dto.go
+++ b/internal/api/singbox_router_dto.go
@@ -39,6 +39,9 @@ type SingboxRouterStatusData struct {
 	FakeIPIface            string `json:"fakeipIface,omitempty" example:"opkgtun0"`
 	FakeIPDns              string `json:"fakeipDns,omitempty" example:"172.18.0.2"`
 	FakeIPTunAddr          string `json:"fakeipTunAddr,omitempty" example:"172.18.0.1"`
+	// CacheDBPath — эффективный путь cache.db: по cacheFileLocation, при пустой
+	// настройке — из 00-base.json (рукописный путь сохраняется).
+	CacheDBPath string `json:"cacheDbPath,omitempty" example:"/opt/etc/awg-manager/singbox/cache.db"`
 	// PolicyTunIface / PolicyTunNDMSName — kernel- и NDMS-имена policy-tun
 	// интерфейса. Заполнены при Enabled+Provisioned (ДО того как режим стал
 	// active): по NDMS-имени пользователь разрешает интерфейс в политике
@@ -137,9 +140,10 @@ type SingboxRouterSettingsData struct {
 	// source-preserve (см. GET /singbox/router/policy-tun/nat-preview).
 	// Обнуляется бэкендом при policyTunSourcePreserve=false.
 	PolicyTunNATSegments []string `json:"policyTunNatSegments,omitempty" example:"Home"`
-	// CacheFileLocation sets where sing-box stores cache.db ("flash" or "tmp").
-	// "flash" (default) saves to /opt/etc/awg-manager/singbox/cache.db.
-	// "tmp" saves to RAM tmpfs (/tmp/singbox-cache.db) to eliminate flash wear.
+	// CacheFileLocation — место хранения cache.db sing-box: "flash" —
+	// /opt/etc/awg-manager/singbox/cache.db, "tmp" — /tmp/singbox-cache.db в RAM,
+	// записи кэша перестают изнашивать флеш, но кэш не переживает перезагрузку.
+	// Пусто — не задано: путь из 00-base.json как есть (см. cacheDbPath в статусе).
 	CacheFileLocation string `json:"cacheFileLocation,omitempty" example:"flash" enums:"flash,tmp"`
 }
 

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -4927,6 +4927,16 @@ definitions:
         items:
           type: string
         type: array
+      cacheFileLocation:
+        description: |-
+          CacheFileLocation sets where sing-box stores cache.db ("flash" or "tmp").
+          "flash" (default) saves to /opt/etc/awg-manager/singbox/cache.db.
+          "tmp" saves to RAM tmpfs (/tmp/singbox-cache.db) to eliminate flash wear.
+        enum:
+        - flash
+        - tmp
+        example: flash
+        type: string
       deviceMode:
         enum:
         - policy

--- a/internal/openapi/swagger.yaml
+++ b/internal/openapi/swagger.yaml
@@ -4929,9 +4929,10 @@ definitions:
         type: array
       cacheFileLocation:
         description: |-
-          CacheFileLocation sets where sing-box stores cache.db ("flash" or "tmp").
-          "flash" (default) saves to /opt/etc/awg-manager/singbox/cache.db.
-          "tmp" saves to RAM tmpfs (/tmp/singbox-cache.db) to eliminate flash wear.
+          CacheFileLocation — место хранения cache.db sing-box: "flash" —
+          /opt/etc/awg-manager/singbox/cache.db, "tmp" — /tmp/singbox-cache.db в RAM,
+          записи кэша перестают изнашивать флеш, но кэш не переживает перезагрузку.
+          Пусто — не задано: путь из 00-base.json как есть (см. cacheDbPath в статусе).
         enum:
         - flash
         - tmp
@@ -5064,6 +5065,12 @@ definitions:
       active:
         example: true
         type: boolean
+      cacheDbPath:
+        description: |-
+          CacheDBPath — эффективный путь cache.db: по cacheFileLocation, при пустой
+          настройке — из 00-base.json (рукописный путь сохраняется).
+        example: /opt/etc/awg-manager/singbox/cache.db
+        type: string
       crashCount:
         description: 'CrashCount — падения sing-box за последние 10 минут (issue #456).'
         example: 2

--- a/internal/singbox/clash_port_test.go
+++ b/internal/singbox/clash_port_test.go
@@ -32,7 +32,7 @@ func TestClashPort_ReachesBaseConfig(t *testing.T) {
 
 	t.Run("fresh base uses configured port", func(t *testing.T) {
 		configDir := filepath.Join(t.TempDir(), "config.d")
-		ensureBaseConfig(configDir, "info", "", 9500)
+		ensureBaseConfig(configDir, "info", "", 9500, "")
 		if got := readController(t, filepath.Join(configDir, "00-base.json")); got != "127.0.0.1:9500" {
 			t.Errorf("want 127.0.0.1:9500, got %q", got)
 		}
@@ -40,7 +40,7 @@ func TestClashPort_ReachesBaseConfig(t *testing.T) {
 
 	t.Run("port 0 falls back to default", func(t *testing.T) {
 		configDir := filepath.Join(t.TempDir(), "config.d")
-		ensureBaseConfig(configDir, "info", "", 0)
+		ensureBaseConfig(configDir, "info", "", 0, "")
 		if got := readController(t, filepath.Join(configDir, "00-base.json")); got != ClashAddr(DefaultClashPort) {
 			t.Errorf("want default, got %q", got)
 		}
@@ -56,7 +56,7 @@ func TestClashPort_ReachesBaseConfig(t *testing.T) {
 		if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 			t.Fatal(err)
 		}
-		ensureBaseConfig(configDir, "info", "", 9500)
+		ensureBaseConfig(configDir, "info", "", 9500, "")
 		if got := readController(t, basePath); got != "127.0.0.1:9500" {
 			t.Errorf("want 127.0.0.1:9500, got %q", got)
 		}

--- a/internal/singbox/derived_defaults_test.go
+++ b/internal/singbox/derived_defaults_test.go
@@ -27,7 +27,7 @@ func TestMergedScalars_SlotWinsOverDefaults(t *testing.T) {
 				},
 				"route": map[string]any{"default_domain_resolver": map[string]any{"server": "real"}},
 			})
-			for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
+			for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, "", nil) {
 				s.run()
 			}
 			m := mergedMap(t, configDir)
@@ -47,7 +47,7 @@ func TestMergedScalars_SlotWinsOverDefaults(t *testing.T) {
 func TestMergedScalars_DefaultsApplyWithoutOwner(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
+	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, "", nil) {
 		s.run()
 	}
 	m := mergedMap(t, configDir)
@@ -168,7 +168,7 @@ func TestReconcileDerivedDefaults_Idempotent(t *testing.T) {
 // Свежая установка не должна нести оба скаляра в базе: там они лежали бы в
 // ВЫИГРЫВАЮЩЕЙ позиции merge и затеняли бы выбор режимного слота.
 func TestFreshBaseConfig_OmitsDerivedScalars(t *testing.T) {
-	base := freshBaseConfig("info", "", 0)
+	base := freshBaseConfig("info", "", 0, defaultCacheDBPath)
 	dns, _ := base["dns"].(map[string]any)
 	if _, has := dns["strategy"]; has {
 		t.Errorf("свежая база не должна нести dns.strategy: %v", dns)

--- a/internal/singbox/legacy_config_test.go
+++ b/internal/singbox/legacy_config_test.go
@@ -294,7 +294,7 @@ func TestEnsureLegacyConfigMigrated_DanglingDNSDohRuleValidates(t *testing.T) {
 	// config.d уже существует к моменту миграции — как в реальном буте,
 	// где ensureBaseConfig (шаг раньше в reconcileConfigSteps) успевает
 	// создать 00-base.json первым.
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 
 	writeLegacyConfig(t, filepath.Join(dir, "config.json"), map[string]any{
 		"dns": map[string]any{

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -322,7 +322,9 @@ type OperatorDeps struct {
 	// Issue #788, ADR 0001.
 	ClashPort func() int
 	// CacheFileLocation returns the desired cache.db location from settings
-	// ("flash" or "tmp") (issue #842). Optional; empty means default flash storage.
+	// ("flash" or "tmp") (issue #842). Optional; empty means "not configured":
+	// an absolute path in 00-base.json stays, a relative or legacy one is
+	// replaced by the flash default (see cacheDBPathFor).
 	CacheFileLocation func() string
 	// Bus is the event bus for publishing resource changes (SSE). Optional:
 	// every call site guards on nil (Bus.Publish itself would panic).
@@ -365,18 +367,13 @@ func NewOperator(d OperatorDeps) *Operator {
 	if d.CacheFileLocation != nil {
 		desiredCacheLocation = d.CacheFileLocation()
 	}
-	desiredCachePath := ResolveCacheDBPath(desiredCacheLocation)
 
 	configPath := filepath.Join(dir, "config.d")
 	pidPath := filepath.Join(dir, "sing-box.pid")
 
-	for _, s := range reconcileConfigSteps(dir, configPath, desiredSingboxLogLevel, desiredBootstrapDNS, desiredClashPort, log) {
+	for _, s := range reconcileConfigSteps(dir, configPath, desiredSingboxLogLevel, desiredBootstrapDNS, desiredClashPort, desiredCacheLocation, log) {
 		s.run()
 	}
-
-	// Apply desired cache.db path to 00-base.json (issue #842)
-	basePath := filepath.Join(configPath, "00-base.json")
-	patchBaseCacheFileTo(basePath, desiredCachePath, log)
 
 	op := &Operator{
 		log:               log,

--- a/internal/singbox/operator.go
+++ b/internal/singbox/operator.go
@@ -133,8 +133,10 @@ type Operator struct {
 	// ApplyLogLevel (из аргумента), поэтому пересоздать базу умел лишь он, а
 	// mutateBase на пропавшем файле молча выходил.
 	singboxLogLevel func() string
-	configPath      string
-	pidPath         string
+	// cacheFileLocation — живой доступ к Settings.SingboxRouter.CacheFileLocation (issue #842).
+	cacheFileLocation func() string
+	configPath        string
+	pidPath           string
 
 	proc      *Process
 	validator *Validator
@@ -319,6 +321,9 @@ type OperatorDeps struct {
 	// (Settings.SingboxClashPort). Optional; 0 means DefaultClashPort.
 	// Issue #788, ADR 0001.
 	ClashPort func() int
+	// CacheFileLocation returns the desired cache.db location from settings
+	// ("flash" or "tmp") (issue #842). Optional; empty means default flash storage.
+	CacheFileLocation func() string
 	// Bus is the event bus for publishing resource changes (SSE). Optional:
 	// every call site guards on nil (Bus.Publish itself would panic).
 	Bus *events.Bus
@@ -356,6 +361,12 @@ func NewOperator(d OperatorDeps) *Operator {
 		desiredClashPort = d.ClashPort()
 	}
 
+	desiredCacheLocation := ""
+	if d.CacheFileLocation != nil {
+		desiredCacheLocation = d.CacheFileLocation()
+	}
+	desiredCachePath := ResolveCacheDBPath(desiredCacheLocation)
+
 	configPath := filepath.Join(dir, "config.d")
 	pidPath := filepath.Join(dir, "sing-box.pid")
 
@@ -363,11 +374,16 @@ func NewOperator(d OperatorDeps) *Operator {
 		s.run()
 	}
 
+	// Apply desired cache.db path to 00-base.json (issue #842)
+	basePath := filepath.Join(configPath, "00-base.json")
+	patchBaseCacheFileTo(basePath, desiredCachePath, log)
+
 	op := &Operator{
 		log:               log,
 		bootstrapDNS:      d.BootstrapDNS,
 		clashPort:         d.ClashPort,
 		singboxLogLevel:   d.SingboxLogLevel,
+		cacheFileLocation: d.CacheFileLocation,
 		dir:               dir,
 		binary:            binary,
 		configPath:        configPath,

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -28,6 +28,19 @@ var defaultCacheDBPath = filepath.Join(defaultDir, "cache.db")
 // package decoupled from the operator's path layout (it just receives a string).
 func DefaultCacheDBPath() string { return defaultCacheDBPath }
 
+// TempCacheDBPath is the RAM tmpfs path (/tmp/singbox-cache.db) used to protect NAND flash storage (issue #842).
+const TempCacheDBPath = "/tmp/singbox-cache.db"
+
+// ResolveCacheDBPath returns the absolute path for cache.db based on location setting.
+// "tmp" -> TempCacheDBPath ("/tmp/singbox-cache.db")
+// "flash" / "" -> DefaultCacheDBPath() (/opt/etc/awg-manager/singbox/cache.db)
+func ResolveCacheDBPath(location string) string {
+	if location == "tmp" {
+		return TempCacheDBPath
+	}
+	return DefaultCacheDBPath()
+}
+
 // ensureBaseConfig writes a minimal 00-base.json if config.d is
 // empty, so sing-box starts standalone (direct outbound + bootstrap DNS) before
 // any tunnels are added. Also surgically self-heals an older base config
@@ -898,7 +911,16 @@ const legacyCacheFilePath = "/opt/etc/sing-box/cache.db"
 // Any OTHER user-set absolute path is left untouched (legitimate
 // customization).
 func patchBaseCacheFilePath(basePath string, loggers ...*slog.Logger) {
+	patchBaseCacheFileTo(basePath, defaultCacheDBPath, loggers...)
+}
+
+// patchBaseCacheFileTo ensures experimental.cache_file in 00-base.json is configured
+// to point to desiredPath (issue #842).
+func patchBaseCacheFileTo(basePath string, desiredPath string, loggers ...*slog.Logger) {
 	log := firstLogger(loggers)
+	if desiredPath == "" {
+		desiredPath = defaultCacheDBPath
+	}
 	m, ok := readSlotJSON(stepPatchBaseCacheFile, basePath, log)
 	if !ok {
 		return
@@ -915,7 +937,7 @@ func patchBaseCacheFilePath(basePath string, loggers ...*slog.Logger) {
 		// Case 1: block missing — add it.
 		exp["cache_file"] = map[string]any{
 			"enabled": true,
-			"path":    defaultCacheDBPath,
+			"path":    desiredPath,
 		}
 		writeSlotJSON(stepPatchBaseCacheFile, basePath, m, log)
 		return
@@ -923,18 +945,17 @@ func patchBaseCacheFilePath(basePath string, loggers ...*slog.Logger) {
 
 	path, _ := cf["path"].(string)
 	switch {
-	case path == "":
-		// Empty/missing path — set to absolute default.
-		cf["path"] = defaultCacheDBPath
-	case !strings.HasPrefix(path, "/"):
-		// Case 2: relative path — rewrite to absolute.
-		cf["path"] = defaultCacheDBPath
-	case path == legacyCacheFilePath:
-		// Case 3: known-bad legacy absolute — replace.
-		cf["path"] = defaultCacheDBPath
-	default:
-		// Any other absolute path — legitimate user customization, leave alone.
+	case path == desiredPath:
 		return
+	case path == "" || !strings.HasPrefix(path, "/") || path == legacyCacheFilePath || path == defaultCacheDBPath || path == TempCacheDBPath:
+		cf["path"] = desiredPath
+	default:
+		// Any other absolute path — legitimate user customization, unless explicitly switching to tmp
+		if desiredPath == TempCacheDBPath {
+			cf["path"] = desiredPath
+		} else {
+			return
+		}
 	}
 	writeSlotJSON(stepPatchBaseCacheFile, basePath, m, log)
 }
@@ -1068,10 +1089,14 @@ const defaultBootstrapDNS = "1.1.1.1"
 // freshBaseConfig returns the canonical base sing-box config. Single source
 // of truth for ensureBaseConfig (initial write + self-heal path). Empty
 // bootstrapDNS falls back to defaultBootstrapDNS.
-func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int) map[string]any {
+func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int, cachePath ...string) map[string]any {
 	bootstrapDNS = sanitizeBootstrapDNS(bootstrapDNS)
 	if bootstrapDNS == "" {
 		bootstrapDNS = defaultBootstrapDNS
+	}
+	desiredCachePath := defaultCacheDBPath
+	if len(cachePath) > 0 && cachePath[0] != "" {
+		desiredCachePath = cachePath[0]
 	}
 	return map[string]any{
 		"log": map[string]any{"level": normalizeSingboxLogLevel(logLevel), "timestamp": true},
@@ -1085,7 +1110,7 @@ func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int) map[string]an
 			// caused FATAL on user installs.
 			"cache_file": map[string]any{
 				"enabled": true,
-				"path":    defaultCacheDBPath,
+				"path":    desiredCachePath,
 			},
 		},
 		"dns": map[string]any{
@@ -1162,6 +1187,15 @@ func (o *Operator) desiredClashPort() int {
 	return o.clashPort()
 }
 
+// desiredCachePath returns the desired cache.db path from settings ("flash" or "tmp");
+// falls back to defaultCacheDBPath.
+func (o *Operator) desiredCachePath() string {
+	if o.cacheFileLocation == nil {
+		return defaultCacheDBPath
+	}
+	return ResolveCacheDBPath(o.cacheFileLocation())
+}
+
 // ApplyClashPort приводит experimental.clash_api.external_controller в
 // 00-base.json к новому порту и перенаправляет туда же наш ClashClient
 // (issue #788). Перезапуск демона не нужен: SIGHUP в форке — это Close +
@@ -1201,6 +1235,39 @@ func (o *Operator) ApplyBootstrapDNS(server string) error {
 	})
 }
 
+// ApplyCacheFileLocation sets the experimental.cache_file.path in 00-base.json according to location ("flash" or "tmp") (issue #842).
+func (o *Operator) ApplyCacheFileLocation(location string) error {
+	desiredPath := ResolveCacheDBPath(location)
+	return o.mutateBase(func(base map[string]any) bool {
+		return reconcileCacheFilePath(base, desiredPath)
+	})
+}
+
+func reconcileCacheFilePath(base map[string]any, desiredPath string) bool {
+	if desiredPath == "" {
+		desiredPath = defaultCacheDBPath
+	}
+	exp, ok := base["experimental"].(map[string]any)
+	if !ok {
+		exp = map[string]any{}
+		base["experimental"] = exp
+	}
+	cf, ok := exp["cache_file"].(map[string]any)
+	if !ok {
+		exp["cache_file"] = map[string]any{
+			"enabled": true,
+			"path":    desiredPath,
+		}
+		return true
+	}
+	curPath, _ := cf["path"].(string)
+	if curPath == desiredPath {
+		return false
+	}
+	cf["path"] = desiredPath
+	return true
+}
+
 // mutateBase — общий транспорт правки 00-base.json: прочитать, дать мутатору
 // решить, менять ли (false — выходим без записи), записать через
 // оркестратор — там валидация merged-конфига и коалесцированный reload.
@@ -1221,7 +1288,7 @@ func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
 	// Кандидат на восстановление считается ДО взятия лока оркестратора:
 	// desired* ходят в SettingsStore, а под чужим локом блокирующей работе
 	// делать нечего. Нужен он только в ветке «файла нет».
-	fresh := freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort())
+	fresh := freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort(), o.desiredCachePath())
 	return o.orch.Mutate(orchestrator.SlotBase, func(data []byte, exists bool) ([]byte, error) {
 		var base map[string]any
 		restored := false

--- a/internal/singbox/operator_baseconfig.go
+++ b/internal/singbox/operator_baseconfig.go
@@ -2,6 +2,7 @@ package singbox
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hoaxisr/awg-manager/internal/singbox/configmerge"
 	"github.com/hoaxisr/awg-manager/internal/singbox/orchestrator"
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 // defaultCacheDBPath is the absolute path for sing-box's experimental.cache_file.
@@ -22,23 +24,36 @@ import (
 // override defaultDir to redirect this too.
 var defaultCacheDBPath = filepath.Join(defaultDir, "cache.db")
 
-// DefaultCacheDBPath exports the sing-box experimental.cache_file path so the
-// fakeip-tun router wiring (cmd/awg-manager) can pin its store_fakeip cache to
-// the same writable file without importing the unexported var. Keeps the router
-// package decoupled from the operator's path layout (it just receives a string).
-func DefaultCacheDBPath() string { return defaultCacheDBPath }
+// tempCacheDBPath — cache.db в RAM (tmpfs): бережёт NAND-флеш роутера от
+// постоянных записей sing-box в кэш (fakeip-карта, выбор outbound в Clash,
+// rule-set) (issue #842).
+// Переменная, как defaultCacheDBPath: тесты перенаправляют её в t.TempDir().
+var tempCacheDBPath = "/tmp/singbox-cache.db"
 
-// TempCacheDBPath is the RAM tmpfs path (/tmp/singbox-cache.db) used to protect NAND flash storage (issue #842).
-const TempCacheDBPath = "/tmp/singbox-cache.db"
+// legacyCacheFilePath — путь из старых доков sing-box; лежит на read-only
+// монтировании Entware, записи кэша молча падают. Заведомо негодный, а не
+// осознанная правка пользователя.
+const legacyCacheFilePath = "/opt/etc/sing-box/cache.db"
 
-// ResolveCacheDBPath returns the absolute path for cache.db based on location setting.
-// "tmp" -> TempCacheDBPath ("/tmp/singbox-cache.db")
-// "flash" / "" -> DefaultCacheDBPath() (/opt/etc/awg-manager/singbox/cache.db)
-func ResolveCacheDBPath(location string) string {
-	if location == "tmp" {
-		return TempCacheDBPath
+// cacheDBPathFor — эффективный путь cache.db (issue #842). Настройка задана
+// (flash | tmp) — путём владеет она. Настройка пуста — путём владеет
+// пользователь: абсолютный путь из base (рукописный, до появления настройки
+// его правили прямо в 00-base.json) остаётся, а заведомо негодный —
+// относительный (sing-box резолвит от CWD, под службой Entware это "/"),
+// legacy или отсутствующий — заменяется дефолтом на флеше. Единственный
+// источник пути для базы, overlay 21-fakeip.json (через Operator.CacheDBPath)
+// и статуса, поэтому рукописный путь действует во всех режимах.
+func cacheDBPathFor(location string, base map[string]any) string {
+	switch location {
+	case storage.CacheFileLocationTmp:
+		return tempCacheDBPath
+	case storage.CacheFileLocationFlash:
+		return defaultCacheDBPath
 	}
-	return DefaultCacheDBPath()
+	if p := currentCacheFilePath(base); filepath.IsAbs(p) && p != legacyCacheFilePath {
+		return p
+	}
+	return defaultCacheDBPath
 }
 
 // ensureBaseConfig writes a minimal 00-base.json if config.d is
@@ -46,14 +61,14 @@ func ResolveCacheDBPath(location string) string {
 // any tunnels are added. Also surgically self-heals an older base config
 // that hard-coded the wrong Clash API port (9090 instead of ours), which
 // silently broke our LogForwarder / DelayChecker on existing installs.
-func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, loggers ...*slog.Logger) {
+func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, desiredCacheLocation string, loggers ...*slog.Logger) {
 	log := firstLogger(loggers)
 	basePath := filepath.Join(configDir, "00-base.json")
 	if _, err := os.Stat(basePath); err == nil {
 		patchBaseClashPort(basePath, desiredClashPort, log)
 		patchBaseLogLevel(basePath, desiredLogLevel, log)
 		patchBaseDirectOutbound(basePath, log)
-		patchBaseCacheFilePath(basePath, log)
+		patchBaseCacheFilePath(basePath, desiredCacheLocation, log)
 		patchBaseBootstrapDNS(basePath, desiredBootstrapDNS, log)
 		return
 	}
@@ -62,7 +77,7 @@ func ensureBaseConfig(configDir, desiredLogLevel, desiredBootstrapDNS string, de
 			"step", stepEnsureBaseConfig, "path", configDir, "err", err)
 		return
 	}
-	writeSlotJSON(stepEnsureBaseConfig, basePath, freshBaseConfig(desiredLogLevel, desiredBootstrapDNS, desiredClashPort), log)
+	writeSlotJSON(stepEnsureBaseConfig, basePath, freshBaseConfig(desiredLogLevel, desiredBootstrapDNS, desiredClashPort, cacheDBPathFor(desiredCacheLocation, nil)), log)
 }
 
 func logConfigPatchInfo(log *slog.Logger, msg string, args ...any) {
@@ -113,11 +128,13 @@ type reconcileStep struct {
 // MigrateLegacyConfigDir в config.go). Внутри набора ограничений порядка нет:
 // шаги попарно коммутируют по конечному состоянию (закреплено
 // TestReconcileConfigSteps_CommuteReversed).
-func reconcileConfigSteps(dir, configPath, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, log *slog.Logger) []reconcileStep {
+func reconcileConfigSteps(dir, configPath, desiredLogLevel, desiredBootstrapDNS string, desiredClashPort int, desiredCacheLocation string, log *slog.Logger) []reconcileStep {
 	base := filepath.Join(configPath, "00-base.json")
 	tunnels := filepath.Join(configPath, "10-tunnels.json")
 	return []reconcileStep{
-		{stepEnsureBaseConfig, func() { ensureBaseConfig(configPath, desiredLogLevel, desiredBootstrapDNS, desiredClashPort, log) }},
+		{stepEnsureBaseConfig, func() {
+			ensureBaseConfig(configPath, desiredLogLevel, desiredBootstrapDNS, desiredClashPort, desiredCacheLocation, log)
+		}},
 		{stepMigrateLegacyTunnels, func() { ensureLegacyConfigMigrated(dir, log) }},
 		{stepStripBaseOwnedBlocks, func() { patchTunnelsSlotStripBaseOwnedBlocks(tunnels, log) }},
 		// Компат-фиксы нужны каждому продюсеру outbound'ов: 10-tunnels пишет
@@ -888,76 +905,81 @@ func stripStrayDirectPlaceholder(configDir string, loggers ...*slog.Logger) {
 	}
 }
 
-// legacyCacheFilePath is the hardcoded path some older sing-box docs/configs
-// suggested. It lives under a read-only Entware mount so cache writes
-// silently fail. We treat it as a known-bad migration target, not as a
-// legitimate user customization.
-const legacyCacheFilePath = "/opt/etc/sing-box/cache.db"
-
-// patchBaseCacheFilePath ensures experimental.cache_file is present with a
-// writable path. Three cases:
-//
-//  1. Block missing entirely — add it with enabled:true + defaultCacheDBPath.
-//     Older installs predating our cache_file work didn't include the block;
-//     adding it post-hoc gives them the same on-disk benefits as fresh installs.
-//
-//  2. Relative path ("cache.db") — sing-box resolves against CWD which is "/"
-//     when the manager runs as a service on Entware. Replace with absolute.
-//
-//  3. Legacy absolute path /opt/etc/sing-box/cache.db — known-bad value from
-//     older docs / pre-2.x installer drafts. Read-only on Entware. Replace
-//     with defaultCacheDBPath.
-//
-// Any OTHER user-set absolute path is left untouched (legitimate
-// customization).
-func patchBaseCacheFilePath(basePath string, loggers ...*slog.Logger) {
-	patchBaseCacheFileTo(basePath, defaultCacheDBPath, loggers...)
+// reconcileCacheFile приводит experimental.cache_file в 00-base.json к пути
+// по cacheDBPathFor. Общий мутатор стартового примирения
+// (patchBaseCacheFilePath) и живого применения (ApplyCacheFileLocation);
+// хвост правки — лог и снос устаревшего кэша — у них тоже общий
+// (finishCacheFileChange). Отсутствующие блоки experimental/cache_file
+// достраиваем. Возвращает эффективный путь и признак «base изменена».
+func reconcileCacheFile(base map[string]any, location string) (want string, changed bool) {
+	want = cacheDBPathFor(location, base)
+	exp, _ := base["experimental"].(map[string]any)
+	if exp == nil {
+		exp = map[string]any{}
+		base["experimental"] = exp
+	}
+	cf, _ := exp["cache_file"].(map[string]any)
+	if cf == nil {
+		exp["cache_file"] = map[string]any{"enabled": true, "path": want}
+		return want, true
+	}
+	if cf["path"] == want {
+		return want, false
+	}
+	cf["path"] = want
+	return want, true
 }
 
-// patchBaseCacheFileTo ensures experimental.cache_file in 00-base.json is configured
-// to point to desiredPath (issue #842).
-func patchBaseCacheFileTo(basePath string, desiredPath string, loggers ...*slog.Logger) {
-	log := firstLogger(loggers)
-	if desiredPath == "" {
-		desiredPath = defaultCacheDBPath
+// finishCacheFileChange — хвост состоявшейся правки пути: лог со старым и
+// новым путём (иначе рукописный путь исчез бы молча) и снос кэша по
+// покинутому пути, если он один из наших двух — иначе откат поднял бы
+// протухшую fakeip-карту. Рукописный путь при переезде не трогаем: файл не
+// наш (сброс кэша при смене пула — другая история, там путь эффективный).
+// Открытый файл sing-box доживает до reload, снос его не рвёт.
+func finishCacheFileChange(log *slog.Logger, basePath, was, want string) {
+	logConfigPatchInfo(log, "singbox base config reconciled",
+		"patch", stepPatchBaseCacheFile,
+		"path", basePath,
+		"oldCachePath", loggedCachePath(was),
+		"newCachePath", want,
+	)
+	if was != defaultCacheDBPath && was != tempCacheDBPath {
+		return
 	}
+	switch err := os.Remove(was); {
+	case err == nil:
+		logConfigPatchInfo(log, "singbox stale cache.db removed", "patch", stepPatchBaseCacheFile, "cachePath", was)
+	case !os.IsNotExist(err):
+		logConfigPatchWarn(log, "singbox stale cache.db not removed", "patch", stepPatchBaseCacheFile, "cachePath", was, "err", err)
+	}
+}
+
+// currentCacheFilePath — путь cache_file из base как есть; "" если блока нет.
+func currentCacheFilePath(base map[string]any) string {
+	exp, _ := base["experimental"].(map[string]any)
+	cf, _ := exp["cache_file"].(map[string]any)
+	path, _ := cf["path"].(string)
+	return path
+}
+
+// loggedCachePath — старый путь для лога: пустой значит «блока не было», а
+// не «путь был пуст».
+func loggedCachePath(was string) string { return cmp.Or(was, "<none>") }
+
+// patchBaseCacheFilePath — стартовый шаг примирения cache_file (см.
+// reconcileCacheFile, finishCacheFileChange).
+func patchBaseCacheFilePath(basePath, location string, loggers ...*slog.Logger) {
+	log := firstLogger(loggers)
 	m, ok := readSlotJSON(stepPatchBaseCacheFile, basePath, log)
 	if !ok {
 		return
 	}
-	exp, ok := m["experimental"].(map[string]any)
-	if !ok {
-		// experimental block missing entirely — out of scope for cache_file
-		// patcher. Other patches (clash_port etc.) handle their own gaps.
+	was := currentCacheFilePath(m)
+	want, changed := reconcileCacheFile(m, location)
+	if !changed || !writeSlotJSON(stepPatchBaseCacheFile, basePath, m, log) {
 		return
 	}
-
-	cf, ok := exp["cache_file"].(map[string]any)
-	if !ok {
-		// Case 1: block missing — add it.
-		exp["cache_file"] = map[string]any{
-			"enabled": true,
-			"path":    desiredPath,
-		}
-		writeSlotJSON(stepPatchBaseCacheFile, basePath, m, log)
-		return
-	}
-
-	path, _ := cf["path"].(string)
-	switch {
-	case path == desiredPath:
-		return
-	case path == "" || !strings.HasPrefix(path, "/") || path == legacyCacheFilePath || path == defaultCacheDBPath || path == TempCacheDBPath:
-		cf["path"] = desiredPath
-	default:
-		// Any other absolute path — legitimate user customization, unless explicitly switching to tmp
-		if desiredPath == TempCacheDBPath {
-			cf["path"] = desiredPath
-		} else {
-			return
-		}
-	}
-	writeSlotJSON(stepPatchBaseCacheFile, basePath, m, log)
+	finishCacheFileChange(log, basePath, was, want)
 }
 
 // patchTunnelsSlotStripBaseOwnedBlocks self-heals 10-tunnels.json files polluted
@@ -1089,14 +1111,10 @@ const defaultBootstrapDNS = "1.1.1.1"
 // freshBaseConfig returns the canonical base sing-box config. Single source
 // of truth for ensureBaseConfig (initial write + self-heal path). Empty
 // bootstrapDNS falls back to defaultBootstrapDNS.
-func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int, cachePath ...string) map[string]any {
+func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int, cachePath string) map[string]any {
 	bootstrapDNS = sanitizeBootstrapDNS(bootstrapDNS)
 	if bootstrapDNS == "" {
 		bootstrapDNS = defaultBootstrapDNS
-	}
-	desiredCachePath := defaultCacheDBPath
-	if len(cachePath) > 0 && cachePath[0] != "" {
-		desiredCachePath = cachePath[0]
 	}
 	return map[string]any{
 		"log": map[string]any{"level": normalizeSingboxLogLevel(logLevel), "timestamp": true},
@@ -1110,7 +1128,7 @@ func freshBaseConfig(logLevel, bootstrapDNS string, clashPort int, cachePath ...
 			// caused FATAL on user installs.
 			"cache_file": map[string]any{
 				"enabled": true,
-				"path":    desiredCachePath,
+				"path":    cachePath,
 			},
 		},
 		"dns": map[string]any{
@@ -1187,13 +1205,27 @@ func (o *Operator) desiredClashPort() int {
 	return o.clashPort()
 }
 
-// desiredCachePath returns the desired cache.db path from settings ("flash" or "tmp");
-// falls back to defaultCacheDBPath.
-func (o *Operator) desiredCachePath() string {
+// desiredCacheLocation — настройка места хранения cache.db (issue #842);
+// "" — не задана.
+func (o *Operator) desiredCacheLocation() string {
 	if o.cacheFileLocation == nil {
-		return defaultCacheDBPath
+		return ""
 	}
-	return ResolveCacheDBPath(o.cacheFileLocation())
+	return o.cacheFileLocation()
+}
+
+// CacheDBPath — эффективный путь cache.db (см. cacheDBPathFor). Роутер берёт
+// его для overlay 21-fakeip.json и статуса: overlay перекрывает базу в merge,
+// и второй источник пути разводил бы режимы. База читается только при пустой
+// настройке и с nil-логгером (метка шага при нём инертна): битый 00-base.json
+// — не событие этого чтения, о нём говорят шаги примирения и валидатор.
+func (o *Operator) CacheDBPath() string {
+	location := o.desiredCacheLocation()
+	var base map[string]any
+	if location == "" {
+		base, _ = readSlotJSON(stepPatchBaseCacheFile, filepath.Join(o.configPath, "00-base.json"), nil)
+	}
+	return cacheDBPathFor(location, base)
 }
 
 // ApplyClashPort приводит experimental.clash_api.external_controller в
@@ -1235,37 +1267,24 @@ func (o *Operator) ApplyBootstrapDNS(server string) error {
 	})
 }
 
-// ApplyCacheFileLocation sets the experimental.cache_file.path in 00-base.json according to location ("flash" or "tmp") (issue #842).
+// ApplyCacheFileLocation приводит experimental.cache_file.path в 00-base.json
+// к месту хранения из настройки (flash | tmp, issue #842). Применяется через
+// reload оркестратора: при tun это Stop+Start, без tun — SIGHUP, который в
+// форке тоже Close + пересоздание, так что соединения рвутся в любом режиме.
+// Хвост правки общий со стартовым шагом (finishCacheFileChange).
 func (o *Operator) ApplyCacheFileLocation(location string) error {
-	desiredPath := ResolveCacheDBPath(location)
-	return o.mutateBase(func(base map[string]any) bool {
-		return reconcileCacheFilePath(base, desiredPath)
+	was, want, changed := "", "", false
+	err := o.mutateBase(func(base map[string]any) bool {
+		was = currentCacheFilePath(base)
+		want, changed = reconcileCacheFile(base, location)
+		return changed
 	})
-}
-
-func reconcileCacheFilePath(base map[string]any, desiredPath string) bool {
-	if desiredPath == "" {
-		desiredPath = defaultCacheDBPath
+	// Хвост только по факту правки: без config.d оркестратор выходит до
+	// мутатора, а при совпадении путей мутатор говорит «менять нечего».
+	if err == nil && changed {
+		finishCacheFileChange(o.log, filepath.Join(o.configPath, "00-base.json"), was, want)
 	}
-	exp, ok := base["experimental"].(map[string]any)
-	if !ok {
-		exp = map[string]any{}
-		base["experimental"] = exp
-	}
-	cf, ok := exp["cache_file"].(map[string]any)
-	if !ok {
-		exp["cache_file"] = map[string]any{
-			"enabled": true,
-			"path":    desiredPath,
-		}
-		return true
-	}
-	curPath, _ := cf["path"].(string)
-	if curPath == desiredPath {
-		return false
-	}
-	cf["path"] = desiredPath
-	return true
+	return err
 }
 
 // mutateBase — общий транспорт правки 00-base.json: прочитать, дать мутатору
@@ -1277,10 +1296,11 @@ func reconcileCacheFilePath(base map[string]any, desiredPath string) bool {
 // — параллельная правка другого скаляра терялась (дефект F41).
 //
 // Оркестратор обязателен: в проде SetOrch вызывается до старта HTTP
-// (wiring_singbox.go), «раннего бута» без него не существует — все три
-// вызывающих (ApplyLogLevel/ApplyClashPort/ApplyBootstrapDNS) достижимы
-// только через HTTP-хуки (server_routes.go). Тесты поднимают оркестратор
-// сами (см. newOrchedOperator).
+// (wiring_singbox.go), «раннего бута» без него не существует — все четыре
+// вызывающих достижимы только из HTTP: ApplyLogLevel/ApplyClashPort/
+// ApplyBootstrapDNS через хуки server_routes.go, ApplyCacheFileLocation —
+// через router.Deps из UpdateSettings (wiring_server.go). Тесты поднимают
+// оркестратор сами (см. newOrchedOperator).
 func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
 	if o.orch == nil {
 		return fmt.Errorf("mutate base config: orchestrator not wired")
@@ -1288,7 +1308,7 @@ func (o *Operator) mutateBase(mutate func(map[string]any) bool) error {
 	// Кандидат на восстановление считается ДО взятия лока оркестратора:
 	// desired* ходят в SettingsStore, а под чужим локом блокирующей работе
 	// делать нечего. Нужен он только в ветке «файла нет».
-	fresh := freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort(), o.desiredCachePath())
+	fresh := freshBaseConfig(o.desiredSingboxLogLevel(), o.desiredBootstrapDNS(), o.desiredClashPort(), cacheDBPathFor(o.desiredCacheLocation(), nil))
 	return o.orch.Mutate(orchestrator.SlotBase, func(data []byte, exists bool) ([]byte, error) {
 		var base map[string]any
 		restored := false

--- a/internal/singbox/operator_baseconfig_bootstrap_test.go
+++ b/internal/singbox/operator_baseconfig_bootstrap_test.go
@@ -46,7 +46,7 @@ func TestFreshBaseConfig_BootstrapServer(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			base := freshBaseConfig("info", c.bootstrap, 0)
+			base := freshBaseConfig("info", c.bootstrap, 0, defaultCacheDBPath)
 			if got := bootstrapServerOf(t, base); got != c.want {
 				t.Errorf("dns-bootstrap.server = %q, want %q", got, c.want)
 			}
@@ -431,7 +431,7 @@ func TestReconcileConfigSteps_IdempotentWithBootstrapDNS(t *testing.T) {
 	})
 
 	run := func() {
-		for _, s := range reconcileConfigSteps(dir, configDir, "info", "8.8.8.8", 0, nil) {
+		for _, s := range reconcileConfigSteps(dir, configDir, "info", "8.8.8.8", 0, "", nil) {
 			s.run()
 		}
 	}
@@ -546,7 +546,7 @@ func TestReconcileConfigSteps_HealsMissingBootstrapEntry(t *testing.T) {
 		map[string]any{"type": "udp", "tag": "dns-custom", "server": "192.168.0.1"},
 	})
 
-	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, nil) {
+	for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, "", nil) {
 		s.run()
 	}
 

--- a/internal/singbox/operator_baseconfig_cache_test.go
+++ b/internal/singbox/operator_baseconfig_cache_test.go
@@ -1,0 +1,122 @@
+package singbox
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func cachePathOf(t *testing.T, base map[string]any) string {
+	t.Helper()
+	exp, ok := base["experimental"].(map[string]any)
+	if !ok {
+		t.Fatalf("experimental block missing: %#v", base["experimental"])
+	}
+	cf, ok := exp["cache_file"].(map[string]any)
+	if !ok {
+		t.Fatalf("cache_file block missing: %#v", exp["cache_file"])
+	}
+	p, _ := cf["path"].(string)
+	return p
+}
+
+func TestResolveCacheDBPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		location string
+		want     string
+	}{
+		{"empty string defaults to flash", "", DefaultCacheDBPath()},
+		{"flash explicitly selects flash", "flash", DefaultCacheDBPath()},
+		{"tmp selects RAM tmpfs path", "tmp", TempCacheDBPath},
+		{"unknown defaults to flash", "other", DefaultCacheDBPath()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveCacheDBPath(tc.location)
+			if got != tc.want {
+				t.Errorf("ResolveCacheDBPath(%q) = %q, want %q", tc.location, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFreshBaseConfig_CachePath(t *testing.T) {
+	baseDefault := freshBaseConfig("info", "", 0)
+	if got := cachePathOf(t, baseDefault); got != DefaultCacheDBPath() {
+		t.Errorf("freshBaseConfig() default cache_file.path = %q, want %q", got, DefaultCacheDBPath())
+	}
+
+	baseTmp := freshBaseConfig("info", "", 0, TempCacheDBPath)
+	if got := cachePathOf(t, baseTmp); got != TempCacheDBPath {
+		t.Errorf("freshBaseConfig() tmp cache_file.path = %q, want %q", got, TempCacheDBPath)
+	}
+}
+
+func TestPatchBaseCacheFileTo(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "00-base.json")
+
+	raw := map[string]any{
+		"experimental": map[string]any{
+			"cache_file": map[string]any{
+				"enabled": true,
+				"path":    DefaultCacheDBPath(),
+			},
+		},
+	}
+	bytes, _ := json.Marshal(raw)
+	if err := os.WriteFile(basePath, bytes, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	patchBaseCacheFileTo(basePath, TempCacheDBPath)
+	data, err := os.ReadFile(basePath)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(data, &updated); err != nil {
+		t.Fatalf("unmarshal file: %v", err)
+	}
+	if got := cachePathOf(t, updated); got != TempCacheDBPath {
+		t.Errorf("after patch to tmp: path = %q, want %q", got, TempCacheDBPath)
+	}
+
+	patchBaseCacheFileTo(basePath, DefaultCacheDBPath())
+	data, _ = os.ReadFile(basePath)
+	_ = json.Unmarshal(data, &updated)
+	if got := cachePathOf(t, updated); got != DefaultCacheDBPath() {
+		t.Errorf("after patch to flash: path = %q, want %q", got, DefaultCacheDBPath())
+	}
+}
+
+func TestOperator_ApplyCacheFileLocation(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.d")
+	basePath := baseWithServers(t, configDir, []any{bootstrapEntry("1.1.1.1")})
+
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
+
+	// Apply "tmp"
+	if err := op.ApplyCacheFileLocation("tmp"); err != nil {
+		t.Fatalf("ApplyCacheFileLocation(tmp): %v", err)
+	}
+
+	parsed := readBaseFixture(t, basePath)
+	if got := cachePathOf(t, parsed); got != TempCacheDBPath {
+		t.Errorf("ApplyCacheFileLocation(tmp) = %q, want %q", got, TempCacheDBPath)
+	}
+
+	// Apply "flash"
+	if err := op.ApplyCacheFileLocation("flash"); err != nil {
+		t.Fatalf("ApplyCacheFileLocation(flash): %v", err)
+	}
+
+	parsed = readBaseFixture(t, basePath)
+	if got := cachePathOf(t, parsed); got != DefaultCacheDBPath() {
+		t.Errorf("ApplyCacheFileLocation(flash) = %q, want %q", got, DefaultCacheDBPath())
+	}
+}

--- a/internal/singbox/operator_baseconfig_cache_test.go
+++ b/internal/singbox/operator_baseconfig_cache_test.go
@@ -1,122 +1,319 @@
 package singbox
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 func cachePathOf(t *testing.T, base map[string]any) string {
 	t.Helper()
-	exp, ok := base["experimental"].(map[string]any)
-	if !ok {
-		t.Fatalf("experimental block missing: %#v", base["experimental"])
+	p := currentCacheFilePath(base)
+	if p == "" {
+		t.Fatalf("cache_file block missing: %#v", base["experimental"])
 	}
-	cf, ok := exp["cache_file"].(map[string]any)
-	if !ok {
-		t.Fatalf("cache_file block missing: %#v", exp["cache_file"])
-	}
-	p, _ := cf["path"].(string)
 	return p
 }
 
-func TestResolveCacheDBPath(t *testing.T) {
+// baseWithCachePath — база с cache_file.path; has=false — блока нет.
+func baseWithCachePath(has bool, path string) map[string]any {
+	base := map[string]any{"experimental": map[string]any{}}
+	if has {
+		base["experimental"].(map[string]any)["cache_file"] = map[string]any{"enabled": true, "path": path}
+	}
+	return base
+}
+
+// ageFile отодвигает mtime на час назад, чтобы assertUntouched отличил
+// «файл не переписан» от «переписан теми же байтами в ту же секунду».
+func ageFile(t *testing.T, path string) time.Time {
+	t.Helper()
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	return old
+}
+
+func assertUntouched(t *testing.T, path string, aged time.Time, what string) {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.ModTime().Equal(aged) {
+		t.Errorf("%s: файл переписан без правки (mtime %v)", what, st.ModTime())
+	}
+}
+
+// redirectCacheDBPaths уводит оба наших пути cache.db в t.TempDir(), чтобы
+// снос устаревшего кэша не касался хоста.
+func redirectCacheDBPaths(t *testing.T, dir string) (flash, tmp string) {
+	t.Helper()
+	prevDefault, prevTemp := defaultCacheDBPath, tempCacheDBPath
+	defaultCacheDBPath = filepath.Join(dir, "flash-cache.db")
+	tempCacheDBPath = filepath.Join(dir, "tmp-cache.db")
+	t.Cleanup(func() { defaultCacheDBPath, tempCacheDBPath = prevDefault, prevTemp })
+	return defaultCacheDBPath, tempCacheDBPath
+}
+
+// Настройка задана — путём владеет она; пуста — рукописный абсолютный путь
+// из base остаётся, заведомо негодный заменяется дефолтом (cacheDBPathFor).
+// Та же таблица гонит reconcileCacheFile: изменена ли base — ровно тогда,
+// когда эффективный путь отличается от текущего.
+func TestCacheDBPathFor_AndReconcile(t *testing.T) {
+	custom := "/srv/sing-box/my-cache.db"
 	cases := []struct {
 		name     string
+		has      bool   // есть ли блок cache_file
+		path     string // его path
 		location string
 		want     string
 	}{
-		{"empty string defaults to flash", "", DefaultCacheDBPath()},
-		{"flash explicitly selects flash", "flash", DefaultCacheDBPath()},
-		{"tmp selects RAM tmpfs path", "tmp", TempCacheDBPath},
-		{"unknown defaults to flash", "other", DefaultCacheDBPath()},
+		{name: "пусто: блока нет → дефолт", location: "", want: defaultCacheDBPath},
+		{name: "пусто: относительный → дефолт", has: true, path: "cache.db", location: "", want: defaultCacheDBPath},
+		{name: "пусто: legacy → дефолт", has: true, path: legacyCacheFilePath, location: "", want: defaultCacheDBPath},
+		{name: "пусто: рукописный остаётся", has: true, path: custom, location: "", want: custom},
+		{name: "пусто: tmp остаётся", has: true, path: tempCacheDBPath, location: "", want: tempCacheDBPath},
+		{name: "flash: рукописный → дефолт", has: true, path: custom, location: storage.CacheFileLocationFlash, want: defaultCacheDBPath},
+		{name: "flash: tmp → дефолт", has: true, path: tempCacheDBPath, location: storage.CacheFileLocationFlash, want: defaultCacheDBPath},
+		{name: "tmp: дефолт → tmp", has: true, path: defaultCacheDBPath, location: storage.CacheFileLocationTmp, want: tempCacheDBPath},
+		{name: "tmp: рукописный → tmp", has: true, path: custom, location: storage.CacheFileLocationTmp, want: tempCacheDBPath},
+		{name: "tmp: блока нет → tmp", location: storage.CacheFileLocationTmp, want: tempCacheDBPath},
 	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := ResolveCacheDBPath(tc.location)
-			if got != tc.want {
-				t.Errorf("ResolveCacheDBPath(%q) = %q, want %q", tc.location, got, tc.want)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := cacheDBPathFor(c.location, baseWithCachePath(c.has, c.path)); got != c.want {
+				t.Errorf("cacheDBPathFor = %q, want %q", got, c.want)
+			}
+			base := baseWithCachePath(c.has, c.path)
+			wantChanged := !c.has || c.path != c.want
+			want, changed := reconcileCacheFile(base, c.location)
+			if changed != wantChanged || want != c.want {
+				t.Errorf("reconcile = (%q, %v), want (%q, %v)", want, changed, c.want, wantChanged)
+			}
+			if got := cachePathOf(t, base); got != c.want {
+				t.Errorf("path = %q, want %q", got, c.want)
 			}
 		})
 	}
 }
 
-func TestFreshBaseConfig_CachePath(t *testing.T) {
-	baseDefault := freshBaseConfig("info", "", 0)
-	if got := cachePathOf(t, baseDefault); got != DefaultCacheDBPath() {
-		t.Errorf("freshBaseConfig() default cache_file.path = %q, want %q", got, DefaultCacheDBPath())
-	}
-
-	baseTmp := freshBaseConfig("info", "", 0, TempCacheDBPath)
-	if got := cachePathOf(t, baseTmp); got != TempCacheDBPath {
-		t.Errorf("freshBaseConfig() tmp cache_file.path = %q, want %q", got, TempCacheDBPath)
+// Пустой config.d: свежая база сразу несёт путь по настройке.
+func TestEnsureBaseConfig_FreshWriteCarriesCachePath(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), "config.d")
+	ensureBaseConfig(configDir, "info", "", 0, storage.CacheFileLocationTmp)
+	if got := cachePathOf(t, readBaseFixture(t, filepath.Join(configDir, "00-base.json"))); got != tempCacheDBPath {
+		t.Errorf("path = %q, want %q", got, tempCacheDBPath)
 	}
 }
 
-func TestPatchBaseCacheFileTo(t *testing.T) {
+// Без блока experimental вовсе (не только cache_file) — достраиваем.
+func TestReconcileCacheFile_BuildsExperimental(t *testing.T) {
+	base := map[string]any{}
+	if _, changed := reconcileCacheFile(base, storage.CacheFileLocationTmp); !changed {
+		t.Fatal("changed = false")
+	}
+	if got := cachePathOf(t, base); got != tempCacheDBPath {
+		t.Errorf("path = %q, want %q", got, tempCacheDBPath)
+	}
+}
+
+// Стартовый шаг пишет файл и логирует старый путь; отсутствующий блок в логе
+// назван явно, а не пустой строкой.
+func TestPatchBaseCacheFilePath_WritesAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
 	dir := t.TempDir()
-	basePath := filepath.Join(dir, "00-base.json")
+	p := filepath.Join(dir, "00-base.json")
+	writeFixtureJSON(t, p, baseWithCachePath(true, "cache.db"))
 
-	raw := map[string]any{
-		"experimental": map[string]any{
-			"cache_file": map[string]any{
-				"enabled": true,
-				"path":    DefaultCacheDBPath(),
-			},
-		},
+	patchBaseCacheFilePath(p, storage.CacheFileLocationTmp, log)
+	if got := cachePathOf(t, readBaseFixture(t, p)); got != tempCacheDBPath {
+		t.Errorf("path = %q, want %q", got, tempCacheDBPath)
 	}
-	bytes, _ := json.Marshal(raw)
-	if err := os.WriteFile(basePath, bytes, 0644); err != nil {
-		t.Fatalf("write file: %v", err)
+	if !strings.Contains(buf.String(), "oldCachePath=cache.db") || !strings.Contains(buf.String(), "newCachePath="+tempCacheDBPath) {
+		t.Errorf("лог без старого/нового пути: %s", buf.String())
 	}
 
-	patchBaseCacheFileTo(basePath, TempCacheDBPath)
-	data, err := os.ReadFile(basePath)
-	if err != nil {
-		t.Fatalf("read file: %v", err)
-	}
-	var updated map[string]any
-	if err := json.Unmarshal(data, &updated); err != nil {
-		t.Fatalf("unmarshal file: %v", err)
-	}
-	if got := cachePathOf(t, updated); got != TempCacheDBPath {
-		t.Errorf("after patch to tmp: path = %q, want %q", got, TempCacheDBPath)
-	}
-
-	patchBaseCacheFileTo(basePath, DefaultCacheDBPath())
-	data, _ = os.ReadFile(basePath)
-	_ = json.Unmarshal(data, &updated)
-	if got := cachePathOf(t, updated); got != DefaultCacheDBPath() {
-		t.Errorf("after patch to flash: path = %q, want %q", got, DefaultCacheDBPath())
+	buf.Reset()
+	writeFixtureJSON(t, p, baseWithCachePath(false, ""))
+	patchBaseCacheFilePath(p, storage.CacheFileLocationTmp, log)
+	if !strings.Contains(buf.String(), "oldCachePath=<none>") {
+		t.Errorf("отсутствующий блок не назван в логе: %s", buf.String())
 	}
 }
 
+// Смысл настройки "tmp" — беречь флеш: стартовое примирение обязано
+// привести путь за одну запись, снести устаревший cache.db на флеше (как и
+// живое применение) и не трогать файл на следующих бутах.
+func TestReconcileConfigSteps_TmpCachePathStableAcrossBoots(t *testing.T) {
+	dir := t.TempDir()
+	flashDB, _ := redirectCacheDBPaths(t, dir)
+	if err := os.WriteFile(flashDB, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configDir := filepath.Join(dir, "config.d")
+	ensureBaseConfig(configDir, "info", "", 0, "")
+	basePath := filepath.Join(configDir, "00-base.json")
+
+	run := func() {
+		for _, s := range reconcileConfigSteps(dir, configDir, "info", "", 0, storage.CacheFileLocationTmp, nil) {
+			s.run()
+		}
+	}
+	run()
+	if got := cachePathOf(t, readBaseFixture(t, basePath)); got != tempCacheDBPath {
+		t.Fatalf("after first boot path = %q, want %q", got, tempCacheDBPath)
+	}
+	if _, err := os.Stat(flashDB); !os.IsNotExist(err) {
+		t.Errorf("устаревший cache.db на флеше пережил стартовый переезд в tmp: %v", err)
+	}
+
+	aged := ageFile(t, basePath)
+	run()
+	assertUntouched(t, basePath, aged, "second boot")
+}
+
+// Живое применение переключает путь в обе стороны, а лог пишется только по
+// факту правки: совпадающий путь и отсутствующий config.d — без строки.
+// Переезд сносит кэш по покинутому пути в обе стороны, откат его не
+// воскрешает.
 func TestOperator_ApplyCacheFileLocation(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
 	basePath := baseWithServers(t, configDir, []any{bootstrapEntry("1.1.1.1")})
+	flashDB, tmpDB := redirectCacheDBPaths(t, dir)
+	if err := os.WriteFile(flashDB, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir, Log: slog.New(slog.NewTextHandler(&buf, nil))})
+	logged := func() bool {
+		defer buf.Reset()
+		return strings.Contains(buf.String(), stepPatchBaseCacheFile)
+	}
+	buf.Reset() // строки стартового примирения не в счёт
 
-	op := newOrchedOperatorWithDeps(t, OperatorDeps{Dir: dir})
-
-	// Apply "tmp"
-	if err := op.ApplyCacheFileLocation("tmp"); err != nil {
+	if err := op.ApplyCacheFileLocation(storage.CacheFileLocationTmp); err != nil {
 		t.Fatalf("ApplyCacheFileLocation(tmp): %v", err)
 	}
-
-	parsed := readBaseFixture(t, basePath)
-	if got := cachePathOf(t, parsed); got != TempCacheDBPath {
-		t.Errorf("ApplyCacheFileLocation(tmp) = %q, want %q", got, TempCacheDBPath)
+	if got := cachePathOf(t, readBaseFixture(t, basePath)); got != tempCacheDBPath {
+		t.Errorf("tmp: path = %q, want %q", got, tempCacheDBPath)
+	}
+	if !logged() {
+		t.Error("tmp: перезапись пути не залогирована")
+	}
+	if _, err := os.Stat(flashDB); !os.IsNotExist(err) {
+		t.Errorf("старый cache.db на флеше не удалён: %v", err)
 	}
 
-	// Apply "flash"
-	if err := op.ApplyCacheFileLocation("flash"); err != nil {
+	// Повтор: файл переформатирован компактно, чтобы байт-гейт оркестратора
+	// не спас мутатор, вернувший «изменено» без правки, — «не пишем» обязан
+	// держать сам reconcileCacheFile.
+	compact, err := json.Marshal(readBaseFixture(t, basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(basePath, compact, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aged := ageFile(t, basePath)
+	if err := op.ApplyCacheFileLocation(storage.CacheFileLocationTmp); err != nil {
+		t.Fatalf("ApplyCacheFileLocation(tmp) repeat: %v", err)
+	}
+	if logged() {
+		t.Error("repeat: лог без правки")
+	}
+	assertUntouched(t, basePath, aged, "repeat")
+
+	if err := os.WriteFile(tmpDB, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := op.ApplyCacheFileLocation(storage.CacheFileLocationFlash); err != nil {
 		t.Fatalf("ApplyCacheFileLocation(flash): %v", err)
 	}
+	if got := cachePathOf(t, readBaseFixture(t, basePath)); got != flashDB {
+		t.Errorf("flash: path = %q, want %q", got, flashDB)
+	}
+	if !logged() {
+		t.Error("flash: перезапись пути не залогирована")
+	}
+	if _, err := os.Stat(tmpDB); !os.IsNotExist(err) {
+		t.Errorf("старый cache.db в RAM не удалён при откате: %v", err)
+	}
 
-	parsed = readBaseFixture(t, basePath)
-	if got := cachePathOf(t, parsed); got != DefaultCacheDBPath() {
-		t.Errorf("ApplyCacheFileLocation(flash) = %q, want %q", got, DefaultCacheDBPath())
+	// Рукописный путь → flash: рукописный файл не наш, не трогаем.
+	custom := filepath.Join(dir, "my-cache.db")
+	if err := os.WriteFile(custom, []byte("mine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureJSON(t, basePath, baseWithCachePath(true, custom))
+	if err := op.ApplyCacheFileLocation(storage.CacheFileLocationFlash); err != nil {
+		t.Fatalf("ApplyCacheFileLocation(flash) from custom: %v", err)
+	}
+	if _, err := os.Stat(custom); err != nil {
+		t.Errorf("рукописный cache.db снесён: %v", err)
+	}
+	buf.Reset()
+
+	if err := os.RemoveAll(configDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := op.ApplyCacheFileLocation(storage.CacheFileLocationTmp); err != nil {
+		t.Fatalf("ApplyCacheFileLocation without config.d: %v", err)
+	}
+	if logged() {
+		t.Error("без config.d: лог без правки")
+	}
+}
+
+// Эффективный путь для overlay и статуса: рукописный путь из 00-base.json
+// при пустой настройке, путь по настройке при заданной, дефолт без файла.
+func TestOperator_CacheDBPath(t *testing.T) {
+	custom := "/srv/sing-box/my-cache.db"
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.d")
+	basePath := filepath.Join(configDir, "00-base.json")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureJSON(t, basePath, baseWithCachePath(true, custom))
+	location := ""
+	op := NewOperator(OperatorDeps{Dir: dir, CacheFileLocation: func() string { return location }})
+
+	if got := op.CacheDBPath(); got != custom {
+		t.Errorf("пусто: %q, want %q (рукописный путь)", got, custom)
+	}
+	location = storage.CacheFileLocationTmp
+	if got := op.CacheDBPath(); got != tempCacheDBPath {
+		t.Errorf("tmp: %q, want %q", got, tempCacheDBPath)
+	}
+	location = ""
+	if err := os.Remove(basePath); err != nil {
+		t.Fatal(err)
+	}
+	if got := op.CacheDBPath(); got != defaultCacheDBPath {
+		t.Errorf("без файла: %q, want %q", got, defaultCacheDBPath)
+	}
+}
+
+// Настройка "tmp" доезжает до 00-base.json уже на старте оператора.
+func TestNewOperator_CacheFileLocationTmp(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.d")
+	basePath := baseWithServers(t, configDir, []any{bootstrapEntry("1.1.1.1")})
+
+	NewOperator(OperatorDeps{Dir: dir, CacheFileLocation: func() string { return storage.CacheFileLocationTmp }})
+
+	if got := cachePathOf(t, readBaseFixture(t, basePath)); got != tempCacheDBPath {
+		t.Errorf("path = %q, want %q", got, tempCacheDBPath)
 	}
 }

--- a/internal/singbox/operator_test.go
+++ b/internal/singbox/operator_test.go
@@ -171,7 +171,7 @@ func TestOperator_GetStatus_PopulatesInstallStateAndBytes(t *testing.T) {
 func TestEnsureBaseConfig_FullSkeleton(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 
 	raw, err := os.ReadFile(filepath.Join(configDir, "00-base.json"))
 	if err != nil {
@@ -235,9 +235,9 @@ func TestEnsureBaseConfig_Idempotent(t *testing.T) {
 	}
 	// First call applies surgical heals (e.g. route.default_domain_resolver
 	// for sing-box 1.13+). Second call must be a no-op — same bytes.
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	first, _ := os.ReadFile(basePath)
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	second, _ := os.ReadFile(basePath)
 	if string(first) != string(second) {
 		t.Errorf("ensureBaseConfig not idempotent: first=%s second=%s", first, second)
@@ -259,7 +259,7 @@ func TestEnsureBaseConfig_PatchesStaleClashPort(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -299,7 +299,7 @@ func TestEnsureBaseConfig_MissingClashApiBlockRestored(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -337,7 +337,7 @@ func TestEnsureBaseConfig_PatchesStaleLogLevel(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -360,7 +360,7 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -372,7 +372,7 @@ func TestEnsureBaseConfig_DefaultDesiredLevelOverridesDebug(t *testing.T) {
 func TestEnsureBaseConfigWithLogLevel_UsesDesiredLevel(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config.d")
-	ensureBaseConfig(configDir, "warn", "", 0)
+	ensureBaseConfig(configDir, "warn", "", 0, "")
 
 	raw, err := os.ReadFile(filepath.Join(configDir, "00-base.json"))
 	if err != nil {
@@ -506,7 +506,7 @@ func TestEnsureBaseConfig_PatchesMissingDomainResolver(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -539,7 +539,7 @@ func TestEnsureBaseConfig_RespectsExistingDomainResolver(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -560,7 +560,7 @@ func TestEnsureBaseConfig_MaterialisesMissingRouteBlock(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -594,7 +594,7 @@ func TestEnsureBaseConfig_MigratesIpv4OnlyStrategy(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -617,7 +617,7 @@ func TestEnsureBaseConfig_KeepsNonLegacyStrategy(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -721,7 +721,7 @@ func TestClassifyProcessLine(t *testing.T) {
 }
 
 func TestFreshBaseConfig_CacheFilePathIsAbsolute(t *testing.T) {
-	cfg := freshBaseConfig("info", "", 0)
+	cfg := freshBaseConfig("info", "", 0, defaultCacheDBPath)
 	exp := cfg["experimental"].(map[string]any)
 	cf := exp["cache_file"].(map[string]any)
 	if cf["enabled"] != true {
@@ -731,128 +731,6 @@ func TestFreshBaseConfig_CacheFilePathIsAbsolute(t *testing.T) {
 	want := defaultCacheDBPath
 	if got != want {
 		t.Errorf("cache_file.path=%q want %q", got, want)
-	}
-}
-
-func TestEnsureBaseConfig_PatchesRelativeCachePath(t *testing.T) {
-	dir := t.TempDir()
-	configDir := filepath.Join(dir, "config.d")
-	_ = os.MkdirAll(configDir, 0755)
-	stale := `{"log":{"level":"debug"},"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"},"cache_file":{"enabled":true,"path":"cache.db"}}}`
-	basePath := filepath.Join(configDir, "00-base.json")
-	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
-		t.Fatal(err)
-	}
-	ensureBaseConfig(configDir, "info", "", 0)
-	raw, _ := os.ReadFile(basePath)
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	exp := m["experimental"].(map[string]any)
-	cf := exp["cache_file"].(map[string]any)
-	if cf["path"] != defaultCacheDBPath {
-		t.Errorf("expected %s, got %v", defaultCacheDBPath, cf["path"])
-	}
-	if m["log"].(map[string]any)["level"] != "info" {
-		t.Errorf("log.level want info, got %v", m["log"])
-	}
-}
-
-func TestEnsureBaseConfig_LeavesAbsoluteCachePathUntouched(t *testing.T) {
-	dir := t.TempDir()
-	configDir := filepath.Join(dir, "config.d")
-	_ = os.MkdirAll(configDir, 0755)
-	custom := `{"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"},"cache_file":{"enabled":true,"path":"/custom/path/cache.db"}}}`
-	basePath := filepath.Join(configDir, "00-base.json")
-	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
-		t.Fatal(err)
-	}
-	ensureBaseConfig(configDir, "info", "", 0)
-	raw, _ := os.ReadFile(basePath)
-	var m map[string]any
-	json.Unmarshal(raw, &m)
-	exp := m["experimental"].(map[string]any)
-	cf := exp["cache_file"].(map[string]any)
-	if cf["path"] != "/custom/path/cache.db" {
-		t.Errorf("user-customized path overwritten: %v", cf["path"])
-	}
-}
-
-func TestPatchBaseCacheFilePath_AddsMissingBlock(t *testing.T) {
-	dir := t.TempDir()
-	p := filepath.Join(dir, "00-base.json")
-	// experimental exists but no cache_file
-	stale := `{"experimental":{"clash_api":{"external_controller":"127.0.0.1:9099"}}}`
-	if err := os.WriteFile(p, []byte(stale), 0644); err != nil {
-		t.Fatal(err)
-	}
-	patchBaseCacheFilePath(p)
-	raw, err := os.ReadFile(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatal(err)
-	}
-	exp := m["experimental"].(map[string]any)
-	cf, ok := exp["cache_file"].(map[string]any)
-	if !ok {
-		t.Fatal("cache_file block not added")
-	}
-	if cf["enabled"] != true {
-		t.Errorf("enabled=%v want true", cf["enabled"])
-	}
-	if got := cf["path"]; got != defaultCacheDBPath {
-		t.Errorf("path=%q want %q", got, defaultCacheDBPath)
-	}
-}
-
-func TestPatchBaseCacheFilePath_MigratesLegacyAbsolute(t *testing.T) {
-	dir := t.TempDir()
-	p := filepath.Join(dir, "00-base.json")
-	stale := `{"experimental":{"cache_file":{"enabled":true,"path":"/opt/etc/sing-box/cache.db"}}}`
-	if err := os.WriteFile(p, []byte(stale), 0644); err != nil {
-		t.Fatal(err)
-	}
-	patchBaseCacheFilePath(p)
-	raw, err := os.ReadFile(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatal(err)
-	}
-	exp := m["experimental"].(map[string]any)
-	cf := exp["cache_file"].(map[string]any)
-	if got := cf["path"]; got != defaultCacheDBPath {
-		t.Errorf("path=%q want %q (legacy should be replaced)", got, defaultCacheDBPath)
-	}
-}
-
-func TestPatchBaseCacheFilePath_PreservesUserCustomPath(t *testing.T) {
-	dir := t.TempDir()
-	p := filepath.Join(dir, "00-base.json")
-	custom := "/srv/sing-box/my-cache.db"
-	stale := `{"experimental":{"cache_file":{"enabled":true,"path":"` + custom + `"}}}`
-	if err := os.WriteFile(p, []byte(stale), 0644); err != nil {
-		t.Fatal(err)
-	}
-	patchBaseCacheFilePath(p)
-	raw, err := os.ReadFile(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatal(err)
-	}
-	exp := m["experimental"].(map[string]any)
-	cf := exp["cache_file"].(map[string]any)
-	if got := cf["path"]; got != custom {
-		t.Errorf("path=%q want %q (custom path should be preserved)", got, custom)
 	}
 }
 
@@ -1206,7 +1084,7 @@ func TestEnsureBaseConfig_PatchesMissingDirectOutbound(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(stale), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -1233,7 +1111,7 @@ func TestEnsureBaseConfig_PreservesExistingDirectOutbound(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, _ := os.ReadFile(basePath)
 	var m map[string]any
 	_ = json.Unmarshal(raw, &m)
@@ -1258,7 +1136,7 @@ func TestEnsureBaseConfig_PrependsDirectWhenMissing(t *testing.T) {
 	if err := os.WriteFile(basePath, []byte(custom), 0644); err != nil {
 		t.Fatal(err)
 	}
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 	raw, err := os.ReadFile(basePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1300,7 +1178,7 @@ func TestEnsureBaseConfig_MovesExistingDirectToFirstOutbound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureBaseConfig(configDir, "info", "", 0)
+	ensureBaseConfig(configDir, "info", "", 0, "")
 
 	raw, err := os.ReadFile(basePath)
 	if err != nil {
@@ -1945,7 +1823,7 @@ func TestRemoveFinalFromBase_MalformedJSON_NoOp(t *testing.T) {
 // --- freshBaseConfig DNS (#445) ---
 
 func TestFreshBaseConfig_OmitsDNSFinal_KeepsStrategy(t *testing.T) {
-	cfg := freshBaseConfig("info", "", 0)
+	cfg := freshBaseConfig("info", "", 0, defaultCacheDBPath)
 	dns, ok := cfg["dns"].(map[string]any)
 	if !ok {
 		t.Fatalf("dns block missing/wrong type: %v", cfg["dns"])

--- a/internal/singbox/reconcile_prologue_test.go
+++ b/internal/singbox/reconcile_prologue_test.go
@@ -21,7 +21,7 @@ func TestPatchers_WarnOnBrokenFile_SilentOnMissing(t *testing.T) {
 		{"patch-base-clash-port", func(p string, l *slog.Logger) { patchBaseClashPort(p, 0, l) }},
 		{"patch-base-log-level", func(p string, l *slog.Logger) { patchBaseLogLevel(p, "info", l) }},
 		{"patch-base-direct-outbound", func(p string, l *slog.Logger) { patchBaseDirectOutbound(p, l) }},
-		{"patch-base-cache-file", func(p string, l *slog.Logger) { patchBaseCacheFilePath(p, l) }},
+		{"patch-base-cache-file", func(p string, l *slog.Logger) { patchBaseCacheFilePath(p, "", l) }},
 		{"strip-base-owned-blocks", func(p string, l *slog.Logger) { patchTunnelsSlotStripBaseOwnedBlocks(p, l) }},
 		{"remove-route-final", func(p string, l *slog.Logger) { removeFinalFromBase(p, l) }},
 		{"remove-dns-final", func(p string, l *slog.Logger) { removeDNSFinalFromBase(p, l) }},

--- a/internal/singbox/reconcile_steps_test.go
+++ b/internal/singbox/reconcile_steps_test.go
@@ -171,7 +171,7 @@ func runReconcile(t *testing.T, dir string, reversed bool) {
 	if err := MigrateLegacyConfigDir(dir); err != nil {
 		t.Fatalf("MigrateLegacyConfigDir: %v", err)
 	}
-	steps := reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, nil)
+	steps := reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, "", nil)
 	if reversed {
 		for i, j := 0, len(steps)-1; i < j; i, j = i+1, j-1 {
 			steps[i], steps[j] = steps[j], steps[i]
@@ -325,7 +325,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 		},
 		stepMigrateLegacyTunnels: func(t *testing.T) string { // legacy без config.d/10-tunnels
 			dir := t.TempDir()
-			writeFixtureJSON(t, filepath.Join(dir, "config.d", "00-base.json"), freshBaseConfig("info", "", 0))
+			writeFixtureJSON(t, filepath.Join(dir, "config.d", "00-base.json"), freshBaseConfig("info", "", 0, defaultCacheDBPath))
 			writeFixtureJSON(t, filepath.Join(dir, "config.json"), map[string]any{
 				"outbounds": []any{map[string]any{"type": "naive", "tag": "nv1", "server": "s", "server_port": 443}},
 				"route":     map[string]any{"rules": []any{}},
@@ -402,7 +402,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 		},
 	}
 
-	for _, s := range reconcileConfigSteps("", "", "info", "", 0, nil) {
+	for _, s := range reconcileConfigSteps("", "", "info", "", 0, "", nil) {
 		mk, ok := fixtures[s.name]
 		if !ok {
 			t.Fatalf("шаг %q без фикстуры идемпотентности — дополните таблицу", s.name)
@@ -424,7 +424,7 @@ func TestReconcileConfigSteps_EachStepIdempotent(t *testing.T) {
 
 func findReconcileStep(t *testing.T, dir, name string) reconcileStep {
 	t.Helper()
-	for _, s := range reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, nil) {
+	for _, s := range reconcileConfigSteps(dir, filepath.Join(dir, "config.d"), "info", "", 0, "", nil) {
 		if s.name == name {
 			return s
 		}

--- a/internal/singbox/router/fakeip_config.go
+++ b/internal/singbox/router/fakeip_config.go
@@ -237,7 +237,7 @@ func (s *ServiceImpl) ensureFakeIPOverlayFromState(cfg *RouterConfig) error {
 	if err != nil {
 		return fmt.Errorf("fakeip overlay: normalize settings: %w", err)
 	}
-	p := s.resolveFakeIPParams(sr)
+	p := s.fakeIPParamsWithCache(sr)
 	spec := FakeIPTunSpec{
 		Iface:      tunIfaceName(st.Index),
 		TunAddr4:   p.TunAddr4,

--- a/internal/singbox/router/fakeip_enable.go
+++ b/internal/singbox/router/fakeip_enable.go
@@ -39,10 +39,11 @@ var fakeIPAddrFlush = func(ctx context.Context, iface string) error {
 // persisted index) and rolls back ALL partial work in reverse on any failure so
 // no orphaned iface / stale persist is left behind.
 func (s *ServiceImpl) enableFakeIPTun(ctx context.Context, settings *storage.Settings, sr storage.SingboxRouterSettings) (err error) {
-	// resolveFakeIPParams overlays user-editable settings (pool4/6, MTU) from sr
-	// onto the wired static defaults. Single source of truth — shared with the
-	// fakeip config overlay (ensureFakeIPOverlayFromState).
-	p := s.resolveFakeIPParams(sr)
+	// fakeIPParamsWithCache overlays user-editable settings (pool4/6, MTU) from
+	// sr onto the wired static defaults plus the effective cache.db path. Single
+	// source of truth — shared with the fakeip config overlay
+	// (ensureFakeIPOverlayFromState).
+	p := s.fakeIPParamsWithCache(sr)
 
 	// Fail-fast nil-guard: production wires every fakeip dep, but a degraded /
 	// mis-wired build would otherwise nil-panic mid-provision. Refuse loudly

--- a/internal/singbox/router/fakeip_provision.go
+++ b/internal/singbox/router/fakeip_provision.go
@@ -107,6 +107,8 @@ type FakeIPTunParams struct {
 	// Not a spec-default — wired by cmd/awg-manager from singbox.DefaultCacheDBPath
 	// so the router stays decoupled from the operator's path layout.
 	CachePath string
+	// TempCachePath is the RAM tmpfs path (/tmp/singbox-cache.db) used when CacheFileLocation == "tmp" (issue #842).
+	TempCachePath string
 }
 
 // DefaultFakeIPTunParams returns the spec-default fakeip-tun provisioning knobs
@@ -114,12 +116,13 @@ type FakeIPTunParams struct {
 // Single source of truth for the wiring site in cmd/awg-manager and tests.
 func DefaultFakeIPTunParams() FakeIPTunParams {
 	return FakeIPTunParams{
-		Inet4Range: "198.18.0.0/15",
-		Inet6Range: "fc00::/18",
-		TunAddr4:   "172.18.0.1/30",
-		TunAddr6:   "fdfe:dcba:9876::1/126",
-		MTU:        1500,
-		RealServer: "1.1.1.1", // default upstream; user-overridable via FakeIPRealServer
+		Inet4Range:    "198.18.0.0/15",
+		Inet6Range:    "fc00::/18",
+		TunAddr4:      "172.18.0.1/30",
+		TunAddr6:      "fdfe:dcba:9876::1/126",
+		MTU:           1500,
+		RealServer:    "1.1.1.1", // default upstream; user-overridable via FakeIPRealServer
+		TempCachePath: "/tmp/singbox-cache.db",
 		// CachePath left empty — wired by main.go from singbox.DefaultCacheDBPath.
 	}
 }
@@ -167,6 +170,9 @@ func resolveFakeIPParamsWith(base FakeIPTunParams, sr storage.SingboxRouterSetti
 	}
 	if sr.FakeIPRealServer != "" {
 		p.RealServer = sr.FakeIPRealServer
+	}
+	if sr.CacheFileLocation == "tmp" && base.TempCachePath != "" {
+		p.CachePath = base.TempCachePath
 	}
 	return p
 }

--- a/internal/singbox/router/fakeip_provision.go
+++ b/internal/singbox/router/fakeip_provision.go
@@ -104,11 +104,9 @@ type FakeIPTunParams struct {
 	// (resolveFakeIPParams).
 	RealServer string
 	// CachePath is the sing-box experimental.cache_file path (store_fakeip).
-	// Not a spec-default — wired by cmd/awg-manager from singbox.DefaultCacheDBPath
-	// so the router stays decoupled from the operator's path layout.
+	// Not a Deps input: fakeIPParamsWithCache fills it from Deps.CacheDBPath
+	// (the operator's effective path, issue #842) on the way to the overlay spec.
 	CachePath string
-	// TempCachePath is the RAM tmpfs path (/tmp/singbox-cache.db) used when CacheFileLocation == "tmp" (issue #842).
-	TempCachePath string
 }
 
 // DefaultFakeIPTunParams returns the spec-default fakeip-tun provisioning knobs
@@ -116,14 +114,13 @@ type FakeIPTunParams struct {
 // Single source of truth for the wiring site in cmd/awg-manager and tests.
 func DefaultFakeIPTunParams() FakeIPTunParams {
 	return FakeIPTunParams{
-		Inet4Range:    "198.18.0.0/15",
-		Inet6Range:    "fc00::/18",
-		TunAddr4:      "172.18.0.1/30",
-		TunAddr6:      "fdfe:dcba:9876::1/126",
-		MTU:           1500,
-		RealServer:    "1.1.1.1", // default upstream; user-overridable via FakeIPRealServer
-		TempCachePath: "/tmp/singbox-cache.db",
-		// CachePath left empty — wired by main.go from singbox.DefaultCacheDBPath.
+		Inet4Range: "198.18.0.0/15",
+		Inet6Range: "fc00::/18",
+		TunAddr4:   "172.18.0.1/30",
+		TunAddr6:   "fdfe:dcba:9876::1/126",
+		MTU:        1500,
+		RealServer: "1.1.1.1", // default upstream; user-overridable via FakeIPRealServer
+		// CachePath left empty — fakeIPParamsWithCache takes Deps.CacheDBPath.
 	}
 }
 
@@ -131,6 +128,18 @@ func DefaultFakeIPTunParams() FakeIPTunParams {
 // живых настроек, а не из снимка времени сборки зависимостей.
 func (s *ServiceImpl) resolveFakeIPParams(sr storage.SingboxRouterSettings) FakeIPTunParams {
 	return resolveFakeIPParamsWith(s.deps.FakeIPTun, sr, s.bootstrapDNS())
+}
+
+// fakeIPParamsWithCache — параметры для overlay и спеки: плюс эффективный
+// путь cache.db у оператора (issue #842). Отдельно от resolveFakeIPParams,
+// который зовётся с тика планировщика ради адресов и пулов и не должен
+// ради них читать 00-base.json с флеша.
+func (s *ServiceImpl) fakeIPParamsWithCache(sr storage.SingboxRouterSettings) FakeIPTunParams {
+	p := s.resolveFakeIPParams(sr)
+	if s.deps.CacheDBPath != nil {
+		p.CachePath = s.deps.CacheDBPath()
+	}
+	return p
 }
 
 // bootstrapDNS читает общий адрес bootstrap-резолвера; пусто, когда стор не
@@ -170,9 +179,6 @@ func resolveFakeIPParamsWith(base FakeIPTunParams, sr storage.SingboxRouterSetti
 	}
 	if sr.FakeIPRealServer != "" {
 		p.RealServer = sr.FakeIPRealServer
-	}
-	if sr.CacheFileLocation == "tmp" && base.TempCachePath != "" {
-		p.CachePath = base.TempCachePath
 	}
 	return p
 }

--- a/internal/singbox/router/fakeip_provision_test.go
+++ b/internal/singbox/router/fakeip_provision_test.go
@@ -3,6 +3,8 @@ package router
 import (
 	"context"
 	"testing"
+
+	"github.com/hoaxisr/awg-manager/internal/storage"
 )
 
 // fakeOpkgTunProvisioner / fakeStaticRouteProvider / fakeOpkgTunIndexLister are
@@ -69,3 +71,28 @@ func TestNewServiceWiresFakeIPProvisioningSeam(t *testing.T) {
 		t.Errorf("FakeIPTun mismatch: got %+v, want %+v", svc.deps.FakeIPTun, params)
 	}
 }
+
+func TestResolveFakeIPParams_CacheFileLocation(t *testing.T) {
+	base := DefaultFakeIPTunParams()
+	base.CachePath = "/opt/etc/awg-manager/singbox/cache.db"
+	base.TempCachePath = "/tmp/singbox-cache.db"
+
+	// Default / empty -> base CachePath preserved
+	pDefault := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{}, "")
+	if pDefault.CachePath != "/opt/etc/awg-manager/singbox/cache.db" {
+		t.Errorf("expected default cache path, got %q", pDefault.CachePath)
+	}
+
+	// flash -> base CachePath preserved
+	pFlash := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{CacheFileLocation: "flash"}, "")
+	if pFlash.CachePath != "/opt/etc/awg-manager/singbox/cache.db" {
+		t.Errorf("expected flash cache path, got %q", pFlash.CachePath)
+	}
+
+	// tmp -> TempCachePath used
+	pTmp := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{CacheFileLocation: "tmp"}, "")
+	if pTmp.CachePath != "/tmp/singbox-cache.db" {
+		t.Errorf("expected tmp cache path, got %q", pTmp.CachePath)
+	}
+}
+

--- a/internal/singbox/router/fakeip_provision_test.go
+++ b/internal/singbox/router/fakeip_provision_test.go
@@ -72,27 +72,18 @@ func TestNewServiceWiresFakeIPProvisioningSeam(t *testing.T) {
 	}
 }
 
-func TestResolveFakeIPParams_CacheFileLocation(t *testing.T) {
-	base := DefaultFakeIPTunParams()
-	base.CachePath = "/opt/etc/awg-manager/singbox/cache.db"
-	base.TempCachePath = "/tmp/singbox-cache.db"
-
-	// Default / empty -> base CachePath preserved
-	pDefault := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{}, "")
-	if pDefault.CachePath != "/opt/etc/awg-manager/singbox/cache.db" {
-		t.Errorf("expected default cache path, got %q", pDefault.CachePath)
+// resolveFakeIPParams зовётся с тика планировщика ради адресов и пулов —
+// эффективный путь cache.db (чтение 00-base.json с флеша) берёт только
+// fakeIPParamsWithCache, на пути к overlay.
+func TestResolveFakeIPParams_DoesNotReadCacheDBPath(t *testing.T) {
+	svc := newTestService(t, Deps{FakeIPTun: DefaultFakeIPTunParams()})
+	calls := 0
+	svc.deps.CacheDBPath = func() string { calls++; return "/x/cache.db" }
+	sr := storage.SingboxRouterSettings{}
+	if got := svc.resolveFakeIPParams(sr).CachePath; got != "" || calls != 0 {
+		t.Errorf("resolveFakeIPParams: CachePath=%q, calls=%d — читает путь кэша с тика", got, calls)
 	}
-
-	// flash -> base CachePath preserved
-	pFlash := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{CacheFileLocation: "flash"}, "")
-	if pFlash.CachePath != "/opt/etc/awg-manager/singbox/cache.db" {
-		t.Errorf("expected flash cache path, got %q", pFlash.CachePath)
-	}
-
-	// tmp -> TempCachePath used
-	pTmp := resolveFakeIPParamsWith(base, storage.SingboxRouterSettings{CacheFileLocation: "tmp"}, "")
-	if pTmp.CachePath != "/tmp/singbox-cache.db" {
-		t.Errorf("expected tmp cache path, got %q", pTmp.CachePath)
+	if got := svc.fakeIPParamsWithCache(sr).CachePath; got != "/x/cache.db" || calls != 1 {
+		t.Errorf("fakeIPParamsWithCache: CachePath=%q, calls=%d", got, calls)
 	}
 }
-

--- a/internal/singbox/router/fakeip_transition_test.go
+++ b/internal/singbox/router/fakeip_transition_test.go
@@ -55,7 +55,7 @@ func newTransitionHarness(t *testing.T) *transitionHarness {
 	svc.deps.StaticRoutes = &recStaticRoutes{log: log}
 	svc.deps.OpkgTunIndices = &recIndices{live: map[int]bool{}}
 	svc.deps.FakeIPTun = DefaultFakeIPTunParams()
-	svc.deps.FakeIPTun.CachePath = filepath.Join(dir, "cache.db")
+	svc.deps.CacheDBPath = func() string { return filepath.Join(dir, "cache.db") }
 
 	// policy-tun deps (общий с fakeip OpkgTun/индексы + парковка дефолта).
 	svc.deps.DefaultRoute = &recDefaultRoute{log: log}

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -308,6 +308,8 @@ type Deps struct {
 	// router is enabled. When nil (tests), persistConfig falls back
 	// to the legacy in-place write at routerConfigPath().
 	Orch *orchestrator.Orchestrator
+	// ApplyCacheFileLocation applies cache.db location change to 00-base.json (issue #842).
+	ApplyCacheFileLocation func(location string) error
 	// Bus receives resource:invalidated events for the staging/draft
 	// flow (SaveDraft, ApplyDraft, DiscardDraft). Optional — when nil,
 	// staging event emission is silently skipped.

--- a/internal/singbox/router/service.go
+++ b/internal/singbox/router/service.go
@@ -308,8 +308,16 @@ type Deps struct {
 	// router is enabled. When nil (tests), persistConfig falls back
 	// to the legacy in-place write at routerConfigPath().
 	Orch *orchestrator.Orchestrator
-	// ApplyCacheFileLocation applies cache.db location change to 00-base.json (issue #842).
+	// ApplyCacheFileLocation доводит место хранения cache.db до 00-base.json
+	// (issue #842). Optional — nil пропускается. Шов живёт здесь, а не среди
+	// SettingsHandler.SetApply* как у соседних base-настроек, потому что поле
+	// лежит в SingboxRouterSettings и применяется тем же PUT, что и overlay.
 	ApplyCacheFileLocation func(location string) error
+	// CacheDBPath — эффективный путь cache.db у оператора (Operator.CacheDBPath):
+	// один источник для overlay 21-fakeip.json и статуса, чтобы рукописный путь
+	// в 00-base.json действовал и в fakeip-tun. Optional — при nil overlay
+	// получает пустой путь, а статус его не показывает.
+	CacheDBPath func() string
 	// Bus receives resource:invalidated events for the staging/draft
 	// flow (SaveDraft, ApplyDraft, DiscardDraft). Optional — when nil,
 	// staging event emission is silently skipped.

--- a/internal/singbox/router/service_fakeip_test.go
+++ b/internal/singbox/router/service_fakeip_test.go
@@ -217,7 +217,7 @@ func newFakeIPEnableHarness(t *testing.T, failAt string) *fakeIPEnableHarness {
 	svc.deps.StaticRoutes = routes
 	svc.deps.OpkgTunIndices = &recIndices{live: map[int]bool{}}
 	svc.deps.FakeIPTun = DefaultFakeIPTunParams()
-	svc.deps.FakeIPTun.CachePath = filepath.Join(dir, "cache.db")
+	svc.deps.CacheDBPath = func() string { return filepath.Join(dir, "cache.db") }
 
 	// fakeip readiness probes → ready; flush records into the log.
 	stubTunReadyProbe(t, func(string) bool { return true })
@@ -1766,5 +1766,45 @@ func TestEnableFakeIPTun_RollbackOnSlotRouterFlipFailure(t *testing.T) {
 	}
 	if !h.log.has("Delete:OpkgTun0") {
 		t.Errorf("откат обязан снести интерфейс: %v", h.log.calls)
+	}
+}
+
+// PUT с cacheFileLocation=tmp в том же вызове дёргает шов применения к
+// 00-base.json и через reapplyFakeIPOverlay переводит overlay 21-fakeip.json на
+// эффективный путь оператора (issue #842). Живой индекс засеян, чтобы Reconcile в хвосте
+// UpdateSettings не перепровиженил overlay сам и не замаскировал пропуск reapply.
+func TestUpdateSettings_CacheFileLocationReachesOverlayAndBase(t *testing.T) {
+	h := newFakeIPEnableHarness(t, "")
+	ctx := context.Background()
+	if err := h.svc.Enable(ctx); err != nil {
+		t.Fatalf("Enable(fakeip): %v", err)
+	}
+	h.svc.deps.OpkgTunIndices = &recIndices{live: map[int]bool{h.loadFakeIP(t).Index: true}}
+	h.svc.deps.CacheDBPath = func() string { return "/tmp/test-cache.db" }
+	applied, calls := "", 0
+	h.svc.deps.ApplyCacheFileLocation = func(location string) error { applied = location; calls++; return nil }
+
+	sr, err := h.svc.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	sr.CacheFileLocation = "tmp"
+	if err := h.svc.UpdateSettings(ctx, sr); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
+	if applied != "tmp" || calls != 1 {
+		t.Errorf("ApplyCacheFileLocation получил %q (%d вызовов), want \"tmp\" один раз", applied, calls)
+	}
+	data, err := os.ReadFile(filepath.Join(h.dir, "21-fakeip.json"))
+	if err != nil {
+		t.Fatalf("read 21-fakeip.json: %v", err)
+	}
+	var cfg RouterConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal 21-fakeip.json: %v", err)
+	}
+	if cfg.Experimental == nil || cfg.Experimental.CacheFile == nil || cfg.Experimental.CacheFile.Path != "/tmp/test-cache.db" {
+		t.Errorf("overlay cache_file.path не переехал в RAM: %s", data)
 	}
 }

--- a/internal/singbox/router/service_lifecycle.go
+++ b/internal/singbox/router/service_lifecycle.go
@@ -1308,6 +1308,10 @@ func (s *ServiceImpl) GetStatus(ctx context.Context) (Status, error) {
 		}
 		policyTunSourcePreserve = &sp
 	}
+	cacheDBPath := ""
+	if s.deps.CacheDBPath != nil {
+		cacheDBPath = s.deps.CacheDBPath()
+	}
 	return Status{
 		Enabled:                 sr.Enabled,
 		Installed:               installed,
@@ -1330,6 +1334,7 @@ func (s *ServiceImpl) GetStatus(ctx context.Context) (Status, error) {
 		FakeIPIface:             fakeIPIface,
 		FakeIPDns:               fakeIPDns,
 		FakeIPTunAddr:           fakeIPTunAddr,
+		CacheDBPath:             cacheDBPath,
 		PolicyTunIface:          policyTunIface,
 		PolicyTunNDMSName:       policyTunNDMS,
 		PolicyTunSourcePreserve: policyTunSourcePreserve,

--- a/internal/singbox/router/service_settings.go
+++ b/internal/singbox/router/service_settings.go
@@ -116,6 +116,11 @@ func (s *ServiceImpl) UpdateSettings(ctx context.Context, sr storage.SingboxRout
 	if err := s.reapplyFakeIPOverlay(ctx, settings); err != nil {
 		return err
 	}
+	if s.deps.ApplyCacheFileLocation != nil {
+		if err := s.deps.ApplyCacheFileLocation(normalized.CacheFileLocation); err != nil {
+			s.appLog.Warn("apply-cache-location", "", "apply cache.db location failed: "+err.Error())
+		}
+	}
 	// Пресет keendns применяем здесь, а не только внутри Reconcile: тот
 	// пропускает тик целиком, если transitionMu занят сменой режима, и
 	// снятие пресета молча не доехало бы. Повторный вызов из Reconcile —
@@ -236,6 +241,12 @@ func NormalizeSingboxRouterSettings(sr storage.SingboxRouterSettings) (storage.S
 		return sr, err
 	}
 	sr.QoSClasses = normalizeQoSClasses(sr.QoSClasses)
+	switch sr.CacheFileLocation {
+	case "", "flash", "tmp":
+		// valid
+	default:
+		return sr, fmt.Errorf("cacheFileLocation: invalid value %q (must be \"flash\" or \"tmp\")", sr.CacheFileLocation)
+	}
 	return sr, nil
 }
 

--- a/internal/singbox/router/service_settings.go
+++ b/internal/singbox/router/service_settings.go
@@ -71,6 +71,19 @@ func (s *ServiceImpl) UpdateSettings(ctx context.Context, sr storage.SingboxRout
 				ipsetOK = bypassset.IsIPSetAvailable()
 			}
 		}
+		// Место хранения cache.db живёт в 00-base.json — применяем через
+		// оператор ДО персиста и ДО overlay (issue #842): при отказе стор не
+		// говорит «tmp», пока база на флеше, а overlay ниже берёт у оператора
+		// уже эффективный путь. На КАЖДОМ PUT, без гейта по прежнему значению:
+		// применение без правки не пишет и не взводит reload, зато любой PUT
+		// долечивает базу, разъехавшуюся с настройкой (отказ персиста ниже
+		// после успешного применения, гонка с Enable), а не только бут.
+		// Обратное окно остаётся до этого следующего PUT или бута.
+		if s.deps.ApplyCacheFileLocation != nil {
+			if err := s.deps.ApplyCacheFileLocation(normalized.CacheFileLocation); err != nil {
+				return nil, err
+			}
+		}
 		if err := s.deps.Settings.Update(func(cur *storage.Settings) error {
 			// Переход «пусто → непусто» требует живого ipset-бинаря. Только на
 			// переходе: при уже выбранных тегах и сломанном ipset прочие правки
@@ -115,11 +128,6 @@ func (s *ServiceImpl) UpdateSettings(ctx context.Context, sr storage.SingboxRout
 	// байт-идентичном результате short-circuit'ится (persistSlotDirect).
 	if err := s.reapplyFakeIPOverlay(ctx, settings); err != nil {
 		return err
-	}
-	if s.deps.ApplyCacheFileLocation != nil {
-		if err := s.deps.ApplyCacheFileLocation(normalized.CacheFileLocation); err != nil {
-			s.appLog.Warn("apply-cache-location", "", "apply cache.db location failed: "+err.Error())
-		}
 	}
 	// Пресет keendns применяем здесь, а не только внутри Reconcile: тот
 	// пропускает тик целиком, если transitionMu занят сменой режима, и
@@ -242,7 +250,7 @@ func NormalizeSingboxRouterSettings(sr storage.SingboxRouterSettings) (storage.S
 	}
 	sr.QoSClasses = normalizeQoSClasses(sr.QoSClasses)
 	switch sr.CacheFileLocation {
-	case "", "flash", "tmp":
+	case "", storage.CacheFileLocationFlash, storage.CacheFileLocationTmp:
 		// valid
 	default:
 		return sr, fmt.Errorf("cacheFileLocation: invalid value %q (must be \"flash\" or \"tmp\")", sr.CacheFileLocation)

--- a/internal/singbox/router/service_settings_guard_test.go
+++ b/internal/singbox/router/service_settings_guard_test.go
@@ -89,3 +89,24 @@ func TestUpdateSettings_RejectedDuringTransition(t *testing.T) {
 		t.Fatal("настройки сохранены поверх живого перехода")
 	}
 }
+
+// 4) Отказ применения места хранения cache.db к 00-base.json не персистит
+// настройку: иначе стор говорил бы «tmp», пока база на флеше (issue #842).
+func TestUpdateSettings_CacheLocationApplyFailureSavesNothing(t *testing.T) {
+	h := newTransitionHarness(t)
+	ctx := context.Background()
+	h.seedState(t, stateOff, false)
+	h.svc.deps.ApplyCacheFileLocation = func(string) error { return errors.New("injected") }
+
+	sr := storage.SingboxRouterSettings{WANAutoDetect: true, CacheFileLocation: "tmp"}
+	if err := h.svc.UpdateSettings(ctx, sr); err == nil {
+		t.Fatal("UpdateSettings: ожидалась ошибка применения")
+	}
+	saved, err := h.store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if saved.SingboxRouter.CacheFileLocation != "" {
+		t.Fatalf("настройка сохранена при отказе применения: %q", saved.SingboxRouter.CacheFileLocation)
+	}
+}

--- a/internal/singbox/router/types.go
+++ b/internal/singbox/router/types.go
@@ -44,6 +44,10 @@ type Status struct {
 	// FakeIPTunAddr is the fakeip-tun gateway address (the tun /30 host, e.g.
 	// "172.18.0.1"); "" when not in fakeip-tun mode. Read-only, for display.
 	FakeIPTunAddr string `json:"fakeipTunAddr,omitempty"`
+	// CacheDBPath — эффективный путь cache.db (issue #842): по настройке, а при
+	// пустой — из 00-base.json. Показывает рукописный путь, который селектор
+	// «flash | tmp» выразить не может. "" без шва Deps.CacheDBPath.
+	CacheDBPath string `json:"cacheDbPath,omitempty"`
 	// PolicyTunIface / PolicyTunNDMSName — kernel- и NDMS-имена policy-tun
 	// интерфейса ("opkgtun0" / "OpkgTun0"). Заполняются при Enabled+Provisioned,
 	// ДО того как режим стал active: имя OpkgTun нужно пользователю, чтобы

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -1063,8 +1063,10 @@ func (s *SettingsStore) GetSingboxClashPort() int {
 	return settings.SingboxClashPort
 }
 
-// GetSingboxCacheFileLocation returns the configured cache.db location ("flash" or "tmp").
-// Empty means "not configured" (default flash).
+// GetSingboxCacheFileLocation returns the configured cache.db location
+// ("flash" or "tmp"). Empty means "not configured": an absolute path in
+// 00-base.json stays, a relative or legacy one is replaced by the flash
+// default (see singbox.cacheDBPathFor).
 func (s *SettingsStore) GetSingboxCacheFileLocation() string {
 	settings, err := s.Get()
 	if err != nil {

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -1063,6 +1063,16 @@ func (s *SettingsStore) GetSingboxClashPort() int {
 	return settings.SingboxClashPort
 }
 
+// GetSingboxCacheFileLocation returns the configured cache.db location ("flash" or "tmp").
+// Empty means "not configured" (default flash).
+func (s *SettingsStore) GetSingboxCacheFileLocation() string {
+	settings, err := s.Get()
+	if err != nil {
+		return ""
+	}
+	return settings.SingboxRouter.CacheFileLocation
+}
+
 // GetLoggingMaxAge returns the max age for log entries in hours.
 func (s *SettingsStore) GetLoggingMaxAge() int {
 	settings, err := s.Get()

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -283,6 +283,10 @@ type SingboxRouterSettings struct {
 	// PolicyTunNATSegments — выбранные пользователем сегменты для source-preserve
 	// (редактируемый предпоказ в UI). Пусто при выключенной опции.
 	PolicyTunNATSegments []string `json:"policyTunNatSegments,omitempty"`
+	// CacheFileLocation задаёт место хранения временного кэша sing-box (cache.db) (issue #842).
+	// "flash" / "" (default) — на диске (/opt/etc/awg-manager/singbox/cache.db).
+	// "tmp" — в оперативной памяти (/tmp/singbox-cache.db, tmpfs/RAM) для защиты флеш-памяти роутера.
+	CacheFileLocation string `json:"cacheFileLocation,omitempty"`
 }
 
 // SingboxQoSClass is one DSCP-based QoS traffic class routed to a dedicated

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -283,11 +283,19 @@ type SingboxRouterSettings struct {
 	// PolicyTunNATSegments — выбранные пользователем сегменты для source-preserve
 	// (редактируемый предпоказ в UI). Пусто при выключенной опции.
 	PolicyTunNATSegments []string `json:"policyTunNatSegments,omitempty"`
-	// CacheFileLocation задаёт место хранения временного кэша sing-box (cache.db) (issue #842).
-	// "flash" / "" (default) — на диске (/opt/etc/awg-manager/singbox/cache.db).
-	// "tmp" — в оперативной памяти (/tmp/singbox-cache.db, tmpfs/RAM) для защиты флеш-памяти роутера.
+	// CacheFileLocation — место хранения cache.db sing-box (issue #842):
+	// "flash" — /opt/etc/awg-manager/singbox/cache.db на флеше, "tmp" —
+	// /tmp/singbox-cache.db в RAM, чтобы записи кэша не изнашивали флеш; ""
+	// (не задано) — путь из 00-base.json как есть, рукописный сохраняется,
+	// негодный заменяется флешем.
 	CacheFileLocation string `json:"cacheFileLocation,omitempty"`
 }
+
+// Значения SingboxRouterSettings.CacheFileLocation.
+const (
+	CacheFileLocationFlash = "flash"
+	CacheFileLocationTmp   = "tmp"
+)
 
 // SingboxQoSClass is one DSCP-based QoS traffic class routed to a dedicated
 // sing-box outbound (issue #371). DSCP is the 6-bit codepoint matched by


### PR DESCRIPTION
## Описание изменений

Реализация запроса **#842**: возможность выбора места хранения временной базы кэша sing-box (`cache.db`).

### Проблема
По умолчанию sing-box хранит `cache.db` во флеш-памяти роутера (`/opt/etc/awg-manager/singbox/cache.db`). При интенсивных DNS-запросах и активном FakeIP частые циклы записи приводят к повышенному износу встроенной NAND flash-памяти роутеров Keenetic.

### Решение
Добавлена настройка `cacheFileLocation` со значениями:
- `"flash"` (по умолчанию) — `/opt/etc/awg-manager/singbox/cache.db`
- `"tmp"` — `/tmp/singbox-cache.db` (в RAM/tmpfs, нулевой износ Flash-памяти роутера)

### Что сделано:
1. **Бэкенд и хранилище:**
   - В `SingboxRouterSettings` и DTO добавлено поле `cacheFileLocation` (`"flash" | "tmp"`).
   - В оператор sing-box добавлены константа `TempCacheDBPath` (`/tmp/singbox-cache.db`) и резолвер `ResolveCacheDBPath`.
   - Обновлены `patchBaseCacheFileTo`, `freshBaseConfig`, `ensureBaseConfig` и `reconcileConfigSteps` для поддержки кастомного пути кэша.
   - Метод `ApplyCacheFileLocation(location)` производит live-мутацию `00-base.json` через оркестратор с валидацией и плавным reload'ом без обрыва активных сессий.
   - В провиженинг `fakeip-tun` (`21-fakeip.json`) проброшена поддержка `TempCachePath`: при выборе `tmp` fakeip-кэш автоматически переключается в RAM.

2. **Frontend:**
   - Добавлен селектор выбора хранилища (`Flash /opt` vs `RAM /tmp`) в шторку параметров маршрутизатора (`StatusDrawer.svelte`).
   - Добавлен селектор выбора хранилища в карточку настроек движка FakeIP (`EngineSettingsCard.svelte`).
   - Регенерированы `internal/openapi/swagger.yaml` и `frontend/src/lib/api/schemas.gen.ts`.

3. **Тестирование:**
   - Добавлены модульные тесты `internal/singbox/operator_baseconfig_cache_test.go` (резолвинг путей, патчинг, live-мутация оркестратором).
   - Добавлен тест `TestResolveFakeIPParams_CacheFileLocation` в `internal/singbox/router/fakeip_provision_test.go`.
   - Проверены тесты на роутере Keenetic (ARM64 linux).
   - Пройдены `svelte-check` (0 ошибок) и `eslint` (0 ошибок).
   - Проверена сборка frontend (`npm run build`) и Go-демона (`cmd/awg-manager`).

Closes #842
