### PR TITLE
docs(readme): ссылка на docker-amneziawg в разделе «Полезное»

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,6 @@ Telegram: [@awgmanager](https://t.me/awgmanager)
 
 Другой вариант управления AmneziaWG сервером - https://github.com/pumbaX/awg-multi-script
 
+Docker-образ AmneziaWG сервера - https://github.com/AYastrebov/docker-amneziawg
+
 Документация проекта - https://awgm.hoaxisr.ru/install/


### PR DESCRIPTION
Добавил в раздел «Полезное» ссылку на Docker-образ AmneziaWG сервера — https://github.com/AYastrebov/docker-amneziawg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjaPaFaFoCf7rsvEQL7Dgb