### PR TITLE
fix(settings): кнопки в карточке интеграций — одна ширина и честная подпись у HydraRoute

### DIFF
--- a/frontend/scripts/mock-proxy.mjs
+++ b/frontend/scripts/mock-proxy.mjs
@@ -43,6 +43,11 @@
  * - POST /__mock/singbox-install-fail {"enabled": true|false};
  * - POST /__mock/singbox-running {"running": true|false} — живость sing-box в
  *   GET /singbox/status (env MOCK_SINGBOX_DOWN=1 выключает её на старте).
+ * - POST /__mock/hydraroute-installed {"installed": true|false} — установлен ли
+ *   HydraRoute в GET /system/hydraroute-status (env MOCK_HYDRAROUTE_ABSENT=1
+ *   снимает на старте). Нужен, чтобы посмотреть карточку интеграций в
+ *   состоянии «ничего не установлено»: там у HydraRoute вместо «Открыть»
+ *   ссылка «Инструкция →».
  *
  * Default upstream: http://127.0.0.1:8080 (Prism). Listen: 8081.
  */
@@ -139,6 +144,7 @@ const MOCK_CAPABILITY_GROUPS = Object.freeze([
 			'POST /__mock/reset',
 			'POST /__mock/singbox-install-fail',
 			'POST /__mock/singbox-running',
+			'POST /__mock/hydraroute-installed',
 			'POST /__mock/download-faults',
 			'POST /__mock/keenetic-os',
 		],
@@ -184,6 +190,7 @@ function getRuntimeState() {
 		mcpKeys: mockMcpKeys.length,
 		singboxInstallShouldFail,
 		singboxRunning,
+		hydraRouteInstalled,
 		downloadFaultsEnabled,
 		downloadFaultProbability,
 		logsCleared: { ...bucketCleared },
@@ -203,6 +210,7 @@ function resetRuntimeControls() {
 	mockMcpKeySeq = 0;
 	singboxInstallShouldFail = process.env.MOCK_SINGBOX_INSTALL_FAIL === '1';
 	singboxRunning = process.env.MOCK_SINGBOX_DOWN !== '1';
+	hydraRouteInstalled = process.env.MOCK_HYDRAROUTE_ABSENT !== '1';
 	downloadFaultsEnabled = process.env.MOCK_DOWNLOAD_FAULTS !== '0';
 	downloadFaultProbability = parseProbability(process.env.MOCK_DOWNLOAD_FAULT_PROB, 0.4);
 	bucketCleared.app = false;
@@ -2705,13 +2713,21 @@ const mockDnsProxyInfo = {
 };
 
 /** HydraRoute Neo в блоке AWGM (GET /system/hydraroute-status). */
-const mockHydraRouteStatus = {
+const mockHydraRouteStatusInstalled = {
 	installed: true,
 	running: true,
 	version: '2.4.1',
 	pid: 2345,
 	processState: 'running',
 };
+
+const mockHydraRouteStatusAbsent = {
+	installed: false,
+	running: false,
+	processState: 'not_installed',
+};
+
+let hydraRouteInstalled = process.env.MOCK_HYDRAROUTE_ABSENT !== '1';
 
 const mockRoutingDnsRoutes = [
 	{
@@ -6133,7 +6149,10 @@ const server = http.createServer(async (req, res) => {
 	}
 
 	if (req.method === 'GET' && path === '/system/hydraroute-status') {
-		send(res, 200, { success: true, data: mockHydraRouteStatus });
+		send(res, 200, {
+			success: true,
+			data: hydraRouteInstalled ? mockHydraRouteStatusInstalled : mockHydraRouteStatusAbsent,
+		});
 		return;
 	}
 
@@ -6375,6 +6394,18 @@ const server = http.createServer(async (req, res) => {
 			singboxRunning = body.running !== false;
 			send(res, 200, { ok: true, singboxRunning });
 			console.log(`[mock-proxy] singboxRunning → ${singboxRunning}`);
+		} catch (e) {
+			send(res, 400, { error: String(e) });
+		}
+		return;
+	}
+
+	if (req.method === 'POST' && path === '/__mock/hydraroute-installed') {
+		try {
+			const body = await readJsonBody(req);
+			hydraRouteInstalled = body.installed !== false;
+			send(res, 200, { ok: true, hydraRouteInstalled });
+			console.log(`[mock-proxy] hydraRouteInstalled → ${hydraRouteInstalled}`);
 		} catch (e) {
 			send(res, 400, { error: String(e) });
 		}
@@ -9103,7 +9134,7 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(PORT, '127.0.0.1', () => {
 	console.log(`mock-proxy on http://127.0.0.1:${PORT} → ${UPSTREAM} (usageLevel=${usageLevel})`);
-	console.log('[mock-proxy] controls: GET /__mock/capabilities, GET /__mock/tunnels, POST /__mock/reset-runtime, POST /__mock/singbox-install-fail, POST /__mock/singbox-running, POST /__mock/download-faults, POST /__mock/keenetic-os');
+	console.log('[mock-proxy] controls: GET /__mock/capabilities, GET /__mock/tunnels, POST /__mock/reset-runtime, POST /__mock/singbox-install-fail, POST /__mock/singbox-running, POST /__mock/hydraroute-installed, POST /__mock/download-faults, POST /__mock/keenetic-os');
 	console.log(`[mock-proxy] keenetic-os: ${mockKeeneticProfile.key} (supportsExtendedASC=${mockKeeneticProfile.extended}; default: 5.1, force: MOCK_KEENETIC_OS=5.0|5.1, switch: POST /__mock/keenetic-os)`);
 	console.log(`[mock-proxy] download faults: enabled=${downloadFaultsEnabled} p=${downloadFaultProbability} (disable: MOCK_DOWNLOAD_FAULTS=0)`);
 });

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -465,14 +465,18 @@
 				{:else if hydraStatusLoading}
 					<Button variant="secondary" size="sm" disabled>Ожидание…</Button>
 				{:else}
+					<!-- HydraRoute ставится не отсюда: своего установщика у нас нет, ссылка ведёт
+					     на инструкцию проекта. Кнопка поэтому и подписана иначе, и выглядит иначе,
+					     чем «Установить» у остальных интеграций — те действительно ставят. -->
 					<Button
 						variant="outline-primary"
 						size="sm"
 						href="https://github.com/Ground-Zerro/HydraRoute"
 						target="_blank"
 						rel="noopener noreferrer"
+						title="Инструкция по установке HydraRoute на GitHub (откроется в новой вкладке)"
 					>
-						Установить
+						Инструкция →
 					</Button>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/settings/IntegrationsCard.svelte
+++ b/frontend/src/lib/components/settings/IntegrationsCard.svelte
@@ -637,12 +637,22 @@
 		grid-column: 1 / -1;
 	}
 
-	/* Same action-button floor as settings actions-card (fits «Обновление…»). */
+	/* Same action-button floor as settings actions-card (fits «Обновление…»):
+	   ширина не прыгает, когда подпись уезжает в «Установка…»/«Обновление…».
+	   Одиночная кнопка в .integration-actions получает тот же пол — иначе
+	   «Установить» у sing-box (прямой ребёнок строки) шире, чем у прокси-
+	   бинарей (обёрнуты в группу), хотя это одно и то же действие. Пары
+	   кнопок («Открыть» + «Удалить») пол не получают: там ширину задаёт
+	   содержимое, а 7.5rem на каждую распирало бы строку. */
 	@media (min-width: 641px) {
+		.setting-row > :global(.btn),
+		.integration-actions > :global(.btn:only-child) {
+			min-width: 7.5rem;
+		}
+
 		.setting-row > :global(.btn) {
 			justify-self: end;
 			align-self: center;
-			min-width: 7.5rem;
 		}
 	}
 
@@ -688,10 +698,14 @@
 				gap: 0.625rem;
 			}
 
+			.setting-row > :global(.btn),
+			.integration-actions > :global(.btn:only-child) {
+				min-width: 7.5rem;
+			}
+
 			.setting-row > :global(.btn) {
 				justify-self: end;
 				align-self: center;
-				min-width: 7.5rem;
 			}
 		}
 	}

--- a/frontend/src/lib/components/settings/IntegrationsCard.test.ts
+++ b/frontend/src/lib/components/settings/IntegrationsCard.test.ts
@@ -90,3 +90,49 @@ describe('IntegrationsCard — HydraRoute', () => {
 		expect(open?.getAttribute('href')).toBe('/routing?tab=hrneo');
 	});
 });
+
+describe('IntegrationsCard — ширина кнопок установки', () => {
+	// Пол ширины (min-width: 7.5rem) вешается на прямого ребёнка .setting-row
+	// и на ОДИНОЧНУЮ кнопку в .integration-actions. У sing-box кнопка — прямой
+	// ребёнок строки, у прокси-бинарей она обёрнута в группу, и пока пол не
+	// доставал до вложенных, «Установить» у sing-box был шире остальных.
+	// Тест держит структуру, на которую опирается селектор :only-child:
+	// появится вторая кнопка в ветке «не установлен» — пол молча отвалится.
+	const binary = (key: string, label: string) => ({
+		key,
+		label,
+		present: false,
+		installAvailable: true,
+		updateAvailable: false,
+		busy: false,
+		instances: 0,
+		oninstall: vi.fn(),
+		onuninstall: vi.fn(),
+	});
+
+	it('у неустановленного прокси-бинаря «Установить» — единственная кнопка в группе', () => {
+		render(IntegrationsCard, {
+			...baseProps,
+			singboxStatus: status(false),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			proxyBinaries: [binary('wdtt', 'WDTT'), binary('freeturn', 'FreeTurn')] as any,
+		});
+
+		const groups = document.querySelectorAll('.integration-actions');
+		expect(groups.length).toBe(2);
+		for (const g of groups) {
+			const buttons = g.querySelectorAll('.btn');
+			expect(buttons.length).toBe(1);
+			expect(buttons[0].textContent?.trim()).toBe('Установить');
+		}
+	});
+
+	it('sing-box без установки держит кнопку прямым ребёнком строки', () => {
+		render(IntegrationsCard, { ...baseProps, singboxStatus: status(false) });
+
+		const row = document.querySelector('.setting-row');
+		expect(row).not.toBeNull();
+		const direct = row?.querySelector(':scope > .btn');
+		expect(direct?.textContent?.trim()).toBe('Установить');
+	});
+});

--- a/frontend/src/lib/components/settings/IntegrationsCard.test.ts
+++ b/frontend/src/lib/components/settings/IntegrationsCard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/svelte';
 import IntegrationsCard from './IntegrationsCard.svelte';
-import type { SingboxStatus } from '$lib/types';
+import type { HydraRouteStatus, SingboxStatus } from '$lib/types';
 
 const status = (installed: boolean): SingboxStatus =>
 	({ installed, running: false, version: '1.14.0' }) as SingboxStatus;
@@ -50,5 +50,43 @@ describe('IntegrationsCard — удаление sing-box', () => {
 	it('без обработчика удаления кнопки нет (старый вызов карточки)', () => {
 		render(IntegrationsCard, { ...baseProps, singboxStatus: status(true) });
 		expect(screen.queryByText('Удалить')).toBeNull();
+	});
+});
+
+describe('IntegrationsCard — HydraRoute', () => {
+	const hydra = (installed: boolean): HydraRouteStatus =>
+		({ installed, running: false }) as HydraRouteStatus;
+
+	// Своего установщика HydraRoute у нас нет — кнопка ведёт на инструкцию
+	// проекта. Подписывать её «Установить», как у остальных интеграций, значит
+	// обещать установку и открыть вместо неё GitHub.
+	it('не установлен — ссылка на инструкцию, а не кнопка установки', () => {
+		render(IntegrationsCard, {
+			...baseProps,
+			singboxStatus: status(true),
+			showHydra: true,
+			hydraStatus: hydra(false),
+		});
+
+		const link = screen.getByText('Инструкция →').closest('a');
+		expect(link).not.toBeNull();
+		expect(link?.getAttribute('href')).toBe('https://github.com/Ground-Zerro/HydraRoute');
+		expect(link?.getAttribute('target')).toBe('_blank');
+		expect(link?.getAttribute('rel')).toContain('noopener');
+	});
+
+	it('установлен — «Открыть» вместо инструкции', () => {
+		// sing-box держим неустановленным: у установленного своя кнопка
+		// «Открыть», и по тексту их потом не различить.
+		render(IntegrationsCard, {
+			...baseProps,
+			singboxStatus: status(false),
+			showHydra: true,
+			hydraStatus: hydra(true),
+		});
+		expect(screen.queryByText('Инструкция →')).toBeNull();
+
+		const open = screen.getByText('Открыть').closest('a');
+		expect(open?.getAttribute('href')).toBe('/routing?tab=hrneo');
 	});
 });

--- a/frontend/src/lib/components/settings/IntegrationsCard.test.ts
+++ b/frontend/src/lib/components/settings/IntegrationsCard.test.ts
@@ -54,8 +54,7 @@ describe('IntegrationsCard — удаление sing-box', () => {
 });
 
 describe('IntegrationsCard — HydraRoute', () => {
-	const hydra = (installed: boolean): HydraRouteStatus =>
-		({ installed, running: false }) as HydraRouteStatus;
+	const hydra = (installed: boolean): HydraRouteStatus => ({ installed, running: false });
 
 	// Своего установщика HydraRoute у нас нет — кнопка ведёт на инструкцию
 	// проекта. Подписывать её «Установить», как у остальных интеграций, значит


### PR DESCRIPTION
## Что было видно

В карточке интеграций «Установить» у sing-box заметно шире, чем у WDTT и FreeTurn, а кнопка HydraRoute вдобавок выделена другим стилем.

| было | стало |
|---|---|
| <img src="https://raw.githubusercontent.com/AYastrebov/awg-manager/assets/integrations-buttons/integrations-before.png" width="360"> | <img src="https://raw.githubusercontent.com/AYastrebov/awg-manager/assets/integrations-buttons/integrations-after.png" width="360"> |

Обе картинки сняты на моке в одном и том же состоянии «ничего не установлено», разница между ними — ровно этот PR.

## Ширина кнопок

Виновата не вёрстка строки, а комбинатор:

```css
.setting-row > :global(.btn) { min-width: 7.5rem }
```

`>` берёт только прямых детей. У sing-box и HydraRoute кнопка лежит в `.setting-row` напрямую и пол получает; у прокси-бинарей она обёрнута в `.integration-actions`, то есть внук, и правило до неё не достаёт. Замерено в браузере: 105px против 84.4px.

Пол тут не косметика — он держит ширину, когда подпись уезжает в «Установка…»/«Обновление…» (об этом и комментарий рядом со ссылкой на actions-card). Прокси-бинари подпись по `busy` меняют ровно так же, то есть защиту они потеряли не по решению, а по недосмотру.

Теперь пол достаётся и одиночной кнопке в `.integration-actions`. Пары («Открыть» + «Удалить») оставлены на ширине по содержимому: 7.5rem на каждую распирало бы строку. Это расходится с actions-card, где `width: 7.5rem` висит на всех кнопках группы, но там пар в строке и не бывает.

## Подпись у HydraRoute

Кнопка называлась «Установить», но ничего не ставила: обработчика установки для HydraRoute во фронтенде нет вовсе, `href` ведёт на GitHub проекта и открывается в новой вкладке. Разный стиль (`outline-primary` против `primary` у остальных) появился в `3918fb67` и был единственным намёком на это.

Причесать до `primary` значило бы сделать хуже: все шесть кнопок стали бы неразличимы, намёк пропал бы, а поведение осталось прежним — обещание установки и GitHub вместо неё. Поэтому подпись говорит, что делает кнопка: «Инструкция →», как у внешних ссылок в SystemInfoGrid («Telegram →»). Outline оставлен намеренно: это не действие над роутером.

Если установку HydraRoute когда-нибудь сделают по-настоящему, кнопка вернётся к `primary` и к «Установить» вместе с реальным обработчиком.

## Мок

Состояние «ничего не установлено» на моке было недостижимо: sing-box снимался существующим `MOCK_SINGBOX_INSTALL_FAIL`, а HydraRoute был захардкожен `installed: true`. Добавлен `MOCK_HYDRAROUTE_ABSENT=1` и `POST /__mock/hydraroute-installed` — по образцу соседнего `singbox-running` и в духе контракта файла («prefer additive mock controls over destructive fixture rewrites»). Отдельным коммитом, выкидывается независимо.

```
MOCK_SINGBOX_INSTALL_FAIL=1 MOCK_HYDRAROUTE_ABSENT=1 npm run dev:mock:proxy
```

## Проверка

Замеры в живом браузере на моке, состояние «ничего не установлено»:

| строка | подпись | элемент | ширина |
|---|---|---|---|
| Sing-box | Установить | `button` | 105px |
| WDTT | Установить | `button` | 105px |
| FreeTurn | Установить | `button` | 105px |
| wg-obfuscator (Phobos) | Удалить | `button` | 105px |
| HydraRoute Neo | Инструкция → | `a[href=…/HydraRoute]` | 105px |

105px = 7.5rem, правый край у всех 366px. До правки WDTT и FreeTurn были 84.4px.

Причинность проверена A/B прямо на странице: если снять через CSSOM только добавленную половину правила, та же кнопка становится 84.4px. Отношение 105/84.4 = 1.24 сходится с тем, что видно на скриншоте «было».

- `svelte-check`: 0 ошибок, 6 предупреждений, ни одного в затронутых файлах. Тут это существенно: Svelte ругается на несовпадающий селектор как на «Unused CSS selector», так что опечатка в нём всплыла бы.
- Полный прогон фронтенда: 205 файлов, 1998 тестов, всё зелёное.
- Тестами закреплены подпись и `href`/`target`/`rel` у ссылки, «Открыть» на `/routing?tab=hrneo` в установленном состоянии, и структура, на которую опирается `:only-child`: появится в группе вторая кнопка — пол молча отвалится, и тест это поймает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPZZPbHQ3KL3FyRjzunTN2
